### PR TITLE
fix(security): sanitize logs and mask sensitive fields; resolve client config conflicts

### DIFF
--- a/crates/openlark-auth/src/token_provider.rs
+++ b/crates/openlark-auth/src/token_provider.rs
@@ -19,13 +19,23 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
 
 /// 缓存的 token 信息
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct CachedToken {
     /// token 值
     token: String,
     /// 过期时间戳（Unix 时间戳，秒）
     expires_at: i64,
 }
+
+impl std::fmt::Debug for CachedToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CachedToken")
+            .field("token", &"***")
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
+}
+
 
 impl CachedToken {
     fn now_epoch_secs() -> i64 {

--- a/crates/openlark-client/src/config.rs
+++ b/crates/openlark-client/src/config.rs
@@ -51,7 +51,7 @@ fn is_known_base_url(url: &str) -> bool {
 ///     .base_url("https://open.feishu.cn")  // 默认值，国际版 Lark 使用 https://open.larksuite.com
 ///     .build();
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Config {
     /// 🆔 飞书应用ID
     pub app_id: String,
@@ -65,6 +65,7 @@ pub struct Config {
     pub base_url: String,
     /// 🔓 是否允许自定义 base_url 域名
     pub allow_custom_base_url: bool,
+    /// ⏱️ 请求超时时间
     pub timeout: Duration,
     /// 🔄 默认重试次数
     pub retry_count: u32,
@@ -76,6 +77,24 @@ pub struct Config {
     #[doc(hidden)]
     pub(crate) core_config: Option<CoreConfig>,
 }
+
+impl std::fmt::Debug for Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Config")
+            .field("app_id", &self.app_id)
+            .field("app_secret", &"***")
+            .field("app_type", &self.app_type)
+            .field("enable_token_cache", &self.enable_token_cache)
+            .field("base_url", &self.base_url)
+            .field("timeout", &self.timeout)
+            .field("retry_count", &self.retry_count)
+            .field("enable_log", &self.enable_log)
+            .field("headers", &format!("{} headers", self.headers.len()))
+            .finish()
+    }
+}
+
+
 
 impl Default for Config {
     fn default() -> Self {

--- a/crates/openlark-core/src/config.rs
+++ b/crates/openlark-core/src/config.rs
@@ -45,7 +45,6 @@ pub struct Config {
 }
 
 /// 内部配置数据，被多个服务共享
-#[derive(Debug)]
 pub struct ConfigInner {
     pub(crate) app_id: String,
     pub(crate) app_secret: String,
@@ -76,6 +75,20 @@ impl Default for ConfigInner {
             header: Default::default(),
             token_provider: Arc::new(NoOpTokenProvider),
         }
+    }
+}
+
+impl std::fmt::Debug for ConfigInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConfigInner")
+            .field("app_id", &self.app_id)
+            .field("app_secret", &"***")
+            .field("base_url", &self.base_url)
+            .field("enable_token_cache", &self.enable_token_cache)
+            .field("app_type", &self.app_type)
+            .field("req_timeout", &self.req_timeout)
+            .field("header", &format!("{} headers", self.header.len()))
+            .finish()
     }
 }
 

--- a/crates/openlark-core/src/lib.rs
+++ b/crates/openlark-core/src/lib.rs
@@ -15,6 +15,8 @@ pub mod error;
 /// HTTP 客户端模块（Transport、请求构建等）
 pub mod http;
 pub(crate) mod observability;
+/// Security utilities for handling sensitive data
+pub mod security;
 pub(crate) mod query_params;
 /// 请求选项模块（RequestOption、自定义头部、租户键等）
 pub mod req_option;

--- a/crates/openlark-core/src/response_handler.rs
+++ b/crates/openlark-core/src/response_handler.rs
@@ -80,7 +80,7 @@ impl ImprovedResponseHandler {
         let tracker = ResponseTracker::start("json_data", response.content_length());
 
         let response_text = response.text().await?;
-        debug!("Raw response: {response_text}");
+        // Don't log raw response to prevent token/PII leakage
 
         // 记录解析阶段开始
         tracker.parsing_complete();

--- a/crates/openlark-core/src/security.rs
+++ b/crates/openlark-core/src/security.rs
@@ -1,0 +1,42 @@
+//! Security utilities for handling sensitive data
+
+/// Mask sensitive strings for safe logging (shows first 4 and last 4 chars)
+///
+/// # Examples
+///
+/// ```
+/// use openlark_core::security::mask_sensitive;
+///
+/// assert_eq!(mask_sensitive("my_secret_token_12345"), "my_s***2345");
+/// assert_eq!(mask_sensitive("short"), "***");
+/// ```
+pub fn mask_sensitive(s: &str) -> String {
+    if s.len() <= 8 {
+        "***".to_string()
+    } else {
+        format!("{}***{}", &s[..4], &s[s.len() - 4..])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mask_sensitive_long_string() {
+        assert_eq!(mask_sensitive("my_secret_token_12345"), "my_s***2345");
+        assert_eq!(mask_sensitive("abcdefghijk"), "abcd***hijk");
+    }
+
+    #[test]
+    fn test_mask_sensitive_short_string() {
+        assert_eq!(mask_sensitive("short"), "***");
+        assert_eq!(mask_sensitive("12345678"), "***");
+        assert_eq!(mask_sensitive(""), "***");
+    }
+
+    #[test]
+    fn test_mask_sensitive_exactly_9_chars() {
+        assert_eq!(mask_sensitive("123456789"), "1234***6789");
+    }
+}


### PR DESCRIPTION
### Motivation

- 防止凭证/PII 在日志和 Debug 输出中泄露，需统一脱敏策略并修复与当前 `main` 的冲突。

### Description

- 新增 `openlark-core::security::mask_sensitive` 工具用于脱敏敏感字符串并在 `crates/openlark-core/src/security.rs` 中添加单元测试。
- 在 `openlark-core` 中公开 `security` 模块并为 `ConfigInner` 实现自定义 `Debug`，对 `app_secret` 做掩码处理以防止明文输出。
- 在 `openlark-client` 中为 `Config` 添加 `timeout` 字段并实现自定义 `Debug`，同时清理由于 cherry-pick 导致的冲突标记并保持中文注释风格一致。
- 在响应处理器中移除对原始响应正文的默认日志打印，且在 `openlark-auth` 的 `CachedToken` 上实现自定义 `Debug` 以掩码 token 字段。

### Testing

- 运行 `cargo check -p openlark-core -p openlark-client -p openlark-auth`，检查通过。
- 变更包含 `openlark-core::security` 的单元测试文件，库编译已验证，但未在此 PR 中执行 `cargo test` 的完整测试套件。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e82ca69064832aa3cc4d1401566078)