### PR TITLE
feat: add --all-crates batch mode and per-crate typed API coverage reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ println!("{}", endpoint);
 ## 📖 文档和资源
 
 - **[openlark-docs AGENTS.md](crates/openlark-docs/AGENTS.md)** - 文档服务模块知识库
+- **[Typed API 覆盖率说明](docs/typed-api-coverage.md)** - 覆盖率口径、批量报告与规划输入规范
 - **[快速启动示例](examples/)** - 完整功能演示示例集
 
 ## ​​📊 项目状态

--- a/docs/typed-api-coverage.md
+++ b/docs/typed-api-coverage.md
@@ -7,6 +7,7 @@
 - 数据源：仓库根目录 `api_list_export.csv`。
 - 实现源：`tools/api_coverage.toml` 中配置的 crate 源码目录与 bizTag 映射。
 - 默认排除 `meta.Version=old`（脚本默认开启 `--skip-old`）。
+- 报告默认不写入时间戳，确保同输入下可稳定复现（可通过 `--with-timestamp` 打开时间戳）。
 - 覆盖率定义：`已实现 / API 总数 * 100%`。
 
 ## 2. 报告产物

--- a/docs/typed-api-coverage.md
+++ b/docs/typed-api-coverage.md
@@ -1,0 +1,57 @@
+# Typed API 覆盖率报告说明
+
+本文档定义 `tools/validate_apis.py` 的覆盖率统计口径与生成流程，用于支持按 crate 的缺口跟踪、里程碑规划与发布节奏管理。
+
+## 1. 统计口径
+
+- 数据源：仓库根目录 `api_list_export.csv`。
+- 实现源：`tools/api_coverage.toml` 中配置的 crate 源码目录与 bizTag 映射。
+- 默认排除 `meta.Version=old`（脚本默认开启 `--skip-old`）。
+- 覆盖率定义：`已实现 / API 总数 * 100%`。
+
+## 2. 报告产物
+
+执行批量模式后，会生成以下文件：
+
+- `reports/api_validation/summary.md`：面向人读的汇总看板（总览 + 各 crate 指标）。
+- `reports/api_validation/summary.json`：机器可读汇总（便于 CI/看板系统消费）。
+- `reports/api_validation/crates/<crate>.md`：每个 crate 的详细报告（含未实现清单）。
+
+每个 crate 的报告至少包含：
+
+- API 总数
+- 已实现数量
+- 未实现数量
+- 完成率
+
+## 3. 使用方式
+
+### 3.1 生成全量覆盖率（推荐）
+
+```bash
+just api-coverage
+```
+
+等价命令：
+
+```bash
+python3 tools/validate_apis.py --all-crates
+```
+
+### 3.2 单 crate 验证
+
+```bash
+python3 tools/validate_apis.py --crate openlark-docs
+```
+
+### 3.3 包含 old 版本 API
+
+```bash
+python3 tools/validate_apis.py --all-crates --include-old
+```
+
+## 4. 规划建议
+
+- 以 `summary.md` 的 `未实现` 列作为季度缺口清单输入。
+- 以 `completion_rate` 追踪里程碑完成趋势。
+- 优先处理高流量核心 crate 的高缺口模块，再补尾部模块。

--- a/justfile
+++ b/justfile
@@ -28,6 +28,12 @@ issue41-guardrail:
   @echo "🛡️ Running issue #41 guardrail..."
   python3 tools/issue41_guardrail.py
 
+# Generate typed API coverage reports per crate and summary dashboard
+api-coverage:
+  @echo "📊 Generating typed API coverage reports..."
+  python3 tools/validate_apis.py --all-crates
+  @echo "✅ Coverage reports generated in reports/api_validation/"
+
 # Build release
 build-release:
   @echo "🚀 Building release..."
@@ -204,6 +210,7 @@ help:
   @echo "  coverage     - Run coverage analysis"
   @echo "  coverage-check - Run coverage with threshold check"
   @echo "  audit        - Run security audit"
