### PR TITLE
feat(codegen): typed response（R 强类型化 + ApiResponseTrait）

### DIFF
--- a/tools/api_contracts/codegen_ir.py
+++ b/tools/api_contracts/codegen_ir.py
@@ -468,9 +468,17 @@ def _body_struct_name(api: ApiIdentity) -> str:
 
 
 def _response_struct_name(api: ApiIdentity, data_schema: dict[str, Any]) -> str:
-    """优先官方 objectName，否则动词+资源+Response。"""
+    """优先官方 objectName（仅当已 PascalCase，如 CreateDraftResp），否则动词+资源+Response。
+
+    objectName 大小写不统一（有的 PascalCase 如 CreateDraftResp，有的小写如 message），
+    小写值不能直接作 Rust struct 名，故仅采纳首字母大写的 objectName。
+    """
     object_name = str(data_schema.get("objectName") or "")
-    if object_name and object_name.replace("_", "").isalnum():
+    if (
+        object_name
+        and object_name.replace("_", "").isalnum()
+        and object_name[0].isupper()
+    ):
         return object_name
     return to_pascal(api.meta_name.replace(":", "_")) + to_pascal(api.meta_resource) + "Response"
 

--- a/tools/api_contracts/codegen_render.py
+++ b/tools/api_contracts/codegen_render.py
@@ -34,7 +34,7 @@ def render_api_file(ir: ApiIR) -> str:
         _module_doc(ir),
         _imports(ir),
     ]
