### PR TITLE
fix(webhook): 共享 reqwest::Client，消除每请求新建连接池

### DIFF
--- a/crates/openlark-webhook/src/robot/v1/client.rs
+++ b/crates/openlark-webhook/src/robot/v1/client.rs
@@ -7,6 +7,9 @@ use serde_json::json;
 use crate::common::signature;
 
 /// Webhook 客户端。
+///
+/// 内部复用进程级共享的 `reqwest::Client`（连接池），不走 `openlark_core::Transport`
+/// ——webhook 是出站自定义机器人 URL，非飞书开放平台 API（见 `send` 模块说明 + issue #214）。
 #[derive(Debug, Clone)]
 pub struct WebhookClient {
     client: reqwest::Client,
@@ -15,10 +18,10 @@ pub struct WebhookClient {
 }
 
 impl WebhookClient {
-    /// 创建新的 Webhook 客户端
+    /// 创建新的 Webhook 客户端（复用进程级共享 HTTP 连接池）
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: super::send::shared_client().clone(),
             #[cfg(feature = "signature")]
             secret: None,
         }

--- a/crates/openlark-webhook/src/robot/v1/send.rs
+++ b/crates/openlark-webhook/src/robot/v1/send.rs
@@ -2,12 +2,28 @@ use crate::common::error::{Result, WebhookError};
 use crate::common::validation;
 use crate::models::{FileContent, ImageContent, PostContent, TextContent};
 use serde_json::json;
+use std::sync::OnceLock;
 
 #[cfg(feature = "signature")]
 use crate::common::signature;
 
 #[cfg(feature = "card")]
 use crate::models::InteractiveContent;
+
+/// 进程级共享的 `reqwest::Client`（连接池复用）。
+///
+/// # 为什么不走 `openlark_core::Transport`？
+///
+/// Webhook 自定义机器人**不是飞书开放平台 API**：目标 URL 是用户配置的绝对地址，
+/// 鉴权用 URL 里携带的签名密钥（非 Bearer token），响应体是 `{code,msg}` 等非标准
+/// 包装（非 `{code,msg,data}`）。`Transport` 固定 `/open-apis/` 基址、强制 token 注入、
+/// 且把响应解析为 `ApiResponse<R>`，三者都不适用。因此 webhook **有意保留独立的
+/// reqwest 路径**（见 GitHub issue #214 的调研结论），但通过共享单个 `reqwest::Client`
+/// 避免每个请求 `reqwest::Client::new()` 新建连接池的开销。
+pub(super) fn shared_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new)
+}
 
 /// 发送 Webhook 消息请求构建器。
 #[derive(Debug, Clone)]
@@ -92,9 +108,7 @@ impl SendWebhookMessageRequest {
 
         #[cfg(feature = "signature")]
         let request_builder = {
-            let mut rb = reqwest::Client::new()
-                .post(&self.webhook_url)
-                .json(&payload);
+            let mut rb = shared_client().post(&self.webhook_url).json(&payload);
             if let Some(secret) = &self.secret {
                 let timestamp = signature::current_timestamp();
                 let sign = signature::sign(timestamp, secret);
@@ -106,9 +120,7 @@ impl SendWebhookMessageRequest {
         };
 
         #[cfg(not(feature = "signature"))]
-        let request_builder = reqwest::Client::new()
-            .post(&self.webhook_url)
-            .json(&payload);
+        let request_builder = shared_client().post(&self.webhook_url).json(&payload);
 
         let response = request_builder
             .send()


### PR DESCRIPTION
Closes #214.

## 调研结论（issue #214 第一项 checklist）

`openlark_core::Transport` **不适用**于 webhook，三条硬理由：
1. **URL**：Transport 按 `config.base_url + /open-apis/` 拼；webhook 是用户配置的绝对 URL
2. **Token**：`Transport::request` 强制 `validate_token_type` + 注入 `Authorization`；webhook 机器人鉴权是 URL 携带的签名密钥（非 Bearer token）
3. **响应**：Transport 解析为 `ApiResponse<R> = {code,msg,data}`；webhook 响应是 `{code,msg}` 非标准包装

→ 走 issue 的「选项 2」：webhook 有意保留独立 reqwest 路径，但消除每请求 `reqwest::Client::new()` 的连接池开销。

## 改动

- `send.rs`：新增 `shared_client()`（进程级 `OnceLock<reqwest::Client>`），`execute()` 两个分支（signature / 非 signature）都改用它。加了文档说明「为何不走 Transport」+ 指向 #214 调研
- `client.rs`：`WebhookClient::new()` 也复用 `shared_client().clone()`，与 send 路径统一

## 验证
- ✅ 51 tests pass（含 10 个真实 mock 服务器的集成测试，覆盖 `shared_client` 实际发送路径）
- ✅ clippy 0 warning，fmt clean，`cargo doc` 通过
- ✅ `rg "reqwest::Client::new"` 在 webhook 仅剩 OnceLock 一次性初始化（即共享 client 本身）+ 文档引用——非绕过 Transport 的端点调用

## 附
与 #211（acs）/ #212（security_and_compliance）的迁移不同：那两个是「迁移到 Transport」，webhook 是「确认不迁 + 共享 client」。代码库内绕过 Transport 的真实端点债务至此清零。