+  @echo "  api-coverage - Generate typed API coverage reports (per crate + summary)"
   @echo "  update-audit-db - Update security advisory database"
   @echo "  install-dev-tools - Install development tools"
   @echo "  check-all    - Run all pre-release checks (includes coverage & security)"

--- a/tools/validate_apis.py
+++ b/tools/validate_apis.py
@@ -43,11 +43,19 @@ class APIInfo:
 class APIValidator:
     """API 验证器"""
 
-    def __init__(self, csv_path: str, src_path: str, filter_tags: List[str] = None, skip_old_versions: bool = True):
+    def __init__(
+        self,
+        csv_path: str,
+        src_path: str,
+        filter_tags: List[str] = None,
+        skip_old_versions: bool = True,
+        with_timestamp: bool = False,
+    ):
         self.csv_path = csv_path
         self.src_path = Path(src_path)
         self.filter_tags = filter_tags
         self.skip_old_versions = skip_old_versions
+        self.with_timestamp = with_timestamp
         self.apis: List[APIInfo] = []
         self.implemented_files: Set[str] = set()
         self.missing_apis: List[APIInfo] = []
@@ -239,7 +247,8 @@ class APIValidator:
         with open(output_path, 'w', encoding='utf-8') as f:
             # 标题
             f.write("# API 验证报告\n\n")
-            f.write(f"**生成时间**: {self._get_timestamp()}\n")
+            if self.with_timestamp:
+                f.write(f"**生成时间**: {self._get_timestamp()}\n")
             f.write(f"**CSV 文件**: {self.csv_path}\n")
             f.write(f"**源码目录**: {self.src_path}\n")
             f.write(f"**命名规范**: `src/bizTag/meta.project/meta.version/meta.resource/meta.name.rs`\n\n")
@@ -393,6 +402,8 @@ def main():
                         help='跳过旧版本 API (version=old，默认启用)')
     parser.add_argument('--include-old', dest='skip_old', action='store_false',
                         help='包含旧版本 API (version=old)')
+    parser.add_argument('--with-timestamp', action='store_true',
+                        help='在报告中写入生成时间（默认关闭，以支持稳定复现）')
 
     args = parser.parse_args()
 
@@ -427,8 +438,14 @@ def main():
             print(f"- {crate_name}: src={src} biz_tags=[{tags_text}]")
         return 0
 
-    def _run_validator(csv_path: str, src_path: str, filter_tags: Optional[List[str]], skip_old: bool) -> APIValidator:
-        validator = APIValidator(csv_path, src_path, filter_tags, skip_old)
+    def _run_validator(
+        csv_path: str,
+        src_path: str,
+        filter_tags: Optional[List[str]],
+        skip_old: bool,
+        with_timestamp: bool,
+    ) -> APIValidator:
+        validator = APIValidator(csv_path, src_path, filter_tags, skip_old, with_timestamp)
         validator.parse_csv()
         validator.scan_implementations()
         validator.compare()
@@ -488,6 +505,9 @@ def main():
         )
 
     if args.all_crates:
+        if not os.path.exists(args.csv):
+            print(f"❌ 错误: CSV 文件不存在: {args.csv}")
+            return 1
         crates = _load_mapping(args.mapping)
         report_dir = Path(args.report_dir)
         crate_dir = report_dir / "crates"
@@ -504,7 +524,7 @@ def main():
             report_path = crate_dir / f"{crate_name}.md"
             print()
             print(f"📦 处理 {crate_name}")
-            validator = _run_validator(args.csv, src, tags, args.skip_old)
+            validator = _run_validator(args.csv, src, tags, args.skip_old, args.with_timestamp)
             report_path.parent.mkdir(parents=True, exist_ok=True)
             validator.generate_report(str(report_path))
             stats = validator.calculate_summary()
@@ -586,7 +606,7 @@ def main():
         return 1
 
     # 执行验证