-    # 嵌套 struct：只渲染 body 可达的（MVP 不渲染 response struct 及其 nested，避免 dead code）
+    # 嵌套 struct：渲染 body + response 可达的
     reachable = _reachable_struct_keys(ir)
     for struct in sorted(
         (
@@ -47,6 +47,9 @@ def render_api_file(ir: ApiIR) -> str:
         parts.append(_render_struct(ir, struct))
     if ir.body_struct is not None:
         parts.append(_render_struct(ir, ir.body_struct))
+    if ir.response_struct is not None:
+        parts.append(_render_struct(ir, ir.response_struct, force_optional=True))
+        parts.append(_render_api_response_trait(ir))
     parts.append(_request_struct(ir))
     parts.append(_request_impl(ir))
     parts.append(_tests(ir))
@@ -75,28 +78,40 @@ def _module_doc(ir: ApiIR) -> str:
 
 def _imports(ir: ApiIR) -> str:
     has_body = ir.body_struct is not None
+    is_typed = ir.response_struct is not None
     lines = ["use openlark_core::{"]
-    core_items = ["SDKResult", "api::ApiRequest", "config::Config", "http::Transport"]
+    if is_typed:
+        core_items = [
+            "SDKResult",
+            "api::{ApiRequest, ApiResponseTrait, Response, ResponseFormat}",
+            "config::Config",
+            "http::Transport",
+        ]
+    else:
+        core_items = ["SDKResult", "api::ApiRequest", "config::Config", "http::Transport"]
     if _needs_validate_required(ir):
         core_items.append("validate_required")
     if _emit_token_decl(ir.supported_access_tokens) is not None:
         core_items.append("constants::AccessTokenType")
     lines.append("    " + ", ".join(core_items) + ",")
     lines.append("};")
-    if has_body:
+    if has_body or is_typed:
         lines.append("use serde::{Deserialize, Serialize};")
     lines.append("")
     lines.append("use crate::{")
-    utils = ["extract_response_data"]
+    utils = []
+    if not is_typed:
+        utils.append("extract_response_data")
     if has_body:
         utils.append("serialize_params")
-    lines.append("    common::api_utils::{" + ", ".join(utils) + "},")
+    if utils:
+        lines.append("    common::api_utils::{" + ", ".join(utils) + "},")
     lines.append(f"    endpoints::{ir.endpoint_const_name},")
     lines.append("};")
     return "\n".join(lines)
 
 
-def _render_struct(ir: ApiIR, struct: StructDef) -> str:
+def _render_struct(ir: ApiIR, struct: StructDef, *, force_optional: bool = False) -> str:
     lines: list[str] = []
     if struct.origin == "request_body":
         lines.append(f"/// {ir.name}请求体。")
@@ -108,18 +123,19 @@ def _render_struct(ir: ApiIR, struct: StructDef) -> str:
     lines.append('#[serde(rename_all = "camelCase")]')
     lines.append(f"pub struct {struct.rust_name} {{")
     for field in struct.fields:
-        lines.extend(_field_lines(field))
+        lines.extend(_field_lines(field, force_optional=force_optional))
     lines.append("}")
     return "\n".join(lines)
 
 
-def _field_lines(field: FieldDef) -> list[str]:
+def _field_lines(field: FieldDef, *, force_optional: bool = False) -> list[str]:
+    optional = (not field.required) or force_optional
     out: list[str] = []
     if field.description:
         out.append(f"    /// {_oneliner(field.description)}")
-    if not field.required:
+    if optional:
         out.append('    #[serde(skip_serializing_if = "Option::is_none")]')
-    rust_t = _rust_type(field.type_expr, field.required)
+    rust_t = _rust_type(field.type_expr, field.required and not force_optional)
     out.append(f"    pub {field.rust_name}: {rust_t},")
     return out
 
@@ -157,6 +173,8 @@ def _request_impl(ir: ApiIR) -> str:
     has_body = ir.body_struct is not None
     body_type = ir.body_struct.rust_name if has_body else None
     method = ir.method.lower()
+    resp_type = _response_type(ir)
+    is_typed = ir.response_struct is not None
 
     lines: list[str] = [f"impl {name} {{"]
 
@@ -189,7 +207,7 @@ def _request_impl(ir: ApiIR) -> str:
     # execute（委托）
     exec_sig = f"(self, body: {body_type})" if has_body else "(self)"
     lines.append("    /// 执行请求。")
-    lines.append(f"    pub async fn execute{exec_sig} -> SDKResult<serde_json::Value> {{")
+    lines.append(f"    pub async fn execute{exec_sig} -> SDKResult<{resp_type}> {{")
     if has_body:
         lines.append(
             "        self.execute_with_options(body, "
@@ -213,7 +231,7 @@ def _request_impl(ir: ApiIR) -> str:
     for i, p in enumerate(params_sig):
         sep = "," if i < len(params_sig) - 1 else ","
         lines.append(f"        {p}{sep}")
-    lines.append("    ) -> SDKResult<serde_json::Value> {")
+    lines.append(f"    ) -> SDKResult<{resp_type}> {{")
     lines.append("        // === 必填字段验证 ===")
     # body required String 字段
     if has_body:
@@ -238,7 +256,7 @@ def _request_impl(ir: ApiIR) -> str:
     # url
     lines.append(f"        // url: {ir.method}:{ir.endpoint_path}")
     url_expr = _endpoint_url_expr(ir)
-    lines.append(f"        let req: ApiRequest<serde_json::Value> = ApiRequest::{method}({url_expr})")
+    lines.append(f"        let req: ApiRequest<{resp_type}> = ApiRequest::{method}({url_expr})")
     # body（无分号，链式续）
     if has_body:
         lines.append(f'            .body(serialize_params(&body, "{ir.name}")?)')
@@ -254,8 +272,19 @@ def _request_impl(ir: ApiIR) -> str:
         lines.append(f"            .with_supported_access_token_types({token_decl})")
     # 统一收口：链尾补分号
     lines[-1] = lines[-1] + ";"
-    lines.append("        let resp = Transport::request(req, &self.config, Some(option)).await?;")
-    lines.append(f'        extract_response_data(resp, "{ir.name}")')
+    if is_typed:
+        lines.append(
+            f"        let response: Response<{resp_type}> = "
+            "Transport::request(req, &self.config, Some(option)).await?;"
+        )
+        lines.append("        response.data.ok_or_else(|| {")
+        lines.append(
+            '            openlark_core::error::validation_error("response", "响应数据为空")'
+        )
+        lines.append("        })")
+    else:
+        lines.append("        let resp = Transport::request(req, &self.config, Some(option)).await?;")
+        lines.append(f'        extract_response_data(resp, "{ir.name}")')
     lines.append("    }")
     lines.append("}")
     return "\n".join(lines)
@@ -362,6 +391,23 @@ def _emit_token_decl(tokens: tuple[str, ...]) -> str | None:
     return "vec![" + ", ".join(f"AccessTokenType::{v}" for v in variants) + "]"
 
 
+def _response_type(ir: ApiIR) -> str:
+    """execute 的返回类型：typed response struct 名，或 serde_json::Value（无 data 时回退）。"""
+    return ir.response_struct.rust_name if ir.response_struct is not None else "serde_json::Value"
+
+
+def _render_api_response_trait(ir: ApiIR) -> str:
+    """渲染 impl ApiResponseTrait for XxxResp（契约 2：R 是 data 内容类型，非包装层）。"""
+    name = ir.response_struct.rust_name
+    return (
+        f"impl ApiResponseTrait for {name} {{\n"
+        f"    fn data_format() -> ResponseFormat {{\n"
+        f"        ResponseFormat::Data\n"
+        f"    }}\n"
+        f"}}"
+    )
+
+
 def _needs_validate_required(ir: ApiIR) -> bool:
     """是否用到 validate_required!（path param 必用；body required String 字段用）。"""
     if ir.path_params:
@@ -388,14 +434,14 @@ def _collect_struct_refs(t: object):
 
 
 def _reachable_struct_keys(ir: ApiIR) -> set[str]:
-    """从 body_struct 出发可达的 struct key 集合（MVP 只渲染 body 子树，排除 response）。
-
-    递归 TypeArray/TypeMap 内层的 TypeStructRef（array of object 等场景）。
-    """
+    """从 body + response 出发可达的 struct key 集合（递归 array/map 内层 TypeStructRef）。"""
     visited: set[str] = set()
-    if ir.body_struct is None:
-        return visited
-    stack = [ir.body_struct.key]
+    roots = []
+    if ir.body_struct is not None:
+        roots.append(ir.body_struct.key)
+    if ir.response_struct is not None:
+        roots.append(ir.response_struct.key)
+    stack = list(roots)
     while stack:
         key = stack.pop()
         if key in visited:

--- a/tools/api_contracts/test_codegen_render.py
+++ b/tools/api_contracts/test_codegen_render.py
@@ -85,7 +85,10 @@ def _assert_core_contracts(testcase, code: str) -> None:
     testcase.assertIn("pub async fn execute_with_options", code)
     testcase.assertIn("RequestOption::default()", code)
     testcase.assertIn("Transport::request(req, &self.config, Some(option))", code)
-    testcase.assertIn("extract_response_data(resp,", code)
+    # 取 data（typed: response.data.ok_or_else；value: extract_response_data）
+    testcase.assertTrue(
+        "response.data.ok_or_else" in code or "extract_response_data(resp," in code
+    )
     # 端点用常量（契约 5）
     testcase.assertIn("endpoints::", code)
     # 契约 1：Config owned 非 Arc
@@ -165,6 +168,17 @@ class RenderPostTest(unittest.TestCase):
         self.assertIn("#[cfg(test)]", self.code)
         self.assertIn("fn test_body_construct()", self.code)
 
+    def test_typed_response(self):
+        # typed response：response struct + ApiResponseTrait impl + execute 返回 typed
+        self.assertIn("pub struct CreateMessageResp {", self.code)
+        self.assertIn("impl ApiResponseTrait for CreateMessageResp {", self.code)
+        self.assertIn(
+            "pub async fn execute(self, body: CreateMessageBody) -> SDKResult<CreateMessageResp>",
+            self.code,
+        )
+        self.assertIn("ApiRequest<CreateMessageResp>", self.code)
+        self.assertIn("response.data.ok_or_else", self.code)
+
 
 class RenderGetPathTest(unittest.TestCase):
     def setUp(self) -> None:
@@ -176,7 +190,7 @@ class RenderGetPathTest(unittest.TestCase):
 
     def test_no_body(self):
         # GET 无 body：execute(self) 无 body 参数，不调 serialize_params
-        self.assertIn("pub async fn execute(self) -> SDKResult<serde_json::Value>", self.code)
+        self.assertIn("pub async fn execute(self) -> SDKResult<GetMessageResponse>", self.code)
         self.assertNotIn("serialize_params", self.code)
         self.assertNotIn("Body", self.code)
 


### PR DESCRIPTION
## typed response

把 IR 已解析的 `response_struct` 渲染成强类型 Rust struct，R 不再裸 `serde_json::Value`。

- response struct + `impl ApiResponseTrait { data_format() -> ResponseFormat::Data }`（契约 2：R 是 data 内容类型，非包装层）
- `ApiRequest<XxxResp>`（R = typed）+ `Transport::request` 返回 `Response<XxxResp>` + 直接 `response.data.ok_or_else(...)`（不再 `extract_response_data`）
- response 字段全 `Option` + `skip_serializing_if`（保守，对齐 docs 范例 `CreateDraftResp.draft: Option<Draft>`——schema 的 required 对 response 不可靠，避免反序列化失败）
- import 分叉：typed 用 `api::{ApiRequest, ApiResponseTrait, Response, ResponseFormat}`；Value 回退用 `extract_response_data`
- `_reachable` 现含 response 子树（渲染 response 的嵌套 struct）
- 修 `_response_struct_name`：objectName 仅当已 PascalCase（如 `CreateDraftResp`）才用，小写值（如 `message`）派生 `<Verb><Resource>Response`

## 回退

无 response data 的接口（response 只有 code/msg）仍用 `serde_json::Value` + `extract_response_data`。typed 仅在 `response.data` schema 存在时启用。

## 验证

- im/message/create（typed response + 嵌套 response struct）生成代码：`cargo check` ✅ `clippy -Dwarnings` ✅ `fmt --check` ✅
- 58 单元测试（+1 `test_typed_response`）
