### PR TITLE
fix(deps): 升级 quinn-proto 修复 RUSTSEC-2026-0185

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2390,9 +2390,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## 修复

`quinn-proto` **RUSTSEC-2026-0185**（远程内存耗尽：unbounded out-of-order stream reassembly，severity 7.5 high）。官方修复版 `>=0.11.15`。

## 改动

`cargo update -p quinn-proto`（0.11.14 → 0.11.15），semver 兼容升级，**仅 Cargo.lock 2 行，不动任何 Cargo.toml**。

依赖链：`quinn-proto` ← `quinn 0.11.9` ← `reqwest 0.13.3`（HTTP/3 传递依赖）。

## 验证

- `cargo audit` → exit 0（0 vulnerability）✅
- `cargo check -p openlark-core` → 通过 ✅

> 此漏洞在 main 上预存（`just check-all` 的 audit 步失败于此），独立于 #217（codegen MVP）。
