### PR TITLE
fix: 多维表格 batch_create/batch_update records 上限改为 1000

### DIFF
--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_create.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_create.rs
@@ -117,15 +117,7 @@ impl BatchCreateRecordRequest {
         // === 必填字段验证 ===
         validate_required!(self.app_token.trim(), "app_token");
         validate_required!(self.table_id.trim(), "table_id");
-        validate_required_list!(self.records, 100, "records 不能为空且不能超过 100 个");
-
-        // === 业务规则验证 ===
-        if self.records.len() > 500 {
-            return Err(openlark_core::error::validation_error(
-                "records",
-                "单次最多新增 500 条记录",
-            ));
-        }
+        validate_required_list!(self.records, 1000, "records 不能为空且单次最多 1000 条");
 
         use crate::common::api_endpoints::BitableApiV1;
         let api_endpoint =

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_update.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_update.rs
@@ -111,15 +111,7 @@ impl BatchUpdateRecordRequest {
         // === 必填字段验证 ===
         validate_required!(self.app_token.trim(), "app_token");
         validate_required!(self.table_id.trim(), "table_id");
-        validate_required_list!(self.records, 100, "records 不能为空且不能超过 100 个");
-
-        // === 业务规则验证 ===
-        if self.records.len() > 500 {
-            return Err(openlark_core::error::validation_error(
-                "records",
-                "单次最多更新 500 条记录",
-            ));
-        }
+        validate_required_list!(self.records, 1000, "records 不能为空且单次最多 1000 条");
 
         use crate::common::api_endpoints::BitableApiV1;
         let api_endpoint =


### PR DESCRIPTION
## 问题

PR #207 (issue #203) 将 `batch_create`/`batch_update` 的 `records` 上限设为 100，存在两个问题：

1. **上限过严**：飞书官方上限为 1000 条（错误码 1254104 RecordExceedLimit），设为 100 会拒绝 101-1000 条的合法请求
2. **死代码**：原 `if records.len() > 500` 业务规则检查被新的 100 限制覆盖，永不触发

## 修复

- MAX_LEN 从 100 改为 1000（匹配飞书官方上限）
- 删除冗余的 500 业务规则检查块（已被宏覆盖）
- 错误消息更新为「单次最多 1000 条」

## 来源

PR #206/#207 code review 发现（Minor #1）。

## 验证

- `cargo build -p openlark-docs` 通过