### PR TITLE
fix(core): 清洗 Content-Disposition 文件名以防路径穿越

### DIFF
--- a/crates/openlark-core/src/content_disposition.rs
+++ b/crates/openlark-core/src/content_disposition.rs
@@ -2,6 +2,44 @@
 //!
 //! 目标：在 core 内集中处理响应头解析逻辑，避免各处重复实现（DRY）。
 
+/// 清洗文件名，降低路径穿越和恶意文件名风险。
+///
+/// 处理规则：
+/// - 去除空字节
+/// - 仅保留最后一段路径（兼容 `/` 与 `\`）
+/// - 去除前导 `.`（避免隐藏文件与 `..` 路径片段）
+/// - 压缩多余空白
+/// - 截断到 255 字节
+fn sanitize_filename(name: &str) -> String {
+    let name = name.trim();
+
+    // 去除空字节
+    let name: String = name.chars().filter(|c| *c != '\0').collect();
+
+    // 仅保留最后一段路径，防止路径穿越
+    let name = name.rsplit(['/', '\\']).next().unwrap_or(&name);
+
+    // 移除前导点号，避免 .hidden / ../ 等形式
+    let name = name.trim_start_matches('.');
+
+    // 规范化空白字符
+    let name: String = name.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    // 限制长度为 255 字节（按 UTF-8 字节数截断）
+    let mut result = String::new();
+    let mut byte_count = 0;
+    for ch in name.chars() {
+        let char_bytes = ch.len_utf8();
+        if byte_count + char_bytes > 255 {
+            break;
+        }
+        result.push(ch);
+        byte_count += char_bytes;
+    }
+
+    result
+}
+
 /// 从 `Content-Disposition` 头中提取文件名。
 ///
 /// 支持：
@@ -20,7 +58,12 @@ pub(crate) fn extract_filename(content_disposition: &str) -> Option<String> {
             let _charset = it.next();
             let _lang = it.next();
             if let Some(value) = it.next() {
-                return Some(value.to_string());
+                let sanitized = sanitize_filename(value);
+                return if sanitized.is_empty() {
+                    None
+                } else {
+                    Some(sanitized)
+                };
             }
 
             // 兼容：若格式不完整，则忽略
@@ -30,7 +73,10 @@ pub(crate) fn extract_filename(content_disposition: &str) -> Option<String> {
         if let Some(filename) = part.strip_prefix("filename=") {
             // `filename*` 存在时应优先使用它；这里先记录 fallback，继续扫描后续项。
             if fallback_filename.is_none() {
-                fallback_filename = Some(filename.trim_matches('"').to_string());
+                let sanitized = sanitize_filename(filename.trim_matches('"'));
+                if !sanitized.is_empty() {
+                    fallback_filename = Some(sanitized);
+                }
             }
         }
     }
@@ -81,5 +127,56 @@ mod tests {
     #[test]
     fn extract_filename_empty() {
         assert_eq!(extract_filename("").as_deref(), None);
+    }
+
+    #[test]
+    fn sanitize_removes_path_traversal() {
+        let raw = r#"attachment; filename="../../../etc/passwd""#;
+        let result = extract_filename(raw);
+        assert_eq!(result.as_deref(), Some("passwd"));
+    }
+
+    #[test]
+    fn sanitize_removes_path_separators() {
+        let raw = r#"attachment; filename="foo/bar/baz.txt""#;
+        let result = extract_filename(raw);
+        assert_eq!(result.as_deref(), Some("baz.txt"));
+    }
+
+    #[test]
+    fn sanitize_removes_backslash() {
+        let raw = r#"attachment; filename="foo\bar\baz.txt""#;
+        let result = extract_filename(raw);
+        assert_eq!(result.as_deref(), Some("baz.txt"));
+    }
+
+    #[test]
+    fn sanitize_removes_null_bytes() {
+        let raw = "attachment; filename=\"foo\0bar.txt\"";
+        let result = extract_filename(raw);
+        assert_eq!(result.as_deref(), Some("foobar.txt"));
+    }
+
+    #[test]
+    fn sanitize_limits_length() {
+        let long_name = "a".repeat(300);
+        let raw = format!("attachment; filename=\"{long_name}\"");
+        let result = extract_filename(&raw);
+        let name = result.unwrap();
+        assert!(name.len() <= 255);
+    }
+
+    #[test]
+    fn sanitize_removes_leading_dots() {
+        let raw = r#"attachment; filename=".hidden""#;
+        let result = extract_filename(raw);
+        assert_eq!(result.as_deref(), Some("hidden"));
+    }
+
+    #[test]
+    fn sanitize_empty_after_cleaning_returns_none() {
+        let raw = r#"attachment; filename="....""#;
+        let result = extract_filename(raw);
+        assert_eq!(result.as_deref(), None);
     }
 }


### PR DESCRIPTION
### Motivation
- 修复安全问题：解析自 `Content-Disposition` 的文件名可能包含路径分隔符、空字节、前导点或超长数据，若宿主应用直接写盘会引发路径穿越或覆盖风险。

### Description
- 在 `crates/openlark-core/src/content_disposition.rs` 新增 `sanitize_filename`，实现去除空字节、仅保留最后路径片段（`/` 与 `\`）、移除前导点、压缩空白并按 UTF‑8 字节数截断到 255 字节的清洗规则。 
- 将 `filename*` 与 `filename` 的解析结果统一通过 `sanitize_filename` 处理，并在清洗后为空时返回 `None`，避免产生无效文件名。 
- 新增安全单元测试覆盖路径穿越、路径分隔符、反斜杠、空字节、长度限制、前导点与清洗后为空等场景。

### Testing
- 运行 `cargo test -p openlark-core content_disposition`，相关单测全部通过（15 个测试通过）。
- 运行 `cargo fmt --all` 格式化通过。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e79b216b30832a8624419953174f48)