-    validator = _run_validator(args.csv, args.src, args.filter, args.skip_old)
+    validator = _run_validator(args.csv, args.src, args.filter, args.skip_old, args.with_timestamp)
 
     Path(args.output).parent.mkdir(parents=True, exist_ok=True)
     validator.generate_report(args.output)

--- a/tools/validate_apis.py
+++ b/tools/validate_apis.py
@@ -509,6 +509,17 @@ def main():
             print(f"❌ 错误: CSV 文件不存在: {args.csv}")
             return 1
         crates = _load_mapping(args.mapping)
+        invalid_crates: List[Tuple[str, Any]] = []
+        for crate_name, cfg in sorted(crates.items()):
+            src = cfg.get("src")
+            if not src or not os.path.exists(src):
+                invalid_crates.append((crate_name, src))
+        if invalid_crates:
+            print("❌ 错误: 发现映射中的 crate 源码目录不存在，批量验证终止。")
+            for crate_name, src in invalid_crates:
+                print(f"   - {crate_name}: {src}")
+            return 1
+
         report_dir = Path(args.report_dir)
         crate_dir = report_dir / "crates"
         crate_rows: List[Tuple[str, Dict[str, Any], str, List[str]]] = []
@@ -518,9 +529,6 @@ def main():
             cfg = crates[crate_name]
             src = cfg.get("src")
             tags = cfg.get("biz_tags", [])
-            if not src or not os.path.exists(src):
-                print(f"⚠️ 跳过 {crate_name}: 源码目录不存在 ({src})")
-                continue
             report_path = crate_dir / f"{crate_name}.md"
             print()
             print(f"📦 处理 {crate_name}")

--- a/tools/validate_apis.py
+++ b/tools/validate_apis.py
@@ -14,7 +14,7 @@ import csv
 import os
 import re
 from pathlib import Path
-from typing import Dict, List, Set
+from typing import Any, Dict, List, Optional, Set, Tuple
 from dataclasses import dataclass
 from collections import defaultdict
 
@@ -322,6 +322,23 @@ class APIValidator:
 
             print(f"✅ 报告生成完成")
 
+    def calculate_summary(self) -> Dict[str, Any]:
+        """生成可序列化的统计摘要。"""
+        total_apis = len(self.apis)
+        implemented = len([a for a in self.apis if a.is_implemented])
+        missing = len(self.missing_apis)
+        completion_rate = (implemented / total_apis * 100) if total_apis > 0 else 0.0
+
+        return {
+            "total_apis": total_apis,
+            "implemented": implemented,
+            "missing": missing,
+            "completion_rate": round(completion_rate, 1),
+            "extra_files": len(self.extra_files),
+            "skipped_old_versions": self.skipped_old_count if self.skip_old_versions else 0,
+            "module_stats": self._calculate_module_stats(),
+        }
+
     def _calculate_module_stats(self) -> Dict[str, Dict]:
         """计算各模块的统计数据"""
         module_stats = defaultdict(lambda: {'total': 0, 'implemented': 0, 'missing': 0, 'rate': 0.0})
@@ -368,6 +385,10 @@ def main():
                         help='crate→bizTag 映射文件路径 (默认: tools/api_coverage.toml)')
     parser.add_argument('--list-crates', action='store_true',
                         help='列出映射文件中的 crate 与 bizTag，然后退出')
