### PR TITLE
feat(codegen): G4 mod.rs 多层增量自动补全

### DIFF
--- a/tools/api_contracts/mod_tree.py
+++ b/tools/api_contracts/mod_tree.py
@@ -1,0 +1,68 @@
+"""模块树增量维护：从 expected_file 推多层 mod.rs，增量补 pub mod（不重写现有）。
+
+G4：让 codegen 生成的 .rs 自动挂到模块树。安全原则——只 append 缺失的
+`pub mod <seg>;`，绝不重写或删除现有内容（pub use / re-export / doc 注释全保留）。
+
+仅处理 expected_file 第一段之后的层（假设 crate lib.rs 已声明顶层 biz 模块，
+如 `pub mod im;`——lib.rs 有 feature gate，codegen 不触碰）。
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def ensure_mod_chain(
+    crate_src: Path, expected_file: str, *, dry_run: bool = False
+) -> list[str]:
+    """从 expected_file 推多层模块路径，每层 mod.rs 增量补 `pub mod <下一段>;`。
+
+    expected_file 形如 "im/im/v1/message/create.rs"（相对 crate_src）。逐层：
+      src/im/mod.rs          += pub mod im;
+      src/im/im/mod.rs       += pub mod v1;
+      src/im/im/v1/mod.rs    += pub mod message;
+      src/im/im/v1/message/mod.rs += pub mod create;
+
+    已有则跳过；mod.rs 不存在则创建（含最小 module doc）；存在则 append。
+    返回操作描述列表；dry_run 时只报告不写盘。
+    """
+    segments = expected_file.removesuffix(".rs").split("/")
+    actions: list[str] = []
+    for i in range(len(segments) - 1):
+        dir_path = crate_src.joinpath(*segments[: i + 1])
+        next_seg = segments[i + 1]
+        mod_rs = dir_path / "mod.rs"
+        actions.extend(_ensure_pub_mod(mod_rs, next_seg, dry_run=dry_run))
+    return actions
+
+
+def _ensure_pub_mod(
+    mod_rs: Path, segment: str, *, dry_run: bool
+) -> list[str]:
+    line = f"pub mod {segment};"
+    if mod_rs.exists():
+        content = mod_rs.read_text(encoding="utf-8")
+        if _has_pub_mod(content, segment):
+            return []  # 已声明，跳过
+        if dry_run:
+            return [f"[MOD] {mod_rs}: +{line}"]
+        # append（保留全部现有内容）
+        new_content = content.rstrip() + "\n" + line + "\n"
+        mod_rs.write_text(new_content, encoding="utf-8")
+        return [f"[MOD] {mod_rs}: +{line}"]
+    # mod.rs 不存在 → 创建（最小骨架）
+    if dry_run:
+        return [f"[CREATE] {mod_rs}"]
+    mod_rs.parent.mkdir(parents=True, exist_ok=True)
+    mod_rs.write_text(
+        f"//! {segment} 模块（由 codegen 自动创建）。\n\n{line}\n", encoding="utf-8"
+    )
+    return [f"[CREATE] {mod_rs}"]
+
+
+def _has_pub_mod(content: str, segment: str) -> bool:
+    """mod.rs 是否已声明 `pub mod <segment>;`（容忍缩进/空格）。"""
+    return bool(
+        re.search(rf"^\s*pub\s+mod\s+{re.escape(segment)}\s*;", content, re.MULTILINE)
+    )

--- a/tools/api_contracts/test_mod_tree.py
+++ b/tools/api_contracts/test_mod_tree.py
@@ -1,0 +1,76 @@
+"""mod_tree 增量维护测试：多层补、已有跳过、不抹现有、新建。"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.api_contracts.mod_tree import ensure_mod_chain
+
+
+class EnsureModChainTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.root = Path(tempfile.mkdtemp())
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def _read(self, rel: str) -> str:
+        return (self.root / rel).read_text(encoding="utf-8")
+
+    def test_creates_missing_chain(self):
+        # expected_file im/im/v1/message/create.rs，所有 mod.rs 不存在
+        actions = ensure_mod_chain(self.root, "im/im/v1/message/create.rs")
+        # 应创建 4 层 mod.rs（im, im, v1, message 各层）+ 补 create
+        created = [a for a in actions if a.startswith("[CREATE]")]
+        self.assertEqual(len(created), 4)
+        # 逐层 pub mod 对
+        self.assertIn("pub mod im;", self._read("im/mod.rs"))
+        self.assertIn("pub mod v1;", self._read("im/im/mod.rs"))
+        self.assertIn("pub mod message;", self._read("im/im/v1/mod.rs"))
+        self.assertIn("pub mod create;", self._read("im/im/v1/message/mod.rs"))
+
+    def test_skips_existing_pub_mod(self):
+        # 预建 message/mod.rs 已含 pub mod create
+        msg_mod = self.root / "im" / "im" / "v1" / "message" / "mod.rs"
+        msg_mod.parent.mkdir(parents=True, exist_ok=True)
+        msg_mod.write_text("//! message\n\npub mod create;\npub mod get;\n", encoding="utf-8")
+        actions = ensure_mod_chain(self.root, "im/im/v1/message/create.rs")
+        # message/mod.rs 已有 create → 不重复加
+        self.assertNotIn("[MOD]", "".join(a for a in actions if "message/mod.rs" in a))
+        # 内容不变（无重复 pub mod create）
+        content = msg_mod.read_text(encoding="utf-8")
+        self.assertEqual(content.count("pub mod create;"), 1)
+        self.assertIn("pub mod get;", content)  # 现有保留
+
+    def test_appends_without_destroying_existing(self):
+        # message/mod.rs 有 doc + pub use + pub mod，append create 不破坏
+        msg_mod = self.root / "im" / "im" / "v1" / "message" / "mod.rs"
+        msg_mod.parent.mkdir(parents=True, exist_ok=True)
+        original = "//! 消息模块\npub mod get;\npub use get::GetMessageRequest;\n"
+        msg_mod.write_text(original, encoding="utf-8")
+        ensure_mod_chain(self.root, "im/im/v1/message/create.rs")
+        content = msg_mod.read_text(encoding="utf-8")
+        # 现有全保留
+        self.assertIn("//! 消息模块", content)
+        self.assertIn("pub mod get;", content)
+        self.assertIn("pub use get::GetMessageRequest;", content)
+        # 新增 create
+        self.assertIn("pub mod create;", content)
+
+    def test_dry_run_no_write(self):
+        actions = ensure_mod_chain(self.root, "a/b/c.rs", dry_run=True)
+        self.assertTrue(any("[CREATE]" in a for a in actions))
+        # dry_run 不写盘
+        self.assertFalse((self.root / "a" / "mod.rs").exists())
+
+    def test_single_segment_no_mod_needed(self):
+        # expected_file 无目录（罕见）→ 无 mod.rs 操作
+        actions = ensure_mod_chain(self.root, "lonely.rs")
+        self.assertEqual(actions, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/codegen.py
+++ b/tools/codegen.py
@@ -31,6 +31,7 @@ from tools.api_contracts.codegen_render import (  # noqa: E402
     render_api_file,
     render_endpoint_const_snippet,
 )
+from tools.api_contracts.mod_tree import ensure_mod_chain  # noqa: E402
 from tools.api_contracts.official import load_api_identities  # noqa: E402
 from tools.schema_cache.cache import DEFAULT_CACHE_DIR, get_or_fetch, record_error  # noqa: E402
 
@@ -99,7 +100,7 @@ def main() -> int:
     print(f"[INFO] 待生成 {len(apis)} 个 API（crate={MVP_CRATE}）")
     stats = {"generated": 0, "skipped": 0, "errors": 0}
     manual_consts: list[str] = []
-    manual_mods: list[str] = []
+    mod_actions: list[str] = []
 
     for api in apis:
         try:
@@ -125,10 +126,8 @@ def main() -> int:
                     snippet = render_endpoint_const_snippet(ir)
                     manual_consts.append(snippet)
                     print(f"  [MANUAL] endpoints/{api.biz_tag}.rs 追加: {snippet}")
-                # mod.rs 提示（直接父目录）
-                mod_rel = target.parent.relative_to(REPO_ROOT)
-                mod_line = f"pub mod {target.stem};"
-                manual_mods.append(f"{mod_rel}/mod.rs: {mod_line}")
+                # G4: mod.rs 多层增量补全（自动写盘，不重写现有内容）
+                mod_actions.extend(ensure_mod_chain(CRATE_SRC, api.expected_file))
             else:
                 print(f"\n{'='*70}\n=== {rel}\n{'='*70}")
                 print(content)
@@ -138,13 +137,15 @@ def main() -> int:
             print(f"[ERROR] {api.api_id} {api.name}: {exc}")
 
     if args.write:
-        if manual_mods:
-            print("\n[MANUAL] 需在 mod.rs 追加（增量，勿重写）：")
-            seen = set()
-            for m in manual_mods:
-                if m not in seen:
-                    seen.add(m)
-                    print(f"  {m}")
+        if mod_actions:
+            print("\n[MOD-TREE] mod.rs 已增量补全：")
+            for a in mod_actions:
+                print(f"  {a}")
+        if stats["generated"]:
+            print(
+                "\n[MANUAL] service 链（chain.rs）需手动加 client.<biz>...<api>() "
+                "方法（G4-phase2，手工精写不自动生成）"
+            )
         rc = 0
         if stats["generated"] and not args.no_validate:
             rc = run_closed_loop()


### PR DESCRIPTION
## G4: mod.rs 多层增量自动补全

codegen `--write` 生成的 .rs 自动挂到模块树，不再手动加 `pub mod xxx;`。

- 新增 `tools/api_contracts/mod_tree.py`：`ensure_mod_chain` 从 expected_file 推多层模块路径，逐层 mod.rs 增量补 `pub mod <下一段>;`
- **安全**：已有则跳过；mod.rs 不存在则创建（最小骨架）；存在则 append——保留全部现有 `pub use` / re-export / doc 注释，**绝不重写**
- codegen `--write` 调用，打印 `[MOD-TREE]` 操作明细
- 只处理 expected_file 第一段之后（lib.rs 顶层 biz 模块有 feature gate，不触碰）

## service 链（留 G4-phase2）

`chain.rs` 是手工精写的多级 Service 链式树（`client.im.message().create()`，400+ 行），自动生成风险高。G4 打印 `[MANUAL]` 提示，不自动生成。

## 验证

- mod_tree 5 单元测试（多层创建 / 已有跳过 / 不抹现有 / 新建 / dry-run）
- 端到端：人为破坏 moments/post（删 get.rs + mod.rs 删 `pub mod get`），`codegen --write` 自动补回，`git diff` 确认**只增量不破坏**
- 63 单元测试
