### PR TITLE
fix: 修复 authen v1 token 接口请求格式 (#196)

### DIFF
--- a/crates/openlark-auth/src/auth/authen/v1/access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/access_token/create.rs
@@ -28,6 +28,7 @@ pub struct UserAccessTokenV1Builder {
 
 /// 用户访问令牌响应（v1版本）
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(transparent)]
 pub struct UserAccessTokenV1ResponseData {
     /// 用户访问令牌响应
     pub data: UserAccessTokenResponse,
@@ -182,7 +183,8 @@ mod tests {
 
     #[test]
     fn test_user_access_token_v1_response_data_deserialization() {
-        let json = r#"{"data":{"user_access_token":"token123","expires_in":7200,"refresh_token":"refresh456"}}"#;
+        let json =
+            r#"{"user_access_token":"token123","expires_in":7200,"refresh_token":"refresh456"}"#;
         let response: UserAccessTokenV1ResponseData =
             serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.data.user_access_token, "token123");

--- a/crates/openlark-auth/src/auth/authen/v1/access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/access_token/create.rs
@@ -9,6 +9,7 @@ use openlark_core::{
     SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
+    constants::AccessTokenType,
     http::Transport,
     req_option::RequestOption,
     validate_required,
@@ -18,6 +19,7 @@ use serde::{Deserialize, Serialize};
 /// 用户访问令牌请求（v1版本）
 pub struct UserAccessTokenV1Builder {
     grant_code: String,
+    grant_type: String,
     app_id: String,
     app_secret: String,
     /// 配置信息
@@ -33,7 +35,7 @@ pub struct UserAccessTokenV1ResponseData {
 
 impl ApiResponseTrait for UserAccessTokenV1ResponseData {
     fn data_format() -> ResponseFormat {
-        ResponseFormat::Data
+        ResponseFormat::Flatten
     }
 }
 
@@ -42,6 +44,7 @@ impl UserAccessTokenV1Builder {
     pub fn new(config: Config) -> Self {
         Self {
             grant_code: String::new(),
+            grant_type: "authorization_code".to_string(),
             app_id: String::new(),
             app_secret: String::new(),
             config,
@@ -51,6 +54,17 @@ impl UserAccessTokenV1Builder {
     /// 设置授权码
     pub fn grant_code(mut self, grant_code: impl Into<String>) -> Self {
         self.grant_code = grant_code.into();
+        self
+    }
+
+    /// 设置登录预授权码
+    pub fn code(self, code: impl Into<String>) -> Self {
+        self.grant_code(code)
+    }
+
+    /// 设置授权类型
+    pub fn grant_type(mut self, grant_type: impl Into<String>) -> Self {
+        self.grant_type = grant_type.into();
         self
     }
 
@@ -78,8 +92,6 @@ impl UserAccessTokenV1Builder {
     ) -> SDKResult<UserAccessTokenV1ResponseData> {
         // 验证必填字段
         validate_required!(self.grant_code, "授权码不能为空");
-        validate_required!(self.app_id, "应用ID不能为空");
-        validate_required!(self.app_secret, "应用密钥不能为空");
 
         // 🚀 使用新的enum+builder系统生成API端点
         use crate::common::api_endpoints::AuthenApiV1;
@@ -87,14 +99,17 @@ impl UserAccessTokenV1Builder {
 
         // 构建请求体
         let request_body = UserAccessTokenV1Request {
+            grant_type: self.grant_type.clone(),
             grant_code: self.grant_code.clone(),
-            app_id: self.app_id.clone(),
-            app_secret: self.app_secret.clone(),
+            app_id: (!self.app_id.is_empty()).then(|| self.app_id.clone()),
+            app_secret: (!self.app_secret.is_empty()).then(|| self.app_secret.clone()),
         };
 
         // 创建API请求 - 使用类型安全的URL生成
         let api_request: ApiRequest<UserAccessTokenV1ResponseData> =
-            ApiRequest::post(api_endpoint.path()).body(serde_json::to_value(&request_body)?);
+            ApiRequest::post(api_endpoint.path())
+                .body(serde_json::to_value(&request_body)?)
+                .with_supported_access_token_types(vec![AccessTokenType::App]);
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
@@ -109,6 +124,12 @@ impl UserAccessTokenV1Builder {
 mod tests {
     use super::*;
     use openlark_core::config::Config;
+    use openlark_core::req_option::RequestOption;
+    use serde_json::json;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_json, header, method, path},
+    };
 
     fn create_test_config() -> Config {
         Config::builder()
@@ -173,7 +194,51 @@ mod tests {
     fn test_user_access_token_v1_response_data_format() {
         assert_eq!(
             UserAccessTokenV1ResponseData::data_format(),
-            ResponseFormat::Data
+            ResponseFormat::Flatten
         );
+    }
+
+    #[tokio::test]
+    async fn test_execute_uses_current_json_body_and_access_token_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/authen/v1/access_token"))
+            .and(header("authorization", "Bearer app_token"))
+            .and(header("content-type", "application/json; charset=utf-8"))
+            .and(body_json(json!({
+                "grant_type": "authorization_code",
+                "code": "login_code"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "access_token": "u-token",
+                    "token_type": "Bearer",
+                    "expires_in": 7140,
+                    "refresh_token": "ur-token"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("test_app")
+            .app_secret("test_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let option = RequestOption::builder()
+            .app_access_token("app_token")
+            .build();
+
+        let response = UserAccessTokenV1Builder::new(config)
+            .code("login_code")
+            .execute_with_options(option)
+            .await
+            .expect("access_token 请求应成功");
+
+        assert_eq!(response.data.user_access_token, "u-token");
+        assert_eq!(response.data.refresh_token, Some("ur-token".to_string()));
     }
 }

--- a/crates/openlark-auth/src/auth/authen/v1/access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/access_token/create.rs
@@ -35,7 +35,7 @@ pub struct UserAccessTokenV1ResponseData {
 
 impl ApiResponseTrait for UserAccessTokenV1ResponseData {
     fn data_format() -> ResponseFormat {
-        ResponseFormat::Flatten
+        ResponseFormat::Data
     }
 }
 
@@ -194,7 +194,7 @@ mod tests {
     fn test_user_access_token_v1_response_data_format() {
         assert_eq!(
             UserAccessTokenV1ResponseData::data_format(),
-            ResponseFormat::Flatten
+            ResponseFormat::Data
         );
     }
 

--- a/crates/openlark-auth/src/auth/authen/v1/oidc/access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/oidc/access_token/create.rs
@@ -37,7 +37,7 @@ pub struct OidcAccessTokenResponseData {
 
 impl ApiResponseTrait for OidcAccessTokenResponseData {
     fn data_format() -> ResponseFormat {
-        ResponseFormat::Flatten
+        ResponseFormat::Data
     }
 }
 
@@ -239,7 +239,7 @@ mod tests {
     fn test_oidc_access_token_response_data_format() {
         assert_eq!(
             OidcAccessTokenResponseData::data_format(),
-            ResponseFormat::Flatten
+            ResponseFormat::Data
         );
     }
 

--- a/crates/openlark-auth/src/auth/authen/v1/oidc/access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/oidc/access_token/create.rs
@@ -30,6 +30,7 @@ pub struct OidcAccessTokenBuilder {
 
 /// OIDC 用户访问令牌响应
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(transparent)]
 pub struct OidcAccessTokenResponseData {
     /// 用户访问令牌响应
     pub data: UserAccessTokenResponse,
@@ -227,7 +228,8 @@ mod tests {
 
     #[test]
     fn test_oidc_access_token_response_data_deserialization() {
-        let json = r#"{"data":{"user_access_token":"token123","expires_in":7200,"refresh_token":"refresh456"}}"#;
+        let json =
+            r#"{"user_access_token":"token123","expires_in":7200,"refresh_token":"refresh456"}"#;
         let response: OidcAccessTokenResponseData =
             serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.data.user_access_token, "token123");

--- a/crates/openlark-auth/src/auth/authen/v1/oidc/access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/oidc/access_token/create.rs
@@ -1,6 +1,6 @@
 //! OIDC 用户访问令牌获取API
 //! docPath: https://open.feishu.cn/document/historic-version/authen/create-3
-use crate::models::authen::UserAccessTokenResponse;
+use crate::models::authen::{OidcUserAccessTokenRequest, UserAccessTokenResponse};
 ///
 /// API文档: https://open.feishu.cn/document/server-docs/user-authentication/access-token/oidc_access_token
 ///
@@ -9,6 +9,7 @@ use openlark_core::{
     SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
+    constants::AccessTokenType,
     http::Transport,
     req_option::RequestOption,
     validate_required,
@@ -36,7 +37,7 @@ pub struct OidcAccessTokenResponseData {
 
 impl ApiResponseTrait for OidcAccessTokenResponseData {
     fn data_format() -> ResponseFormat {
-        ResponseFormat::Data
+        ResponseFormat::Flatten
     }
 }
 
@@ -107,30 +108,21 @@ impl OidcAccessTokenBuilder {
         use crate::common::api_endpoints::AuthenApiV1;
         let api_endpoint = AuthenApiV1::OidcAccessToken;
 
-        // 构建表单数据
-        let mut form_data = std::collections::HashMap::new();
-        form_data.insert("code".to_string(), self.code.clone());
-        if let Some(ref code_verifier) = self.code_verifier {
-            form_data.insert("code_verifier".to_string(), code_verifier.clone());
-        }
-        if let Some(ref redirect_uri) = self.redirect_uri {
-            form_data.insert("redirect_uri".to_string(), redirect_uri.clone());
-        }
-        if let Some(ref client_id) = self.client_id {
-            form_data.insert("client_id".to_string(), client_id.clone());
-        }
-        if let Some(ref client_secret) = self.client_secret {
-            form_data.insert("client_secret".to_string(), client_secret.clone());
-        }
-        if let Some(ref grant_type) = self.grant_type {
-            form_data.insert("grant_type".to_string(), grant_type.clone());
-        }
+        // 构建请求体
+        let request_body = OidcUserAccessTokenRequest {
+            code: self.code.clone(),
+            code_verifier: self.code_verifier.clone(),
+            redirect_uri: self.redirect_uri.clone(),
+            client_id: self.client_id.clone(),
+            client_secret: self.client_secret.clone(),
+            grant_type: self.grant_type.clone(),
+        };
 
         // 创建API请求 - 使用类型安全的URL生成
         let api_request: ApiRequest<OidcAccessTokenResponseData> =
             ApiRequest::post(api_endpoint.path())
-                .header("Content-Type", "application/x-www-form-urlencoded")
-                .body(openlark_core::api::RequestData::Form(form_data));
+                .body(serde_json::to_value(&request_body)?)
+                .with_supported_access_token_types(vec![AccessTokenType::App]);
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
@@ -145,6 +137,12 @@ impl OidcAccessTokenBuilder {
 mod tests {
     use super::*;
     use openlark_core::config::Config;
+    use openlark_core::req_option::RequestOption;
+    use serde_json::json;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_json, header, method, path},
+    };
 
     fn create_test_config() -> Config {
         Config::builder()
@@ -241,7 +239,56 @@ mod tests {
     fn test_oidc_access_token_response_data_format() {
         assert_eq!(
             OidcAccessTokenResponseData::data_format(),
-            ResponseFormat::Data
+            ResponseFormat::Flatten
+        );
+    }
+
+    #[tokio::test]
+    async fn test_execute_uses_json_body_and_access_token_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/authen/v1/oidc/access_token"))
+            .and(header("authorization", "Bearer app_token"))
+            .and(header("content-type", "application/json; charset=utf-8"))
+            .and(body_json(json!({
+                "grant_type": "authorization_code",
+                "code": "login_code"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "access_token": "u-oidc-token",
+                    "refresh_token": "ur-oidc-token",
+                    "token_type": "Bearer",
+                    "expires_in": 7199,
+                    "refresh_expires_in": 2591999,
+                    "scope": "auth:user.id:read"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("test_app")
+            .app_secret("test_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let option = RequestOption::builder()
+            .app_access_token("app_token")
+            .build();
+
+        let response = OidcAccessTokenBuilder::new(config)
+            .code("login_code")
+            .execute_with_options(option)
+            .await
+            .expect("OIDC access_token 请求应成功");
+
+        assert_eq!(response.data.user_access_token, "u-oidc-token");
+        assert_eq!(
+            response.data.refresh_token,
+            Some("ur-oidc-token".to_string())
         );
     }
 }

--- a/crates/openlark-auth/src/auth/authen/v1/oidc/refresh_access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/oidc/refresh_access_token/create.rs
@@ -1,6 +1,6 @@
 //! OIDC 用户访问令牌刷新API
 //! docPath: https://open.feishu.cn/document/historic-version/authen/create-4
-use crate::models::authen::UserAccessTokenResponse;
+use crate::models::authen::{OidcRefreshUserAccessTokenRequest, UserAccessTokenResponse};
 ///
 /// API文档: https://open.feishu.cn/document/server-docs/user-authentication/access-token/oidc_refresh_access_token
 ///
@@ -9,6 +9,7 @@ use openlark_core::{
     SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
+    constants::AccessTokenType,
     http::Transport,
     req_option::RequestOption,
     validate_required,
@@ -34,7 +35,7 @@ pub struct OidcRefreshAccessTokenResponseData {
 
 impl ApiResponseTrait for OidcRefreshAccessTokenResponseData {
     fn data_format() -> ResponseFormat {
-        ResponseFormat::Data
+        ResponseFormat::Flatten
     }
 }
 
@@ -91,24 +92,19 @@ impl OidcRefreshAccessTokenBuilder {
         use crate::common::api_endpoints::AuthenApiV1;
         let api_endpoint = AuthenApiV1::OidcRefreshAccessToken;
 
-        // 构建表单数据
-        let mut form_data = std::collections::HashMap::new();
-        form_data.insert("refresh_token".to_string(), self.refresh_token.clone());
-        if let Some(ref client_id) = self.client_id {
-            form_data.insert("client_id".to_string(), client_id.clone());
-        }
-        if let Some(ref client_secret) = self.client_secret {
-            form_data.insert("client_secret".to_string(), client_secret.clone());
-        }
-        if let Some(ref grant_type) = self.grant_type {
-            form_data.insert("grant_type".to_string(), grant_type.clone());
-        }
+        // 构建请求体
+        let request_body = OidcRefreshUserAccessTokenRequest {
+            refresh_token: self.refresh_token.clone(),
+            client_id: self.client_id.clone(),
+            client_secret: self.client_secret.clone(),
+            grant_type: self.grant_type.clone(),
+        };
 
         // 创建API请求 - 使用类型安全的URL生成
         let api_request: ApiRequest<OidcRefreshAccessTokenResponseData> =
             ApiRequest::post(api_endpoint.path())
-                .header("Content-Type", "application/x-www-form-urlencoded")
-                .body(openlark_core::api::RequestData::Form(form_data));
+                .body(serde_json::to_value(&request_body)?)
+                .with_supported_access_token_types(vec![AccessTokenType::App]);
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
@@ -123,6 +119,12 @@ impl OidcRefreshAccessTokenBuilder {
 mod tests {
     use super::*;
     use openlark_core::config::Config;
+    use openlark_core::req_option::RequestOption;
+    use serde_json::json;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_json, header, method, path},
+    };
 
     fn create_test_config() -> Config {
         Config::builder()
@@ -202,7 +204,56 @@ mod tests {
     fn test_oidc_refresh_access_token_response_data_format() {
         assert_eq!(
             OidcRefreshAccessTokenResponseData::data_format(),
-            ResponseFormat::Data
+            ResponseFormat::Flatten
+        );
+    }
+
+    #[tokio::test]
+    async fn test_execute_uses_json_body_and_access_token_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/authen/v1/oidc/refresh_access_token"))
+            .and(header("authorization", "Bearer app_token"))
+            .and(header("content-type", "application/json; charset=utf-8"))
+            .and(body_json(json!({
+                "grant_type": "refresh_token",
+                "refresh_token": "old_oidc_refresh_token"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "access_token": "new-oidc-token",
+                    "refresh_token": "new-oidc-refresh-token",
+                    "token_type": "Bearer",
+                    "expires_in": 7140,
+                    "refresh_expires_in": 2591999,
+                    "scope": "auth:user.id:read"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("test_app")
+            .app_secret("test_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let option = RequestOption::builder()
+            .app_access_token("app_token")
+            .build();
+
+        let response = OidcRefreshAccessTokenBuilder::new(config)
+            .refresh_token("old_oidc_refresh_token")
+            .execute_with_options(option)
+            .await
+            .expect("OIDC refresh_access_token 请求应成功");
+
+        assert_eq!(response.data.user_access_token, "new-oidc-token");
+        assert_eq!(
+            response.data.refresh_token,
+            Some("new-oidc-refresh-token".to_string())
         );
     }
 }

--- a/crates/openlark-auth/src/auth/authen/v1/oidc/refresh_access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/oidc/refresh_access_token/create.rs
@@ -35,7 +35,7 @@ pub struct OidcRefreshAccessTokenResponseData {
 
 impl ApiResponseTrait for OidcRefreshAccessTokenResponseData {
     fn data_format() -> ResponseFormat {
-        ResponseFormat::Flatten
+        ResponseFormat::Data
     }
 }
 
@@ -204,7 +204,7 @@ mod tests {
     fn test_oidc_refresh_access_token_response_data_format() {
         assert_eq!(
             OidcRefreshAccessTokenResponseData::data_format(),
-            ResponseFormat::Flatten
+            ResponseFormat::Data
         );
     }
 

--- a/crates/openlark-auth/src/auth/authen/v1/oidc/refresh_access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/oidc/refresh_access_token/create.rs
@@ -28,6 +28,7 @@ pub struct OidcRefreshAccessTokenBuilder {
 
 /// OIDC 用户访问令牌刷新响应
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(transparent)]
 pub struct OidcRefreshAccessTokenResponseData {
     /// 用户访问令牌响应
     pub data: UserAccessTokenResponse,
@@ -192,7 +193,8 @@ mod tests {
 
     #[test]
     fn test_oidc_refresh_access_token_response_data_deserialization() {
-        let json = r#"{"data":{"user_access_token":"token123","expires_in":7200,"refresh_token":"refresh456"}}"#;
+        let json =
+            r#"{"user_access_token":"token123","expires_in":7200,"refresh_token":"refresh456"}"#;
         let response: OidcRefreshAccessTokenResponseData =
             serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.data.user_access_token, "token123");

--- a/crates/openlark-auth/src/auth/authen/v1/refresh_access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/refresh_access_token/create.rs
@@ -36,7 +36,7 @@ pub struct RefreshUserAccessTokenV1ResponseData {
 
 impl ApiResponseTrait for RefreshUserAccessTokenV1ResponseData {
     fn data_format() -> ResponseFormat {
-        ResponseFormat::Flatten
+        ResponseFormat::Data
     }
 }
 

--- a/crates/openlark-auth/src/auth/authen/v1/refresh_access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/refresh_access_token/create.rs
@@ -29,6 +29,7 @@ pub struct RefreshUserAccessTokenV1Builder {
 
 /// 用户访问令牌刷新响应（v1版本）
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(transparent)]
 pub struct RefreshUserAccessTokenV1ResponseData {
     /// 用户访问令牌响应
     pub data: UserAccessTokenResponse,

--- a/crates/openlark-auth/src/auth/authen/v1/refresh_access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/refresh_access_token/create.rs
@@ -10,6 +10,7 @@ use openlark_core::{
     SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
+    constants::AccessTokenType,
     http::Transport,
     req_option::RequestOption,
     validate_required,
@@ -19,6 +20,7 @@ use serde::{Deserialize, Serialize};
 /// 用户访问令牌刷新请求（v1版本）
 pub struct RefreshUserAccessTokenV1Builder {
     refresh_token: String,
+    grant_type: String,
     app_id: String,
     app_secret: String,
     /// 配置信息
@@ -34,7 +36,7 @@ pub struct RefreshUserAccessTokenV1ResponseData {
 
 impl ApiResponseTrait for RefreshUserAccessTokenV1ResponseData {
     fn data_format() -> ResponseFormat {
-        ResponseFormat::Data
+        ResponseFormat::Flatten
     }
 }
 
@@ -43,6 +45,7 @@ impl RefreshUserAccessTokenV1Builder {
     pub fn new(config: Config) -> Self {
         Self {
             refresh_token: String::new(),
+            grant_type: "refresh_token".to_string(),
             app_id: String::new(),
             app_secret: String::new(),
             config,
@@ -52,6 +55,12 @@ impl RefreshUserAccessTokenV1Builder {
     /// 设置刷新令牌
     pub fn refresh_token(mut self, refresh_token: impl Into<String>) -> Self {
         self.refresh_token = refresh_token.into();
+        self
+    }
+
+    /// 设置授权类型
+    pub fn grant_type(mut self, grant_type: impl Into<String>) -> Self {
+        self.grant_type = grant_type.into();
         self
     }
 
@@ -79,8 +88,6 @@ impl RefreshUserAccessTokenV1Builder {
     ) -> SDKResult<RefreshUserAccessTokenV1ResponseData> {
         // 验证必填字段
         validate_required!(self.refresh_token, "刷新令牌不能为空");
-        validate_required!(self.app_id, "应用ID不能为空");
-        validate_required!(self.app_secret, "应用密钥不能为空");
 
         // 🚀 使用新的enum+builder系统生成API端点
         use crate::common::api_endpoints::AuthenApiV1;
@@ -88,14 +95,17 @@ impl RefreshUserAccessTokenV1Builder {
 
         // 构建请求体
         let request_body = RefreshUserAccessTokenV1Request {
+            grant_type: self.grant_type.clone(),
             refresh_token: self.refresh_token.clone(),
-            app_id: self.app_id.clone(),
-            app_secret: self.app_secret.clone(),
+            app_id: (!self.app_id.is_empty()).then(|| self.app_id.clone()),
+            app_secret: (!self.app_secret.is_empty()).then(|| self.app_secret.clone()),
         };
 
         // 创建API请求 - 使用类型安全的URL生成
         let api_request: ApiRequest<RefreshUserAccessTokenV1ResponseData> =
-            ApiRequest::post(api_endpoint.path()).body(serde_json::to_value(&request_body)?);
+            ApiRequest::post(api_endpoint.path())
+                .body(serde_json::to_value(&request_body)?)
+                .with_supported_access_token_types(vec![AccessTokenType::App]);
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
@@ -108,6 +118,13 @@ impl RefreshUserAccessTokenV1Builder {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use openlark_core::{config::Config, req_option::RequestOption};
+    use serde_json::json;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_json, header, method, path},
+    };
 
     #[test]
     fn test_serialization_roundtrip() {
@@ -122,5 +139,53 @@ mod tests {
         let json = r#"{"field": "data"}"#;
         let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(value["field"], "data");
+    }
+
+    #[tokio::test]
+    async fn test_execute_uses_current_json_body_and_access_token_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/authen/v1/refresh_access_token"))
+            .and(header("authorization", "Bearer app_token"))
+            .and(header("content-type", "application/json; charset=utf-8"))
+            .and(body_json(json!({
+                "grant_type": "refresh_token",
+                "refresh_token": "old_refresh_token"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "access_token": "new-u-token",
+                    "refresh_token": "new-refresh-token",
+                    "token_type": "Bearer",
+                    "expires_in": 7140,
+                    "refresh_expires_in": 2591999
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("test_app")
+            .app_secret("test_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let option = RequestOption::builder()
+            .app_access_token("app_token")
+            .build();
+
+        let response = RefreshUserAccessTokenV1Builder::new(config)
+            .refresh_token("old_refresh_token")
+            .execute_with_options(option)
+            .await
+            .expect("refresh_access_token 请求应成功");
+
+        assert_eq!(response.data.user_access_token, "new-u-token");
+        assert_eq!(
+            response.data.refresh_token,
+            Some("new-refresh-token".to_string())
+        );
     }
 }

--- a/crates/openlark-auth/src/models/authen/mod.rs
+++ b/crates/openlark-auth/src/models/authen/mod.rs
@@ -6,6 +6,13 @@ use chrono::{DateTime, Utc};
 use openlark_core::api::responses::ApiResponseTrait;
 use serde::{Deserialize, Serialize};
 
+mod token;
+
+pub use token::{
+    OidcRefreshUserAccessTokenRequest, OidcUserAccessTokenRequest, RefreshUserAccessTokenV1Request,
+    UserAccessTokenResponse, UserAccessTokenV1Request,
+};
+
 /// 用户信息响应
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct UserInfoResponse {
@@ -14,7 +21,7 @@ pub struct UserInfoResponse {
 }
 
 /// 用户信息
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct UserInfo {
     /// 用户Open ID
     pub open_id: String,
@@ -57,7 +64,7 @@ pub struct UserInfo {
 }
 
 /// 用户头像
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct UserAvatar {
     /// 头像72x72
     pub avatar_72: Option<String>,
@@ -70,7 +77,7 @@ pub struct UserAvatar {
 }
 
 /// 用户状态
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct UserStatus {
     /// 是否激活
     pub is_activated: Option<bool>,
@@ -83,7 +90,7 @@ pub struct UserStatus {
 }
 
 /// 企业扩展属性
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct UserEnterpriseExtension {
     /// 入职时间
     pub hire_date: Option<DateTime<Utc>>,
@@ -114,79 +121,12 @@ pub struct UserEnterpriseExtension {
 }
 
 /// 用户自定义属性
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct UserCustomAttr {
     /// 属性Key
     pub key: Option<String>,
     /// 属性值
     pub value: Option<serde_json::Value>,
-}
-
-/// 用户访问令牌响应
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct UserAccessTokenResponse {
-    /// 用户访问令牌
-    pub user_access_token: String,
-    /// 刷新令牌
-    pub refresh_token: Option<String>,
-    /// 令牌有效期（秒）
-    pub expires_in: u64,
-    /// 令牌类型
-    pub token_type: Option<String>,
-    /// 授权范围
-    pub scope: Option<String>,
-}
-
-/// 用户访问令牌请求（v1版本）
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UserAccessTokenV1Request {
-    /// 授权码
-    pub grant_code: String,
-    /// 应用ID
-    pub app_id: String,
-    /// 应用密钥
-    pub app_secret: String,
-}
-
-/// 用户访问令牌刷新请求（v1版本）
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RefreshUserAccessTokenV1Request {
-    /// 刷新令牌
-    pub refresh_token: String,
-    /// 应用ID
-    pub app_id: String,
-    /// 应用密钥
-    pub app_secret: String,
-}
-
-/// OIDC用户访问令牌请求
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct OidcUserAccessTokenRequest {
-    /// 授权码
-    pub code: String,
-    /// 授权验证码
-    pub code_verifier: Option<String>,
-    /// 授权流程
-    pub redirect_uri: Option<String>,
-    /// 客户端ID
-    pub client_id: Option<String>,
-    /// 客户端密钥
-    pub client_secret: Option<String>,
-    /// 授权类型
-    pub grant_type: Option<String>,
-}
-
-/// OIDC用户访问令牌刷新请求
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct OidcRefreshUserAccessTokenRequest {
-    /// 刷新令牌
-    pub refresh_token: String,
-    /// 客户端ID
-    pub client_id: Option<String>,
-    /// 客户端密钥
-    pub client_secret: Option<String>,
-    /// 授权类型
-    pub grant_type: Option<String>,
 }
 
 /// 用户信息获取请求
@@ -196,72 +136,6 @@ pub struct UserInfoRequest {
     pub user_access_token: String,
     /// 用户ID类型
     pub user_id_type: Option<String>,
-}
-
-impl PartialEq for UserInfo {
-    fn eq(&self, other: &Self) -> bool {
-        self.open_id == other.open_id
-            && self.union_id == other.union_id
-            && self.user_id == other.user_id
-            && self.name == other.name
-            && self.en_name == other.en_name
-            && self.email == other.email
-            && self.enterprise_email == other.enterprise_email
-            && self.mobile == other.mobile
-            && self.avatar_url == other.avatar_url
-            && self.avatar == other.avatar
-            && self.status == other.status
-            && self.department_ids == other.department_ids
-            && self.group_ids == other.group_ids
-            && self.positions == other.positions
-            && self.employee_no == other.employee_no
-            && self.dingtalk_user_id == other.dingtalk_user_id
-            && self.enterprise_extension == other.enterprise_extension
-            && self.custom_attrs == other.custom_attrs
-            && self.tenant_key == other.tenant_key
-    }
-}
-
-impl PartialEq for UserAvatar {
-    fn eq(&self, other: &Self) -> bool {
-        self.avatar_72 == other.avatar_72
-            && self.avatar_240 == other.avatar_240
-            && self.avatar_640 == other.avatar_640
-            && self.avatar_origin == other.avatar_origin
-    }
-}
-
-impl PartialEq for UserStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.is_activated == other.is_activated
-            && self.is_joined == other.is_joined
-            && self.is_reserved == other.is_reserved
-            && self.is_exited == other.is_exited
-    }
-}
-
-impl PartialEq for UserEnterpriseExtension {
-    fn eq(&self, other: &Self) -> bool {
-        self.hire_date == other.hire_date
-            && self.location == other.location
-            && self.work_station == other.work_station
-            && self.work_station_id == other.work_station_id
-            && self.address == other.address
-            && self.postcode == other.postcode
-            && self.mobile_phone == other.mobile_phone
-            && self.extension_number == other.extension_number
-            && self.contact_phone == other.contact_phone
-            && self.primary_phone == other.primary_phone
-            && self.emergency_contact == other.emergency_contact
-            && self.emergency_phone == other.emergency_phone
-            && self.home_phone == other.home_phone
-    }
-}
-
-impl PartialEq for UserCustomAttr {
-    fn eq(&self, other: &Self) -> bool {
-        self.key == other.key && self.value == other.value
-    }
 }
 
 // 为所有响应类型实现ApiResponseTrait

--- a/crates/openlark-auth/src/models/authen/token.rs
+++ b/crates/openlark-auth/src/models/authen/token.rs
@@ -1,0 +1,90 @@
+//! 用户访问令牌相关模型
+
+use serde::{Deserialize, Serialize};
+
+/// 用户访问令牌响应
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct UserAccessTokenResponse {
+    /// 用户访问令牌
+    #[serde(alias = "access_token")]
+    pub user_access_token: String,
+    /// 刷新令牌
+    pub refresh_token: Option<String>,
+    /// 令牌有效期（秒）
+    pub expires_in: u64,
+    /// 令牌类型
+    pub token_type: Option<String>,
+    /// 刷新令牌有效期（秒）
+    pub refresh_expires_in: Option<u64>,
+    /// 授权范围
+    pub scope: Option<String>,
+}
+
+/// 用户访问令牌请求（v1版本）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserAccessTokenV1Request {
+    /// 授权类型
+    pub grant_type: String,
+    /// 登录预授权码
+    #[serde(rename = "code")]
+    pub grant_code: String,
+    /// 应用ID（历史兼容字段）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_id: Option<String>,
+    /// 应用密钥（历史兼容字段）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_secret: Option<String>,
+}
+
+/// 用户访问令牌刷新请求（v1版本）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RefreshUserAccessTokenV1Request {
+    /// 授权类型
+    pub grant_type: String,
+    /// 刷新令牌
+    pub refresh_token: String,
+    /// 应用ID（历史兼容字段）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_id: Option<String>,
+    /// 应用密钥（历史兼容字段）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_secret: Option<String>,
+}
+
+/// OIDC用户访问令牌请求
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OidcUserAccessTokenRequest {
+    /// 授权码
+    pub code: String,
+    /// 授权验证码
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code_verifier: Option<String>,
+    /// 授权流程
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redirect_uri: Option<String>,
+    /// 客户端ID
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<String>,
+    /// 客户端密钥
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_secret: Option<String>,
+    /// 授权类型
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grant_type: Option<String>,
+}
+
+/// OIDC用户访问令牌刷新请求
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OidcRefreshUserAccessTokenRequest {
+    /// 刷新令牌
+    pub refresh_token: String,
+    /// 客户端ID
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<String>,
+    /// 客户端密钥
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_secret: Option<String>,
+    /// 授权类型
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grant_type: Option<String>,
+}

--- a/crates/openlark-core/src/api/mod.rs
+++ b/crates/openlark-core/src/api/mod.rs
@@ -108,6 +108,7 @@ pub struct ApiRequest<R> {
     pub(crate) body: Option<RequestData>,
     pub(crate) file: Option<Vec<u8>>,
     pub(crate) timeout: Option<Duration>,
+    pub(crate) supported_access_token_types: Option<Vec<crate::constants::AccessTokenType>>,
     pub(crate) _phantom: std::marker::PhantomData<R>,
 }
 
@@ -122,6 +123,7 @@ impl<R> ApiRequest<R> {
             body: None,
             file: None,
             timeout: None,
+            supported_access_token_types: None,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -136,6 +138,7 @@ impl<R> ApiRequest<R> {
             body: None,
             file: None,
             timeout: None,
+            supported_access_token_types: None,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -150,6 +153,7 @@ impl<R> ApiRequest<R> {
             body: None,
             file: None,
             timeout: None,
+            supported_access_token_types: None,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -164,6 +168,7 @@ impl<R> ApiRequest<R> {
             body: None,
             file: None,
             timeout: None,
+            supported_access_token_types: None,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -178,6 +183,7 @@ impl<R> ApiRequest<R> {
             body: None,
             file: None,
             timeout: None,
+            supported_access_token_types: None,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -247,6 +253,15 @@ impl<R> ApiRequest<R> {
         self
     }
 
+    /// 覆盖当前请求支持的访问令牌类型。
+    pub fn with_supported_access_token_types(
+        mut self,
+        token_types: Vec<crate::constants::AccessTokenType>,
+    ) -> Self {
+        self.supported_access_token_types = Some(token_types);
+        self
+    }
+
     /// 构建完整 URL（包含查询参数）
     pub fn build_url(&self) -> String {
         if self.query.is_empty() {
@@ -280,6 +295,10 @@ impl<R> ApiRequest<R> {
 
     /// 获取支持的访问令牌类型
     pub fn supported_access_token_types(&self) -> Vec<crate::constants::AccessTokenType> {
+        if let Some(token_types) = &self.supported_access_token_types {
+            return token_types.clone();
+        }
+
         // 默认返回用户和租户令牌类型
         vec![
             crate::constants::AccessTokenType::User,
@@ -361,6 +380,7 @@ impl<R> Default for ApiRequest<R> {
             body: None,
             file: None,
             timeout: None,
+            supported_access_token_types: None,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -427,5 +447,16 @@ mod tests {
         assert_eq!(delete_req.method.as_str(), "DELETE");
 
         println!("✅ All HTTP methods test passed!");
+    }
+
+    #[test]
+    fn test_supported_access_token_types_override() {
+        let request: ApiRequest<()> = ApiRequest::post("/open-apis/authen/v1/access_token")
+            .with_supported_access_token_types(vec![crate::constants::AccessTokenType::App]);
+
+        assert_eq!(
+            request.supported_access_token_types(),
+            vec![crate::constants::AccessTokenType::App]
+        );
     }
 }

--- a/crates/openlark-core/src/http.rs
+++ b/crates/openlark-core/src/http.rs
@@ -222,6 +222,31 @@ fn determine_token_type(
     enable_token_cache: bool,
 ) -> AccessTokenType {
     if !enable_token_cache {
+        if !access_token_types.is_empty() {
+            for access_token_type in access_token_types.iter() {
+                match access_token_type {
+                    AccessTokenType::User => {
+                        if option.user_access_token.is_some() {
+                            return AccessTokenType::User;
+                        }
+                    }
+                    AccessTokenType::Tenant => {
+                        if option.tenant_access_token.is_some() || option.tenant_key.is_some() {
+                            return AccessTokenType::Tenant;
+                        }
+                    }
+                    AccessTokenType::App => {
+                        if option.app_access_token.is_some() {
+                            return AccessTokenType::App;
+                        }
+                    }
+                    AccessTokenType::None => {}
+                }
+            }
+
+            return AccessTokenType::None;
+        }
+
         if option.user_access_token.is_some() {
             return AccessTokenType::User;
         }

--- a/tools/api_contracts/models.py
+++ b/tools/api_contracts/models.py
@@ -6,6 +6,17 @@ from dataclasses import asdict, dataclass, field
 from typing import Any
 
 
+_HTTP_METHODS = {"GET", "POST", "PATCH", "PUT", "DELETE", "HEAD", "OPTIONS", "CONNECT", "TRACE"}
+
+
+def _split_official_url(value: str) -> tuple[str, str]:
+    method, _, path = value.partition(":")
+    method = method.strip().upper()
+    if method in _HTTP_METHODS and path:
+        return method, path.strip()
+    return "", value.strip()
+
+
 @dataclass(frozen=True)
 class ApiIdentity:
     api_id: str
@@ -22,12 +33,18 @@ class ApiIdentity:
 
     @property
     def official_method(self) -> str:
-        method, _, _ = self.url.partition(":")
-        return method.upper()
+        method, path = _split_official_url(self.url)
+        if method:
+            return method
+        method, _ = _split_official_url(self.full_path)
+        return method
 
     @property
     def official_path(self) -> str:
-        _, _, path = self.url.partition(":")
+        _, path = _split_official_url(self.url)
+        if path:
+            return path
+        _, path = _split_official_url(self.full_path)
         return path
 
 


### PR DESCRIPTION
## 摘要

- 修复 authen v1 四个 token 接口的请求/响应形态兼容，解决 OIDC 与 v1 access_token 的响应空值问题（issue #196）。
- 更新请求体为 JSON 格式，补齐默认 grant_type，并在接口端使用 access_token 鉴权。
- 在核心层新增 ApiRequest 的 per-request token 类型覆盖能力：AccessTokenType::App。
- 抽出 token 相关模型并补齐响应别名处理。
- 增加四条 wiremock 回归测试（v1 access/refresh，OIDC access/refresh）覆盖请求 body、Authorization、response 映射。

## 验证

- cargo fmt --all
- cargo test -p openlark-auth
- cargo test -p openlark-core
- cargo clippy -p openlark-core -p openlark-auth --all-targets -- -D warnings
- git diff --check