### PR TITLE
feat(codegen): G5 Token 类型自动声明 + 修复嵌套 array struct 可达性

### DIFF
--- a/tools/api_contracts/codegen_render.py
+++ b/tools/api_contracts/codegen_render.py
@@ -79,6 +79,8 @@ def _imports(ir: ApiIR) -> str:
     core_items = ["SDKResult", "api::ApiRequest", "config::Config", "http::Transport"]
     if _needs_validate_required(ir):
         core_items.append("validate_required")
+    if _emit_token_decl(ir.supported_access_tokens) is not None:
+        core_items.append("constants::AccessTokenType")
     lines.append("    " + ", ".join(core_items) + ",")
     lines.append("};")
     if has_body:
@@ -237,22 +239,21 @@ def _request_impl(ir: ApiIR) -> str:
     lines.append(f"        // url: {ir.method}:{ir.endpoint_path}")
     url_expr = _endpoint_url_expr(ir)
     lines.append(f"        let req: ApiRequest<serde_json::Value> = ApiRequest::{method}({url_expr})")
-    # body
+    # body（无分号，链式续）
     if has_body:
-        lines.append(f'            .body(serialize_params(&body, "{ir.name}")?);')
-    else:
-        # 无 body：链式终止，末尾分号。把上一行末尾补分号
-        lines[-1] = lines[-1] + ";"
+        lines.append(f'            .body(serialize_params(&body, "{ir.name}")?)')
     # query params（required 用 query(key, String)；optional 用 query_opt）
-    if ir.query_params:
-        # 上一行去掉分号，改链式
-        lines[-1] = lines[-1].rstrip(";")
-        for p in ir.query_params:
-            if p.required:
-                lines.append(f'            .query("{p.name}", {p.rust_name})')
-            else:
-                lines.append(f'            .query_opt("{p.name}", self.{p.rust_name})')
-        lines[-1] = lines[-1] + ";"
+    for p in ir.query_params:
+        if p.required:
+            lines.append(f'            .query("{p.name}", {p.rust_name})')
+        else:
+            lines.append(f'            .query_opt("{p.name}", self.{p.rust_name})')
+    # G5: token 类型声明（非默认 {User, Tenant} 组合才生成，否则保持 core 默认）
+    token_decl = _emit_token_decl(ir.supported_access_tokens)
+    if token_decl is not None:
+        lines.append(f"            .with_supported_access_token_types({token_decl})")
+    # 统一收口：链尾补分号
+    lines[-1] = lines[-1] + ";"
     lines.append("        let resp = Transport::request(req, &self.config, Some(option)).await?;")
     lines.append(f'        extract_response_data(resp, "{ir.name}")')
     lines.append("    }")
@@ -337,6 +338,30 @@ def _oneliner(text: str, limit: int = 80) -> str:
     return ""
 
 
+_TOKEN_MAP = {
+    "user_access_token": "User",
+    "tenant_access_token": "Tenant",
+    "app_access_token": "App",
+}
+
+
+def _emit_token_decl(tokens: tuple[str, ...]) -> str | None:
+    """supportedAccessToken 字符串 → "vec![...]" 或 None（默认/空时不生成）。
+
+    集合 == {User, Tenant}（core getter 默认）→ None，省略显式声明（契约 4 由 core 兜底）。
+    非默认 → 保留 dump 顺序输出。未知值跳过（不阻塞 codegen，演进友好）。
+    绝不返回空 vec（core 会兜底成 [None]，导致不带 token）。
+    """
+    if not tokens:
+        return None
+    variants = [_TOKEN_MAP[t] for t in tokens if t in _TOKEN_MAP]
+    if not variants:
+        return None
+    if set(variants) == {"User", "Tenant"}:
+        return None
+    return "vec![" + ", ".join(f"AccessTokenType::{v}" for v in variants) + "]"
+
+
 def _needs_validate_required(ir: ApiIR) -> bool:
     """是否用到 validate_required!（path param 必用；body required String 字段用）。"""
     if ir.path_params:
@@ -352,8 +377,21 @@ def _needs_validate_required(ir: ApiIR) -> bool:
     return False
 
 
