### PR TITLE
fix(security): mask sensitive fields in Debug & remove raw response logs

### DIFF
--- a/crates/openlark-auth/src/auth/auth/v3/auth/app_access_token.rs
+++ b/crates/openlark-auth/src/auth/auth/v3/auth/app_access_token.rs
@@ -141,7 +141,8 @@ mod tests {
     #[test]
     fn test_app_access_token_response_data_deserialization() {
         let json = r#"{"data":{"app_access_token":"token123","expires_in":7200,"tenant_key":"test_tenant"}}"#;
-        let response: AppAccessTokenResponseData = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: AppAccessTokenResponseData =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.data.app_access_token, "token123");
         assert_eq!(response.data.expires_in, 7200);
         assert_eq!(response.data.tenant_key, "test_tenant");

--- a/crates/openlark-auth/src/auth/auth/v3/auth/tenant_access_token.rs
+++ b/crates/openlark-auth/src/auth/auth/v3/auth/tenant_access_token.rs
@@ -164,7 +164,8 @@ mod tests {
     #[test]
     fn test_tenant_access_token_response_data_deserialization() {
         let json = r#"{"data":{"tenant_access_token":"token123","expires_in":7200}}"#;
-        let response: TenantAccessTokenResponseData = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: TenantAccessTokenResponseData =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.data.tenant_access_token, "token123");
         assert_eq!(response.data.expires_in, 7200);
     }

--- a/crates/openlark-auth/src/auth/auth/v3/auth/tenant_access_token_internal.rs
+++ b/crates/openlark-auth/src/auth/auth/v3/auth/tenant_access_token_internal.rs
@@ -135,7 +135,8 @@ mod tests {
     #[test]
     fn test_tenant_access_token_internal_response_deserialization() {
         let json = r#"{"data":{"tenant_access_token":"tenant_token","expires_in":7200}}"#;
-        let response: TenantAccessTokenInternalResponseData = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: TenantAccessTokenInternalResponseData =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.data.tenant_access_token, "tenant_token");
         assert_eq!(response.data.expires_in, 7200);
     }

--- a/crates/openlark-auth/src/auth/authen/v1/access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/access_token/create.rs
@@ -160,7 +160,8 @@ mod tests {
     #[test]
     fn test_user_access_token_v1_response_data_deserialization() {
         let json = r#"{"data":{"user_access_token":"token123","expires_in":7200,"refresh_token":"refresh456"}}"#;
-        let response: UserAccessTokenV1ResponseData = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: UserAccessTokenV1ResponseData =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.data.user_access_token, "token123");
         assert_eq!(response.data.expires_in, 7200);
         assert_eq!(response.data.refresh_token, Some("refresh456".to_string()));

--- a/crates/openlark-auth/src/auth/authen/v1/oidc/access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/oidc/access_token/create.rs
@@ -228,7 +228,8 @@ mod tests {
     #[test]
     fn test_oidc_access_token_response_data_deserialization() {
         let json = r#"{"data":{"user_access_token":"token123","expires_in":7200,"refresh_token":"refresh456"}}"#;
-        let response: OidcAccessTokenResponseData = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: OidcAccessTokenResponseData =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.data.user_access_token, "token123");
         assert_eq!(response.data.expires_in, 7200);
         assert_eq!(response.data.refresh_token, Some("refresh456".to_string()));

--- a/crates/openlark-auth/src/auth/authen/v1/oidc/refresh_access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/oidc/refresh_access_token/create.rs
@@ -189,7 +189,8 @@ mod tests {
     #[test]
     fn test_oidc_refresh_access_token_response_data_deserialization() {
         let json = r#"{"data":{"user_access_token":"token123","expires_in":7200,"refresh_token":"refresh456"}}"#;
-        let response: OidcRefreshAccessTokenResponseData = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: OidcRefreshAccessTokenResponseData =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.data.user_access_token, "token123");
         assert_eq!(response.data.expires_in, 7200);
         assert_eq!(response.data.refresh_token, Some("refresh456".to_string()));

--- a/crates/openlark-auth/src/human_authentication/human_authentication/v1/identity/create.rs
+++ b/crates/openlark-auth/src/human_authentication/human_authentication/v1/identity/create.rs
@@ -209,7 +209,8 @@ mod tests {
     #[test]
     fn test_identity_create_response_deserialization() {
         let json = r#"{"verify_uid":"ou_2eb5483cb377daa5054bc6f86e2089a5"}"#;
-        let response: IdentityCreateResponse = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: IdentityCreateResponse =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.verify_uid, "ou_2eb5483cb377daa5054bc6f86e2089a5");
         assert_eq!(response.identity_id, "ou_2eb5483cb377daa5054bc6f86e2089a5");
     }
@@ -220,7 +221,8 @@ mod tests {
             "verify_uid":"ou_verify",
             "identity_id":"legacy_identity"
         }"#;
-        let response: IdentityCreateResponse = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: IdentityCreateResponse =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.verify_uid, "ou_verify");
         assert_eq!(response.identity_id, "legacy_identity");
     }

--- a/crates/openlark-auth/src/token_provider.rs
+++ b/crates/openlark-auth/src/token_provider.rs
@@ -8,6 +8,7 @@ use openlark_core::{
     config::Config,
     constants::{AccessTokenType, AppType},
     error::{api_error, configuration_error},
+    security::mask_sensitive,
     SDKResult,
 };
 use serde_json::{json, Value};
@@ -19,12 +20,21 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
 
 /// 缓存的 token 信息
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct CachedToken {
     /// token 值
     token: String,
     /// 过期时间戳（Unix 时间戳，秒）
     expires_at: i64,
+}
+
+impl std::fmt::Debug for CachedToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CachedToken")
+            .field("token", &mask_sensitive(&self.token))
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
 }
 
 impl CachedToken {
@@ -255,7 +265,7 @@ impl TokenProvider for AuthTokenProvider {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    use super::AuthTokenProvider;
+    use super::{AuthTokenProvider, CachedToken};
     use openlark_core::{
         auth::{TokenProvider, TokenRequest},
         config::Config,
@@ -276,5 +286,13 @@ mod tests {
             .expect_err("should fail on unreachable test endpoint");
 
         assert!(!err.to_string().contains("NoOpTokenProvider"));
+    }
+
+    #[test]
+    fn cached_token_debug_masks_token_value() {
+        let token = CachedToken::new("token_secret_value".to_string(), 3600);
+        let debug_str = format!("{:?}", token);
+        assert!(debug_str.contains("***"));
+        assert!(!debug_str.contains("token_secret_value"));
     }
 }

--- a/crates/openlark-client/src/config.rs
+++ b/crates/openlark-client/src/config.rs
@@ -7,14 +7,11 @@ use std::time::Duration;
 
 use openlark_core::config::Config as CoreConfig;
 use openlark_core::constants::AppType;
+use openlark_core::security::mask_sensitive;
 
 /// Check if the base_url points to a known Lark/Feishu domain
 fn is_known_base_url(url: &str) -> bool {
-    let allowed_suffixes = [
-        "feishu.cn",
-        "larksuite.com",
-        "larkoffice.com",
-    ];
+    let allowed_suffixes = ["feishu.cn", "larksuite.com", "larkoffice.com"];
     // Parse URL, extract host, check suffix
     if let Ok(parsed) = url::Url::parse(url) {
         if let Some(host) = parsed.host_str() {
@@ -51,7 +48,7 @@ fn is_known_base_url(url: &str) -> bool {
 ///     .base_url("https://open.feishu.cn")  // 默认值，国际版 Lark 使用 https://open.larksuite.com
 ///     .build();
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Config {
     /// 🆔 飞书应用ID
     pub app_id: String,
@@ -75,6 +72,24 @@ pub struct Config {
     /// 🔧 底层 core 配置（按需生成）
     #[doc(hidden)]
     pub(crate) core_config: Option<CoreConfig>,
+}
+
+impl std::fmt::Debug for Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Config")
+            .field("app_id", &self.app_id)
+            .field("app_secret", &mask_sensitive(&self.app_secret))
+            .field("app_type", &self.app_type)
+            .field("enable_token_cache", &self.enable_token_cache)
+            .field("base_url", &self.base_url)
+            .field("allow_custom_base_url", &self.allow_custom_base_url)
+            .field("timeout", &self.timeout)
+            .field("retry_count", &self.retry_count)
+            .field("enable_log", &self.enable_log)
+            .field("headers", &self.headers)
+            .field("core_config", &self.core_config)
+            .finish()
+    }
 }
 
 impl Default for Config {
@@ -692,6 +707,19 @@ mod tests {
     }
 
     #[test]
+    fn test_config_debug_masks_app_secret() {
+        let config = Config {
+            app_id: "test_app_id".to_string(),
+            app_secret: "test_app_secret".to_string(),
+            ..Default::default()
+        };
+
+        let debug_str = format!("{:?}", config);
+        assert!(debug_str.contains("***"));
+        assert!(!debug_str.contains("test_app_secret"));
+    }
+
+    #[test]
     fn test_config_is_complete() {
         let mut config = Config::default();
         assert!(!config.is_complete());
@@ -704,86 +732,82 @@ mod tests {
     }
 }
 
-    #[test]
-    fn test_config_validation_known_base_url() {
-        // 测试已知的 Feishu/Lark 域名
-        let known_urls = vec![
-            "https://open.feishu.cn",
-            "https://api.feishu.cn",
-            "https://custom.feishu.cn",
-            "https://open.larksuite.com",
-            "https://api.larksuite.com",
-            "https://custom.larksuite.com",
-            "https://open.larkoffice.com",
-            "https://custom.larkoffice.com",
-        ];
+#[test]
+fn test_config_validation_known_base_url() {
+    // 测试已知的 Feishu/Lark 域名
+    let known_urls = vec![
+        "https://open.feishu.cn",
+        "https://api.feishu.cn",
+        "https://custom.feishu.cn",
+        "https://open.larksuite.com",
+        "https://api.larksuite.com",
+        "https://custom.larksuite.com",
+        "https://open.larkoffice.com",
+        "https://custom.larkoffice.com",
+    ];
 
-        for url in known_urls {
-            let config = Config {
-                app_id: "test_app_id".to_string(),
-                app_secret: "test_app_secret".to_string(),
-                app_type: AppType::SelfBuild,
-                enable_token_cache: true,
-                base_url: url.to_string(),
-                allow_custom_base_url: false,
-                timeout: Duration::from_secs(30),
-                retry_count: 3,
-                enable_log: true,
-                headers: std::collections::HashMap::new(),
-                core_config: None,
-            };
-            assert!(config.validate().is_ok(), "URL {} should be valid", url);
-        }
-    }
-
-    #[test]
-    fn test_config_validation_unknown_base_url_rejected() {
-        // 测试未知域名被拒绝
-        let unknown_urls = vec![
-            "https://evil.com",
-            "https://malicious-site.com",
-            "https://example.com",
-            "https://not-feishu.cn",
-            "https://fake-larksuite.com",
-        ];
-
-        for url in unknown_urls {
-            let config = Config {
-                app_id: "test_app_id".to_string(),
-                app_secret: "test_app_secret".to_string(),
-                app_type: AppType::SelfBuild,
-                enable_token_cache: true,
-                base_url: url.to_string(),
-                allow_custom_base_url: false,
-                timeout: Duration::from_secs(30),
-                retry_count: 3,
-                enable_log: true,
-                headers: std::collections::HashMap::new(),
-                core_config: None,
-            };
-            assert!(
-                config.validate().is_err(),
-                "URL {} should be rejected",
-                url
-            );
-        }
-    }
-
-    #[test]
-    fn test_config_validation_custom_base_url_allowed() {
-        // 测试 allow_custom_base_url 允许使用自定义域名
+    for url in known_urls {
         let config = Config {
             app_id: "test_app_id".to_string(),
             app_secret: "test_app_secret".to_string(),
             app_type: AppType::SelfBuild,
             enable_token_cache: true,
-            base_url: "https://open.feishu.cn".to_string(),
-            allow_custom_base_url: true,
+            base_url: url.to_string(),
+            allow_custom_base_url: false,
             timeout: Duration::from_secs(30),
             retry_count: 3,
             enable_log: true,
             headers: std::collections::HashMap::new(),
             core_config: None,
         };
-        assert!(config.validate().is_ok());
+        assert!(config.validate().is_ok(), "URL {} should be valid", url);
     }
+}
+
+#[test]
+fn test_config_validation_unknown_base_url_rejected() {
+    // 测试未知域名被拒绝
+    let unknown_urls = vec![
+        "https://evil.com",
+        "https://malicious-site.com",
+        "https://example.com",
+        "https://not-feishu.cn",
+        "https://fake-larksuite.com",
+    ];
+
+    for url in unknown_urls {
+        let config = Config {
+            app_id: "test_app_id".to_string(),
+            app_secret: "test_app_secret".to_string(),
+            app_type: AppType::SelfBuild,
+            enable_token_cache: true,
+            base_url: url.to_string(),
+            allow_custom_base_url: false,
+            timeout: Duration::from_secs(30),
+            retry_count: 3,
+            enable_log: true,
+            headers: std::collections::HashMap::new(),
+            core_config: None,
+        };
+        assert!(config.validate().is_err(), "URL {} should be rejected", url);
+    }
+}
+
+#[test]
+fn test_config_validation_custom_base_url_allowed() {
+    // 测试 allow_custom_base_url 允许使用自定义域名
+    let config = Config {
+        app_id: "test_app_id".to_string(),
+        app_secret: "test_app_secret".to_string(),
+        app_type: AppType::SelfBuild,
+        enable_token_cache: true,
+        base_url: "https://open.feishu.cn".to_string(),
+        allow_custom_base_url: true,
+        timeout: Duration::from_secs(30),
+        retry_count: 3,
+        enable_log: true,
+        headers: std::collections::HashMap::new(),
+        core_config: None,
+    };
+    assert!(config.validate().is_ok());
+}

--- a/crates/openlark-client/src/config.rs
+++ b/crates/openlark-client/src/config.rs
@@ -62,6 +62,7 @@ pub struct Config {
     pub base_url: String,
     /// 🔓 是否允许自定义 base_url 域名
     pub allow_custom_base_url: bool,
+    /// ⏱️ 请求超时时间
     pub timeout: Duration,
     /// 🔄 默认重试次数
     pub retry_count: u32,
@@ -225,9 +226,7 @@ impl Config {
             );
             return Err(crate::error::validation_error(
                 "base_url",
-                &format!(
-                    "base_url 域名不在白名单中，已知域名: *.feishu.cn, *.larksuite.com, *.larkoffice.com。如需使用自定义域名，请设置 allow_custom_base_url(true)"
-                ),
+                "base_url 域名不在白名单中，已知域名: *.feishu.cn, *.larksuite.com, *.larkoffice.com。如需使用自定义域名，请设置 allow_custom_base_url(true)",
             ));
         }
 

--- a/crates/openlark-communication/src/contact/contact/v3/user/basic_batch.rs
+++ b/crates/openlark-communication/src/contact/contact/v3/user/basic_batch.rs
@@ -187,7 +187,8 @@ mod tests {
                 }
             }]
         }"#;
-        let response: BasicBatchUsersResponse = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: BasicBatchUsersResponse =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.users.len(), 1);
         assert_eq!(response.users[0].name.as_deref(), Some("张三"));
         assert_eq!(
@@ -205,9 +206,7 @@ mod tests {
             .execute_with_options(RequestOption::default())
             .await;
         assert!(result.is_err());
-        let error = result
-            .expect_err("缺少 user_ids 应该返回错误")
-            .to_string();
+        let error = result.expect_err("缺少 user_ids 应该返回错误").to_string();
         assert!(error.contains("user_ids"));
     }
 

--- a/crates/openlark-core/src/api/responses.rs
+++ b/crates/openlark-core/src/api/responses.rs
@@ -310,7 +310,8 @@ mod tests {
     #[test]
     fn test_response_deserialize_with_raw_response_error_keeps_code_and_msg() {
         let payload = r#"{"raw_response":{"code":400,"msg":"Bad Request","request_id":null,"data":null,"error":null},"data":null}"#;
-        let parsed = serde_json::from_str::<Response<serde_json::Value>>(payload).expect("JSON 反序列化失败");
+        let parsed = serde_json::from_str::<Response<serde_json::Value>>(payload)
+            .expect("JSON 反序列化失败");
         assert_eq!(parsed.raw_response.code, 400);
         assert_eq!(parsed.raw_response.msg, "Bad Request");
         assert!(!parsed.is_success());

--- a/crates/openlark-core/src/config.rs
+++ b/crates/openlark-core/src/config.rs
@@ -4,6 +4,7 @@ use crate::{
     auth::token_provider::{NoOpTokenProvider, TokenProvider},
     constants::{AppType, FEISHU_BASE_URL},
     performance::OptimizedHttpConfig,
+    security::mask_sensitive,
 };
 
 /// # 零拷贝配置共享实现
@@ -35,7 +36,7 @@ use crate::{
 /// - 克隆速度: ~10-20纳秒
 /// - 内存开销: 每个克隆仅8字节
 /// - 引用计数: 自动维护
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Config {
     /// 包装在 Arc 中的共享配置数据
     ///
@@ -45,7 +46,6 @@ pub struct Config {
 }
 
 /// 内部配置数据，被多个服务共享
-#[derive(Debug)]
 pub struct ConfigInner {
     pub(crate) app_id: String,
     pub(crate) app_secret: String,
@@ -61,6 +61,30 @@ pub struct ConfigInner {
     pub(crate) header: HashMap<String, String>,
     /// Token 获取抽象（由业务 crate 实现，例如 openlark-auth）
     pub(crate) token_provider: Arc<dyn TokenProvider>,
+}
+
+impl std::fmt::Debug for Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Config")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for ConfigInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConfigInner")
+            .field("app_id", &self.app_id)
+            .field("app_secret", &mask_sensitive(&self.app_secret))
+            .field("base_url", &self.base_url)
+            .field("enable_token_cache", &self.enable_token_cache)
+            .field("app_type", &self.app_type)
+            .field("http_client", &self.http_client)
+            .field("req_timeout", &self.req_timeout)
+            .field("header", &self.header)
+            .field("token_provider", &"<dyn TokenProvider>")
+            .finish()
+    }
 }
 
 impl Default for ConfigInner {
@@ -380,13 +404,18 @@ mod tests {
 
     #[test]
     fn test_config_debug() {
-        let config = Config::default();
+        let config = Config::new(ConfigInner {
+            app_secret: "test_app_secret".to_string(),
+            ..ConfigInner::default()
+        });
         let debug_str = format!("{:?}", config);
 
         assert!(debug_str.contains("Config"));
         assert!(debug_str.contains("app_id"));
         assert!(debug_str.contains("app_secret"));
         assert!(debug_str.contains("base_url"));
+        assert!(debug_str.contains("***"));
+        assert!(!debug_str.contains("test_app_secret"));
     }
 
     #[test]

--- a/crates/openlark-core/src/lib.rs
+++ b/crates/openlark-core/src/lib.rs
@@ -19,6 +19,8 @@ pub(crate) mod query_params;
 /// 请求选项模块（RequestOption、自定义头部、租户键等）
 pub mod req_option;
 pub(crate) mod request_builder;
+/// 安全工具（敏感信息脱敏等）
+pub mod security;
 #[cfg(feature = "testing")]
 pub mod testing;
 pub mod trait_system;

--- a/crates/openlark-core/src/request_builder/mod.rs
+++ b/crates/openlark-core/src/request_builder/mod.rs
@@ -276,9 +276,8 @@ mod tests {
         let result = UnifiedRequestBuilder::build_url(&config, &api_req);
 
         assert!(result.is_ok());
-        let url = result.map_err(|e| {
-            crate::error::configuration_error(format!("构建URL失败: {}", e))
-        })?;
+        let url =
+            result.map_err(|e| crate::error::configuration_error(format!("构建URL失败: {}", e)))?;
         // May have trailing ? due to parse_with_params implementation
         assert!(url
             .as_str()
@@ -296,9 +295,8 @@ mod tests {
         let result = UnifiedRequestBuilder::build_url(&config, &api_req);
 
         assert!(result.is_ok());
-        let url = result.map_err(|e| {
-            crate::error::configuration_error(format!("构建URL失败: {}", e))
-        })?;
+        let url =
+            result.map_err(|e| crate::error::configuration_error(format!("构建URL失败: {}", e)))?;
         let url_str = url.as_str();
         assert!(url_str.starts_with("https://open.feishu.cn/open-apis/test"));
         assert!(url_str.contains("page=1"));
@@ -320,9 +318,8 @@ mod tests {
         let result = UnifiedRequestBuilder::build_url(&config, &api_req);
 
         assert!(result.is_ok());
-        let url = result.map_err(|e| {
-            crate::error::configuration_error(format!("构建URL失败: {}", e))
-        })?;
+        let url =
+            result.map_err(|e| crate::error::configuration_error(format!("构建URL失败: {}", e)))?;
         // URL encoding should be handled properly
         assert!(url.as_str().contains("query="));
         assert!(url.as_str().contains("filter="));
@@ -338,9 +335,8 @@ mod tests {
         let result = UnifiedRequestBuilder::build_url(&config, &api_req);
 
         assert!(result.is_ok());
-        let url = result.map_err(|e| {
-            crate::error::configuration_error(format!("构建URL失败: {}", e))
-        })?;
+        let url =
+            result.map_err(|e| crate::error::configuration_error(format!("构建URL失败: {}", e)))?;
         assert!(url.as_str().contains("empty="));
         Ok(())
     }
@@ -488,9 +484,8 @@ mod tests {
         let result = UnifiedRequestBuilder::build_url(&config, &api_req);
 
         assert!(result.is_ok());
-        let url = result.map_err(|e| {
-            crate::error::configuration_error(format!("构建URL失败: {}", e))
-        })?;
+        let url =
+            result.map_err(|e| crate::error::configuration_error(format!("构建URL失败: {}", e)))?;
         // May have trailing ? due to parse_with_params implementation
         assert!(url
             .as_str()

--- a/crates/openlark-core/src/response_handler.rs
+++ b/crates/openlark-core/src/response_handler.rs
@@ -80,7 +80,6 @@ impl ImprovedResponseHandler {
         let tracker = ResponseTracker::start("json_data", response.content_length());
 
         let response_text = response.text().await?;
-        debug!("Raw response: {response_text}");
 
         // 记录解析阶段开始
         tracker.parsing_complete();
@@ -164,7 +163,6 @@ impl ImprovedResponseHandler {
         let tracker = ResponseTracker::start("json_flatten", response.content_length());
 
         let response_text = response.text().await?;
-        debug!("Raw response: {response_text}");
 
         // 解析阶段
         let raw_value: Value = match serde_json::from_str(&response_text) {
@@ -855,7 +853,8 @@ mod tests {
         let json = serde_json::to_string(&original).unwrap();
 
         // Deserialize back
-        let deserialized: OptimizedBaseResponse<TestData> = serde_json::from_str(&json).expect("JSON 反序列化失败");
+        let deserialized: OptimizedBaseResponse<TestData> =
+            serde_json::from_str(&json).expect("JSON 反序列化失败");
 
         // Verify all fields are preserved
         assert_eq!(deserialized.code, original.code);
@@ -993,7 +992,8 @@ mod tests {
 
         // Test error response with missing msg
         let error_missing_msg = r#"{"code": 500}"#;
-        let parsed_missing: Value = serde_json::from_str(error_missing_msg).expect("JSON 反序列化失败");
+        let parsed_missing: Value =
+            serde_json::from_str(error_missing_msg).expect("JSON 反序列化失败");
         assert_eq!(parsed_missing["code"], 500);
         assert!(!parsed_missing["msg"].is_string());
 

--- a/crates/openlark-core/src/security.rs
+++ b/crates/openlark-core/src/security.rs
@@ -1,0 +1,25 @@
+/// 敏感信息脱敏处理。
+///
+/// 对非空字符串统一返回 `***`，避免 token / secret / PII 在日志与 Debug 中泄露。
+pub fn mask_sensitive(value: &str) -> String {
+    if value.is_empty() {
+        String::new()
+    } else {
+        "***".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mask_sensitive;
+
+    #[test]
+    fn test_mask_sensitive_non_empty() {
+        assert_eq!(mask_sensitive("token_abc"), "***");
+    }
+
+    #[test]
+    fn test_mask_sensitive_empty() {
+        assert_eq!(mask_sensitive(""), "");
+    }
+}

--- a/crates/openlark-docs/src/base/bitable/v1/field_types.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/field_types.rs
@@ -245,10 +245,7 @@ impl RecordFieldValue {
     ///
     /// 这是用于与现有 API 兼容的辅助方法。
     /// 新代码建议使用 `RecordFieldValue` 枚举类型。
-    #[deprecated(
-        since = "0.15.0",
-        note = "新代码应直接使用 RecordFieldValue 类型"
-    )]
+    #[deprecated(since = "0.15.0", note = "新代码应直接使用 RecordFieldValue 类型")]
     pub fn to_value(&self) -> serde_json::Value {
         json!(self)
     }

--- a/crates/openlark-docs/src/ccm/sheets_v2/models.rs
+++ b/crates/openlark-docs/src/ccm/sheets_v2/models.rs
@@ -829,7 +829,8 @@ mod tests {
             },
             "spreadsheetId": "spreadsheet_id_123"
         }"#;
-        let response: ReadSingleRangeResponse = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: ReadSingleRangeResponse =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert!(response.value_range.is_some());
         assert_eq!(
             response.spreadsheet_id,

--- a/crates/openlark-platform/src/spark/spark/v1/directory/user/id_convert.rs
+++ b/crates/openlark-platform/src/spark/spark/v1/directory/user/id_convert.rs
@@ -173,7 +173,8 @@ mod tests {
             ]
         }"#;
 
-        let response: DirectoryUserIdConvertResponse = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: DirectoryUserIdConvertResponse =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.items.len(), 1);
         assert_eq!(response.items[0].source_id, "123445678933432");
         assert_eq!(response.items[0].target_id, "ou_1234cdjhjfedgfhgdhy3884");

--- a/crates/openlark-webhook/src/robot/v1/send.rs
+++ b/crates/openlark-webhook/src/robot/v1/send.rs
@@ -195,7 +195,8 @@ mod tests {
     #[test]
     fn test_send_webhook_message_response_serialization() {
         let json = r#"{"code":0,"msg":"ok"}"#;
-        let response: SendWebhookMessageResponse = serde_json::from_str(json).expect("JSON 反序列化失败");
+        let response: SendWebhookMessageResponse =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.code, 0);
         assert_eq!(response.msg, "ok");
     }


### PR DESCRIPTION
### Motivation
- Prevent accidental leakage of tokens, app secrets and other PII via `Debug` output and debug logs introduced in a prior change. 
- Provide a single reusable masking utility to ensure consistent redaction across crates. 
- Reduce risk of sensitive data appearing in response logging during parsing/diagnostics.

### Description
- Add `openlark-core::security::mask_sensitive()` to provide a single masking strategy (non-empty strings -> `***`).
- Implement custom `Debug` for `openlark-core::Config` / `ConfigInner` to redact `app_secret` using `mask_sensitive`.
- Implement custom `Debug` for `openlark-client::Config` to redact `app_secret` using `mask_sensitive`.
- Implement custom `Debug` for `openlark-auth::CachedToken` to redact cached token values, and remove debug logs that printed full raw responses in `openlark-core::response_handler`.
- Add/update unit tests to assert masked debug output for config and cached token.

### Testing
- Ran `cargo check -p openlark-core -p openlark-client -p openlark-auth` which completed successfully. 
- Ran `cargo test -p openlark-core` (including `security` and `config` tests) and the relevant tests passed. 
- Ran `cargo test -p openlark-client` for the `test_config_debug_masks_app_secret` test which passed. 
- Ran `cargo test -p openlark-auth` for the `cached_token_debug_masks_token_value` test which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e82c15dae8832aaf511e99ec67cbd2)