### PR TITLE
fix(ci): 移除未使用的 quick_cache 依赖 (#140)

### DIFF
--- a/crates/openlark-core/Cargo.toml
+++ b/crates/openlark-core/Cargo.toml
@@ -31,7 +31,6 @@ hmac = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
 rand = { workspace = true }
-quick_cache = { workspace = true }
 futures-util = { workspace = true }
 regex = { workspace = true }
 tokio-tungstenite = { workspace = true, optional = true }


### PR DESCRIPTION
## 问题

MSRV 检查持续失败，即使降级 quick_cache 到 v0.6.18：


## 解决方案

**直接移除未使用的 quick_cache 依赖**

quick_cache 虽然被声明在 Cargo.toml 中，但实际上没有在任何代码中使用。

## 改动

- 从  移除  依赖

## 好处

1. ✅ 修复 MSRV 检查失败
2. ✅ 减少编译时间
3. ✅ 减小二进制体积
4. ✅ 简化依赖树

## 验证

- [x] 代码中未使用 quick_cache（已通过 grep 验证）
- [x] 本地  通过

## 关联 Issue

Fixes #140