+def _collect_struct_refs(t: object):
+    """从 TypeExpr 收集所有 TypeStructRef 的 struct_key（递归 array/map 内层）。"""
+    if isinstance(t, TypeStructRef):
+        yield t.struct_key
+    elif isinstance(t, TypeArray):
+        yield from _collect_struct_refs(t.item)
+    elif isinstance(t, TypeMap):
+        yield from _collect_struct_refs(t.value)
+
+
 def _reachable_struct_keys(ir: ApiIR) -> set[str]:
-    """从 body_struct 出发可达的 struct key 集合（MVP 只渲染 body 子树，排除 response）。"""
+    """从 body_struct 出发可达的 struct key 集合（MVP 只渲染 body 子树，排除 response）。
+
+    递归 TypeArray/TypeMap 内层的 TypeStructRef（array of object 等场景）。
+    """
     visited: set[str] = set()
     if ir.body_struct is None:
         return visited
@@ -367,10 +405,8 @@ def _reachable_struct_keys(ir: ApiIR) -> set[str]:
         if struct is None:
             continue
         for f in struct.fields:
-            if (
-                isinstance(f.type_expr, TypeStructRef)
-                and f.type_expr.struct_key in ir.structs
-            ):
-                stack.append(f.type_expr.struct_key)
+            for ref_key in _collect_struct_refs(f.type_expr):
+                if ref_key in ir.structs:
+                    stack.append(ref_key)
     return visited
 

--- a/tools/api_contracts/test_codegen_render.py
+++ b/tools/api_contracts/test_codegen_render.py
@@ -7,7 +7,11 @@ import unittest
 from pathlib import Path
 
 from tools.api_contracts.codegen_ir import parse_api_schema_to_ir
-from tools.api_contracts.codegen_render import render_api_file, render_endpoint_const_snippet
+from tools.api_contracts.codegen_render import (
+    _emit_token_decl,
+    render_api_file,
+    render_endpoint_const_snippet,
+)
 from tools.api_contracts.models import ApiIdentity
 
 SAMPLES = Path(__file__).resolve().parent.parent / "schema_cache" / "samples"
@@ -92,6 +96,19 @@ def _assert_core_contracts(testcase, code: str) -> None:
     testcase.assertNotIn(", None).await", code)
     # codegen 标记
     testcase.assertIn("由 codegen 自动生成", code)
+
+
+SCHEMA_TENANT_ONLY = {
+    "httpMethod": "post",
+    "path": "/open-apis/contact/v3/departments",
+    "parameters": [],
+    "requestBody": {"content": {"application/json": {"schema": {"properties": [
+        {"name": "name", "type": "string", "required": True},
+    ]}}}},
+    "responses": {"200": {"content": {"application/json": {"schema": {"properties": [
+        {"name": "code", "type": "integer"}, {"name": "msg", "type": "string"}]}}}}},
+    "security": {"supportedAccessToken": ["tenant_access_token"]},
+}
 
 
 class EndpointSnippetTest(unittest.TestCase):
@@ -209,6 +226,87 @@ class RealSampleTest(unittest.TestCase):
         self.assertIn("pub content: String,", code)
         # 把渲染产物落一份到 /tmp 便于人工 review（测试不依赖它）
         Path("/tmp/codegen_create.rs").write_text(code, encoding="utf-8")
