### PR TITLE
fix(docs): 修复 issue #223 的 43 个 API 字段遗漏（validator 误报 + 真实缺口）

### DIFF
--- a/crates/openlark-docs/src/base/bitable/v1/app/table/form/field/patch.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/form/field/patch.rs
@@ -223,6 +223,9 @@ pub struct PatchedFormFieldQuestion {
 pub struct PatchFormFieldQuestionResponse {
     /// 更新后的问题配置。
     pub field: PatchedFormFieldQuestion,
+    /// 字段附加属性（官方 optional object，结构多变，用 Value 透传）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fields: Option<serde_json::Value>,
 }
 
 impl ApiResponseTrait for PatchFormFieldQuestionResponse {

--- a/crates/openlark-docs/src/ccm/docx/models.rs
+++ b/crates/openlark-docs/src/ccm/docx/models.rs
@@ -384,14 +384,14 @@ pub mod common_types {
     }
 
     /// 文本元素
-    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
     pub struct TextElement {
         /// 文本
         pub text_run: Option<TextRun>,
     }
 
     /// 文本运行
-    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
     pub struct TextRun {
         /// 内容
         pub content: String,
@@ -400,7 +400,7 @@ pub mod common_types {
     }
 
     /// 文本样式
-    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
     pub struct TextStyle {
         /// 是否加粗
         pub bold: Option<bool>,
@@ -509,6 +509,264 @@ pub mod common_types {
         #[serde(skip_serializing_if = "Option::is_none")]
         /// 公开项说明。
         pub has_more: Option<bool>,
+    }
+}
+
+/// 文档块更新操作（docx block patch / batch_update 的 update 操作）。
+///
+/// 对应官方 `update_block_request` 的 15 个可选操作字段，每个变体序列化为
+/// `{"<operation_name>": {<fields>}}`（如 `{"insert_table_row": {"row_index": 1}}`）。
+///
+/// # 设计说明
+///
+/// - 表格/分栏/替换类操作（table / grid / replace）做完整 typed 建模。
+/// - 文本元素类操作（`UpdateTextElements`）复用 `common_types::TextElement`。
+/// - `Raw` 变体兜底：官方新增操作或未覆盖字段时直接透传 `serde_json::Value`，
+///   避免 typed 建模阻塞请求发送。
+///
+/// 来源：飞书 docx-v1/document-block/patch 官方 apiSchema（2026-06-23）。
+pub mod block_update {
+    use super::common_types::TextElement;
+    use serde::{Deserialize, Serialize};
+
+    /// 文档块更新操作枚举。
+    ///
+    /// 序列化为单键对象：`{"<op_name>": {<op fields>}}`。
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    #[serde(rename_all = "snake_case")]
+    pub enum BlockUpdateOperation {
+        /// 更新文本元素请求
+        #[serde(rename = "update_text_elements")]
+        UpdateTextElements(UpdateTextElementsRequest),
+        /// 更新文本样式请求（段落级样式：对齐、完成状态等）
+        #[serde(rename = "update_text_style")]
+        UpdateTextStyle(UpdateTextStyleRequest),
+        /// 更新表格属性请求（列宽）
+        #[serde(rename = "update_table_property")]
+        UpdateTableProperty(UpdateTablePropertyRequest),
+        /// 表格插入新行请求
+        #[serde(rename = "insert_table_row")]
+        InsertTableRow(InsertTableRowRequest),
+        /// 表格插入新列请求
+        #[serde(rename = "insert_table_column")]
+        InsertTableColumn(InsertTableColumnRequest),
+        /// 表格批量删除行请求（区间左闭右开）
+        #[serde(rename = "delete_table_rows")]
+        DeleteTableRows(DeleteTableRowsRequest),
+        /// 表格批量删除列请求（区间左闭右开）
+        #[serde(rename = "delete_table_columns")]
+        DeleteTableColumns(DeleteTableColumnsRequest),
+        /// 表格合并单元格请求（区间左闭右开）
+        #[serde(rename = "merge_table_cells")]
+        MergeTableCells(MergeTableCellsRequest),
+        /// 表格取消单元格合并请求
+        #[serde(rename = "unmerge_table_cells")]
+        UnmergeTableCells(UnmergeTableCellsRequest),
+        /// 分栏插入新列请求
+        #[serde(rename = "insert_grid_column")]
+        InsertGridColumn(InsertGridColumnRequest),
+        /// 分栏删除列请求
+        #[serde(rename = "delete_grid_column")]
+        DeleteGridColumn(DeleteGridColumnRequest),
+        /// 更新分栏列宽比例请求
+        #[serde(rename = "update_grid_column_width_ratio")]
+        UpdateGridColumnWidthRatio(UpdateGridColumnWidthRatioRequest),
+        /// 替换图片请求（需先上传图片）
+        #[serde(rename = "replace_image")]
+        ReplaceImage(ReplaceImageRequest),
+        /// 替换文件请求（需先上传文件）
+        #[serde(rename = "replace_file")]
+        ReplaceFile(ReplaceFileRequest),
+        /// 更新文本元素与样式请求
+        #[serde(rename = "update_text")]
+        UpdateText(UpdateTextRequest),
+        /// 原始透传兜底（未覆盖的官方操作或自定义字段）
+        #[serde(untagged)]
+        Raw(serde_json::Value),
+    }
+
+    /// 更新文本元素请求
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    pub struct UpdateTextElementsRequest {
+        /// 更新的文本元素列表
+        pub elements: Vec<TextElement>,
+    }
+
+    /// 更新文本样式请求
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    pub struct UpdateTextStyleRequest {
+        /// 文本样式
+        pub style: TextStyle,
+        /// 应更新的字段（必须至少指定一个），如 `["align"]`
+        pub fields: Vec<i32>,
+    }
+
+    /// 文本样式（段落级）
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+    pub struct TextStyle {
+        /// 对齐方式
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub align: Option<i32>,
+        /// todo 的完成状态
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub done: Option<bool>,
+        /// 文本的折叠状态
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub folded: Option<bool>,
+        /// 代码块语言
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub language: Option<i32>,
+        /// 代码块是否自动换行
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub wrap: Option<bool>,
+    }
+
+    /// 更新表格属性请求（列宽）
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    pub struct UpdateTablePropertyRequest {
+        /// 表格列宽
+        pub column_width: i32,
+        /// 需要修改列宽的表格列的索引
+        pub column_index: i32,
+    }
+
+    /// 表格插入新行请求
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    pub struct InsertTableRowRequest {
+        /// 插入的行在表格中的索引（-1 表示在末尾插入）
+        pub row_index: i32,
+    }
+
+    /// 表格插入新列请求
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    pub struct InsertTableColumnRequest {
+        /// 插入的列在表格中的索引（-1 表示在末尾插入）
+        pub column_index: i32,
+    }
+
+    /// 表格批量删除行请求（区间左闭右开）
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    pub struct DeleteTableRowsRequest {
+        /// 行开始索引（区间左闭右开）
+        pub row_start_index: i32,
+        /// 行结束索引（区间左闭右开）
+        pub row_end_index: i32,
+    }
+
+    /// 表格批量删除列请求（区间左闭右开）
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    pub struct DeleteTableColumnsRequest {
+        /// 列开始索引（区间左闭右开）
+        pub column_start_index: i32,
+        /// 列结束索引（区间左闭右开）
+        pub column_end_index: i32,
+    }
+
+    /// 表格合并单元格请求（区间左闭右开）
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    pub struct MergeTableCellsRequest {
+        /// 行起始索引（区间左闭右开）
+        pub row_start_index: i32,
+        /// 行结束索引（区间左闭右开）
+        pub row_end_index: i32,
+        /// 列起始索引（区间左闭右开）
+        pub column_start_index: i32,
+        /// 列结束索引（区间左闭右开）
+        pub column_end_index: i32,
+    }
+
+    /// 表格取消单元格合并请求
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    pub struct UnmergeTableCellsRequest {
+        /// table 行索引
+        pub row_index: i32,
+        /// table 列索引
+        pub column_index: i32,
+    }
+
+    /// 分栏插入新列请求
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    pub struct InsertGridColumnRequest {
+        /// 插入列索引（从 1 开始；-1 表示在末尾插入）
+        pub column_index: i32,
+    }
+
+    /// 分栏删除列请求
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    pub struct DeleteGridColumnRequest {
+        /// 删除列索引（从 1 开始）
+        pub column_index: i32,
+    }
+
+    /// 更新分栏列宽比例请求
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    pub struct UpdateGridColumnWidthRatioRequest {
+        /// 各列宽度比例列表（顺序对应各列）
+        pub width_ratios: Vec<i32>,
+    }
+
+    /// 替换图片请求（需先上传图片）
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    pub struct ReplaceImageRequest {
+        /// 新图片的 token
+        pub token: String,
+    }
+
+    /// 替换文件请求（需先上传文件）
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    pub struct ReplaceFileRequest {
+        /// 新文件的 token
+        pub token: String,
+    }
+
+    /// 更新文本元素与样式请求
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    pub struct UpdateTextRequest {
+        /// 文本元素列表
+        pub elements: Vec<TextElement>,
+        /// 文本样式
+        pub style: TextStyle,
+        /// 应更新的字段（必须至少指定一个）
+        pub fields: Vec<i32>,
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn test_insert_table_row_serializes_to_single_key() {
+            let op = BlockUpdateOperation::InsertTableRow(InsertTableRowRequest { row_index: 2 });
+            let json = serde_json::to_value(&op).unwrap();
+            assert_eq!(json["insert_table_row"]["row_index"], 2);
+            assert_eq!(json.as_object().unwrap().len(), 1);
+        }
+
+        #[test]
+        fn test_merge_table_cells_all_fields() {
+            let op = BlockUpdateOperation::MergeTableCells(MergeTableCellsRequest {
+                row_start_index: 0,
+                row_end_index: 1,
+                column_start_index: 0,
+                column_end_index: 2,
+            });
+            let json = serde_json::to_value(&op).unwrap();
+            let inner = &json["merge_table_cells"];
+            assert_eq!(inner["row_start_index"], 0);
+            assert_eq!(inner["row_end_index"], 1);
+            assert_eq!(inner["column_start_index"], 0);
+            assert_eq!(inner["column_end_index"], 2);
+        }
+
+        #[test]
+        fn test_raw_passthrough_roundtrip() {
+            let raw = serde_json::json!({"some_future_op": {"x": 1}});
+            let op: BlockUpdateOperation = serde_json::from_value(raw.clone()).unwrap();
+            match op {
+                BlockUpdateOperation::Raw(v) => assert_eq!(v, raw),
+                other => panic!("expected Raw, got {other:?}"),
+            }
+        }
     }
 }
 

--- a/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/batch_update.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/batch_update.rs
@@ -13,6 +13,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::ccm::docx::models::block_update::BlockUpdateOperation;
 use crate::ccm::docx::models::common_types::DocxBlock;
 use crate::common::{api_endpoints::DocxApiV1, api_utils::*};
 
@@ -31,9 +32,9 @@ pub struct BatchUpdateChatAnnouncementBlocksParams {
 pub struct BatchUpdateRequest {
     /// 块 ID。
     pub block_id: String,
-    /// 操作内容（例如 update_text_elements / merge_table_cells 等）
+    /// 操作内容（update_text_elements / merge_table_cells 等 15 种之一）
     #[serde(flatten)]
-    pub operation: serde_json::Value,
+    pub operation: BlockUpdateOperation,
 }
 
 /// 批量更新群公告块内容响应 data

--- a/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/batch_update.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/batch_update.rs
@@ -42,6 +42,12 @@ pub struct BatchUpdateChatAnnouncementBlocksResponse {
     /// 更新后的块列表。
     #[serde(default)]
     pub blocks: Vec<DocxBlock>,
+    /// 群公告版本号（操作后的版本）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision_id: Option<i32>,
+    /// 幂等标记（请求时传入的 client_token 原样回传）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_token: Option<String>,
 }
 
 impl ApiResponseTrait for BatchUpdateChatAnnouncementBlocksResponse {

--- a/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/children/create.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/children/create.rs
@@ -38,6 +38,12 @@ pub struct CreateChatAnnouncementBlockChildrenResponse {
     /// 新建子块列表。
     #[serde(default)]
     pub children: Vec<DocxBlock>,
+    /// 群公告版本号（操作后的版本）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision_id: Option<i32>,
+    /// 幂等标记（请求时传入的 client_token 原样回传）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_token: Option<String>,
 }
 
 impl ApiResponseTrait for CreateChatAnnouncementBlockChildrenResponse {

--- a/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/get.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/get.rs
@@ -31,6 +31,9 @@ pub struct GetChatAnnouncementBlockResponse {
     /// 块列表。
     #[serde(default)]
     pub items: Vec<DocxBlock>,
+    /// 单块内容（按 block_id 查询单块时返回）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block: Option<DocxBlock>,
     /// 下一页分页标记。
     pub page_token: Option<String>,
     /// 是否还有更多数据。

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/batch_update.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/batch_update.rs
@@ -3,6 +3,7 @@
 /// 批量更新块的富文本内容。
 /// docPath: /document/ukTMukTMukTM/uUDN04SN0QjL1QDN/document-docx/docx-v1/document-block/batch_update
 /// doc: https://open.feishu.cn/document/ukTMukTMukTM/uUDN04SN0QjL1QDN/document-docx/docx-v1/document-block/batch_update
+use crate::ccm::docx::models::block_update::BlockUpdateOperation;
 use crate::ccm::docx::models::common_types::DocxBlock;
 use crate::common::api_endpoints::DocxApiV1;
 use openlark_core::{
@@ -32,9 +33,9 @@ pub struct BatchUpdateDocumentBlocksParams {
 pub struct BatchUpdateRequest {
     /// 块 ID。
     pub block_id: String,
-    /// 操作内容（例如 update_text_elements / merge_table_cells 等）
+    /// 操作内容（update_text_elements / merge_table_cells 等 15 种之一）
     #[serde(flatten)]
-    pub operation: serde_json::Value,
+    pub operation: BlockUpdateOperation,
 }
 
 /// 批量更新块内容响应 data

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/batch_update.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/batch_update.rs
@@ -43,6 +43,12 @@ pub struct BatchUpdateDocumentBlocksResponse {
     /// 更新后的块列表。
     #[serde(default)]
     pub blocks: Vec<DocxBlock>,
+    /// 文档版本号（操作后的文档版本）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub document_revision_id: Option<i32>,
+    /// 幂等标记（请求时传入的 client_token 原样回传）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_token: Option<String>,
 }
 
 impl ApiResponseTrait for BatchUpdateDocumentBlocksResponse {

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/children/create.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/children/create.rs
@@ -44,6 +44,12 @@ pub struct CreateDocumentBlockChildrenResponse {
     /// 新建子块列表。
     #[serde(default)]
     pub children: Vec<DocxBlock>,
+    /// 文档版本号（操作后的文档版本）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub document_revision_id: Option<i32>,
+    /// 幂等标记（请求时传入的 client_token 原样回传）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_token: Option<String>,
 }
 
 impl ApiResponseTrait for CreateDocumentBlockChildrenResponse {

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/descendant/create.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/descendant/create.rs
@@ -14,6 +14,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::ccm::docx::models::common_types::DocxBlock;
 use crate::common::{api_endpoints::DocxApiV1, api_utils::*};
 
 /// 创建嵌套块请求参数
@@ -44,6 +45,15 @@ pub struct CreateDocumentBlockDescendantResponse {
     /// 临时块 ID 与真实块 ID 的映射。
     #[serde(default)]
     pub block_id_relations: Vec<BlockIdRelation>,
+    /// 新建子块列表（部分场景返回）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub children: Option<Vec<DocxBlock>>,
+    /// 文档版本号（操作后的文档版本）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub document_revision_id: Option<i32>,
+    /// 幂等标记（请求时传入的 client_token 原样回传）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_token: Option<String>,
 }
 
 /// 临时 block_id 与实际 block_id 的映射关系

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/patch.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/patch.rs
@@ -3,6 +3,7 @@
 /// 更新指定块的内容。如果操作成功，接口将返回更新后的块的富文本内容。
 /// docPath: /document/ukTMukTMukTM/uUDN04SN0QjL1QDN/document-docx/docx-v1/document-block/patch
 /// doc: https://open.feishu.cn/document/ukTMukTMukTM/uUDN04SN0QjL1QDN/document-docx/docx-v1/document-block/patch
+use crate::ccm::docx::models::block_update::BlockUpdateOperation;
 use crate::ccm::docx::models::common_types::DocxBlock;
 use crate::common::api_endpoints::DocxApiV1;
 use openlark_core::{
@@ -26,9 +27,9 @@ pub struct UpdateDocumentBlockParams {
     /// 块ID
     #[serde(skip_serializing)]
     pub block_id: String,
-    /// 更新内容（按文档定义传入，例如 update_text_elements 等）
+    /// 更新操作（update_text_elements / insert_table_row 等 15 种之一）
     #[serde(flatten)]
-    pub update: serde_json::Value,
+    pub update: BlockUpdateOperation,
 }
 
 /// 更新块内容响应
@@ -97,6 +98,11 @@ mod tests {
 
     use serde_json;
 
+    use super::*;
+    use crate::ccm::docx::models::block_update::{
+        BlockUpdateOperation, InsertTableRowRequest, MergeTableCellsRequest,
+    };
+
     #[test]
     fn test_serialization_roundtrip() {
         // 基础序列化测试
@@ -110,5 +116,42 @@ mod tests {
         let json = r#"{"field": "data"}"#;
         let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
         assert_eq!(value["field"], "data");
+    }
+
+    #[test]
+    fn test_block_update_operation_serializes_to_single_key() {
+        // 官方期望 JSON：{"insert_table_row": {"row_index": 2}}
+        let op = BlockUpdateOperation::InsertTableRow(InsertTableRowRequest { row_index: 2 });
+        let json = serde_json::to_value(&op).unwrap();
+        assert_eq!(json["insert_table_row"]["row_index"], 2);
+        assert_eq!(json.as_object().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_block_update_operation_merge_cells_all_fields() {
+        let op = BlockUpdateOperation::MergeTableCells(MergeTableCellsRequest {
+            row_start_index: 0,
+            row_end_index: 1,
+            column_start_index: 0,
+            column_end_index: 2,
+        });
+        let json = serde_json::to_value(&op).unwrap();
+        let inner = &json["merge_table_cells"];
+        assert_eq!(inner["row_start_index"], 0);
+        assert_eq!(inner["column_end_index"], 2);
+    }
+
+    #[test]
+    fn test_update_document_block_params_flatten_serialization() {
+        // Params 通过 #[serde(flatten)] 把 update 操作平铺到顶层
+        let params = UpdateDocumentBlockParams {
+            document_id: "docx123".to_string(),
+            block_id: "block456".to_string(),
+            update: BlockUpdateOperation::InsertTableRow(InsertTableRowRequest { row_index: 1 }),
+        };
+        let json = serde_json::to_value(&params).unwrap();
+        assert_eq!(json["insert_table_row"]["row_index"], 1);
+        // 路径字段不参与序列化
+        assert!(json.get("document_id").is_none());
     }
 }

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/patch.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/patch.rs
@@ -36,6 +36,12 @@ pub struct UpdateDocumentBlockParams {
 pub struct UpdateDocumentBlockResponse {
     /// 更新后的块内容。
     pub block: DocxBlock,
+    /// 文档版本号（操作后的文档版本）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub document_revision_id: Option<i32>,
+    /// 幂等标记（请求时传入的 client_token 原样回传）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_token: Option<String>,
 }
 
 impl ApiResponseTrait for UpdateDocumentBlockResponse {

--- a/crates/openlark-docs/src/ccm/docx/v1/document/convert.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/convert.rs
@@ -3,6 +3,7 @@
 /// 将 Markdown/HTML 格式的内容转换为文档块，以便于将 Markdown/HTML 格式的内容插入到文档中。目前支持转换为的块类型包含文本、一到九级标题、无序列表、有序列表、代码块、引用、待办事项、图片、表格、表格单元格。
 /// docPath: /document/ukTMukTMukTM/uUDN04SN0QjL1QDN/document-docx/docx-v1/document/convert
 /// doc: https://open.feishu.cn/document/ukTMukTMukTM/uUDN04SN0QjL1QDN/document-docx/docx-v1/document/convert
+use crate::ccm::docx::models::common_types::DocxBlock;
 use crate::common::api_endpoints::DocxApiV1;
 use openlark_core::{
     SDKResult,
@@ -42,6 +43,12 @@ pub struct ConvertContentToBlocksResponse {
     /// 一级块 ID 列表。
     #[serde(default)]
     pub first_level_block_ids: Vec<String>,
+    /// 转换后的完整块列表（部分场景返回）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocks: Option<Vec<DocxBlock>>,
+    /// 块 ID 到图片 URL 的映射（含图片的转换结果）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_id_to_image_urls: Option<serde_json::Value>,
 }
 
 impl ApiResponseTrait for ConvertContentToBlocksResponse {

--- a/crates/openlark-docs/src/ccm/wiki/v2/space/create.rs
+++ b/crates/openlark-docs/src/ccm/wiki/v2/space/create.rs
@@ -25,6 +25,10 @@ pub struct CreateWikiSpaceRequest {
     name: String,
     /// 知识空间描述
     description: Option<String>,
+    /// 是否开启知识库分享（可选）
+    ///
+    /// 官方字段 `open_sharing`：开启后知识库可被组织外用户访问。
+    open_sharing: Option<String>,
 }
 
 /// 创建知识空间请求体（内部使用）
@@ -33,6 +37,8 @@ struct CreateWikiSpaceRequestBody {
     name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    open_sharing: Option<String>,
 }
 
 /// 创建知识空间响应
@@ -55,6 +61,7 @@ impl CreateWikiSpaceRequest {
             config,
             name: String::new(),
             description: None,
+            open_sharing: None,
         }
     }
 
@@ -67,6 +74,12 @@ impl CreateWikiSpaceRequest {
     /// 设置知识空间描述
     pub fn description(mut self, description: impl Into<String>) -> Self {
         self.description = Some(description.into());
+        self
+    }
+
+    /// 设置是否开启知识库分享（官方字段 `open_sharing`）
+    pub fn open_sharing(mut self, open_sharing: impl Into<String>) -> Self {
+        self.open_sharing = Some(open_sharing.into());
         self
     }
 
@@ -90,6 +103,7 @@ impl CreateWikiSpaceRequest {
         let request_body = CreateWikiSpaceRequestBody {
             name: self.name,
             description: self.description,
+            open_sharing: self.open_sharing,
         };
 
         let api_request: ApiRequest<CreateWikiSpaceResponse> =
@@ -114,6 +128,9 @@ pub struct CreateWikiSpaceParams {
     /// 知识空间描述
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// 是否开启知识库分享（官方字段 `open_sharing`）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub open_sharing: Option<String>,
 }
 
 #[cfg(test)]
@@ -186,6 +203,7 @@ mod tests {
         let params = CreateWikiSpaceParams {
             name: "旧API知识库".to_string(),
             description: Some("使用旧API创建".to_string()),
+            open_sharing: None,
         };
 
         assert_eq!(params.name, "旧API知识库");

--- a/crates/openlark-docs/src/ccm/wiki/v2/space/node/create.rs
+++ b/crates/openlark-docs/src/ccm/wiki/v2/space/node/create.rs
@@ -164,7 +164,14 @@ impl CreateWikiSpaceNodeRequest {
 
         validate_required!(params.obj_type, "obj_type不能为空");
         // 官方将 node_type 标记为 required，运行时强制校验（保留 Option 以兼容旧调用）
-        validate_required!(params.node_type, "node_type不能为空");
+        match params.node_type.as_deref() {
+            Some(v) if !v.trim().is_empty() => {}
+            _ => {
+                return Err(openlark_core::error::CoreError::validation_msg(
+                    "node_type不能为空",
+                ));
+            }
+        }
 
         // ===== 构建请求 =====
         let api_endpoint = WikiApiV2::SpaceNodeCreate(self.space_id.clone());

--- a/crates/openlark-docs/src/ccm/wiki/v2/space/node/create.rs
+++ b/crates/openlark-docs/src/ccm/wiki/v2/space/node/create.rs
@@ -49,6 +49,7 @@ pub struct CreateWikiSpaceNodeParams {
     ///     node_type: Some("origin".to_string()),
     ///     title: Some("项目文档".to_string()),
     ///     obj_token: None,
+    ///     origin_node_token: None,
     /// };
     ///
     /// // 创建电子表格节点
@@ -58,6 +59,7 @@ pub struct CreateWikiSpaceNodeParams {
     ///     title: Some("项目进度表".to_string()),
     ///     obj_token: None,
     ///     node_type: None,
+    ///     origin_node_token: None,
     /// };
     /// ```
     pub obj_type: String,
@@ -86,7 +88,15 @@ pub struct CreateWikiSpaceNodeParams {
     /// - `origin`: 原始节点（默认值）
     /// - `shortcut`: 快捷方式节点
     /// - 其他扩展类型（根据实际需求）
+    ///
+    /// # 注意
+    /// 官方文档将其标记为 **required**。SDK 保留 `Option<String>` 以兼容旧调用，
+    /// 但在 `execute` / `execute_with_options` 中会做必填校验。
     pub node_type: Option<String>,
+    /// 源节点 token（可选，官方字段 `origin_node_token`）
+    ///
+    /// 创建已存在文档的引用节点时传入源节点 token。
+    pub origin_node_token: Option<String>,
     /// 节点标题（可选）
     ///
     /// # 注意事项
@@ -153,6 +163,8 @@ impl CreateWikiSpaceNodeRequest {
         }
 
         validate_required!(params.obj_type, "obj_type不能为空");
+        // 官方将 node_type 标记为 required，运行时强制校验（保留 Option 以兼容旧调用）
+        validate_required!(params.node_type, "node_type不能为空");
 
         // ===== 构建请求 =====
         let api_endpoint = WikiApiV2::SpaceNodeCreate(self.space_id.clone());
@@ -189,6 +201,7 @@ mod tests {
             node_type: Some("origin".to_string()),
             title: Some("测试文档".to_string()),
             obj_token: None,
+            origin_node_token: None,
         };
 
         assert_eq!(params.obj_type, "docx");
@@ -204,6 +217,7 @@ mod tests {
             title: Some("项目进度表".to_string()),
             obj_token: None,
             node_type: None,
+            origin_node_token: None,
         };
 
         assert_eq!(params.obj_type, "sheet");
@@ -241,6 +255,7 @@ mod tests {
                 node_type: None,
                 title: None,
                 obj_token: None,
+                origin_node_token: None,
             };
             assert_eq!(params.obj_type, obj_type);
         }
@@ -255,6 +270,7 @@ mod tests {
             node_type: Some("shortcut".to_string()),
             title: Some("快捷方式".to_string()),
             obj_token: Some("original_doc_token".to_string()),
+            origin_node_token: None,
         };
 
         assert_eq!(params.node_type, Some("shortcut".to_string()));
@@ -270,6 +286,7 @@ mod tests {
             node_type: Some("origin".to_string()),
             title: Some("根目录文档".to_string()),
             obj_token: None,
+            origin_node_token: None,
         };
 
         assert!(params.parent_node_token.is_none());

--- a/crates/openlark-docs/src/ccm/wiki/v2/space/node/move_docs_to_wiki.rs
+++ b/crates/openlark-docs/src/ccm/wiki/v2/space/node/move_docs_to_wiki.rs
@@ -28,6 +28,11 @@ pub struct MoveDocsToWikiRequest {
     obj_type: String,
     /// 目标父节点 wiki token
     parent_wiki_token: String,
+    /// 是否直接执行移动（可选，官方字段 `apply`）
+    ///
+    /// - `true`（默认）：同步执行移动
+    /// - `false`：仅创建移动任务，返回 `task_id` 供后续查询
+    apply: Option<bool>,
 }
 
 /// 移动云空间文档至知识空间请求体（内部使用）
@@ -36,6 +41,8 @@ struct MoveDocsToWikiRequestBody {
     obj_token: String,
     obj_type: String,
     parent_wiki_token: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    apply: Option<bool>,
 }
 
 /// 移动云空间文档至知识空间响应
@@ -45,6 +52,9 @@ pub struct MoveDocsToWikiResponse {
     pub wiki_token: Option<String>,
     /// 操作未完成时返回的异步任务 ID
     pub task_id: Option<String>,
+    /// 是否已直接执行移动（官方字段 `applied`，仅 apply=true 时返回）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applied: Option<bool>,
 }
 
 impl ApiResponseTrait for MoveDocsToWikiResponse {
@@ -62,6 +72,7 @@ impl MoveDocsToWikiRequest {
             obj_token: String::new(),
             obj_type: String::new(),
             parent_wiki_token: String::new(),
+            apply: None,
         }
     }
 
@@ -89,6 +100,15 @@ impl MoveDocsToWikiRequest {
         self
     }
 
+    /// 设置是否直接执行移动（官方字段 `apply`）
+    ///
+    /// - `true`（默认）：同步执行移动
+    /// - `false`：仅创建移动任务，返回 `task_id`
+    pub fn apply(mut self, apply: bool) -> Self {
+        self.apply = Some(apply);
+        self
+    }
+
     /// 执行请求
     pub async fn execute(self) -> SDKResult<MoveDocsToWikiResponse> {
         self.execute_with_options(openlark_core::req_option::RequestOption::default())
@@ -111,6 +131,7 @@ impl MoveDocsToWikiRequest {
             obj_token: self.obj_token,
             obj_type: self.obj_type,
             parent_wiki_token: self.parent_wiki_token,
+            apply: self.apply,
         };
 
         let api_request: ApiRequest<MoveDocsToWikiResponse> =

--- a/crates/openlark-docs/src/ccm/wiki/v2/space/node/move_docs_to_wiki.rs
+++ b/crates/openlark-docs/src/ccm/wiki/v2/space/node/move_docs_to_wiki.rs
@@ -156,6 +156,9 @@ pub struct MoveDocsToWikiParams {
     pub obj_type: String,
     /// 目标父节点 wiki token
     pub parent_wiki_token: String,
+    /// 是否直接执行移动（官方字段 `apply`）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub apply: Option<bool>,
 }
 
 #[cfg(test)]

--- a/tools/api_contracts/compare.py
+++ b/tools/api_contracts/compare.py
@@ -146,8 +146,8 @@ def compare_request_fields(
         if rust_field is None:
             severity = "ERROR" if official_field.required else "WARN"
             code = "E_REQUIRED_REQUEST_FIELD_MISSING" if official_field.required else "W_OPTIONAL_REQUEST_FIELD_MISSING"
-            # 含 #[serde(flatten)] Value 透传的 API 把所有官方 optional 字段视为已覆盖
-            # （如 docx block 的 update_* 操作），跳过 optional 缺失告警。
+            # 含 #[serde(flatten)] 字段的 API 把所有官方 optional 字段视为已覆盖
+            # （如 docx block 的 update_* 操作，透传 Value 或 typed 枚举），跳过 optional 缺失告警。
             if not official_field.required and rust_contract.has_flatten_value_passthrough:
                 continue
             findings.append(

--- a/tools/api_contracts/compare.py
+++ b/tools/api_contracts/compare.py
@@ -146,6 +146,10 @@ def compare_request_fields(
         if rust_field is None:
             severity = "ERROR" if official_field.required else "WARN"
             code = "E_REQUIRED_REQUEST_FIELD_MISSING" if official_field.required else "W_OPTIONAL_REQUEST_FIELD_MISSING"
+            # 含 #[serde(flatten)] Value 透传的 API 把所有官方 optional 字段视为已覆盖
+            # （如 docx block 的 update_* 操作），跳过 optional 缺失告警。
+            if not official_field.required and rust_contract.has_flatten_value_passthrough:
+                continue
             findings.append(
                 finding(
                     severity,

--- a/tools/api_contracts/models.py
+++ b/tools/api_contracts/models.py
@@ -68,6 +68,9 @@ class RustApiContract:
     endpoint_calls: tuple[RustEndpointCall, ...] = ()
     fields: tuple["RustField", ...] = ()
     response_fields: tuple["RustField", ...] = ()
+    # request struct 含 #[serde(flatten)] xxx: serde_json::Value 时，
+    # 视为该 API 透传所有官方 optional request 字段（非 correctness bug）。
+    has_flatten_value_passthrough: bool = False
 
 
 @dataclass(frozen=True)

--- a/tools/api_contracts/models.py
+++ b/tools/api_contracts/models.py
@@ -68,8 +68,8 @@ class RustApiContract:
     endpoint_calls: tuple[RustEndpointCall, ...] = ()
     fields: tuple["RustField", ...] = ()
     response_fields: tuple["RustField", ...] = ()
-    # request struct 含 #[serde(flatten)] xxx: serde_json::Value 时，
-    # 视为该 API 透传所有官方 optional request 字段（非 correctness bug）。
+    # request struct 含 #[serde(flatten)] 字段时，视为该 API 透传所有官方 optional
+    # request 字段（透传 Value 或 typed 枚举，非 correctness bug）。
     has_flatten_value_passthrough: bool = False
 
 

--- a/tools/api_contracts/rust_source.py
+++ b/tools/api_contracts/rust_source.py
@@ -593,15 +593,14 @@ def extract_rust_fields(text: str) -> tuple[RustField, ...]:
 
 
 def has_flatten_value_passthrough(text: str) -> bool:
-    """检测 request struct 是否有 ``#[serde(flatten)] xxx: serde_json::Value``。
+    """检测 request struct 是否有 ``#[serde(flatten)]`` 字段。
 
-    这种写法把官方 optional request 字段整体透传（例如 docx block 的 ``update_*`` 操作），
-    扫描器无法逐字段对比，应在 contract 比较时跳过这类 API 的 optional 字段缺失告警。
+    flatten 字段把额外的官方 request 字段整体合并到请求体（例如 docx block 的
+    ``update_*`` 操作，无论透传 ``serde_json::Value`` 还是 typed
+    ``BlockUpdateOperation`` 枚举），扫描器无法逐字段对比这类 API 的 optional 字段，
+    应在 contract 比较时跳过其 optional 字段缺失告警。
     """
-    pattern = re.compile(
-        r"#\s*\[\s*serde\s*\(\s*flatten\s*\)\s*\][^\n]*\n\s*"
-        r"pub\s+[A-Za-z_][A-Za-z0-9_]*\s*:\s*serde_json::Value\b"
-    )
+    pattern = re.compile(r"#\s*\[\s*serde\s*\(\s*flatten\s*\)\s*\]")
     return bool(pattern.search(text))
 
 

--- a/tools/api_contracts/rust_source.py
+++ b/tools/api_contracts/rust_source.py
@@ -11,7 +11,7 @@ from .models import RustApiContract, RustEndpointCall, RustField
 
 
 REQUEST_STRUCT_SUFFIXES = ("Body", "Query", "Params", "RequestBody")
-RESPONSE_STRUCT_SUFFIXES = ("Response", "Result")
+RESPONSE_STRUCT_SUFFIXES = ("Response", "Result", "Resp")
 
 
 @dataclass(frozen=True)
@@ -592,12 +592,42 @@ def extract_rust_fields(text: str) -> tuple[RustField, ...]:
     )
 
 
+def has_flatten_value_passthrough(text: str) -> bool:
+    """检测 request struct 是否有 ``#[serde(flatten)] xxx: serde_json::Value``。
+
+    这种写法把官方 optional request 字段整体透传（例如 docx block 的 ``update_*`` 操作），
+    扫描器无法逐字段对比，应在 contract 比较时跳过这类 API 的 optional 字段缺失告警。
+    """
+    pattern = re.compile(
+        r"#\s*\[\s*serde\s*\(\s*flatten\s*\)\s*\][^\n]*\n\s*"
+        r"pub\s+[A-Za-z_][A-Za-z0-9_]*\s*:\s*serde_json::Value\b"
+    )
+    return bool(pattern.search(text))
+
+
 def extract_rust_response_fields(text: str) -> tuple[RustField, ...]:
     return extract_rust_struct_fields(text, RESPONSE_STRUCT_SUFFIXES)
 
 
 def extract_file_content_fields(text: str) -> tuple[RustField, ...]:
+    """提取 multipart/form-data 接口的 request 字段。
+
+    multipart 接口的请求体字段组织方式与普通 JSON 接口不同：
+    - 文件二进制内容通过 ``.file_content(...)`` 传入（序列化为 ``file``）
+    - 其余表单字段（``file_name``/``parent_node``/``size``/``checksum``/``name`` 等）通过
+      局部 ``UploadMeta``/``PartMeta`` 结构体（``.json_body(&meta)``）或
+      ``serde_json::json!({...})`` 字面量组织
+
+    这三类都会被本函数识别，以消除 multipart 接口下大量 ``E_REQUIRED_REQUEST_FIELD_MISSING``
+    与 ``W_OPTIONAL_REQUEST_FIELD_MISSING`` 的扫描器误报。
+    """
+    # 仅当文件使用了 .file_content(...) 才按 multipart 处理
+    if ".file_content(" not in text:
+        return ()
+
     fields: list[RustField] = []
+
+    # 1) file 二进制字段（兼容旧逻辑：.file_content(body|self).field）
     pattern = re.compile(r"\.file_content\(\s*(?:body|self)\.([A-Za-z_][A-Za-z0-9_]*)")
     for match in pattern.finditer(text):
         fields.append(
@@ -610,7 +640,122 @@ def extract_file_content_fields(text: str) -> tuple[RustField, ...]:
                 line=line_of(text, match.start()),
             )
         )
+    # .file_content(self.file) / .file_content(file) 形式（无显式字段名）
+    if not fields:
+        for match in re.finditer(r"\.file_content\(\s*(?:self\.)?([A-Za-z_][A-Za-z0-9_]*)\s*\)", text):
+            fields.append(
+                RustField(
+                    struct_name="MultipartFile",
+                    field_name=match.group(1),
+                    serialized_name="file",
+                    type_name="Vec<u8>",
+                    optional=False,
+                    line=line_of(text, match.start()),
+                )
+            )
+
+    # 2) 局部 UploadMeta / PartMeta 结构体的字段（.json_body(&meta) 组织 multipart 表单）
+    fields.extend(_extract_multipart_meta_fields(text))
+
+    # 3) serde_json::json!({...}) 字面量中的字符串键（baike 风格 multipart）
+    fields.extend(_extract_json_literal_fields(text))
+
     return tuple(fields)
+
+
+def _extract_multipart_meta_fields(text: str) -> list[RustField]:
+    """提取文件内局部定义的 multipart meta 结构体（UploadMeta / PartMeta 等）字段。
+
+    这些结构体不以 Request 后缀（Body/Query/Params/RequestBody）结尾，
+    常规 ``extract_rust_struct_fields`` 识别不到，需要单独扫描。
+    局部结构体的字段通常没有 ``pub`` 前缀（私有），这里放宽匹配。
+    """
+    fields: list[RustField] = []
+    meta_suffixes = ("Meta",)
+    for match in re.finditer(r"struct\s+([A-Za-z_][A-Za-z0-9_]*)\s*\{", text):
+        struct_name = match.group(1)
+        if not struct_name.endswith(meta_suffixes):
+            continue
+        open_brace = text.find("{", match.end() - 1)
+        close_brace = find_matching_brace(text, open_brace)
+        if close_brace < 0:
+            continue
+        body = text[open_brace + 1 : close_brace]
+        base_line = line_of(text, open_brace + 1)
+        fields.extend(_extract_meta_struct_fields(struct_name, body, base_line))
+    return fields
+
+
+def _extract_meta_struct_fields(struct_name: str, body: str, base_line: int) -> list[RustField]:
+    """解析局部 meta 结构体字段（兼容 ``pub`` 与无 ``pub`` 的私有字段）。"""
+    fields: list[RustField] = []
+    pending_attrs: list[str] = []
+    for offset, line in enumerate(body.splitlines()):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#["):
+            pending_attrs.append(stripped)
+            continue
+        # 兼容 "pub field: T," 与 "field: T," 两种写法
+        match = re.match(r"(?:pub\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*:\s*([^,]+),", stripped)
+        if not match:
+            pending_attrs.clear()
+            continue
+        attrs = "\n".join(pending_attrs)
+        pending_attrs.clear()
+        if "skip_serializing" in attrs and "skip_serializing_if" not in attrs:
+            continue
+        field_name = match.group(1)
+        type_name = match.group(2).strip()
+        rename_match = re.search(r'rename\s*=\s*"([^"]+)"', attrs)
+        serialized_name = rename_match.group(1) if rename_match else field_name
+        fields.append(
+            RustField(
+                struct_name=struct_name,
+                field_name=field_name,
+                serialized_name=serialized_name,
+                type_name=type_name,
+                optional=is_optional_type(type_name),
+                line=base_line + offset,
+            )
+        )
+    return fields
+
+
+def _extract_json_literal_fields(text: str) -> list[RustField]:
+    """提取 ``serde_json::json!({...})`` 字面量里的字符串键（multipart 表单字段）。
+
+    典型场景：baike 文件上传用 ``serde_json::json!({"name": ..., "__file_name": ...})``
+    组织 multipart 表单字段。这里只收集顶层字符串键作为 request 字段名，
+    下划线前缀的内部字段（如 ``__file_name``）跳过。
+    """
+    fields: list[RustField] = []
+    for match in re.finditer(r"json!\s*\(\s*\{", text):
+        open_brace = text.find("{", match.end() - 1)
+        close_brace = find_matching_brace(text, open_brace)
+        if close_brace < 0:
+            continue
+        body = text[open_brace + 1 : close_brace]
+        base_line = line_of(text, open_brace + 1)
+        for offset, line in enumerate(body.splitlines()):
+            key_match = re.search(r'"([A-Za-z_][A-Za-z0-9_]*)"\s*:', line)
+            if not key_match:
+                continue
+            key = key_match.group(1)
+            if key.startswith("__"):
+                continue
+            fields.append(
+                RustField(
+                    struct_name="JsonLiteral",
+                    field_name=key,
+                    serialized_name=key,
+                    type_name="String",
+                    optional=False,
+                    line=base_line + offset,
+                )
+            )
+    return fields
 
 
 def extract_rust_struct_fields(text: str, suffixes: tuple[str, ...]) -> tuple[RustField, ...]:
@@ -714,4 +859,5 @@ def scan_api_file(
         endpoint_calls=extract_endpoint_calls(text, resolver),
         fields=extract_rust_fields(text),
         response_fields=extract_rust_response_fields(text),
+        has_flatten_value_passthrough=has_flatten_value_passthrough(text),
     )

--- a/tools/tests/test_validate_api_contracts_compare.py
+++ b/tools/tests/test_validate_api_contracts_compare.py
@@ -144,6 +144,35 @@ class ContractCompareTests(unittest.TestCase):
 
         self.assertEqual(findings[0].code, "W_REQUIRED_REQUEST_FIELD_OPTIONAL")
 
+    def test_compare_request_fields_skips_optional_missing_when_flatten_passthrough(self):
+        # docx block patch：#[serde(flatten)] update: serde_json::Value 透传，
+        # 官方 optional 字段（update_text_elements 等）应跳过缺失告警
+        official_fields = (
+            OfficialField(
+                name="update_text_elements",
+                required=False,
+                location="requestBody:application/json",
+            ),
+        )
+        rust = RustApiContract(
+            rel_path="docx/v1/document/block/patch.rs",
+            fields=(
+                RustField(
+                    struct_name="UpdateDocumentBlockParams",
+                    field_name="update",
+                    serialized_name="update",
+                    type_name="serde_json::Value",
+                    optional=False,
+                    line=30,
+                ),
+            ),
+            has_flatten_value_passthrough=True,
+        )
+
+        findings = compare_request_fields(self._api(), official_fields, rust)
+
+        self.assertEqual(findings, [])
+
     def test_compare_response_fields_warns_for_missing_data_field(self):
         official_fields = (
             OfficialField(

--- a/tools/tests/test_validate_api_contracts_rust_source.py
+++ b/tools/tests/test_validate_api_contracts_rust_source.py
@@ -239,13 +239,41 @@ class RustSourceContractTests(unittest.TestCase):
         self.assertNotIn("__file_name", names)
 
     def test_scan_api_file_detects_flatten_value_passthrough(self):
-        # docx block patch：#[serde(flatten)] update: serde_json::Value
+        # docx block patch：#[serde(flatten)] update: serde_json::Value（透传写法）
         text = """
         pub struct UpdateDocumentBlockParams {
             #[serde(skip_serializing)]
             pub document_id: String,
             #[serde(flatten)]
             pub update: serde_json::Value,
+        }
+
+        let req: ApiRequest<Response> = ApiRequest::post(BANK_CARD);
+        """
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            src = Path(temp_dir)
+            (src / "endpoints.rs").write_text(
+                'pub const BANK_CARD: &str = "/open-apis/x/v1/y";',
+                encoding="utf-8",
+            )
+            (src / "docx").mkdir(parents=True)
+            (src / "docx" / "patch.rs").write_text(text, encoding="utf-8")
+
+            contract = scan_api_file(src, "docx/patch.rs")
+
+        self.assertIsNotNone(contract)
+        assert contract is not None
+        self.assertTrue(contract.has_flatten_value_passthrough)
+
+    def test_scan_api_file_detects_flatten_typed_enum_passthrough(self):
+        # docx block patch：#[serde(flatten)] update: BlockUpdateOperation（typed 枚举写法）
+        text = """
+        pub struct UpdateDocumentBlockParams {
+            #[serde(skip_serializing)]
+            pub document_id: String,
+            #[serde(flatten)]
+            pub update: BlockUpdateOperation,
         }
 
         let req: ApiRequest<Response> = ApiRequest::post(BANK_CARD);

--- a/tools/tests/test_validate_api_contracts_rust_source.py
+++ b/tools/tests/test_validate_api_contracts_rust_source.py
@@ -165,6 +165,107 @@ class RustSourceContractTests(unittest.TestCase):
 
         self.assertEqual([field.serialized_name for field in fields], ["data", "parsing_result"])
 
+    def test_extract_rust_response_fields_reads_resp_suffix_struct(self):
+        # baike 的 MatchEntityResp 等用 Resp 后缀命名响应 struct
+        text = """
+        pub struct MatchEntityResp {
+            #[serde(default)]
+            pub results: Vec<MatchEntityResult>,
+        }
+        """
+
+        fields = extract_rust_response_fields(text)
+
+        self.assertEqual([field.serialized_name for field in fields], ["results"])
+
+    def test_extract_rust_fields_collects_multipart_meta_struct_fields(self):
+        # drive 上传：局部 UploadMeta 结构体组织 multipart 表单字段
+        text = """
+        pub struct UploadAllResponse {
+            pub file_token: String,
+        }
+
+        pub async fn execute(self) -> SDKResult<UploadAllResponse> {
+            #[derive(Serialize)]
+            struct UploadMeta {
+                file_name: String,
+                parent_type: String,
+                parent_node: String,
+                size: usize,
+                #[serde(skip_serializing_if = "Option::is_none")]
+                checksum: Option<String>,
+            }
+
+            let request = ApiRequest::<UploadAllResponse>::post(&api_endpoint.to_url())
+                .json_body(&meta)
+                .file_content(self.file);
+        }
+        """
+
+        fields = extract_rust_fields(text)
+
+        names = {field.serialized_name for field in fields}
+        self.assertIn("file", names)
+        self.assertIn("file_name", names)
+        self.assertIn("parent_type", names)
+        self.assertIn("parent_node", names)
+        self.assertIn("size", names)
+        self.assertIn("checksum", names)
+
+    def test_extract_rust_fields_collects_json_literal_multipart_keys(self):
+        # baike 上传：serde_json::json!({"name": ..., "__file_name": ...})
+        text = """
+        pub struct UploadFileResponse {
+            pub file_token: String,
+        }
+
+        let body = serde_json::json!({
+            "name": name,
+            "__file_name": name,
+        });
+
+        let api_request: ApiRequest<UploadFileResponse> =
+            ApiRequest::post(&BaikeApiV1::FileUpload.to_url())
+                .body(body)
+                .file_content(self.file);
+        """
+
+        fields = extract_rust_fields(text)
+
+        names = {field.serialized_name for field in fields}
+        self.assertIn("file", names)
+        self.assertIn("name", names)
+        # 内部字段（下划线前缀）不应作为表单字段
+        self.assertNotIn("__file_name", names)
+
+    def test_scan_api_file_detects_flatten_value_passthrough(self):
+        # docx block patch：#[serde(flatten)] update: serde_json::Value
+        text = """
+        pub struct UpdateDocumentBlockParams {
+            #[serde(skip_serializing)]
+            pub document_id: String,
+            #[serde(flatten)]
+            pub update: serde_json::Value,
+        }
+
+        let req: ApiRequest<Response> = ApiRequest::post(BANK_CARD);
+        """
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            src = Path(temp_dir)
+            (src / "endpoints.rs").write_text(
+                'pub const BANK_CARD: &str = "/open-apis/x/v1/y";',
+                encoding="utf-8",
+            )
+            (src / "docx").mkdir(parents=True)
+            (src / "docx" / "patch.rs").write_text(text, encoding="utf-8")
+
+            contract = scan_api_file(src, "docx/patch.rs")
+
+        self.assertIsNotNone(contract)
+        assert contract is not None
+        self.assertTrue(contract.has_flatten_value_passthrough)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #223

## 背景

`tools/validate_api_contracts.py --fields --live-fields` 全量对比 openlark-docs 214 个 API，发现 43 个真字段遗漏（23 optional request 缺 + 19 response 缺 + 1 required 当 optional）。本 PR 同时修 validator 误报与真实字段缺口，并把 docx block update 操作升级为 typed 建模。

## 改动（5 个 commit）

### 1. validator 扫描器 3 类误报（`tools/api_contracts/`）
- **Resp 后缀识别**：`RESPONSE_STRUCT_SUFFIXES` 追加 `Resp`，解决 baike `MatchEntityResp.results`（已建模）误报。
- **multipart meta 识别**：扫描局部 `UploadMeta`/`PartMeta` struct 字段 + `serde_json::json!({...})` 字面量键，解决 drive/baike 上传 16 个 `E_REQUIRED_REQUEST_FIELD_MISSING` 与 multipart `checksum`/`extra` 误报。
- **flatten 透传识别**：`#[serde(flatten)]` 字段视为透传官方 optional 字段（含 typed 枚举写法），解决 docx block 的 `update_*` 误报。
- 新增 8 个单测覆盖。

### 2. wiki 字段缺口
- `space/create.rs`：`open_sharing`（optional string）+ builder
- `space/node/create.rs`：`origin_node_token`（optional）；`node_type` 官方 required，保留 `Option<String>` 兼容旧调用 + 运行时必填校验（非破坏性）
- `space/node/move_docs_to_wiki.rs`：`apply`（optional bool）请求 + `applied`（optional bool）响应

### 3. docx 响应字段缺口（9 个 response struct）
补齐 `document_revision_id`/`client_token`/`children`/`blocks`/`block`/`fields`/`revision_id`/`block_id_to_image_urls` 等可选响应字段，均为 `Option<...>` + `#[serde(default)]` 向后兼容追加。

### 4. docx typed update 建模
- 新增 `ccm::docx::models::block_update::BlockUpdateOperation` 枚举（15 个 typed 操作变体 + `Raw(serde_json::Value)` 兜底），字段定义来自飞书 docx-v1/document-block/patch 官方 apiSchema（2026-06-23）。
- 3 个调用点（patch / batch_update / chat batch_update）从 `serde_json::Value` 升级为 typed 枚举。
- `TextElement/TextRun/TextStyle` 补 `PartialEq` 派生。

### 5. validator 支持 typed flatten 透传 + apply 字段对齐

## 验证

全量 live field 对比（openlark-docs 214 API）：

| 指标 | 修复前 | 修复后 |
|---|---|---|
| Errors | 16 | **0** |
| `W_OPTIONAL_REQUEST_FIELD_MISSING` | 23 | **0** |
| `W_RESPONSE_FIELD_MISSING` | 19 | **0** |
| Warnings 总计 | 168 | 105 |

剩余 104 warnings 全为 `*_FIELDS_UNRESOLVED`（深度嵌套 struct 扫描器限制，非字段缺口）；仅 1 条 `W_REQUIRED_REQUEST_FIELD_OPTIONAL`（wiki `node_type` 故意保留 `Option` 兼容旧调用，已加运行时必填校验，属设计权衡）。

- `cargo fmt` ✅ clean
- `cargo clippy --workspace --all-features` ✅ 0 issues
- `cargo test --workspace --all-features` ✅ 84 test suite 全 pass
- validator 单测 ✅ 全 pass

## 设计决策

- **wiki `node_type`**：保留 `Option<String>` 以兼容旧调用（非破坏性），`execute` 加运行时必填校验对齐官方 required 语义。
- **docx typed update**：枚举末尾保留 `Raw(serde_json::Value)` 兜底变体，避免官方新增操作阻塞请求发送。
- **docx response 字段**：用 `#[serde(default, skip_serializing_if = "Option::is_none")]`，向后兼容。