### PR TITLE
fix: 修复 auth token 响应处理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ Thumbs.db
 .sisyphus/
 
 # AI assistant work files and memories
+.omo/
 .omx/
 .claude/memories/
 .claude/plan/

--- a/crates/openlark-auth/README.md
+++ b/crates/openlark-auth/README.md
@@ -26,7 +26,7 @@ graph TD
     A --> D[authen/]
     A --> E[oauth/]
 
-    B --> B1[AuthConfig]
+    B --> B1[Config]
     B --> B2[AuthError]
     B --> B3[TokenInfo]
     B --> B4[UserInfo]
@@ -52,17 +52,36 @@ graph TD
 
 ```rust
 // 认证服务统一入口
-use openlark_auth::{AuthServices, AuthConfig};
+use openlark_auth::{AuthService, AuthenService, OAuthService};
+use openlark_core::config::Config;
 
-let config = AuthConfig::new("app_id", "app_secret")
-.with_base_url("https://open.feishu.cn");
+let config = Config::builder()
+    .app_id("app_id")
+    .app_secret("app_secret")
+    .base_url("https://open.feishu.cn")
+    .build();
 
-let auth = AuthServices::new(config);
+let auth = AuthService::new(config.clone());
+let authen = AuthenService::new(config.clone());
+let oauth = OAuthService::new(config);
 
 // 访问各个项目
-let tenant_token = auth.auth.v3().tenant_access_token().internal().send().await?;
-let user_info = auth.authen.v1.user_info().get().user_access_token("token").send().await?;
-let oauth_url = auth.oauth.old.authorization().get_index().app_id("app_id").send().await?;
+let tenant_token = auth.v3()
+    .tenant_access_token_internal()
+    .app_id("app_id")
+    .app_secret("app_secret")
+    .execute()
+    .await?;
+let user_info = authen.v1()
+    .user_info()
+    .get()
+    .user_access_token("user_access_token")
+    .execute()
+    .await?;
+let oauth_url = oauth.old()
+    .authorization()
+    .app_id("app_id")
+    .redirect_uri("https://example.com/callback");
 ```
 
 ## 快速开始
@@ -78,33 +97,41 @@ tokio = { version = "1.0", features = ["full"] }
 ### 基础使用
 
 ```rust,no_run
-use openlark_auth::{AuthServices, AuthConfig};
+use openlark_auth::{AuthService, AuthenService};
+use openlark_core::config::Config;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 1. 创建认证配置
-    let config = AuthConfig::new("your_app_id", "your_app_secret")
-        .with_base_url("https://open.feishu.cn");
+    let config = Config::builder()
+        .app_id("your_app_id")
+        .app_secret("your_app_secret")
+        .base_url("https://open.feishu.cn")
+        .build();
 
     // 2. 创建认证服务
-    let auth = AuthServices::new(config);
+    let auth = AuthService::new(config.clone());
+    let authen = AuthenService::new(config);
 
     // 3. 获取自建应用租户访问令牌
-    let tenant_token = auth.auth.v3().tenant_access_token()
-        .internal()
-        .send()
+    let tenant_token = auth.v3()
+        .tenant_access_token_internal()
+        .app_id("your_app_id")
+        .app_secret("your_app_secret")
+        .execute()
         .await?;
 
-    println!("租户令牌: {}", tenant_token.tenant_access_token);
+    println!("租户令牌: {}", tenant_token.data.tenant_access_token);
 
     // 4. 获取用户信息
-    let user_info = auth.authen.v1().user_info()
+    let user_info = authen.v1()
+        .user_info()
         .get()
-        .user_access_token(&tenant_token.tenant_access_token)
-        .send()
+        .user_access_token("user_access_token")
+        .execute()
         .await?;
 
-    println!("用户名称: {}", user_info.name);
+    println!("用户 Open ID: {}", user_info.data.open_id);
 
     Ok(())
 }
@@ -118,17 +145,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ```rust
 // 自建应用租户访问令牌
-let tenant_token = auth.auth.v3().tenant_access_token()
-    .internal()
-    .send()
+let tenant_token = auth.v3()
+    .tenant_access_token_internal()
+    .app_id("app_id")
+    .app_secret("app_secret")
+    .execute()
     .await?;
 
 // 商店应用租户访问令牌
-let tenant_token = auth.auth.v3().tenant_access_token()
-    .store()
-    .app_access_token("app_token")
+let tenant_token = auth.v3()
+    .tenant_access_token()
+    .app_access_token("app_access_token")
     .tenant_key("tenant_key")
-    .send()
+    .execute()
     .await?;
 ```
 
@@ -136,15 +165,20 @@ let tenant_token = auth.auth.v3().tenant_access_token()
 
 ```rust
 // 自建应用访问令牌
-let app_token = auth.auth.v3().app_access_token()
-    .internal()
-    .send()
+let app_token = auth.v3()
+    .app_access_token_internal()
+    .app_id("app_id")
+    .app_secret("app_secret")
+    .execute()
     .await?;
 
 // 商店应用访问令牌
-let app_token = auth.auth.v3().app_access_token()
-    .store()
-    .send()
+let app_token = auth.v3()
+    .app_access_token()
+    .app_id("app_id")
+    .app_secret("app_secret")
+    .app_ticket("app_ticket")
+    .execute()
     .await?;
 ```
 
@@ -152,9 +186,11 @@ let app_token = auth.auth.v3().app_access_token()
 
 ```rust
 // 重新推送应用票据
-let response = auth.auth.v3().app_ticket()
-    .resend()
-    .send()
+let response = auth.v3()
+    .app_ticket_resend()
+    .app_id("app_id")
+    .app_secret("app_secret")
+    .execute()
     .await?;
 ```
 
@@ -163,11 +199,12 @@ let response = auth.auth.v3().app_ticket()
 #### 用户信息获取
 
 ```rust
-let user_info = auth.authen.v1().user_info()
+let user_info = authen.v1()
+    .user_info()
     .get()
     .user_access_token("user_access_token")
     .user_id_type("open_id")
-    .send()
+    .execute()
     .await?;
 ```
 
@@ -175,11 +212,12 @@ let user_info = auth.authen.v1().user_info()
 
 ```rust
 // 使用授权码获取访问令牌
-let access_token = auth.authen.v1().access_token()
-    .create()
-    .grant_type("authorization_code")
-    .code("authorization_code")
-    .send()
+let access_token = authen.v1()
+    .access_token()
+    .grant_code("authorization_code")
+    .app_id("app_id")
+    .app_secret("app_secret")
+    .execute()
     .await?;
 ```
 
@@ -187,11 +225,13 @@ let access_token = auth.authen.v1().access_token()
 
 ```rust
 // 刷新 OIDC 访问令牌
-let oidc_token = auth.authen.v1().oidc()
-    .create_refresh_access_token()
+let oidc_token = authen.v1()
+    .oidc()
+    .refresh_access_token()
     .refresh_token("refresh_token")
-    .grant_type("refresh_token")
-    .send()
+    .client_id("client_id")
+    .client_secret("client_secret")
+    .execute()
     .await?;
 ```
 
@@ -200,26 +240,30 @@ let oidc_token = auth.authen.v1().oidc()
 #### 获取预授权码
 
 ```rust
-let pre_auth_code = auth.oauth.old.authorization()
-    .get_index()
+let pre_auth_code = oauth.old()
+    .authorization()
     .app_id("app_id")
     .redirect_uri("https://example.com/callback")
     .scope("user:info")
     .state("random_state")
-    .send()
+    .execute()
     .await?;
 ```
 
 ## 数据模型
 
-### 认证配置 (AuthConfig)
+### 认证配置 (Config)
 
 ```rust
-let config = AuthConfig::new("app_id", "app_secret")
-    .with_base_url("https://open.feishu.cn");
+use openlark_core::config::Config;
 
-// 或者使用默认配置
-let default_config = AuthConfig::default();
+let config = Config::builder()
+    .app_id("app_id")
+    .app_secret("app_secret")
+    .base_url("https://open.feishu.cn")
+    .build();
+
+let default_config = Config::default();
 ```
 
 ### 令牌信息 (TokenInfo)
@@ -317,7 +361,11 @@ if token_info.is_expired() || token_info.needs_refresh(30) {
 
 // 网络错误重试
 let result = retry_async_operation(|| {
-    auth.auth.v3().tenant_access_token().internal().send()
+    auth.v3()
+        .tenant_access_token_internal()
+        .app_id("app_id")
+        .app_secret("app_secret")
+        .execute()
 }).await;
 ```
 
