### PR TITLE
fix(security): Content-Disposition 文件名清洗防止路径穿越

### DIFF
--- a/crates/openlark-auth/src/auth/auth/v3/auth/app_access_token.rs
+++ b/crates/openlark-auth/src/auth/auth/v3/auth/app_access_token.rs
@@ -141,7 +141,8 @@ mod tests {
     #[test]
     fn test_app_access_token_response_data_deserialization() {
         let json = r#"{"data":{"app_access_token":"token123","expires_in":7200,"tenant_key":"test_tenant"}}"#;
-        let response: AppAccessTokenResponseData = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: AppAccessTokenResponseData =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.data.app_access_token, "token123");
         assert_eq!(response.data.expires_in, 7200);
         assert_eq!(response.data.tenant_key, "test_tenant");

--- a/crates/openlark-auth/src/auth/auth/v3/auth/tenant_access_token.rs
+++ b/crates/openlark-auth/src/auth/auth/v3/auth/tenant_access_token.rs
@@ -164,7 +164,8 @@ mod tests {
     #[test]
     fn test_tenant_access_token_response_data_deserialization() {
         let json = r#"{"data":{"tenant_access_token":"token123","expires_in":7200}}"#;
-        let response: TenantAccessTokenResponseData = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: TenantAccessTokenResponseData =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.data.tenant_access_token, "token123");
         assert_eq!(response.data.expires_in, 7200);
     }

--- a/crates/openlark-auth/src/auth/auth/v3/auth/tenant_access_token_internal.rs
+++ b/crates/openlark-auth/src/auth/auth/v3/auth/tenant_access_token_internal.rs
@@ -135,7 +135,8 @@ mod tests {
     #[test]
     fn test_tenant_access_token_internal_response_deserialization() {
         let json = r#"{"data":{"tenant_access_token":"tenant_token","expires_in":7200}}"#;
-        let response: TenantAccessTokenInternalResponseData = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: TenantAccessTokenInternalResponseData =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.data.tenant_access_token, "tenant_token");
         assert_eq!(response.data.expires_in, 7200);
     }

--- a/crates/openlark-auth/src/auth/authen/v1/access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/access_token/create.rs
@@ -160,7 +160,8 @@ mod tests {
     #[test]
     fn test_user_access_token_v1_response_data_deserialization() {
         let json = r#"{"data":{"user_access_token":"token123","expires_in":7200,"refresh_token":"refresh456"}}"#;
-        let response: UserAccessTokenV1ResponseData = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: UserAccessTokenV1ResponseData =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.data.user_access_token, "token123");
         assert_eq!(response.data.expires_in, 7200);
         assert_eq!(response.data.refresh_token, Some("refresh456".to_string()));

--- a/crates/openlark-auth/src/auth/authen/v1/oidc/access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/oidc/access_token/create.rs
@@ -228,7 +228,8 @@ mod tests {
     #[test]
     fn test_oidc_access_token_response_data_deserialization() {
         let json = r#"{"data":{"user_access_token":"token123","expires_in":7200,"refresh_token":"refresh456"}}"#;
-        let response: OidcAccessTokenResponseData = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: OidcAccessTokenResponseData =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.data.user_access_token, "token123");
         assert_eq!(response.data.expires_in, 7200);
         assert_eq!(response.data.refresh_token, Some("refresh456".to_string()));

--- a/crates/openlark-auth/src/auth/authen/v1/oidc/refresh_access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/oidc/refresh_access_token/create.rs
@@ -189,7 +189,8 @@ mod tests {
     #[test]
     fn test_oidc_refresh_access_token_response_data_deserialization() {
         let json = r#"{"data":{"user_access_token":"token123","expires_in":7200,"refresh_token":"refresh456"}}"#;
-        let response: OidcRefreshAccessTokenResponseData = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: OidcRefreshAccessTokenResponseData =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.data.user_access_token, "token123");
         assert_eq!(response.data.expires_in, 7200);
         assert_eq!(response.data.refresh_token, Some("refresh456".to_string()));

--- a/crates/openlark-auth/src/human_authentication/human_authentication/v1/identity/create.rs
+++ b/crates/openlark-auth/src/human_authentication/human_authentication/v1/identity/create.rs
@@ -209,7 +209,8 @@ mod tests {
     #[test]
     fn test_identity_create_response_deserialization() {
         let json = r#"{"verify_uid":"ou_2eb5483cb377daa5054bc6f86e2089a5"}"#;
-        let response: IdentityCreateResponse = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: IdentityCreateResponse =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.verify_uid, "ou_2eb5483cb377daa5054bc6f86e2089a5");
         assert_eq!(response.identity_id, "ou_2eb5483cb377daa5054bc6f86e2089a5");
     }
@@ -220,7 +221,8 @@ mod tests {
             "verify_uid":"ou_verify",
             "identity_id":"legacy_identity"
         }"#;
-        let response: IdentityCreateResponse = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: IdentityCreateResponse =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.verify_uid, "ou_verify");
         assert_eq!(response.identity_id, "legacy_identity");
     }

--- a/crates/openlark-communication/src/contact/contact/v3/user/basic_batch.rs
+++ b/crates/openlark-communication/src/contact/contact/v3/user/basic_batch.rs
@@ -187,7 +187,8 @@ mod tests {
                 }
             }]
         }"#;
