### PR TITLE
Add tasklist association support for Task v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Task v2**: 支持在 `CreateTaskRequest` 中指定 `tasklist_guid`，并新增 `TaskService::add_tasklist` 帮助方法，便于将既有任务加入指定清单。
+- **文档**: 更新任务模块文档，补充任务加入清单的示例和能力说明。
+
 ## [0.13.2] - 2025-09-06
 
 ### Fixed - 🐛 WebSocket 消息已读事件修复

--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -104,7 +104,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 | 模块 | 功能说明 | 文档位置 | API数量 |
 |------|----------|----------|---------|
 | **approval** | 审批 - 工作流程管理 | [`src/service/approval/`](src/service/approval/) | 20+ |
-| **task** | 任务 - 任务和项目管理 | [`src/service/task/`](src/service/task/) | 18+ |
+| **task** | 任务 - 任务和项目管理（含任务清单关联能力） | [`src/service/task/`](src/service/task/) | 18+ |
 | **okr** | OKR - 目标管理 | [`src/service/okr/`](src/service/okr/) | 15+ |
 | **calendar** | 日历 - 日程安排 | [`src/service/calendar/`](src/service/calendar/) | 25+ |
 

--- a/docs/apis/task-v2.md
+++ b/docs/apis/task-v2.md
@@ -21,6 +21,39 @@
 [添加依赖](https://open.feishu.cn/document/task-v2/task/add_dependencies)
 [移除依赖](https://open.feishu.cn/document/task-v2/task/remove_dependencies)
 
+### 开发者提示：在清单中管理任务
+
+- 通过 `CreateTaskRequest` 的 `tasklist_guid` 字段，可以在任务创建时直接指定所属清单。
+- 如需将已存在的任务加入新的清单，可使用 `TaskService::add_tasklist` 方法并提供 `AddTaskTasklistRequest`。
+
+```rust,no_run
+use open_lark::prelude::*;
+use open_lark::service::task::v2::task::AddTaskTasklistRequest;
+
+async fn attach_task_to_list(
+    client: &LarkClient,
+    task_guid: &str,
+    tasklist_guid: String,
+) -> SDKResult<()> {
+    let request = AddTaskTasklistRequest {
+        tasklist_guid,
+        section_guid: None,
+    };
+
+    let response = client
+        .task
+        .task
+        .add_tasklist(task_guid, request, None, None)
+        .await?;
+
+    if let Some(data) = response.data {
+        println!("任务已加入清单: {:?}", data.tasklist.name);
+    }
+
+    Ok(())
+}
+```
+
 ## 子任务
 
 [创建子任务](https://open.feishu.cn/document/task-v2/task-subtask/create)

--- a/examples/api/task_demo.rs
+++ b/examples/api/task_demo.rs
@@ -47,6 +47,7 @@ async fn demo_task_management(client: &LarkClient) -> Result<(), Box<dyn std::er
             let create_task_req = CreateTaskRequest {
                 summary: "实现用户认证功能".to_string(),
                 description: Some("需要实现JWT认证和权限管理".to_string()),
+                tasklist_guid: Some(tasklist_guid.clone()),
                 due: Some(TaskDue {
                     timestamp: Some("1672531200000".to_string()), // 2023-01-01
                     is_all_day: Some(false),

--- a/src/core/endpoints.rs
+++ b/src/core/endpoints.rs
@@ -1080,6 +1080,10 @@ impl Endpoints {
     pub const TASK_V2_TASK_REMOVE_REMINDERS: &'static str =
         "/open-apis/task/v2/tasks/{task_guid}/remove_reminders";
 
+    /// 任务加入清单
+    pub const TASK_V2_TASK_ADD_TASKLIST: &'static str =
+        "/open-apis/task/v2/tasks/{task_guid}/add_tasklist";
+
     /// 任务添加依赖
     pub const TASK_V2_TASK_ADD_DEPENDENCIES: &'static str =
         "/open-apis/task/v2/tasks/{task_guid}/add_dependencies";


### PR DESCRIPTION
## Summary
- add support for specifying a tasklist when creating tasks and expose the add_tasklist API endpoint
- wire the new endpoint constant in the client and document the request/response structures
- update the task API example to demonstrate creating a task directly under a tasklist
- document the tasklist association workflow in the Task v2 docs and changelog

## Testing
- cargo test --lib

------
https://chatgpt.com/codex/tasks/task_e_68c9259c67ec832a92146db8d71efcb4