### PR TITLE
refactor: Vec 必填字段统一用 validate_required_list! (#203)

### DIFF
--- a/crates/openlark-ai/src/ai/translation/v1/text/translate.rs
+++ b/crates/openlark-ai/src/ai/translation/v1/text/translate.rs
@@ -6,7 +6,7 @@
 
 use openlark_core::{
     SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
-    validate_required,
+    validate_required, validate_required_list,
 };
 use serde::{Deserialize, Serialize};
 
@@ -29,7 +29,7 @@ impl TextTranslateBody {
     pub fn validate(&self) -> openlark_core::SDKResult<()> {
         validate_required!(self.source_language, "source_language 不能为空");
         validate_required!(self.target_language, "target_language 不能为空");
-        validate_required!(self.texts, "texts 不能为空");
+        validate_required_list!(self.texts, 50, "texts 不能为空且不能超过 50 个");
         for text in &self.texts {
             validate_required!(text, "texts 中的文本不能为空");
         }

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_create.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_create.rs
@@ -7,7 +7,7 @@ use openlark_core::{
     config::Config,
     error::SDKResult,
     http::Transport,
-    validate_required,
+    validate_required, validate_required_list,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -117,7 +117,7 @@ impl BatchCreateRecordRequest {
         // === 必填字段验证 ===
         validate_required!(self.app_token.trim(), "app_token");
         validate_required!(self.table_id.trim(), "table_id");
-        validate_required!(self.records, "records");
+        validate_required_list!(self.records, 100, "records 不能为空且不能超过 100 个");
 
         // === 业务规则验证 ===
         if self.records.len() > 500 {

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_update.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_update.rs
@@ -7,7 +7,7 @@ use openlark_core::{
     config::Config,
     error::SDKResult,
     http::Transport,
-    validate_required,
+    validate_required, validate_required_list,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -111,7 +111,7 @@ impl BatchUpdateRecordRequest {
         // === 必填字段验证 ===
         validate_required!(self.app_token.trim(), "app_token");
         validate_required!(self.table_id.trim(), "table_id");
-        validate_required!(self.records, "records");
+        validate_required_list!(self.records, 100, "records 不能为空且不能超过 100 个");
 
         // === 业务规则验证 ===
         if self.records.len() > 500 {

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_daily_shift/batch_create.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_daily_shift/batch_create.rs
@@ -7,7 +7,7 @@ use openlark_core::{
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
-    validate_required,
+    validate_required_list,
 };
 use serde::{Deserialize, Serialize};
 
@@ -40,7 +40,7 @@ impl BatchCreateRequest {
         use crate::common::api_endpoints::AttendanceApiV1;
 
         // 1. 验证必填字段
-        validate_required!(self.shifts, "shifts");
+        validate_required_list!(self.shifts, 100, "shifts 不能为空且不能超过 100 个");
 
         // 2. 构建端点
         let api_endpoint = AttendanceApiV1::UserDailyShiftBatchCreate;

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_daily_shift/batch_create_temp.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_daily_shift/batch_create_temp.rs
@@ -7,7 +7,7 @@ use openlark_core::{
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
-    validate_required,
+    validate_required_list,
 };
 use serde::{Deserialize, Serialize};
 
@@ -40,7 +40,7 @@ impl BatchCreateTempRequest {
         use crate::common::api_endpoints::AttendanceApiV1;
 
         // 1. 验证必填字段
-        validate_required!(self.shifts, "shifts");
+        validate_required_list!(self.shifts, 100, "shifts 不能为空且不能超过 100 个");
 
         // 2. 构建端点
         let api_endpoint = AttendanceApiV1::UserDailyShiftBatchCreateTemp;

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_setting/query.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_setting/query.rs
@@ -7,7 +7,7 @@ use openlark_core::{
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
-    validate_required,
+    validate_required_list,
 };
 use serde::{Deserialize, Serialize};
 
@@ -40,7 +40,7 @@ impl QueryRequest {
         use crate::common::api_endpoints::AttendanceApiV1;
 
         // 1. 验证必填字段
-        validate_required!(self.user_ids, "user_ids");
+        validate_required_list!(self.user_ids, 50, "user_ids 不能为空且不能超过 50 个");
 
         // 2. 构建端点
         let api_endpoint = AttendanceApiV1::UserSettingQuery;

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_stats_view/update.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_stats_view/update.rs
@@ -7,7 +7,7 @@ use openlark_core::{
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
-    validate_required,
+    validate_required, validate_required_list,
 };
 use serde::{Deserialize, Serialize};
 
@@ -60,7 +60,7 @@ impl UpdateRequest {
         // 1. 验证必填字段
         validate_required!(self.view_id.trim(), "view_id");
         validate_required!(self.name.trim(), "name");
-        validate_required!(self.field_ids, "field_ids");
+        validate_required_list!(self.field_ids, 50, "field_ids 不能为空且不能超过 50 个");
 
         // 2. 构建端点
         let api_endpoint = AttendanceApiV1::UserStatsViewUpdate

--- a/crates/openlark-hr/src/payroll/payroll/v1/datasource_record/save.rs
+++ b/crates/openlark-hr/src/payroll/payroll/v1/datasource_record/save.rs
@@ -7,7 +7,7 @@ use openlark_core::{
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
-    validate_required,
+    validate_required, validate_required_list,
 };
 use serde::{Deserialize, Serialize};
 
@@ -55,8 +55,12 @@ impl SaveRequest {
 
         // 1. 验证必填字段
         validate_required!(self.datasource_id.trim(), "datasource_id");
-        validate_required!(self.employee_ids, "employee_ids");
-        validate_required!(self.records, "records");
+        validate_required_list!(
+            self.employee_ids,
+            50,
+            "employee_ids 不能为空且不能超过 50 个"
+        );
+        validate_required_list!(self.records, 100, "records 不能为空且不能超过 100 个");
 
         // 2. 构建端点
         let api_endpoint = PayrollApiV1::DatasourceRecordSave;

--- a/crates/openlark-hr/src/performance/performance/v1/stage_task/find_by_user_list.rs
+++ b/crates/openlark-hr/src/performance/performance/v1/stage_task/find_by_user_list.rs
@@ -2,13 +2,13 @@
 //!
 //! docPath: https://open.feishu.cn/document/server-docs/performance-v1/stage_task/find_by_user_list
 
-use openlark_core::validate_required;
 use openlark_core::{
     SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
 };
+use openlark_core::{validate_required, validate_required_list};
 use serde::{Deserialize, Serialize};
 
 /// 获取周期任务（指定用户）请求
@@ -53,7 +53,7 @@ impl FindByUserListRequest {
         use crate::common::api_endpoints::PerformanceApiV1;
 
         validate_required!(self.cycle_id.trim(), "cycle_id");
-        validate_required!(self.user_ids, "user_ids");
+        validate_required_list!(self.user_ids, 50, "user_ids 不能为空且不能超过 50 个");
 
         // 1. 构建端点
         let api_endpoint = PerformanceApiV1::StageTaskFindByUserList;

--- a/crates/openlark-hr/src/performance/performance/v2/additional_information/query.rs
+++ b/crates/openlark-hr/src/performance/performance/v2/additional_information/query.rs
@@ -2,13 +2,13 @@
 //!
 //! docPath: https://open.feishu.cn/document/server-docs/performance-v2/additional_information/query
 
-use openlark_core::validate_required;
 use openlark_core::{
     SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
 };
+use openlark_core::{validate_required, validate_required_list};
 use serde::{Deserialize, Serialize};
 
 /// 批量查询补充信息请求
@@ -53,7 +53,7 @@ impl QueryRequest {
         use crate::common::api_endpoints::PerformanceApiV1;
 
         validate_required!(self.cycle_id.trim(), "cycle_id");
-        validate_required!(self.user_ids, "user_ids");
+        validate_required_list!(self.user_ids, 50, "user_ids 不能为空且不能超过 50 个");
 
         // 1. 构建端点
         let api_endpoint = PerformanceApiV1::AdditionalInformationQuery;

--- a/crates/openlark-platform/src/admin/admin/v1/badge/grant/create.rs
+++ b/crates/openlark-platform/src/admin/admin/v1/badge/grant/create.rs
@@ -9,7 +9,7 @@ use openlark_core::{
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    validate_required,
+    validate_required, validate_required_list,
 };
 use serde::{Deserialize, Serialize};
 
@@ -53,7 +53,7 @@ impl CreateBadgeGrantBuilder {
         option: RequestOption,
     ) -> SDKResult<CreateBadgeGrantResponse> {
         validate_required!(self.badge_id, "勋章ID不能为空");
-        validate_required!(self.user_ids, "用户ID列表不能为空");
+        validate_required_list!(self.user_ids, 50, "用户ID列表不能为空且不能超过 50 个");
 
         let request_body = CreateBadgeGrantRequest {
             user_ids: self.user_ids,


### PR DESCRIPTION
## 改动

将 12 处 `Vec` 必填字段的 `validate_required!` 替换为 `validate_required_list!`，补充长度上限校验。

## MAX_LEN 取值依据

按仓库现有 23 处 `validate_required_list!` 的惯例：
- `user_ids`/`employee_ids`/`field_ids`: 50
- `records`/`shifts`: 100
- `texts`: 50

## 探索修正

原计划 13 处，实施中发现 `bank_card/recognize.rs` 的 `file: Vec<u8>` 是二进制 blob（文件内容字节序列）而非元素列表，`validate_required_list!` 的 `len() > max_len` 检查对字节数无意义。该处保留 `validate_required!` 只校验非空，实际替换 12 处。

## 涉及 crate

- openlark-hr: 8 处
- openlark-docs: 2 处
- openlark-ai: 1 处（translate.rs）
- openlark-platform: 1 处

## 测试

- HR: 1254 测试通过
- AI: 212 测试通过
- Platform: 34 测试通过
- docs crate 测试有预存 feature flag 错误（main 分支同样存在，非本次引入）

Closes #203
