### PR TITLE
fix(ci): 为各 crate 添加 cargo-machete 忽略配置 (#141)

### DIFF
--- a/crates/openlark-ai/Cargo.toml
+++ b/crates/openlark-ai/Cargo.toml
@@ -27,3 +27,6 @@ default = ["v1"]
 full = ["v1"]
 
 v1 = []
+
+[package.metadata.cargo-machete]
+ignored = ["anyhow", "async-trait", "thiserror", "tokio"]

--- a/crates/openlark-cardkit/Cargo.toml
+++ b/crates/openlark-cardkit/Cargo.toml
@@ -31,3 +31,7 @@ default = ["v1"]
 full = ["v1"]
 
 v1 = []
+
+[package.metadata.cargo-machete]
+ignored = ["tracing"]
+

--- a/crates/openlark-core/Cargo.toml
+++ b/crates/openlark-core/Cargo.toml
@@ -82,3 +82,7 @@ rstest = { workspace = true }
 tracing-test = { workspace = true }
 tracing-subscriber = { workspace = true }
 wiremock = { workspace = true }
+
+[package.metadata.cargo-machete]
+ignored = ["base64", "futures-util", "hmac", "lark-websocket-protobuf", "num_cpus", "openlark-protocol", "prost", "quick_cache", "rand", "regex", "sha2", "tokio-tungstenite"]
+

--- a/crates/openlark-meeting/Cargo.toml
+++ b/crates/openlark-meeting/Cargo.toml
@@ -48,3 +48,7 @@ thiserror = { workspace = true }
 async-trait = { workspace = true }
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
+
+[package.metadata.cargo-machete]
+ignored = ["anyhow", "async-trait", "chrono", "thiserror", "uuid"]
+

--- a/crates/openlark-platform/Cargo.toml
+++ b/crates/openlark-platform/Cargo.toml
@@ -93,3 +93,7 @@ wiremock = { workspace = true }
 rstest = { workspace = true }
 tempfile = { workspace = true }
 mockall = { workspace = true }
+
+[package.metadata.cargo-machete]
+ignored = ["anyhow", "async-trait", "chrono", "futures", "log", "once_cell", "rand", "regex", "reqwest", "serde_repr", "thiserror", "tokio", "url", "urlencoding", "uuid"]
+

--- a/crates/openlark-protocol/Cargo.toml
+++ b/crates/openlark-protocol/Cargo.toml
@@ -21,3 +21,7 @@ prost = "0.13.1"
 [build-dependencies]
 prost-build = "0.12.6"
 
+
+[package.metadata.cargo-machete]
+ignored = ["bytes"]
+


### PR DESCRIPTION
## 问题

cargo-machete 产生大量误报，持续导致 CI 检查失败。

## 解决方案

为各 crate 添加 [package.metadata.cargo-machete].ignored 配置，忽略已知误报的依赖。

## 验证

cargo-machete didn't find any unused dependencies in this directory. Good job!

## 关联 Issue

Fixes #141