### PR TITLE
fix(security): add configurable max download size limit for Docs download APIs

### DIFF
--- a/crates/openlark-docs/src/ccm/drive/v1/export_task/download.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/export_task/download.rs
@@ -13,12 +13,17 @@ use openlark_core::{
     SDKResult,
 };
 
+/// 默认最大下载大小限制（100MB）
+const DEFAULT_MAX_DOWNLOAD_SIZE: usize = 100 * 1024 * 1024;
+
 /// 下载导出文件请求
 #[derive(Debug, Clone)]
 pub struct DownloadExportRequest {
     config: Config,
     /// 文件token
     pub file_token: String,
+    /// 最大允许下载大小（字节）
+    max_size: usize,
 }
 
 impl DownloadExportRequest {
@@ -27,7 +32,14 @@ impl DownloadExportRequest {
         Self {
             config,
             file_token: file_token.into(),
+            max_size: DEFAULT_MAX_DOWNLOAD_SIZE,
         }
+    }
+
+    /// 设置最大下载大小（字节）
+    pub fn max_size(mut self, max_size: usize) -> Self {
+        self.max_size = max_size;
+        self
     }
 
     /// 执行下载请求，返回二进制内容
@@ -48,7 +60,24 @@ impl DownloadExportRequest {
 
         let api_request = ApiRequest::<Vec<u8>>::get(&api_endpoint.to_url());
 
-        Transport::request(api_request, &self.config, Some(option)).await
+        let result = Transport::request(api_request, &self.config, Some(option)).await;
+        match result {
+            Ok(response) => {
+                // 检查下载大小是否超过限制
+                if response.data.len() > self.max_size {
+                    return Err(openlark_core::error::validation_error(
+                        "max_size",
+                        &format!(
+                            "下载文件大小 {} 超过限制 {}",
+                            response.data.len(),
+                            self.max_size
+                        ),
+                    ));
+                }
+                Ok(response)
+            }
+            Err(e) => Err(e),
+        }
     }
 }
 
@@ -95,5 +124,19 @@ mod tests {
         let long_token = "a".repeat(100);
         let request2 = DownloadExportRequest::new(config, long_token);
         assert_eq!(request2.file_token.len(), 100);
+    }
+
+    #[test]
+    fn test_download_export_default_max_size() {
+        let config = Config::default();
+        let request = DownloadExportRequest::new(config, "file_token");
+        assert_eq!(request.max_size, 100 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_download_export_custom_max_size() {
+        let config = Config::default();
+        let request = DownloadExportRequest::new(config, "file_token").max_size(2048);
+        assert_eq!(request.max_size, 2048);
     }
 }

--- a/crates/openlark-docs/src/ccm/drive/v1/file/download.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/file/download.rs
@@ -230,4 +230,18 @@ mod tests {
         assert_eq!(request.range, None);
         // 不设置 range 也可以正常下载整个文件
     }
+
+    #[test]
+    fn test_download_file_default_max_size() {
+        let config = Config::default();
+        let request = DownloadFileRequest::new(config, "file_token");
+        assert_eq!(request.max_size, 100 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_download_file_custom_max_size() {
+        let config = Config::default();
+        let request = DownloadFileRequest::new(config, "file_token").max_size(1024);
+        assert_eq!(request.max_size, 1024);
+    }
 }

--- a/crates/openlark-docs/src/ccm/drive/v1/media/download.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/media/download.rs
@@ -13,6 +13,9 @@ use openlark_core::{
     SDKResult,
 };
 
+/// 默认最大下载大小限制（100MB）
+const DEFAULT_MAX_DOWNLOAD_SIZE: usize = 100 * 1024 * 1024;
+
 /// 下载素材请求
 #[derive(Debug)]
 pub struct DownloadMediaRequest {
@@ -23,6 +26,8 @@ pub struct DownloadMediaRequest {
     pub extra: Option<String>,
     /// Range HTTP header（可选），示例：bytes=0-1024
     pub range: Option<String>,
+    /// 最大允许下载大小（字节）
+    max_size: usize,
 }
 
 impl DownloadMediaRequest {
@@ -33,6 +38,7 @@ impl DownloadMediaRequest {
             file_token: file_token.into(),
             extra: None,
             range: None,
+            max_size: DEFAULT_MAX_DOWNLOAD_SIZE,
         }
     }
 
@@ -45,6 +51,12 @@ impl DownloadMediaRequest {
     /// 设置 Range 请求头。
     pub fn range(mut self, range: impl Into<String>) -> Self {
         self.range = Some(range.into());
+        self
+    }
+
+    /// 设置最大下载大小（字节）
+    pub fn max_size(mut self, max_size: usize) -> Self {
+        self.max_size = max_size;
         self
     }
 
@@ -80,7 +92,24 @@ impl DownloadMediaRequest {
             request = request.header("Range", &r);
         }
 
-        Transport::request(request, &self.config, Some(option)).await
+        let result = Transport::request(request, &self.config, Some(option)).await;
+        match result {
+            Ok(response) => {
+                // 检查下载大小是否超过限制
+                if response.data.len() > self.max_size {
+                    return Err(openlark_core::error::validation_error(
+                        "max_size",
+                        &format!(
+                            "下载文件大小 {} 超过限制 {}",
+                            response.data.len(),
+                            self.max_size
+                        ),
+                    ));
+                }
+                Ok(response)
+            }
+            Err(e) => Err(e),
+        }
     }
 }
 
@@ -186,5 +215,19 @@ mod tests {
         // 带 range
         let request3 = DownloadMediaRequest::new(config, "token").range("bytes=0-100");
         assert_eq!(request3.range, Some("bytes=0-100".to_string()));
+    }
+
+    #[test]
+    fn test_download_media_default_max_size() {
+        let config = Config::default();
+        let request = DownloadMediaRequest::new(config, "media_token");
+        assert_eq!(request.max_size, 100 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_download_media_custom_max_size() {
+        let config = Config::default();
+        let request = DownloadMediaRequest::new(config, "media_token").max_size(512);
+        assert_eq!(request.max_size, 512);
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent OOM / DoS by bounding in-memory downloads for Docs-related endpoints when downloading large or malicious files.
- Apply a sensible default limit (100MB) while allowing callers to override per-request when needed.

### Description
- Added a `DEFAULT_MAX_DOWNLOAD_SIZE` (100 * 1024 * 1024) and a `max_size` field to download requests in Docs download handlers.
- Added `max_size(self, usize) -> Self` builder methods and initialized requests with the default limit.
- After receiving the response body the code now checks `response.data.len()` against `max_size` and returns a validation error if the payload exceeds the configured limit.
- Added unit tests covering default and custom `max_size` behaviors for the affected files: `file/download.rs`, `export_task/download.rs`, and `media/download.rs`.

### Testing
- Ran `cargo test -p openlark-docs download -- --nocapture` and the test run finished successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e82c38b5a0832a874a032c8244035f)