-        let response: BasicBatchUsersResponse = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: BasicBatchUsersResponse =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.users.len(), 1);
         assert_eq!(response.users[0].name.as_deref(), Some("张三"));
         assert_eq!(
@@ -205,9 +206,7 @@ mod tests {
             .execute_with_options(RequestOption::default())
             .await;
         assert!(result.is_err());
-        let error = result
-            .expect_err("缺少 user_ids 应该返回错误")
-            .to_string();
+        let error = result.expect_err("缺少 user_ids 应该返回错误").to_string();
         assert!(error.contains("user_ids"));
     }
 

--- a/crates/openlark-core/src/api/responses.rs
+++ b/crates/openlark-core/src/api/responses.rs
@@ -310,7 +310,8 @@ mod tests {
     #[test]
     fn test_response_deserialize_with_raw_response_error_keeps_code_and_msg() {
         let payload = r#"{"raw_response":{"code":400,"msg":"Bad Request","request_id":null,"data":null,"error":null},"data":null}"#;
-        let parsed = serde_json::from_str::<Response<serde_json::Value>>(payload).expect("JSON 反序列化失败");
+        let parsed = serde_json::from_str::<Response<serde_json::Value>>(payload)
+            .expect("JSON 反序列化失败");
         assert_eq!(parsed.raw_response.code, 400);
         assert_eq!(parsed.raw_response.msg, "Bad Request");
         assert!(!parsed.is_success());

--- a/crates/openlark-core/src/content_disposition.rs
+++ b/crates/openlark-core/src/content_disposition.rs
@@ -2,6 +2,46 @@
 //!
 //! 目标：在 core 内集中处理响应头解析逻辑，避免各处重复实现（DRY）。
 
+/// Sanitize a filename to prevent path traversal attacks.
+///
+/// Removes:
+/// - Path separators (`/`, `\`)
+/// - Null bytes
+/// - `..` path traversal segments
+/// - Leading dots (hidden files)
+/// - Leading/trailing whitespace
+///
+/// Limits filename length to 255 bytes.
+fn sanitize_filename(name: &str) -> String {
+    let name = name.trim();
+
+    // Remove null bytes
+    let name: String = name.chars().filter(|c| *c != '\0').collect();
+
+    // Take only the last component (after any path separators that might remain)
+    let name = name.rsplit(['/', '\\']).next().unwrap_or(&name);
+
+    // Remove leading dots to prevent hidden files / traversal
+    let name = name.trim_start_matches('.');
+
+    // Collapse multiple whitespace, trim
+    let name: String = name.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    // Limit length to 255 bytes
+    let mut result = String::new();
+    let mut byte_count = 0;
+    for ch in name.chars() {
+        let char_bytes = ch.len_utf8();
+        if byte_count + char_bytes > 255 {
+            break;
+        }
+        result.push(ch);
+        byte_count += char_bytes;
+    }
+
+    result
+}
+
 /// 从 `Content-Disposition` 头中提取文件名。
 ///
 /// 支持：
@@ -20,7 +60,7 @@ pub(crate) fn extract_filename(content_disposition: &str) -> Option<String> {
             let _charset = it.next();
             let _lang = it.next();
             if let Some(value) = it.next() {
-                return Some(value.to_string());
+                return Some(sanitize_filename(value));
             }
 
             // 兼容：若格式不完整，则忽略
@@ -30,7 +70,7 @@ pub(crate) fn extract_filename(content_disposition: &str) -> Option<String> {
         if let Some(filename) = part.strip_prefix("filename=") {
             // `filename*` 存在时应优先使用它；这里先记录 fallback，继续扫描后续项。
             if fallback_filename.is_none() {
-                fallback_filename = Some(filename.trim_matches('"').to_string());
+                fallback_filename = Some(sanitize_filename(filename.trim_matches('"')));
             }
         }
     }
@@ -81,5 +121,50 @@ mod tests {
     #[test]
     fn extract_filename_empty() {
         assert_eq!(extract_filename("").as_deref(), None);
+    }
+
+    // Security tests for path traversal prevention
+    #[test]
+    fn sanitize_removes_path_traversal() {
+        let raw = r#"attachment; filename="../../../etc/passwd""#;
+        let result = extract_filename(raw);
+        assert_eq!(result.as_deref(), Some("passwd"));
+    }
+
+    #[test]
+    fn sanitize_removes_path_separators() {
+        let raw = r#"attachment; filename="foo/bar/baz.txt""#;
+        let result = extract_filename(raw);
+        assert_eq!(result.as_deref(), Some("baz.txt"));
+    }
+
+    #[test]
+    fn sanitize_removes_backslash() {
+        let raw = r#"attachment; filename="foo\bar\baz.txt""#;
+        let result = extract_filename(raw);
+        assert_eq!(result.as_deref(), Some("baz.txt"));
+    }
+
+    #[test]
+    fn sanitize_removes_null_bytes() {
+        let raw = "attachment; filename=\"foo\0bar.txt\"";
+        let result = extract_filename(raw);
+        assert_eq!(result.as_deref(), Some("foobar.txt"));
+    }
+
+    #[test]
+    fn sanitize_limits_length() {
+        let long_name = "a".repeat(300);
+        let raw = format!("attachment; filename=\"{long_name}\"");
+        let result = extract_filename(&raw);
+        let name = result.unwrap();
+        assert!(name.len() <= 255);
+    }
+
+    #[test]
+    fn sanitize_removes_leading_dots() {
+        let raw = r#"attachment; filename=".hidden""#;
+        let result = extract_filename(raw);
+        assert_eq!(result.as_deref(), Some("hidden"));
     }
 }

--- a/crates/openlark-core/src/request_builder/mod.rs
+++ b/crates/openlark-core/src/request_builder/mod.rs
@@ -276,9 +276,8 @@ mod tests {
         let result = UnifiedRequestBuilder::build_url(&config, &api_req);
 
         assert!(result.is_ok());
-        let url = result.map_err(|e| {
-            crate::error::configuration_error(format!("构建URL失败: {}", e))
-        })?;
+        let url =
+            result.map_err(|e| crate::error::configuration_error(format!("构建URL失败: {}", e)))?;
         // May have trailing ? due to parse_with_params implementation
         assert!(url
             .as_str()
@@ -296,9 +295,8 @@ mod tests {
         let result = UnifiedRequestBuilder::build_url(&config, &api_req);
 
         assert!(result.is_ok());
-        let url = result.map_err(|e| {
-            crate::error::configuration_error(format!("构建URL失败: {}", e))
-        })?;
+        let url =
+            result.map_err(|e| crate::error::configuration_error(format!("构建URL失败: {}", e)))?;
         let url_str = url.as_str();
         assert!(url_str.starts_with("https://open.feishu.cn/open-apis/test"));
         assert!(url_str.contains("page=1"));
@@ -320,9 +318,8 @@ mod tests {
         let result = UnifiedRequestBuilder::build_url(&config, &api_req);
 
         assert!(result.is_ok());
-        let url = result.map_err(|e| {
-            crate::error::configuration_error(format!("构建URL失败: {}", e))
-        })?;
+        let url =
+            result.map_err(|e| crate::error::configuration_error(format!("构建URL失败: {}", e)))?;
         // URL encoding should be handled properly
         assert!(url.as_str().contains("query="));
         assert!(url.as_str().contains("filter="));
@@ -338,9 +335,8 @@ mod tests {
         let result = UnifiedRequestBuilder::build_url(&config, &api_req);
 
         assert!(result.is_ok());
-        let url = result.map_err(|e| {
-            crate::error::configuration_error(format!("构建URL失败: {}", e))
-        })?;
+        let url =
+            result.map_err(|e| crate::error::configuration_error(format!("构建URL失败: {}", e)))?;
         assert!(url.as_str().contains("empty="));
         Ok(())
     }
@@ -488,9 +484,8 @@ mod tests {
         let result = UnifiedRequestBuilder::build_url(&config, &api_req);
 
         assert!(result.is_ok());
-        let url = result.map_err(|e| {
-            crate::error::configuration_error(format!("构建URL失败: {}", e))
-        })?;
+        let url =
+            result.map_err(|e| crate::error::configuration_error(format!("构建URL失败: {}", e)))?;
         // May have trailing ? due to parse_with_params implementation
         assert!(url
             .as_str()

--- a/crates/openlark-core/src/response_handler.rs
+++ b/crates/openlark-core/src/response_handler.rs
@@ -855,7 +855,8 @@ mod tests {
         let json = serde_json::to_string(&original).unwrap();
 
         // Deserialize back
-        let deserialized: OptimizedBaseResponse<TestData> = serde_json::from_str(&json).expect("JSON 反序列化失败");
+        let deserialized: OptimizedBaseResponse<TestData> =
+            serde_json::from_str(&json).expect("JSON 反序列化失败");
 
         // Verify all fields are preserved
         assert_eq!(deserialized.code, original.code);
@@ -993,7 +994,8 @@ mod tests {
 
         // Test error response with missing msg
         let error_missing_msg = r#"{"code": 500}"#;
-        let parsed_missing: Value = serde_json::from_str(error_missing_msg).expect("JSON 反序列化失败");
+        let parsed_missing: Value =
+            serde_json::from_str(error_missing_msg).expect("JSON 反序列化失败");
         assert_eq!(parsed_missing["code"], 500);
         assert!(!parsed_missing["msg"].is_string());
 

--- a/crates/openlark-docs/src/base/bitable/v1/field_types.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/field_types.rs
@@ -245,10 +245,7 @@ impl RecordFieldValue {
     ///
     /// 这是用于与现有 API 兼容的辅助方法。
     /// 新代码建议使用 `RecordFieldValue` 枚举类型。
-    #[deprecated(
-        since = "0.15.0",
-        note = "新代码应直接使用 RecordFieldValue 类型"
-    )]
+    #[deprecated(since = "0.15.0", note = "新代码应直接使用 RecordFieldValue 类型")]
     pub fn to_value(&self) -> serde_json::Value {
         json!(self)
     }

--- a/crates/openlark-docs/src/ccm/sheets_v2/models.rs
+++ b/crates/openlark-docs/src/ccm/sheets_v2/models.rs
@@ -829,7 +829,8 @@ mod tests {
             },
             "spreadsheetId": "spreadsheet_id_123"
         }"#;
-        let response: ReadSingleRangeResponse = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: ReadSingleRangeResponse =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert!(response.value_range.is_some());
         assert_eq!(
             response.spreadsheet_id,

--- a/crates/openlark-platform/src/spark/spark/v1/directory/user/id_convert.rs
+++ b/crates/openlark-platform/src/spark/spark/v1/directory/user/id_convert.rs
@@ -173,7 +173,8 @@ mod tests {
             ]
         }"#;
 
-        let response: DirectoryUserIdConvertResponse = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: DirectoryUserIdConvertResponse =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.items.len(), 1);
         assert_eq!(response.items[0].source_id, "123445678933432");
         assert_eq!(response.items[0].target_id, "ou_1234cdjhjfedgfhgdhy3884");

--- a/crates/openlark-webhook/src/robot/v1/send.rs
+++ b/crates/openlark-webhook/src/robot/v1/send.rs
@@ -195,7 +195,8 @@ mod tests {
     #[test]
     fn test_send_webhook_message_response_serialization() {
         let json = r#"{"code":0,"msg":"ok"}"#;
-        let response: SendWebhookMessageResponse = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: SendWebhookMessageResponse =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.code, 0);
         assert_eq!(response.msg, "ok");
     }


### PR DESCRIPTION
## Summary
- 在 `extract_filename` 中增加 `sanitize_filename` 清洗逻辑
- 去除路径分隔符 (`/`, `\`)、空字节、`..` 路径片段、前导点号
- 限制文件名长度为 255 字节
- 新增 6 个安全相关测试用例

## Security Impact
- **High**: 防止宿主应用使用未清洗文件名写盘导致路径穿越攻击

Closes #154