### PR TITLE
refactor(event): 移除 9 个孤儿端点常量（占位 public API）

### DIFF
--- a/crates/openlark-communication/src/endpoints/event.rs
+++ b/crates/openlark-communication/src/endpoints/event.rs
@@ -1,31 +1,11 @@
 //! Event (事件系统) 端点定义
 //!
-//! 事件系统 - 事件订阅、处理、分发机制。
-
-/// 事件订阅列表接口。
-pub const EVENT_V1_SUBSCRIPTIONS: &str = "/open-apis/event/v1/subscriptions";
-/// 创建事件订阅接口。
-pub const EVENT_V1_SUBSCRIPTION_CREATE: &str = "/open-apis/event/v1/subscriptions/create";
-/// 获取单个事件订阅接口。
-pub const EVENT_V1_SUBSCRIPTION_GET: &str = "/open-apis/event/v1/subscriptions/{subscription_id}";
-/// 删除单个事件订阅接口。
-pub const EVENT_V1_SUBSCRIPTION_DELETE: &str =
-    "/open-apis/event/v1/subscriptions/{subscription_id}";
-/// 更新单个事件订阅接口。
-pub const EVENT_V1_SUBSCRIPTION_UPDATE: &str =
-    "/open-apis/event/v1/subscriptions/{subscription_id}";
-
-/// 事件历史列表接口。
-pub const EVENT_V1_HISTORY: &str = "/open-apis/event/v1/history";
-/// 事件历史重放接口。
-pub const EVENT_V1_HISTORY_REPLAY: &str = "/open-apis/event/v1/history/replay";
-
-/// 事件分发器接口。
-pub const EVENT_V1_DISPATCHER: &str = "/open-apis/event/v1/dispatcher";
-/// 事件分发器状态接口。
-pub const EVENT_V1_DISPATCHER_STATUS: &str = "/open-apis/event/v1/dispatcher/status";
+//! 仅保留有 Request/Response 实现的端点常量。
+//! subscriptions/history/dispatcher 等无实现的占位常量已移除（见 issue #226）。
 
 /// 事件推送出口 IP 查询接口。
+///
+/// 对应实现：`event::event::v1::outbound_ip::list`
 pub const EVENT_V1_OUTBOUND_IP: &str = "/open-apis/event/v1/outbound_ip";
 
 /// 获取长连接在线数量接口。
@@ -38,12 +18,8 @@ mod tests {
 
     #[test]
     fn test_event_endpoints() {
-        assert!(EVENT_V1_SUBSCRIPTIONS.starts_with("/open-apis/event/v1/"));
-        assert!(EVENT_V1_SUBSCRIPTIONS.contains("subscriptions"));
-        assert!(EVENT_V1_HISTORY.contains("history"));
-        assert!(EVENT_V1_DISPATCHER.contains("dispatcher"));
-        assert!(EVENT_V1_SUBSCRIPTION_CREATE.contains("create"));
-        assert!(EVENT_V1_SUBSCRIPTION_DELETE.contains("{subscription_id}"));
+        assert!(EVENT_V1_OUTBOUND_IP.starts_with("/open-apis/event/v1/"));
+        assert!(EVENT_V1_OUTBOUND_IP.ends_with("/outbound_ip"));
         assert!(EVENT_V1_CONNECTION.starts_with("/open-apis/event/v1/"));
         assert!(EVENT_V1_CONNECTION.ends_with("/connection"));
     }


### PR DESCRIPTION
## 关闭 #226

### 变更内容

移除 `crates/openlark-communication/src/endpoints/event.rs` 中 **9 个孤儿端点常量**（subscriptions×5、history×2、dispatcher×2），仅保留有实现的 `EVENT_V1_OUTBOUND_IP`。

### 背景（来自 PR #225 设计审查）

`endpoints/event.rs` 此前声明了 11 个 event v1 端点常量，其中 9 个：
- **零引用**：全 crate 除定义文件外 0 处引用
- **零实现**：无对应 Request/Response
- 但经 `prelude`（`pub use crate::endpoints::event::*`）暴露为 public API，误导用户以为接口可用

飞书 server-side API catalog（`api_list_export.csv`）中 event bizTag 仅 `connection` + `outbound_ip` 两个接口，这 9 个不在 catalog 内。

### 验证
- ✅ 移除的 9 个常量全仓 0 引用
- ✅ `cargo clippy -p openlark-communication --all-targets -- -D warnings`
- ✅ `cargo fmt --check`
- ✅ `cargo doc`（无 broken intra-doc link）
- ✅ `cargo test -p openlark-communication --lib endpoints::event`

### 与 #225 的关系
本 PR 基于 main，与 PR #225（新增 connection 接口）相互独立。#225 合并后 event.rs 会同时包含 EVENT_V1_CONNECTION（本 PR 不涉及）。

Closes #226