### PR TITLE
fix(security): 日志和 Debug 输出脱敏防止 Token/PII 泄露

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+read @AGENTS.md

--- a/crates/openlark-auth/src/token_provider.rs
+++ b/crates/openlark-auth/src/token_provider.rs
@@ -19,13 +19,23 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
 
 /// 缓存的 token 信息
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct CachedToken {
     /// token 值
     token: String,
     /// 过期时间戳（Unix 时间戳，秒）
     expires_at: i64,
 }
+
+impl std::fmt::Debug for CachedToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CachedToken")
+            .field("token", &"***")
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
+}
+
 
 impl CachedToken {
     fn now_epoch_secs() -> i64 {

--- a/crates/openlark-auth/src/token_provider.rs
+++ b/crates/openlark-auth/src/token_provider.rs
@@ -36,7 +36,6 @@ impl std::fmt::Debug for CachedToken {
     }
 }
 
-
 impl CachedToken {
     fn now_epoch_secs() -> i64 {
         SystemTime::now()

--- a/crates/openlark-client/src/config.rs
+++ b/crates/openlark-client/src/config.rs
@@ -47,7 +47,7 @@ fn is_known_base_url(url: &str) -> bool {
 ///     .base_url("https://open.feishu.cn")  // 默认值，国际版 Lark 使用 https://open.larksuite.com
 ///     .build();
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Config {
     /// 🆔 飞书应用ID
     pub app_id: String,
@@ -73,6 +73,24 @@ pub struct Config {
     #[doc(hidden)]
     pub(crate) core_config: Option<CoreConfig>,
 }
+
+impl std::fmt::Debug for Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Config")
+            .field("app_id", &self.app_id)
+            .field("app_secret", &"***")
+            .field("app_type", &self.app_type)
+            .field("enable_token_cache", &self.enable_token_cache)
+            .field("base_url", &self.base_url)
+            .field("timeout", &self.timeout)
+            .field("retry_count", &self.retry_count)
+            .field("enable_log", &self.enable_log)
+            .field("headers", &format!("{} headers", self.headers.len()))
+            .finish()
+    }
+}
+
+
 
 impl Default for Config {
     fn default() -> Self {

--- a/crates/openlark-client/src/config.rs
+++ b/crates/openlark-client/src/config.rs
@@ -90,8 +90,6 @@ impl std::fmt::Debug for Config {
     }
 }
 
-
-
 impl Default for Config {
     fn default() -> Self {
         Self {

--- a/crates/openlark-core/src/config.rs
+++ b/crates/openlark-core/src/config.rs
@@ -45,7 +45,6 @@ pub struct Config {
 }
 
 /// 内部配置数据，被多个服务共享
-#[derive(Debug)]
 pub struct ConfigInner {
     pub(crate) app_id: String,
     pub(crate) app_secret: String,
@@ -76,6 +75,20 @@ impl Default for ConfigInner {
             header: Default::default(),
             token_provider: Arc::new(NoOpTokenProvider),
         }
+    }
+}
+
+impl std::fmt::Debug for ConfigInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConfigInner")
+            .field("app_id", &self.app_id)
+            .field("app_secret", &"***")
+            .field("base_url", &self.base_url)
+            .field("enable_token_cache", &self.enable_token_cache)
+            .field("app_type", &self.app_type)
+            .field("req_timeout", &self.req_timeout)
+            .field("header", &format!("{} headers", self.header.len()))
+            .finish()
     }
 }
 

--- a/crates/openlark-core/src/lib.rs
+++ b/crates/openlark-core/src/lib.rs
@@ -15,12 +15,12 @@ pub mod error;
 /// HTTP 客户端模块（Transport、请求构建等）
 pub mod http;
 pub(crate) mod observability;
-/// Security utilities for handling sensitive data
-pub mod security;
 pub(crate) mod query_params;
 /// 请求选项模块（RequestOption、自定义头部、租户键等）
 pub mod req_option;
 pub(crate) mod request_builder;
+/// Security utilities for handling sensitive data
+pub mod security;
 #[cfg(feature = "testing")]
 pub mod testing;
 pub mod trait_system;

--- a/crates/openlark-core/src/lib.rs
+++ b/crates/openlark-core/src/lib.rs
@@ -15,6 +15,8 @@ pub mod error;
 /// HTTP 客户端模块（Transport、请求构建等）
 pub mod http;
 pub(crate) mod observability;
+/// Security utilities for handling sensitive data
+pub mod security;
 pub(crate) mod query_params;
 /// 请求选项模块（RequestOption、自定义头部、租户键等）
 pub mod req_option;

--- a/crates/openlark-core/src/response_handler.rs
+++ b/crates/openlark-core/src/response_handler.rs
@@ -80,7 +80,7 @@ impl ImprovedResponseHandler {
         let tracker = ResponseTracker::start("json_data", response.content_length());
 
         let response_text = response.text().await?;
-        debug!("Raw response: {response_text}");
+        // Don't log raw response to prevent token/PII leakage
 
         // 记录解析阶段开始
         tracker.parsing_complete();

--- a/crates/openlark-core/src/security.rs
+++ b/crates/openlark-core/src/security.rs
@@ -1,0 +1,42 @@
+//! Security utilities for handling sensitive data
+
+/// Mask sensitive strings for safe logging (shows first 4 and last 4 chars)
+///
+/// # Examples
+///
+/// ```
+/// use openlark_core::security::mask_sensitive;
+///
+/// assert_eq!(mask_sensitive("my_secret_token_12345"), "my_s***2345");
+/// assert_eq!(mask_sensitive("short"), "***");
+/// ```
+pub fn mask_sensitive(s: &str) -> String {
+    if s.len() <= 8 {
+        "***".to_string()
+    } else {
+        format!("{}***{}", &s[..4], &s[s.len() - 4..])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mask_sensitive_long_string() {
+        assert_eq!(mask_sensitive("my_secret_token_12345"), "my_s***2345");
+        assert_eq!(mask_sensitive("abcdefghijk"), "abcd***hijk");
+    }
+
+    #[test]
+    fn test_mask_sensitive_short_string() {
+        assert_eq!(mask_sensitive("short"), "***");
+        assert_eq!(mask_sensitive("12345678"), "***");
+        assert_eq!(mask_sensitive(""), "***");
+    }
+
+    #[test]
+    fn test_mask_sensitive_exactly_9_chars() {
+        assert_eq!(mask_sensitive("123456789"), "1234***6789");
+    }
+}

--- a/examples/test_debug.rs
+++ b/examples/test_debug.rs
@@ -1,0 +1,21 @@
+use openlark_client::config::Config as ClientConfig;
+use openlark_core::config::Config;
+
+fn main() {
+    // Test core Config Debug
+    let core_config = Config::builder()
+        .app_id("test_app_id")
+        .app_secret("secret_app_secret_12345")
+        .build();
+    println!("Core Config: {:?}", core_config);
+
+    // Test client Config Debug
+    let client_config = ClientConfig::builder()
+        .app_id("test_app_id")
+        .app_secret("secret_app_secret_12345")
+        .build()
+        .unwrap();
+    println!("Client Config: {:?}", client_config);
+
+    println!("Debug output successfully masks secrets!");
+}


### PR DESCRIPTION
## Summary
- 审查并修复 openlark-core 和 openlark-auth 中的日志输出，确保敏感信息不外泄
- 为包含 app_secret 等敏感字段的 struct 实现自定义 Debug trait，输出时以 `***` 替代
- 确保 raw response 不在默认日志级别输出

## Security Impact
- **Medium**: 防止 access_token、app_secret 等凭证通过日志泄露

Closes #155