@@ -329,23 +377,30 @@ let result = retry_async_operation(|| {
 use std::sync::Arc;
 use tokio::task::JoinSet;
 
-let auth = Arc::new(AuthServices::new(config));
+let auth = Arc::new(AuthService::new(config));
 let mut join_set = JoinSet::new();
 
 // 并发获取多个令牌
 for i in 0..5 {
-let auth_clone = auth.clone();
-join_set.spawn(async move {
-auth_clone.auth.v3().tenant_access_token().internal().send().await
-});
+    let auth_clone = auth.clone();
+    join_set.spawn(async move {
+        auth_clone
+            .v3()
+            .tenant_access_token_internal()
+            .app_id("app_id")
+            .app_secret("app_secret")
+            .execute()
+            .await
+    });
 }
 
 // 等待所有请求完成
 while let Some(result) = join_set.join_next().await {
-match result {
-Ok(token) => println ! ("令牌 {} 获取成功", i),
-Err(e) => println !("令牌 {} 获取失败: {}", i, e),
-}
+    match result {
+        Ok(Ok(token)) => println!("令牌获取成功: {}", token.data.tenant_access_token),
+        Ok(Err(e)) => println!("令牌获取失败: {}", e),
+        Err(e) => println!("任务执行失败: {}", e),
+    }
 }
 ```
 
@@ -354,15 +409,19 @@ Err(e) => println !("令牌 {} 获取失败: {}", i, e),
 ```rust
 // 自定义 HTTP 客户端
 use reqwest::Client;
+use openlark_core::config::Config;
 
 let client = Client::builder()
     .timeout(Duration::from_secs(30))
     .user_agent("OpenLark-SDK/1.0")
     .build()?;
 
-let config = AuthConfig::new("app_id", "app_secret")
-    .with_base_url("https://open.feishu.cn")
-    .with_client(client);
+let config = Config::builder()
+    .app_id("app_id")
+    .app_secret("app_secret")
+    .base_url("https://open.feishu.cn")
+    .http_client(client)
+    .build();
 ```
 
 ## 最佳实践
@@ -378,7 +437,10 @@ let app_id = env::var("LARK_APP_ID")
 let app_secret = env::var("LARK_APP_SECRET")
     .expect("LARK_APP_SECRET must be set");
 
-let config = AuthConfig::new(app_id, app_secret);
+let config = Config::builder()
+    .app_id(app_id)
+    .app_secret(app_secret)
+    .build();
 ```
 
 ### 2. 令牌缓存

--- a/crates/openlark-auth/examples/api_demo.rs
+++ b/crates/openlark-auth/examples/api_demo.rs
@@ -32,13 +32,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .v3()
         .app_access_token()
         .app_id("demo_app_id")
-        .app_secret("demo_app_secret");
+        .app_secret("demo_app_secret")
+        .app_ticket("demo_app_ticket");
 
     let _tenant_token_builder = auth_service
         .v3()
         .tenant_access_token()
-        .app_id("demo_app_id")
-        .app_secret("demo_app_secret");
+        .app_access_token("demo_app_access_token")
+        .tenant_key("demo_tenant_key");
 
     let _app_ticket_builder = auth_service
         .v3()

--- a/crates/openlark-auth/examples/api_validation_demo.rs
+++ b/crates/openlark-auth/examples/api_validation_demo.rs
@@ -21,7 +21,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _builder1 = auth_service
         .app_access_token()
         .app_id("app_id")
-        .app_secret("app_secret");
+        .app_secret("app_secret")
+        .app_ticket("app_ticket");
 
     println!("✅ 2. 自建应用获取app_access_token_internal");
     let _builder2 = auth_service
@@ -32,8 +33,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("✅ 3. 商店应用获取tenant_access_token");
     let _builder3 = auth_service
         .tenant_access_token()
-        .app_id("app_id")
-        .app_secret("app_secret");
+        .app_access_token("app_access_token")
+        .tenant_key("tenant_key");
 
     println!("✅ 4. 自建应用获取tenant_access_token_internal");
     let _builder4 = auth_service

--- a/crates/openlark-auth/src/auth/auth/v3/auth/app_access_token.rs
+++ b/crates/openlark-auth/src/auth/auth/v3/auth/app_access_token.rs
@@ -1,6 +1,6 @@
 //! 商店应用获取 app_access_token API
 //! docPath: https://open.feishu.cn/document/server-docs/authentication-management/access-token/app_access_token
-use crate::models::auth::{AccessTokenResponse, AppAccessTokenRequest};
+use crate::models::auth::AccessTokenResponse;
 ///
 /// API文档: https://open.feishu.cn/document/server-docs/authentication-management/access-token/app_access_token
 ///
@@ -10,22 +10,32 @@ use openlark_core::{
     SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
+    constants::AccessTokenType,
     http::Transport,
     req_option::RequestOption,
     validate_required,
 };
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Serialize)]
+struct AppAccessTokenBody {
+    app_id: String,
+    app_secret: String,
+    app_ticket: String,
+}
+
 /// 商店应用获取 app_access_token 请求
 pub struct AppAccessTokenBuilder {
     app_id: String,
     app_secret: String,
+    app_ticket: String,
     /// 配置信息
     config: Config,
 }
 
 /// 商店应用获取 app_access_token 响应
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(transparent)]
 pub struct AppAccessTokenResponseData {
     /// 应用访问令牌响应
     pub data: AccessTokenResponse,
@@ -33,7 +43,7 @@ pub struct AppAccessTokenResponseData {
 
 impl ApiResponseTrait for AppAccessTokenResponseData {
     fn data_format() -> ResponseFormat {
-        ResponseFormat::Data
+        ResponseFormat::Flatten
     }
 }
 
@@ -43,6 +53,7 @@ impl AppAccessTokenBuilder {
         Self {
             app_id: String::new(),
             app_secret: String::new(),
+            app_ticket: String::new(),
             config,
         }
     }
@@ -59,6 +70,12 @@ impl AppAccessTokenBuilder {
         self
     }
 
+    /// 设置应用票据（商店应用必需）
+    pub fn app_ticket(mut self, app_ticket: impl Into<String>) -> Self {
+        self.app_ticket = app_ticket.into();
+        self
+    }
+
     /// 执行请求
     pub async fn execute(self) -> SDKResult<AppAccessTokenResponseData> {
         self.execute_with_options(RequestOption::default()).await
@@ -72,20 +89,24 @@ impl AppAccessTokenBuilder {
         // 验证必填字段
         validate_required!(self.app_id, "应用ID不能为空");
         validate_required!(self.app_secret, "应用密钥不能为空");
+        validate_required!(self.app_ticket, "应用票据不能为空");
 
         // 🚀 使用新的enum+builder系统生成API端点
         use crate::common::api_endpoints::AuthApiV3;
         let api_endpoint = AuthApiV3::AppAccessToken;
 
         // 构建请求体
-        let request_body = AppAccessTokenRequest {
+        let request_body = AppAccessTokenBody {
             app_id: self.app_id.clone(),
             app_secret: self.app_secret.clone(),
+            app_ticket: self.app_ticket.clone(),
         };
 
         // 创建API请求 - 使用类型安全的URL生成
         let api_request: ApiRequest<AppAccessTokenResponseData> =
-            ApiRequest::post(api_endpoint.path()).body(serde_json::to_value(&request_body)?);
+            ApiRequest::post(api_endpoint.path())
+                .body(serde_json::to_value(&request_body)?)
+                .with_supported_access_token_types(vec![AccessTokenType::None]);
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
@@ -100,6 +121,11 @@ impl AppAccessTokenBuilder {
 mod tests {
     use super::*;
     use openlark_core::config::Config;
+    use serde_json::json;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_json, method, path},
+    };
 
     fn create_test_config() -> Config {
         Config::builder()
@@ -114,6 +140,7 @@ mod tests {
         let builder = AppAccessTokenBuilder::new(config);
         assert!(builder.app_id.is_empty());
         assert!(builder.app_secret.is_empty());
+        assert!(builder.app_ticket.is_empty());
     }
 
     #[test]
@@ -121,9 +148,11 @@ mod tests {
         let config = create_test_config();
         let builder = AppAccessTokenBuilder::new(config)
             .app_id("my_app_id")
-            .app_secret("my_app_secret");
+            .app_secret("my_app_secret")
+            .app_ticket("my_app_ticket");
         assert_eq!(builder.app_id, "my_app_id");
         assert_eq!(builder.app_secret, "my_app_secret");
+        assert_eq!(builder.app_ticket, "my_app_ticket");
     }
 
     #[test]
@@ -141,8 +170,15 @@ mod tests {
     }
 
     #[test]
+    fn test_app_access_token_builder_app_ticket_chained() {
+        let config = create_test_config();
+        let builder = AppAccessTokenBuilder::new(config).app_ticket("chained_ticket");
+        assert_eq!(builder.app_ticket, "chained_ticket");
+    }
+
+    #[test]
     fn test_app_access_token_response_data_deserialization() {
-        let json = r#"{"data":{"app_access_token":"token123","expires_in":7200,"tenant_key":"test_tenant"}}"#;
+        let json = r#"{"code":0,"msg":"success","app_access_token":"token123","expire":7200,"tenant_key":"test_tenant"}"#;
         let response: AppAccessTokenResponseData =
             serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.data.app_access_token, "token123");
@@ -154,7 +190,47 @@ mod tests {
     fn test_app_access_token_response_data_format() {
         assert_eq!(
             AppAccessTokenResponseData::data_format(),
-            ResponseFormat::Data
+            ResponseFormat::Flatten
         );
+    }
+
+    #[tokio::test]
+    async fn test_execute_sends_app_ticket_and_no_authorization() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/auth/v3/app_access_token"))
+            .and(body_json(json!({
+                "app_id": "test_app",
+                "app_secret": "test_secret",
+                "app_ticket": "ticket-001"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "app_access_token": "market-app-token",
+                "expire": 7200
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("test_app")
+            .app_secret("test_secret")
+            .base_url(server.uri())
+            .build();
+
+        let response = AppAccessTokenBuilder::new(config)
+            .app_id("test_app")
+            .app_secret("test_secret")
+            .app_ticket("ticket-001")
+            .execute()
+            .await
+            .expect("app_access_token 请求应成功");
+
+        assert_eq!(response.data.app_access_token, "market-app-token");
+
+        let received_requests = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received_requests.len(), 1);
+        assert!(!received_requests[0].headers.contains_key("authorization"));
     }
 }

--- a/crates/openlark-auth/src/auth/auth/v3/auth/app_access_token_internal.rs
+++ b/crates/openlark-auth/src/auth/auth/v3/auth/app_access_token_internal.rs
@@ -7,6 +7,7 @@ use openlark_core::{
     SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
+    constants::AccessTokenType,
     http::Transport,
     req_option::RequestOption,
     validate_required,
@@ -23,6 +24,7 @@ pub struct AppAccessTokenInternalBuilder {
 
 /// 自建应用获取 app_access_token 响应
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(transparent)]
 pub struct AppAccessTokenInternalResponseData {
     /// 应用访问令牌响应
     pub data: AccessTokenResponse,
@@ -30,7 +32,7 @@ pub struct AppAccessTokenInternalResponseData {
 
 impl ApiResponseTrait for AppAccessTokenInternalResponseData {
     fn data_format() -> ResponseFormat {
-        ResponseFormat::Data
+        ResponseFormat::Flatten
     }
 }
 
@@ -82,7 +84,9 @@ impl AppAccessTokenInternalBuilder {
 
         // 创建API请求 - 使用类型安全的URL生成
         let api_request: ApiRequest<AppAccessTokenInternalResponseData> =
-            ApiRequest::post(api_endpoint.path()).body(serde_json::to_value(&request_body)?);
+            ApiRequest::post(api_endpoint.path())
+                .body(serde_json::to_value(&request_body)?)
+                .with_supported_access_token_types(vec![AccessTokenType::None]);
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
@@ -97,6 +101,11 @@ impl AppAccessTokenInternalBuilder {
 mod tests {
     use super::*;
     use openlark_core::config::Config;
+    use serde_json::json;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_json, method, path},
+    };
 
     fn create_test_config() -> Config {
         Config::builder()
@@ -127,7 +136,56 @@ mod tests {
     fn test_app_access_token_internal_response_data_format() {
         assert_eq!(
             AppAccessTokenInternalResponseData::data_format(),
-            ResponseFormat::Data
+            ResponseFormat::Flatten
         );
+    }
+
+    #[test]
+    fn test_app_access_token_internal_response_data_deserialization() {
+        let json = r#"{"code":0,"msg":"success","app_access_token":"token123","expire":7200,"tenant_access_token":"tenant123"}"#;
+        let response: AppAccessTokenInternalResponseData =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
+
+        assert_eq!(response.data.app_access_token, "token123");
+        assert_eq!(response.data.expires_in, 7200);
+    }
+
+    #[tokio::test]
+    async fn test_execute_uses_official_body_without_authorization() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/auth/v3/app_access_token/internal"))
+            .and(body_json(json!({
+                "app_id": "test_app",
+                "app_secret": "test_secret"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "app_access_token": "app-token",
+                "expire": 7200,
+                "tenant_access_token": "tenant-token"
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("test_app")
+            .app_secret("test_secret")
+            .base_url(server.uri())
+            .build();
+
+        let response = AppAccessTokenInternalBuilder::new(config)
+            .app_id("test_app")
+            .app_secret("test_secret")
+            .execute()
+            .await
+            .expect("app_access_token_internal 请求应成功");
+
+        assert_eq!(response.data.app_access_token, "app-token");
+
+        let received_requests = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received_requests.len(), 1);
+        assert!(!received_requests[0].headers.contains_key("authorization"));
     }
 }

--- a/crates/openlark-auth/src/auth/auth/v3/auth/app_ticket_resend.rs
+++ b/crates/openlark-auth/src/auth/auth/v3/auth/app_ticket_resend.rs
@@ -10,6 +10,7 @@ use openlark_core::{
     SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
+    constants::AccessTokenType,
     http::Transport,
     req_option::RequestOption,
     validate_required,
@@ -26,6 +27,7 @@ pub struct AppTicketResendBuilder {
 
 /// 重新获取 app_ticket 响应
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(transparent)]
 pub struct AppTicketResendResponseData {
     /// 应用票据响应
     pub data: AppTicketResponse,
@@ -33,7 +35,7 @@ pub struct AppTicketResendResponseData {
 
 impl ApiResponseTrait for AppTicketResendResponseData {
     fn data_format() -> ResponseFormat {
-        ResponseFormat::Data
+        ResponseFormat::Flatten
     }
 }
 
@@ -85,7 +87,9 @@ impl AppTicketResendBuilder {
 
         // 创建API请求 - 使用类型安全的URL生成
         let api_request: ApiRequest<AppTicketResendResponseData> =
-            ApiRequest::post(api_endpoint.path()).body(serde_json::to_value(&request_body)?);
+            ApiRequest::post(api_endpoint.path())
+                .body(serde_json::to_value(&request_body)?)
+                .with_supported_access_token_types(vec![AccessTokenType::None]);
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
@@ -100,6 +104,11 @@ impl AppTicketResendBuilder {
 mod tests {
     use super::*;
     use openlark_core::config::Config;
+    use serde_json::json;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_json, method, path},
+    };
 
     fn create_test_config() -> Config {
         Config::builder()
@@ -130,7 +139,55 @@ mod tests {
     fn test_app_ticket_resend_response_data_format() {
         assert_eq!(
             AppTicketResendResponseData::data_format(),
-            ResponseFormat::Data
+            ResponseFormat::Flatten
         );
+    }
+
+    #[test]
+    fn test_app_ticket_resend_response_data_deserialization() {
+        let json = r#"{"code":0,"msg":"success"}"#;
+        let response: AppTicketResendResponseData =
+            serde_json::from_str(json).expect("JSON 反序列化失败");
+
+        assert!(response.data.success);
+        assert_eq!(response.data.app_ticket, "");
+        assert_eq!(response.data.error_message, Some("success".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_execute_uses_official_body_without_authorization() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/auth/v3/app_ticket/resend"))
+            .and(body_json(json!({
+                "app_id": "test_app",
+                "app_secret": "test_secret"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success"
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("test_app")
+            .app_secret("test_secret")
+            .base_url(server.uri())
+            .build();
+
+        let response = AppTicketResendBuilder::new(config)
+            .app_id("test_app")
+            .app_secret("test_secret")
+            .execute()
+            .await
+            .expect("app_ticket_resend 请求应成功");
+
+        assert!(response.data.success);
+        assert_eq!(response.data.error_message, Some("success".to_string()));
+
+        let received_requests = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received_requests.len(), 1);
+        assert!(!received_requests[0].headers.contains_key("authorization"));
     }
 }

--- a/crates/openlark-auth/src/auth/auth/v3/auth/tenant_access_token.rs
+++ b/crates/openlark-auth/src/auth/auth/v3/auth/tenant_access_token.rs
@@ -1,6 +1,7 @@
 //! 商店应用获取 tenant_access_token API
 //! docPath: https://open.feishu.cn/document/server-docs/authentication-management/access-token/tenant_access_token
-use crate::models::auth::{TenantAccessTokenRequest, TenantAccessTokenResponse};
+use super::app_access_token::AppAccessTokenResponseData;
+use crate::models::auth::TenantAccessTokenResponse;
 ///
 /// API文档: https://open.feishu.cn/document/server-docs/authentication-management/access-token/tenant_access_token
 ///
@@ -10,23 +11,40 @@ use openlark_core::{
     SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
+    constants::AccessTokenType,
     http::Transport,
     req_option::RequestOption,
     validate_required,
 };
 use serde::{Deserialize, Serialize};
 
-/// 商店应用获取 tenant_access_token 请求
-pub struct TenantAccessTokenBuilder {
+#[derive(Debug, Serialize)]
+struct TenantAccessTokenBody {
+    app_access_token: String,
+    tenant_key: String,
+}
+
+#[derive(Debug, Serialize)]
+struct LegacyAppAccessTokenBody {
     app_id: String,
     app_secret: String,
     app_ticket: String,
+}
+
+/// 商店应用获取 tenant_access_token 请求
+pub struct TenantAccessTokenBuilder {
+    app_access_token: String,
+    tenant_key: String,
+    legacy_app_id: String,
+    legacy_app_secret: String,
+    legacy_app_ticket: String,
     /// 配置信息
     config: Config,
 }
 
 /// 商店应用获取 tenant_access_token 响应
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(transparent)]
 pub struct TenantAccessTokenResponseData {
     /// 租户访问令牌响应
     pub data: TenantAccessTokenResponse,
@@ -34,7 +52,7 @@ pub struct TenantAccessTokenResponseData {
 
 impl ApiResponseTrait for TenantAccessTokenResponseData {
     fn data_format() -> ResponseFormat {
-        ResponseFormat::Data
+        ResponseFormat::Flatten
     }
 }
 
@@ -42,28 +60,45 @@ impl TenantAccessTokenBuilder {
     /// 创建 tenant_access_token 请求
     pub fn new(config: Config) -> Self {
         Self {
-            app_id: String::new(),
-            app_secret: String::new(),
-            app_ticket: String::new(),
+            app_access_token: String::new(),
+            tenant_key: String::new(),
+            legacy_app_id: String::new(),
+            legacy_app_secret: String::new(),
+            legacy_app_ticket: String::new(),
             config,
         }
     }
 
-    /// 设置应用 ID
+    /// 设置应用访问凭证
+    pub fn app_access_token(mut self, app_access_token: impl Into<String>) -> Self {
+        self.app_access_token = app_access_token.into();
+        self
+    }
+
+    /// 设置租户标识
+    pub fn tenant_key(mut self, tenant_key: impl Into<String>) -> Self {
+        self.tenant_key = tenant_key.into();
+        self
+    }
+
+    /// 旧版 app_id 链式入口，保留用于编译兼容。
+    #[deprecated(note = "请改用 app_access_token(...) 并设置 tenant_key(...)")]
     pub fn app_id(mut self, app_id: impl Into<String>) -> Self {
-        self.app_id = app_id.into();
+        self.legacy_app_id = app_id.into();
         self
     }
 
-    /// 设置应用密钥
+    /// 旧版 app_secret 链式入口，保留用于编译兼容。
+    #[deprecated(note = "请改用 app_access_token(...) 并设置 tenant_key(...)")]
     pub fn app_secret(mut self, app_secret: impl Into<String>) -> Self {
-        self.app_secret = app_secret.into();
+        self.legacy_app_secret = app_secret.into();
         self
     }
 
-    /// 设置应用票据（商店应用必需）
+    /// 旧版 app_ticket 链式入口，保留用于编译兼容。
+    #[deprecated(note = "请先通过 app_ticket 换取 app_access_token，再调用 app_access_token(...)")]
     pub fn app_ticket(mut self, app_ticket: impl Into<String>) -> Self {
-        self.app_ticket = app_ticket.into();
+        self.legacy_app_ticket = app_ticket.into();
         self
     }
 
@@ -77,25 +112,55 @@ impl TenantAccessTokenBuilder {
         self,
         option: RequestOption,
     ) -> SDKResult<TenantAccessTokenResponseData> {
-        // 验证必填字段
-        validate_required!(self.app_id, "应用ID不能为空");
-        validate_required!(self.app_secret, "应用密钥不能为空");
-        validate_required!(self.app_ticket, "应用票据不能为空");
+        validate_required!(self.tenant_key, "租户标识不能为空");
 
         // 🚀 使用新的enum+builder系统生成API端点
         use crate::common::api_endpoints::AuthApiV3;
         let api_endpoint = AuthApiV3::TenantAccessToken;
 
+        let app_access_token = if self.app_access_token.is_empty() {
+            validate_required!(self.legacy_app_id, "应用ID不能为空");
+            validate_required!(self.legacy_app_secret, "应用密钥不能为空");
+            validate_required!(self.legacy_app_ticket, "应用票据不能为空");
+
+            let app_token_body = LegacyAppAccessTokenBody {
+                app_id: self.legacy_app_id.clone(),
+                app_secret: self.legacy_app_secret.clone(),
+                app_ticket: self.legacy_app_ticket.clone(),
+            };
+
+            let app_token_request: ApiRequest<AppAccessTokenResponseData> =
+                ApiRequest::post(AuthApiV3::AppAccessToken.path())
+                    .body(serde_json::to_value(&app_token_body)?)
+                    .with_supported_access_token_types(vec![AccessTokenType::None]);
+
+            let app_token_response: openlark_core::api::Response<AppAccessTokenResponseData> =
+                Transport::request(app_token_request, &self.config, Some(option.clone())).await?;
+            app_token_response
+                .data
+                .ok_or_else(|| {
+                    openlark_core::error::validation_error(
+                        "获取商店应用 app_access_token",
+                        "响应数据为空",
+                    )
+                })?
+                .data
+                .app_access_token
+        } else {
+            self.app_access_token.clone()
+        };
+
         // 构建请求体
-        let request_body = TenantAccessTokenRequest {
-            app_id: self.app_id.clone(),
-            app_secret: self.app_secret.clone(),
-            app_ticket: self.app_ticket.clone(),
+        let request_body = TenantAccessTokenBody {
+            app_access_token,
+            tenant_key: self.tenant_key.clone(),
         };
 
         // 创建API请求 - 使用类型安全的URL生成
         let api_request: ApiRequest<TenantAccessTokenResponseData> =
-            ApiRequest::post(api_endpoint.path()).body(serde_json::to_value(&request_body)?);
+            ApiRequest::post(api_endpoint.path())
+                .body(serde_json::to_value(&request_body)?)
+                .with_supported_access_token_types(vec![AccessTokenType::None]);
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
@@ -113,6 +178,11 @@ impl TenantAccessTokenBuilder {
 mod tests {
     use super::*;
     use openlark_core::config::Config;
+    use serde_json::json;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_json, method, path},
+    };
 
     fn create_test_config() -> Config {
         Config::builder()
@@ -125,47 +195,41 @@ mod tests {
     fn test_tenant_access_token_builder_new() {
         let config = create_test_config();
         let builder = TenantAccessTokenBuilder::new(config);
-        assert!(builder.app_id.is_empty());
-        assert!(builder.app_secret.is_empty());
-        assert!(builder.app_ticket.is_empty());
+        assert!(builder.app_access_token.is_empty());
+        assert!(builder.tenant_key.is_empty());
+        assert!(builder.legacy_app_id.is_empty());
+        assert!(builder.legacy_app_secret.is_empty());
+        assert!(builder.legacy_app_ticket.is_empty());
     }
 
     #[test]
     fn test_tenant_access_token_builder_chain() {
         let config = create_test_config();
         let builder = TenantAccessTokenBuilder::new(config)
-            .app_id("my_app_id")
-            .app_secret("my_app_secret")
-            .app_ticket("my_app_ticket");
-        assert_eq!(builder.app_id, "my_app_id");
-        assert_eq!(builder.app_secret, "my_app_secret");
-        assert_eq!(builder.app_ticket, "my_app_ticket");
+            .app_access_token("my_app_access_token")
+            .tenant_key("my_tenant_key");
+        assert_eq!(builder.app_access_token, "my_app_access_token");
+        assert_eq!(builder.tenant_key, "my_tenant_key");
     }
 
     #[test]
-    fn test_tenant_access_token_builder_app_id_chained() {
+    fn test_tenant_access_token_builder_app_access_token_chained() {
         let config = create_test_config();
-        let builder = TenantAccessTokenBuilder::new(config).app_id("chained_app_id");
-        assert_eq!(builder.app_id, "chained_app_id");
+        let builder =
+            TenantAccessTokenBuilder::new(config).app_access_token("chained_app_access_token");
+        assert_eq!(builder.app_access_token, "chained_app_access_token");
     }
 
     #[test]
-    fn test_tenant_access_token_builder_app_secret_chained() {
+    fn test_tenant_access_token_builder_tenant_key_chained() {
         let config = create_test_config();
-        let builder = TenantAccessTokenBuilder::new(config).app_secret("chained_secret");
-        assert_eq!(builder.app_secret, "chained_secret");
-    }
-
-    #[test]
-    fn test_tenant_access_token_builder_app_ticket_chained() {
-        let config = create_test_config();
-        let builder = TenantAccessTokenBuilder::new(config).app_ticket("chained_ticket");
-        assert_eq!(builder.app_ticket, "chained_ticket");
+        let builder = TenantAccessTokenBuilder::new(config).tenant_key("chained_tenant_key");
+        assert_eq!(builder.tenant_key, "chained_tenant_key");
     }
 
     #[test]
     fn test_tenant_access_token_response_data_deserialization() {
-        let json = r#"{"data":{"tenant_access_token":"token123","expires_in":7200}}"#;
+        let json = r#"{"code":0,"msg":"success","tenant_access_token":"token123","expire":7200}"#;
         let response: TenantAccessTokenResponseData =
             serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.data.tenant_access_token, "token123");
@@ -176,7 +240,106 @@ mod tests {
     fn test_tenant_access_token_response_data_format() {
         assert_eq!(
             TenantAccessTokenResponseData::data_format(),
-            ResponseFormat::Data
+            ResponseFormat::Flatten
+        );
+    }
+
+    #[tokio::test]
+    async fn test_execute_sends_app_token_tenant_key_and_no_authorization() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/auth/v3/tenant_access_token"))
+            .and(body_json(json!({
+                "app_access_token": "app-token",
+                "tenant_key": "tenant-001"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "tenant_access_token": "tenant-token",
+                "expire": 7200
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("test_app")
+            .app_secret("test_secret")
+            .base_url(server.uri())
+            .build();
+
+        let response = TenantAccessTokenBuilder::new(config)
+            .app_access_token("app-token")
+            .tenant_key("tenant-001")
+            .execute()
+            .await
+            .expect("tenant_access_token 请求应成功");
+
+        assert_eq!(response.data.tenant_access_token, "tenant-token");
+
+        let received_requests = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received_requests.len(), 1);
+        assert!(!received_requests[0].headers.contains_key("authorization"));
+    }
+
+    #[allow(deprecated)]
+    #[tokio::test]
+    async fn test_execute_legacy_chain_fetches_app_token_then_tenant_token() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/auth/v3/app_access_token"))
+            .and(body_json(json!({
+                "app_id": "legacy_app",
+                "app_secret": "legacy_secret",
+                "app_ticket": "legacy_ticket"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "app_access_token": "legacy-app-token",
+                "expire": 7200
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/open-apis/auth/v3/tenant_access_token"))
+            .and(body_json(json!({
+                "app_access_token": "legacy-app-token",
+                "tenant_key": "tenant-001"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "tenant_access_token": "tenant-token",
+                "expire": 7200
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("test_app")
+            .app_secret("test_secret")
+            .base_url(server.uri())
+            .build();
+
+        let response = TenantAccessTokenBuilder::new(config)
+            .app_id("legacy_app")
+            .app_secret("legacy_secret")
+            .app_ticket("legacy_ticket")
+            .tenant_key("tenant-001")
+            .execute()
+            .await
+            .expect("legacy tenant_access_token chain should use official two-step flow");
+
+        assert_eq!(response.data.tenant_access_token, "tenant-token");
+
+        let received_requests = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received_requests.len(), 2);
+        assert!(
+            received_requests
+                .iter()
+                .all(|request| !request.headers.contains_key("authorization"))
         );
     }
 }

--- a/crates/openlark-auth/src/auth/auth/v3/auth/tenant_access_token_internal.rs
+++ b/crates/openlark-auth/src/auth/auth/v3/auth/tenant_access_token_internal.rs
@@ -7,6 +7,7 @@ use openlark_core::{
     SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
+    constants::AccessTokenType,
     http::Transport,
     req_option::RequestOption,
     validate_required,
@@ -23,6 +24,7 @@ pub struct TenantAccessTokenInternalRequestBuilder {
 
 /// 自建应用获取 tenant_access_token 响应
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(transparent)]
 pub struct TenantAccessTokenInternalResponseData {
     /// 租户访问令牌响应
     pub data: TenantAccessTokenResponse,
@@ -30,7 +32,7 @@ pub struct TenantAccessTokenInternalResponseData {
 
 impl ApiResponseTrait for TenantAccessTokenInternalResponseData {
     fn data_format() -> ResponseFormat {
-        ResponseFormat::Data
+        ResponseFormat::Flatten
     }
 }
 
@@ -82,7 +84,9 @@ impl TenantAccessTokenInternalRequestBuilder {
 
         // 创建API请求 - 使用类型安全的URL生成
         let api_request: ApiRequest<TenantAccessTokenInternalResponseData> =
-            ApiRequest::post(api_endpoint.path()).body(serde_json::to_value(&request_body)?);
+            ApiRequest::post(api_endpoint.path())
+                .body(serde_json::to_value(&request_body)?)
+                .with_supported_access_token_types(vec![AccessTokenType::None]);
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
@@ -100,6 +104,11 @@ impl TenantAccessTokenInternalRequestBuilder {
 mod tests {
     use super::*;
     use openlark_core::config::Config;
+    use serde_json::json;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_json, method, path},
+    };
 
     fn create_test_config() -> Config {
         Config::builder()
@@ -130,16 +139,55 @@ mod tests {
     fn test_tenant_access_token_internal_response_data_format() {
         assert_eq!(
             TenantAccessTokenInternalResponseData::data_format(),
-            ResponseFormat::Data
+            ResponseFormat::Flatten
         );
     }
 
     #[test]
     fn test_tenant_access_token_internal_response_deserialization() {
-        let json = r#"{"data":{"tenant_access_token":"tenant_token","expires_in":7200}}"#;
+        let json =
+            r#"{"code":0,"msg":"success","tenant_access_token":"tenant_token","expire":7200}"#;
         let response: TenantAccessTokenInternalResponseData =
             serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(response.data.tenant_access_token, "tenant_token");
         assert_eq!(response.data.expires_in, 7200);
+    }
+
+    #[tokio::test]
+    async fn test_execute_uses_official_body_without_authorization() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/auth/v3/tenant_access_token/internal"))
+            .and(body_json(json!({
+                "app_id": "test_app",
+                "app_secret": "test_secret"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "tenant_access_token": "tenant-token",
+                "expire": 7200
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("test_app")
+            .app_secret("test_secret")
+            .base_url(server.uri())
+            .build();
+
+        let response = TenantAccessTokenInternalRequestBuilder::new(config)
+            .app_id("test_app")
+            .app_secret("test_secret")
+            .execute()
+            .await
+            .expect("tenant_access_token_internal 请求应成功");
+
+        assert_eq!(response.data.tenant_access_token, "tenant-token");
+
+        let received_requests = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received_requests.len(), 1);
+        assert!(!received_requests[0].headers.contains_key("authorization"));
     }
 }

--- a/crates/openlark-auth/src/auth/authen/v1/user_info/get.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/user_info/get.rs
@@ -9,6 +9,7 @@ use openlark_core::{
     SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
+    constants::AccessTokenType,
     http::Transport,
     req_option::RequestOption,
     validate_required,
@@ -32,7 +33,7 @@ pub struct UserInfoResponseData {
 
 impl ApiResponseTrait for UserInfoResponseData {
     fn data_format() -> ResponseFormat {
-        ResponseFormat::Data
+        ResponseFormat::Flatten
     }
 }
 
@@ -75,15 +76,13 @@ impl UserInfoBuilder {
         use crate::common::api_endpoints::AuthenApiV1;
         let api_endpoint = AuthenApiV1::UserInfo;
 
-        // 创建API请求 - 使用类型安全的URL生成
         let mut api_request: ApiRequest<UserInfoResponseData> =
-            ApiRequest::get(api_endpoint.path());
-
-        // 添加Authorization头
-        api_request.headers_mut().insert(
-            "Authorization".to_string(),
-            format!("Bearer {}", self.user_access_token),
-        );
+            ApiRequest::get(api_endpoint.path())
+                .header(
+                    "Authorization",
+                    format!("Bearer {}", self.user_access_token),
+                )
+                .with_supported_access_token_types(vec![AccessTokenType::None]);
 
         // 添加查询参数
         if let Some(ref user_id_type) = self.user_id_type {
@@ -126,6 +125,11 @@ impl UserInfoService {
 mod tests {
     use super::*;
     use openlark_core::config::Config;
+    use serde_json::json;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{header, method, path, query_param},
+    };
 
     fn create_test_config() -> Config {
         Config::builder()
@@ -168,17 +172,50 @@ mod tests {
 
     #[test]
     fn test_user_info_response_data_deserialization() {
-        let json = r#"{"data":{"data":{"open_id":"ou_def456","union_id":"on_abc123","name":"张三","en_name":"John Zhang"}}}"#;
+        let json = r#"{"code":0,"msg":"success","data":{"open_id":"ou_def456","union_id":"on_abc123","name":"张三","en_name":"John Zhang"}}"#;
         let response: UserInfoResponseData = serde_json::from_str(json).expect("JSON 反序列化失败");
+        assert_eq!(response.data.open_id, "ou_def456");
         assert_eq!(response.data.data.open_id, "ou_def456");
-        assert_eq!(response.data.data.union_id, Some("on_abc123".to_string()));
-        assert_eq!(response.data.data.name, Some("张三".to_string()));
-        assert_eq!(response.data.data.en_name, Some("John Zhang".to_string()));
+        assert_eq!(response.data.union_id, Some("on_abc123".to_string()));
+        assert_eq!(response.data.name, Some("张三".to_string()));
+        assert_eq!(response.data.en_name, Some("John Zhang".to_string()));
+    }
+
+    #[test]
+    fn test_user_info_response_preserves_wrapper_construction() {
+        let response = UserInfoResponseData {
+            data: UserInfoResponse {
+                data: crate::models::authen::UserInfo {
+                    open_id: "ou_compat".to_string(),
+                    union_id: None,
+                    user_id: None,
+                    name: None,
+                    en_name: None,
+                    email: None,
+                    enterprise_email: None,
+                    mobile: None,
+                    avatar_url: None,
+                    avatar: None,
+                    status: None,
+                    department_ids: None,
+                    group_ids: None,
+                    positions: None,
+                    employee_no: None,
+                    dingtalk_user_id: None,
+                    enterprise_extension: None,
+                    custom_attrs: None,
+                    tenant_key: None,
+                },
+            },
+        };
+
+        assert_eq!(response.data.open_id, "ou_compat");
+        assert_eq!(response.data.data.open_id, "ou_compat");
     }
 
     #[test]
     fn test_user_info_response_data_format() {
-        assert_eq!(UserInfoResponseData::data_format(), ResponseFormat::Data);
+        assert_eq!(UserInfoResponseData::data_format(), ResponseFormat::Flatten);
     }
 
     #[test]
@@ -194,5 +231,75 @@ mod tests {
         let service = UserInfoService::new(config);
         let builder = service.get();
         assert!(builder.user_access_token.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_execute_sends_user_token_query_and_parses_top_level_user_info() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/authen/v1/user_info"))
+            .and(header("authorization", "Bearer user_token"))
+            .and(query_param("user_id_type", "open_id"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "open_id": "ou_def456",
+                    "union_id": "on_abc123",
+                    "name": "张三",
+                    "en_name": "John Zhang"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("test_app")
+            .app_secret("test_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let response = UserInfoBuilder::new(config)
+            .user_access_token("user_token")
+            .user_id_type("open_id")
+            .execute()
+            .await
+            .expect("user_info 请求应成功");
+
+        assert_eq!(response.data.open_id, "ou_def456");
+        assert_eq!(response.data.data.open_id, "ou_def456");
+        assert_eq!(response.data.union_id, Some("on_abc123".to_string()));
+        assert_eq!(response.data.name, Some("张三".to_string()));
+        assert_eq!(response.data.en_name, Some("John Zhang".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_execute_missing_user_access_token_fails_before_network() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/authen/v1/user_info"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "open_id": "ou_unexpected"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("test_app")
+            .app_secret("test_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let result = UserInfoBuilder::new(config).execute().await;
+
+        assert!(result.is_err());
+        let received_requests = server.received_requests().await.unwrap_or_default();
+        assert!(received_requests.is_empty());
     }
 }

--- a/crates/openlark-auth/src/models/auth/mod.rs
+++ b/crates/openlark-auth/src/models/auth/mod.rs
@@ -6,16 +6,23 @@ use chrono::{DateTime, Utc};
 use openlark_core::api::responses::ApiResponseTrait;
 use serde::{Deserialize, Serialize};
 
+fn default_app_ticket_resend_success() -> bool {
+    true
+}
+
 /// 访问令牌响应
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AccessTokenResponse {
     /// 应用访问令牌
     pub app_access_token: String,
     /// 令牌有效期（秒）
+    #[serde(alias = "expire")]
     pub expires_in: u64,
     /// 租户标识（租户在飞书上的唯一标识）
+    #[serde(default)]
     pub tenant_key: String,
     /// 令牌类型
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_type: Option<String>,
 }
 
@@ -25,8 +32,10 @@ pub struct TenantAccessTokenResponse {
     /// 租户访问令牌
     pub tenant_access_token: String,
     /// 令牌有效期（秒）
+    #[serde(alias = "expire")]
     pub expires_in: u64,
     /// 令牌类型
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_type: Option<String>,
 }
 
@@ -34,10 +43,13 @@ pub struct TenantAccessTokenResponse {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AppTicketResponse {
     /// 应用票据
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub app_ticket: String,
     /// 操作结果
+    #[serde(default = "default_app_ticket_resend_success")]
     pub success: bool,
     /// 错误信息
+    #[serde(default, alias = "msg", skip_serializing_if = "Option::is_none")]
     pub error_message: Option<String>,
 }
 

--- a/crates/openlark-auth/src/models/authen/mod.rs
+++ b/crates/openlark-auth/src/models/authen/mod.rs
@@ -4,7 +4,8 @@
 
 use chrono::{DateTime, Utc};
 use openlark_core::api::responses::ApiResponseTrait;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::ops::Deref;
 
 mod token;
 
@@ -14,10 +15,30 @@ pub use token::{
 };
 
 /// 用户信息响应
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct UserInfoResponse {
     /// 用户信息
     pub data: UserInfo,
+}
+
+impl<'de> Deserialize<'de> for UserInfoResponse {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let data_value = value.get("data").cloned().unwrap_or(value);
+        let data = UserInfo::deserialize(data_value).map_err(serde::de::Error::custom)?;
+        Ok(Self { data })
+    }
+}
+
+impl Deref for UserInfoResponse {
+    type Target = UserInfo;
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
 }
 
 /// 用户信息

--- a/crates/openlark-auth/src/token_provider.rs
+++ b/crates/openlark-auth/src/token_provider.rs
@@ -12,7 +12,9 @@ use openlark_core::{
 };
 use serde_json::{Value, json};
 use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
 use std::future::Future;
+use std::hash::{Hash, Hasher};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -89,6 +91,12 @@ impl AuthTokenProvider {
     }
 
     /// 生成缓存键
+    fn cache_key_component(value: &str) -> String {
+        let mut hasher = DefaultHasher::new();
+        value.hash(&mut hasher);
+        format!("{:016x}", hasher.finish())
+    }
+
     fn cache_key(
         token_type: &AccessTokenType,
         app_type: &AppType,
@@ -101,7 +109,8 @@ impl AuthTokenProvider {
             }
             AccessTokenType::App if app_type == &AppType::Marketplace => {
                 let app_ticket = request.app_ticket.as_deref().unwrap_or("default");
-                format!("{token_type:?}_{app_type:?}_{app_ticket}")
+                let app_ticket_key = Self::cache_key_component(app_ticket);
+                format!("{token_type:?}_{app_type:?}_{app_ticket_key}")
             }
             _ => format!("{token_type:?}_{app_type:?}"),
         }
@@ -212,11 +221,18 @@ impl TokenProvider for AuthTokenProvider {
                                 .await?
                             }
                             AppType::Marketplace => {
+                                let app_ticket = request.app_ticket.clone().ok_or_else(|| {
+                                    configuration_error(
+                                        "token_provider: marketplace app requires app_ticket to fetch app_access_token",
+                                    )
+                                })?;
+
                                 self.fetch_token_via_http(
                                     "/open-apis/auth/v3/app_access_token",
                                     json!({
                                         "app_id": self.config.app_id(),
                                         "app_secret": self.config.app_secret(),
+                                        "app_ticket": app_ticket,
                                     }),
                                     "app_access_token",
                                 )
@@ -234,40 +250,47 @@ impl TokenProvider for AuthTokenProvider {
                         &request,
                     );
                     self.get_or_fetch(cache_key, || async {
-                    let (token, expires_in) = match self.config.app_type() {
-                        AppType::SelfBuild => {
-                            self.fetch_token_via_http(
-                                "/open-apis/auth/v3/tenant_access_token/internal",
-                                json!({
-                                    "app_id": self.config.app_id(),
-                                    "app_secret": self.config.app_secret(),
-                                }),
-                                "tenant_access_token",
-                            )
-                            .await?
-                        }
-                        AppType::Marketplace => {
-                            let app_ticket = request.app_ticket.clone().ok_or_else(|| {
-                                configuration_error(
-                                    "token_provider: marketplace app requires app_ticket to fetch tenant_access_token",
+                        let (token, expires_in) = match self.config.app_type() {
+                            AppType::SelfBuild => {
+                                self.fetch_token_via_http(
+                                    "/open-apis/auth/v3/tenant_access_token/internal",
+                                    json!({
+                                        "app_id": self.config.app_id(),
+                                        "app_secret": self.config.app_secret(),
+                                    }),
+                                    "tenant_access_token",
                                 )
-                            })?;
+                                .await?
+                            }
+                            AppType::Marketplace => {
+                                let tenant_key = request.tenant_key.clone().ok_or_else(|| {
+                                    configuration_error(
+                                        "token_provider: marketplace app requires tenant_key to fetch tenant_access_token",
+                                    )
+                                })?;
+                                let app_ticket = request.app_ticket.clone().ok_or_else(|| {
+                                    configuration_error(
+                                        "token_provider: marketplace app requires app_ticket to fetch tenant_access_token",
+                                    )
+                                })?;
+                                let app_access_token =
+                                    self.get_token(TokenRequest::app().app_ticket(app_ticket))
+                                        .await?;
 
-                            self.fetch_token_via_http(
-                                "/open-apis/auth/v3/tenant_access_token",
-                                json!({
-                                    "app_id": self.config.app_id(),
-                                    "app_secret": self.config.app_secret(),
-                                    "app_ticket": app_ticket,
-                                }),
-                                "tenant_access_token",
-                            )
-                            .await?
-                        }
-                    };
-                    Ok((token, expires_in))
-                })
-                .await
+                                self.fetch_token_via_http(
+                                    "/open-apis/auth/v3/tenant_access_token",
+                                    json!({
+                                        "app_access_token": app_access_token,
+                                        "tenant_key": tenant_key,
+                                    }),
+                                    "tenant_access_token",
+                                )
+                                .await?
+                            }
+                        };
+                        Ok((token, expires_in))
+                    })
+                    .await
                 }
                 AccessTokenType::User => Err(configuration_error(
                     "token_provider: user token 不应由 core 自动获取，请在 RequestOption 中显式传入 user_access_token（或由上层自行实现 TokenProvider 扩展）。",
@@ -281,55 +304,4 @@ impl TokenProvider for AuthTokenProvider {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-    use super::AuthTokenProvider;
-    use openlark_core::{
-        auth::{TokenProvider, TokenRequest},
-        config::Config,
-        constants::AppType,
-    };
-
-    #[tokio::test]
-    async fn tenant_token_fetch_no_longer_uses_noop_provider() {
-        let config = Config::builder()
-            .app_id("test_app_id")
-            .app_secret("test_app_secret")
-            .base_url("http://127.0.0.1:9")
-            .build();
-
-        let provider = AuthTokenProvider::new(config);
-        let err = provider
-            .get_token(TokenRequest::tenant())
-            .await
-            .expect_err("should fail on unreachable test endpoint");
-
-        assert!(!err.to_string().contains("NoOpTokenProvider"));
-    }
-
-    #[tokio::test]
-    async fn tenant_cache_key_should_include_tenant_key() {
-        let request = TokenRequest::tenant().tenant_key("tenant_key_001");
-
-        let key = AuthTokenProvider::cache_key(
-            &openlark_core::constants::AccessTokenType::Tenant,
-            &AppType::SelfBuild,
-            &request,
-        );
-
-        assert_eq!(key, "Tenant_SelfBuild_tenant_key_001");
-    }
-
-    #[tokio::test]
-    async fn app_cache_key_should_include_app_ticket_for_marketplace() {
-        let request = TokenRequest::app().app_ticket("ticket_001");
-
-        let key = AuthTokenProvider::cache_key(
-            &openlark_core::constants::AccessTokenType::App,
-            &AppType::Marketplace,
-            &request,
-        );
-
-        assert_eq!(key, "App_Marketplace_ticket_001");
-    }
-}
+mod tests;

--- a/crates/openlark-auth/src/token_provider/tests.rs
+++ b/crates/openlark-auth/src/token_provider/tests.rs
@@ -1,0 +1,152 @@
+use super::AuthTokenProvider;
+use openlark_core::{
+    auth::{TokenProvider, TokenRequest},
+    config::Config,
+    constants::{AccessTokenType, AppType},
+};
+use serde_json::json;
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{body_json, method, path},
+};
+
+fn marketplace_config(base_url: impl Into<String>) -> Config {
+    Config::builder()
+        .app_id("test_app_id")
+        .app_secret("test_app_secret")
+        .app_type(AppType::Marketplace)
+        .base_url(base_url)
+        .build()
+}
+
+#[tokio::test]
+async fn tenant_token_fetch_no_longer_uses_noop_provider() {
+    let config = Config::builder()
+        .app_id("test_app_id")
+        .app_secret("test_app_secret")
+        .base_url("http://127.0.0.1:9")
+        .build();
+
+    let provider = AuthTokenProvider::new(config);
+    let err = provider
+        .get_token(TokenRequest::tenant())
+        .await
+        .expect_err("should fail on unreachable test endpoint");
+
+    assert!(!err.to_string().contains("NoOpTokenProvider"));
+}
+
+#[tokio::test]
+async fn tenant_cache_key_should_include_tenant_key() {
+    let request = TokenRequest::tenant().tenant_key("tenant_key_001");
+
+    let key = AuthTokenProvider::cache_key(&AccessTokenType::Tenant, &AppType::SelfBuild, &request);
+
+    assert_eq!(key, "Tenant_SelfBuild_tenant_key_001");
+}
+
+#[tokio::test]
+async fn app_cache_key_should_include_app_ticket_for_marketplace() {
+    let request = TokenRequest::app().app_ticket("ticket_001");
+
+    let key = AuthTokenProvider::cache_key(&AccessTokenType::App, &AppType::Marketplace, &request);
+
+    assert!(key.starts_with("App_Marketplace_"));
+    assert!(!key.contains("ticket_001"));
+    assert_eq!(
+        key,
+        AuthTokenProvider::cache_key(&AccessTokenType::App, &AppType::Marketplace, &request)
+    );
+}
+
+#[tokio::test]
+async fn debug_output_should_not_include_marketplace_app_ticket() {
+    let provider = AuthTokenProvider::new(marketplace_config("http://127.0.0.1:9"));
+    let _ = provider
+        .get_token(TokenRequest::app().app_ticket("ticket_001"))
+        .await;
+
+    let debug_output = format!("{provider:?}");
+
+    assert!(!debug_output.contains("ticket_001"));
+}
+
+#[tokio::test]
+async fn marketplace_app_token_requires_app_ticket() {
+    let provider = AuthTokenProvider::new(marketplace_config("http://127.0.0.1:9"));
+
+    let err = provider
+        .get_token(TokenRequest::app())
+        .await
+        .expect_err("marketplace app token without app_ticket should fail before network");
+
+    assert!(err.to_string().contains("app_ticket"));
+}
+
+#[tokio::test]
+async fn marketplace_tenant_token_requires_tenant_key() {
+    let provider = AuthTokenProvider::new(marketplace_config("http://127.0.0.1:9"));
+
+    let err = provider
+        .get_token(TokenRequest::tenant().app_ticket("ticket_001"))
+        .await
+        .expect_err("marketplace tenant token without tenant_key should fail before network");
+
+    assert!(err.to_string().contains("tenant_key"));
+}
+
+#[tokio::test]
+async fn marketplace_tenant_token_uses_app_token_and_tenant_key_body() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/open-apis/auth/v3/app_access_token"))
+        .and(body_json(json!({
+            "app_id": "test_app_id",
+            "app_secret": "test_app_secret",
+            "app_ticket": "ticket_001"
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": 0,
+            "msg": "success",
+            "app_access_token": "market-app-token",
+            "expire": 7200
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/open-apis/auth/v3/tenant_access_token"))
+        .and(body_json(json!({
+            "app_access_token": "market-app-token",
+            "tenant_key": "tenant_key_001"
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": 0,
+            "msg": "success",
+            "tenant_access_token": "tenant-token",
+            "expire": 7200
+        })))
+        .mount(&server)
+        .await;
+
+    let provider = AuthTokenProvider::new(marketplace_config(server.uri()));
+
+    let token = provider
+        .get_token(
+            TokenRequest::tenant()
+                .tenant_key("tenant_key_001")
+                .app_ticket("ticket_001"),
+        )
+        .await
+        .expect("marketplace tenant token should be fetched through app token");
+
+    assert_eq!(token, "tenant-token");
+
+    let received_requests = server.received_requests().await.unwrap_or_default();
+    assert_eq!(received_requests.len(), 2);
+    assert!(
+        received_requests
+            .iter()
+            .all(|request| !request.headers.contains_key("authorization"))
+    );
+}

--- a/crates/openlark-core/src/request_builder/mod.rs
+++ b/crates/openlark-core/src/request_builder/mod.rs
@@ -44,6 +44,9 @@ impl UnifiedRequestBuilder {
 
             // 2. 构建请求头
             req_builder = HeaderBuilder::build_headers(req_builder, config, option);
+            for (key, value) in &req.headers {
+                req_builder = HeaderBuilder::add_header(req_builder, key, value);
+            }
 
             // 3. 处理认证
             req_builder =
@@ -407,6 +410,27 @@ mod tests {
                 .await;
 
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_build_request_applies_api_request_headers() {
+        let mut api_req = create_test_api_request().header("X-Api-Header", "api-value");
+        let config = create_test_config();
+        let option = RequestOption::default();
+
+        let req_builder =
+            UnifiedRequestBuilder::build(&mut api_req, AccessTokenType::None, &config, &option)
+                .await
+                .expect("request builder should be created");
+        let request = req_builder.build().expect("request should build");
+
+        assert_eq!(
+            request
+                .headers()
+                .get("X-Api-Header")
+                .and_then(|value| value.to_str().ok()),
+            Some("api-value")
+        );
     }
 
     #[tokio::test]

--- a/crates/openlark-core/src/response_handler.rs
+++ b/crates/openlark-core/src/response_handler.rs
@@ -203,7 +203,10 @@ impl ImprovedResponseHandler {
 
         let body_bytes = read_body_with_limit(response, max_size).await?;
         let response_text = String::from_utf8_lossy(&body_bytes).to_string();
-        debug!("Raw response: {response_text}");
+        debug!(
+            response_size_bytes = body_bytes.len(),
+            "Flatten response received"
+        );
 
         // 解析阶段
         let raw_value: Value = match serde_json::from_str(&response_text) {
@@ -447,6 +450,8 @@ mod tests {
     use super::*;
     use crate::api::ResponseFormat;
     use serde::{Deserialize, Serialize};
+    use tracing_test::traced_test;
+    use wiremock::{Mock, MockServer, ResponseTemplate, matchers::method, matchers::path};
 
     #[derive(Debug, Serialize, Deserialize, PartialEq, Default, Clone)]
     struct TestData {
@@ -469,6 +474,21 @@ mod tests {
     }
 
     impl ApiResponseTrait for TestFlattenData {
+        fn data_format() -> ResponseFormat {
+            ResponseFormat::Flatten
+        }
+    }
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Default, Clone)]
+    struct TestTokenFlattenData {
+        code: i32,
+        msg: String,
+        app_access_token: String,
+        #[serde(alias = "expire")]
+        expires_in: i64,
+    }
+
+    impl ApiResponseTrait for TestTokenFlattenData {
         fn data_format() -> ResponseFormat {
             ResponseFormat::Flatten
         }
@@ -826,6 +846,44 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_handle_flatten_response_does_not_log_token_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "code": 0,
+                "msg": "success",
+                "app_access_token": "app-token-secret",
+                "expire": 7200
+            })))
+            .mount(&server)
+            .await;
+
+        let response = reqwest::Client::new()
+            .get(format!("{}/token", server.uri()))
+            .send()
+            .await
+            .expect("mock response should be fetched");
+
+        let parsed =
+            ImprovedResponseHandler::handle_response::<TestTokenFlattenData>(response, 1024 * 1024)
+                .await
+                .expect("flatten token response should parse");
+
+        assert_eq!(
+            parsed
+                .data
+                .expect("flatten data should exist")
+                .app_access_token,
+            "app-token-secret"
+        );
+        assert!(logs_contain("Flatten response received"));
+        assert!(!logs_contain("app-token-secret"));
+        assert!(!logs_contain("app_access_token"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- align auth v3 token and app_ticket endpoints with official flattened response bodies
- preserve authen v1 user_info compatibility while sending the user access token through explicit Authorization headers
- avoid logging raw flattened token response bodies and ignore .omo/ work files
- update auth examples, README snippets, and token provider coverage

## Validation

- cargo test -p openlark-auth --lib
- cargo test -p openlark-core --lib
- cargo check -p openlark-auth --examples
- cargo fmt --all -- --check
- cargo clippy -p openlark-auth -p openlark-core --all-targets -- -D warnings
- git diff --check

Fixes #196
