### PR TITLE
ci: remove docs deployment job from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,33 +126,3 @@ jobs:
         run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-
-  # 可选：更新文档站点
-  docs:
-    needs: crates-io-release
-    runs-on: ubuntu-latest
-    if: success()
-    steps:
-      - uses: actions/checkout@v4
-      
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.CARGO_TOOLCHAIN }}
-      
-      - name: Cache Cargo build files
-        uses: Leafwing-Studios/cargo-cache@v1
-      
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-      
-      - name: Generate docs
-        run: |
-          cargo doc --all-features --no-deps
-          echo "<meta http-equiv=\"refresh\" content=\"0; url=open_lark\">" > target/doc/index.html
-      
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
-        if: startsWith(github.ref, 'refs/tags/v')
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./target/doc


### PR DESCRIPTION
Remove the docs job that deploys documentation to GitHub Pages. This simplifies the release workflow by removing the documentation deployment step after crates.io publication.

# 概要

请用 2-3 句概述改动动机与效果。

## 变更类型

- [ ] 🐛 修复
- [ ] ✨ 新功能
- [ ] 📚 文档 / 格式
- [x] 🔧 构建 / CI
- [ ] 💥 破坏性改动

## 关联 Issue（可选）

Fixes #

## 验证

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`
- [ ] 其它说明：

## 备注（可选）

补充 reviewer 需要知道的细节、迁移步骤或回滚方式。

<details>
<summary>维护者检查（如适用）</summary>

- [ ] 更新 CHANGELOG
- [ ] 评估版本号调整
- [ ] 安全影响评估
- [ ] 更新 API 文档

</details>
