### PR TITLE
fix(ci): 降级 quick_cache 修复 MSRV 检查 (#140)

### DIFF
--- a/.github/msrv/Cargo.lock
+++ b/.github/msrv/Cargo.lock
@@ -2149,9 +2149,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick_cache"
-version = "0.6.21"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a70b1b8b47e31d0498ecbc3c5470bb931399a8bfed1fd79d1717a61ce7f96e3"
+checksum = "7ada44a88ef953a3294f6eb55d2007ba44646015e18613d2f213016379203ef3"
 dependencies = [
  "ahash",
  "equivalent",


### PR DESCRIPTION
## 修复内容

降级 MSRV lockfile 中的 quick_cache 从 v0.6.21 到 v0.6.18：

- v0.6.21 在 Rust 1.75 下编译失败（缺少 'size_of' 导入）
- v0.6.18 是最后一个兼容 Rust 1.75 的版本

## 关联 Issue

Fixes #140

## 测试

- [x] MSRV lockfile 已更新
- [x] quick_cache v0.6.18 兼容 Rust 1.75