+    parser.add_argument('--all-crates', action='store_true',
+                        help='按映射文件批量验证所有 crate，并生成汇总报告')
+    parser.add_argument('--report-dir', default='reports/api_validation',
+                        help='批量模式报告目录 (默认: reports/api_validation)')
     parser.add_argument('--skip-old', dest='skip_old', action='store_true', default=True,
                         help='跳过旧版本 API (version=old，默认启用)')
     parser.add_argument('--include-old', dest='skip_old', action='store_false',
@@ -406,6 +427,129 @@ def main():
             print(f"- {crate_name}: src={src} biz_tags=[{tags_text}]")
         return 0
 
+    def _run_validator(csv_path: str, src_path: str, filter_tags: Optional[List[str]], skip_old: bool) -> APIValidator:
+        validator = APIValidator(csv_path, src_path, filter_tags, skip_old)
+        validator.parse_csv()
+        validator.scan_implementations()
+        validator.compare()
+        return validator
+
+    def _write_summary_markdown(
+        output_path: Path,
+        crate_rows: List[Tuple[str, Dict[str, Any], str, List[str]]],
+        skip_old: bool,
+    ) -> None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as f:
+            f.write("# Typed API 覆盖率汇总报告（按 crate）\n\n")
+            f.write("## 统计口径\n\n")
+            if skip_old:
+                f.write("- 默认排除 `meta.Version=old`。\n")
+            else:
+                f.write("- 包含 `meta.Version=old`。\n")
+            f.write("- 数据来源：`api_list_export.csv` 对比 crate 源码目录。\n\n")
+
+            total_apis = sum(row[1]["total_apis"] for row in crate_rows)
+            total_impl = sum(row[1]["implemented"] for row in crate_rows)
+            total_missing = sum(row[1]["missing"] for row in crate_rows)
+            total_extra = sum(row[1]["extra_files"] for row in crate_rows)
+            total_rate = (total_impl / total_apis * 100) if total_apis > 0 else 0.0
+
+            f.write("## 总览\n\n")
+            f.write("| 指标 | 数量 |\n")
+            f.write("|------|------|\n")
+            f.write(f"| crate 数量 | {len(crate_rows)} |\n")
+            f.write(f"| API 总数 | {total_apis} |\n")
+            f.write(f"| 已实现 | {total_impl} |\n")
+            f.write(f"| 未实现 | {total_missing} |\n")
+            f.write(f"| 完成率 | {total_rate:.1f}% |\n")
+            f.write(f"| 额外文件 | {total_extra} |\n\n")
+
+            f.write("## 各 crate 覆盖率\n\n")
+            f.write("| crate | bizTag | 总数 | 已实现 | 未实现 | 完成率 | 额外文件 | 报告 |\n")
+            f.write("|-------|--------|------|--------|--------|--------|----------|------|\n")
+            for crate_name, stats, report_rel, tags in sorted(crate_rows, key=lambda x: x[0]):
+                tags_text = ", ".join(tags)
+                f.write(
+                    f"| {crate_name} | `{tags_text}` | {stats['total_apis']} | "
+                    f"{stats['implemented']} | {stats['missing']} | {stats['completion_rate']:.1f}% | "
+                    f"{stats['extra_files']} | [{crate_name}]({report_rel}) |\n"
+                )
+
+            f.write("\n")
+
+    def _write_summary_json(output_path: Path, payload: Dict[str, Any]) -> None:
+        import json
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    if args.all_crates:
+        crates = _load_mapping(args.mapping)
+        report_dir = Path(args.report_dir)
+        crate_dir = report_dir / "crates"
+        crate_rows: List[Tuple[str, Dict[str, Any], str, List[str]]] = []
+        crate_summaries: Dict[str, Any] = {}
+
+        for crate_name in sorted(crates.keys()):
+            cfg = crates[crate_name]
+            src = cfg.get("src")
+            tags = cfg.get("biz_tags", [])
+            if not src or not os.path.exists(src):
+                print(f"⚠️ 跳过 {crate_name}: 源码目录不存在 ({src})")
+                continue
+            report_path = crate_dir / f"{crate_name}.md"
+            print()
+            print(f"📦 处理 {crate_name}")
+            validator = _run_validator(args.csv, src, tags, args.skip_old)
+            report_path.parent.mkdir(parents=True, exist_ok=True)
+            validator.generate_report(str(report_path))
+            stats = validator.calculate_summary()
+            report_rel = report_path.relative_to(report_dir).as_posix()
+            crate_rows.append((crate_name, stats, report_rel, tags))
+            crate_summaries[crate_name] = {
+                "source_dir": src,
+                "biz_tags": tags,
+                "report": report_rel,
+                **stats,
+            }
+
+        summary_md = report_dir / "summary.md"
+        summary_json = report_dir / "summary.json"
+        _write_summary_markdown(summary_md, crate_rows, args.skip_old)
+
+        total_apis = sum(item["total_apis"] for item in crate_summaries.values())
+        total_impl = sum(item["implemented"] for item in crate_summaries.values())
+        total_missing = sum(item["missing"] for item in crate_summaries.values())
+        total_extra = sum(item["extra_files"] for item in crate_summaries.values())
+        total_rate = (total_impl / total_apis * 100) if total_apis > 0 else 0.0
+
+        summary_payload = {
+            "csv_path": args.csv,
+            "mapping_path": args.mapping,
+            "skip_old_versions": args.skip_old,
+            "crates_total": len(crate_summaries),
+            "total_apis": total_apis,
+            "implemented": total_impl,
+            "missing": total_missing,
+            "completion_rate": round(total_rate, 1),
+            "extra_files": total_extra,
+            "crates": crate_summaries,
+        }
+        _write_summary_json(summary_json, summary_payload)
+
+        print()
+        print("=" * 60)
+        print("✅ 批量验证完成！")
+        print(f"📄 汇总报告: {summary_md}")
+        print(f"📄 机器可读: {summary_json}")
+        print(f"📁 各 crate 报告目录: {crate_dir}")
+        print("=" * 60)
+        return 0
+
     # 当指定 --crate 时，自动补齐 src/filter（显式参数优先）
     if args.crate:
         crates = _load_mapping(args.mapping)
@@ -442,11 +586,7 @@ def main():
         return 1
 
     # 执行验证
-    validator = APIValidator(args.csv, args.src, args.filter, args.skip_old)
-
-    validator.parse_csv()
-    validator.scan_implementations()
-    validator.compare()
+    validator = _run_validator(args.csv, args.src, args.filter, args.skip_old)
 
     Path(args.output).parent.mkdir(parents=True, exist_ok=True)
     validator.generate_report(args.output)


### PR DESCRIPTION
### Motivation

- Provide reproducible, per-crate typed API coverage reports and a unified summary to support issue/milestone planning and address the coverage reporting gap in issue #43. 
- Make it easy to run a single command to generate machine- and human-readable artifacts for tracking API implementation gaps across all crates.

### Description

- Add batch CLI flags to `tools/validate_apis.py`: `--all-crates` to run across `tools/api_coverage.toml` and `--report-dir` to configure output directory, and keep existing `--crate`/`--filter` behavior. 
- Implement per-crate output flow that generates `reports/api_validation/crates/<crate>.md` and aggregate outputs `reports/api_validation/summary.md` and `reports/api_validation/summary.json`, and add `APIValidator.calculate_summary()` plus helpers `_run_validator`, `_write_summary_markdown`, and `_write_summary_json`. 
- Ensure report directories are created before writing, and preserve default behavior of excluding `meta.Version=old` unless `--include-old` is passed. 
- Add convenience task `api-coverage` to `justfile`, add `docs/typed-api-coverage.md`, and link it from `README.md` to document usage and metric scope.

### Testing

- Ran `python3 tools/validate_apis.py --list-crates` which listed mapped crates and succeeded. 
- Ran `python3 tools/validate_apis.py --all-crates` which executed the batch run, produced per-crate reports under `reports/api_validation/crates/` and generated `reports/api_validation/summary.md` and `summary.json`, and completed successfully. 
- Verified Python syntax with `python3 -m py_compile tools/validate_apis.py` which succeeded. 
- Attempted `just api-coverage` but it failed in the current environment because `just` is not installed (command-line task is present for environments with `just`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc89224d4c832a9217720d1d061fa7)