+
+
+class TokenDeclTest(unittest.TestCase):
+    """_emit_token_decl 映射逻辑：默认/单值/空/未知/集合顺序。"""
+
+    def test_empty(self):
+        self.assertIsNone(_emit_token_decl(()))
+
+    def test_default_set_unordered(self):
+        # 默认 {User, Tenant} → None，无论 dump 顺序
+        self.assertIsNone(_emit_token_decl(("tenant_access_token", "user_access_token")))
+        self.assertIsNone(_emit_token_decl(("user_access_token", "tenant_access_token")))
+
+    def test_tenant_only(self):
+        self.assertEqual(
+            _emit_token_decl(("tenant_access_token",)),
+            "vec![AccessTokenType::Tenant]",
+        )
+
+    def test_user_only(self):
+        self.assertEqual(
+            _emit_token_decl(("user_access_token",)),
+            "vec![AccessTokenType::User]",
+        )
+
+    def test_app_only(self):
+        self.assertEqual(
+            _emit_token_decl(("app_access_token",)),
+            "vec![AccessTokenType::App]",
+        )
+
+    def test_unknown_degrades_to_default(self):
+        self.assertIsNone(_emit_token_decl(("lambda_access_token",)))
+
+    def test_unknown_skipped_keeps_known(self):
+        # 混合：已知 tenant + 未知 → 只输出 tenant（非默认 → 生成）
+        self.assertEqual(
+            _emit_token_decl(("tenant_access_token", "lambda_access_token")),
+            "vec![AccessTokenType::Tenant]",
+        )
+
+
+class RenderTokenTest(unittest.TestCase):
+    """G5 渲染集成：[tenant] 单值 → 生成 token 声明 + import；默认 → 不生成。"""
+
+    def test_tenant_only_emits_decl_and_import(self):
+        ir = parse_api_schema_to_ir(_api(resource="department"), SCHEMA_TENANT_ONLY)
+        code = render_api_file(ir)
+        self.assertIn(
+            ".with_supported_access_token_types(vec![AccessTokenType::Tenant])",
+            code,
+        )
+        self.assertIn("constants::AccessTokenType", code)  # 条件 import
+
+    def test_default_no_token_decl(self):
+        # SCHEMA_POST 无 security → supported_access_tokens=() → 不生成、不 import
+        ir = parse_api_schema_to_ir(_api(), SCHEMA_POST)
+        code = render_api_file(ir)
+        self.assertNotIn("with_supported_access_token_types", code)
+        self.assertNotIn("AccessTokenType", code)
+
+
+class RenderNestedArrayStructTest(unittest.TestCase):
+    """_reachable 递归 array 内层 struct（array of object 不漏渲染）。"""
+
+    def test_array_of_object_struct_rendered(self):
+        schema = {
+            "httpMethod": "post",
+            "path": "/open-apis/im/v1/messages",
+            "requestBody": {"content": {"application/json": {"schema": {"properties": [
+                {"name": "tags", "type": "array", "required": True,
+                 "items": {"type": "object", "properties": [{"name": "key", "type": "string"}]}},
+            ]}}}},
+            "responses": {"200": {"content": {"application/json": {"schema": {"properties": [
+                {"name": "code", "type": "integer"}]}}}}},
+        }
+        ir = parse_api_schema_to_ir(_api(), schema)
+        code = render_api_file(ir)
+        # 嵌套 struct（tags 的 item）应被渲染，不漏
+        self.assertIn("pub struct CreateMessageBodyTagsItem {", code)
+        self.assertIn("Vec<CreateMessageBodyTagsItem>", code)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## G5: Token 类型自动声明

根据 `apiSchema.security.supportedAccessToken` 自动生成 `.with_supported_access_token_types(vec![...])`（核心契约 4）。

- **映射**：`user_access_token`→User、`tenant_access_token`→Tenant、`app_access_token`→App
- **默认 `{User, Tenant}` 不生成**（core getter 已兜底默认 `[User, Tenant]`）；非默认（如 `[Tenant]` 单值，contact/moments 接口）才显式生成
- **集合比较**（dump 顺序 tenant 在前、默认 user 在前，顺序无关）
- **条件 import** `constants::AccessTokenType`（仅非默认时，避免 unused）
- **应用级 App 不从 schema 推**：`supportedAccessToken` 永远不含 `app_access_token`（acs 38 处是人工硬编码，走另一条鉴权路径）。MVP 锁 communication 不涉及应用级，留 `TODO(G5-phase2)` 路径白名单

## 修复：嵌套 array struct 可达性

`_reachable_struct_keys` 现递归 `TypeArray`/`TypeMap` 内层 `TypeStructRef`。之前 array of object（如 `leaders: Vec<{...}>`）的嵌套 struct 被判不可达、漏渲染 → 编译失败。G5 验证用 contact/department/create（含 array struct）暴露并修复。

## 验证

- contact/department/create（`[tenant]` 单值 + array of object 嵌套）生成代码：`cargo check` ✅ `clippy -Dwarnings` ✅ `fmt --check` ✅
- 57 单元测试（+9 G5：TokenDecl 映射逻辑 + RenderToken 集成；+1 array struct 可达性）
