### PR TITLE
fix: 治理非测试代码 unwrap/expect (#202)

### DIFF
--- a/crates/openlark-client/src/utils.rs
+++ b/crates/openlark-client/src/utils.rs
@@ -5,12 +5,23 @@ use crate::{Config, Result, configuration_error, validation_error, with_context}
 use openlark_core::error::ErrorTrait;
 use std::env;
 
+/// 环境变量校验结果
+///
+/// 由 `check_env_config` 返回，承载已校验的必填凭证，
+/// 避免调用方重复读取环境变量。
+pub struct EnvConfig {
+    /// 飞书应用 App ID（已校验非空）
+    pub app_id: String,
+    /// 飞书应用 App Secret（已校验非空）
+    pub app_secret: String,
+}
+
 /// 🔍 检查环境变量配置
 ///
 /// 验证飞书应用所需的环境变量是否正确设置
 ///
 /// # 返回
-/// - `Ok(())`: 环境变量配置正确
+/// - `Ok(EnvConfig)`: 环境变量配置正确，返回已校验的凭证
 /// - `Err(Error)`: 环境变量配置错误，包含详细的错误信息和恢复建议
 ///
 /// # 示例
@@ -18,7 +29,7 @@ use std::env;
 /// use openlark_client::{prelude::*, utils};
 ///
 /// match utils::check_env_config() {
-///     Ok(()) => println!("环境变量配置正确"),
+///     Ok(_) => println!("环境变量配置正确"),
 ///     Err(error) => {
 ///         eprintln!("❌ {}", error.user_message().unwrap_or("未知错误"));
 ///         for step in error.recovery_steps() {
@@ -27,7 +38,7 @@ use std::env;
 ///     }
 /// }
 /// ```
-pub fn check_env_config() -> Result<()> {
+pub fn check_env_config() -> Result<EnvConfig> {
     // 检查 OPENLARK_APP_ID
     let app_id = env::var("OPENLARK_APP_ID")
         .map_err(|_| configuration_error("环境变量检查失败 [variable: OPENLARK_APP_ID]"))?;
@@ -87,7 +98,7 @@ pub fn check_env_config() -> Result<()> {
         );
     }
 
-    Ok(())
+    Ok(EnvConfig { app_id, app_secret })
 }
 
 /// 🔧 从环境变量创建配置
@@ -98,11 +109,11 @@ pub fn check_env_config() -> Result<()> {
 /// - `Ok(Config)`: 成功创建配置
 /// - `Err(Error)`: 配置创建失败，包含详细错误信息
 pub fn create_config_from_env() -> Result<Config> {
-    // 先检查环境变量
-    check_env_config()?;
+    // 校验环境变量并获取已校验的凭证
+    let env_cfg = check_env_config()?;
 
-    let app_id = env::var("OPENLARK_APP_ID").unwrap();
-    let app_secret = env::var("OPENLARK_APP_SECRET").unwrap();
+    let app_id = env_cfg.app_id;
+    let app_secret = env_cfg.app_secret;
 
     let base_url =
         env::var("OPENLARK_BASE_URL").unwrap_or_else(|_| "https://open.feishu.cn".to_string());
@@ -223,7 +234,7 @@ pub fn diagnose_system() -> SystemDiagnostics {
 
     // 检查环境变量
     match check_env_config() {
-        Ok(()) => {
+        Ok(_) => {
             diagnostics.env_config_status = "✅ 正常".to_string();
         }
         Err(error) => {


### PR DESCRIPTION
## 改动

重构 `check_env_config` 返回 `EnvConfig` 结构体，消除 `create_config_from_env` 中的 2 处 `env::var().unwrap()`。

## 探索发现

原 issue 描述的 "1731 处非测试 unwrap" 经精确复核，真实库代码缺陷仅 2 处（`utils.rs:104-105`），其余均在 `tests/` 目录或 `#[cfg(test)]` 模块内。

webhook/core 中的 `.expect()` 带 SAFETY 注释（HMAC 密钥长度、系统时间、测试运行时），逻辑上不可能失败，保留不改。

## Breaking Change

`check_env_config` 返回值从 `Result<()>` 改为 `Result<EnvConfig>`。`openlark-client` 处于 0.17.x Config 迁移期，`utils` 属内部辅助。

Closes #202
