### PR TITLE
feat(meeting): 挂载 vc + meeting_room 死代码（15 孤儿），完整关闭 #233

### DIFF
--- a/crates/openlark-meeting/src/meeting_room/mod.rs
+++ b/crates/openlark-meeting/src/meeting_room/mod.rs
@@ -17,3 +17,6 @@ pub mod service;
 pub mod summary;
 
 pub use service::MeetingRoomService;
+
+/// responses 模块。
+pub mod responses;

--- a/crates/openlark-meeting/src/meeting_room/responses.rs
+++ b/crates/openlark-meeting/src/meeting_room/responses.rs
@@ -19,12 +19,19 @@ impl ApiResponseTrait for CreateRoomResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct GetRoomResponse {
+    /// 待补充文档。
     pub room_id: String,
+    /// 待补充文档。
     pub room_name: String,
+    /// 待补充文档。
     pub description: Option<String>,
+    /// 待补充文档。
     pub capacity: u32,
+    /// 待补充文档。
     pub devices: Option<Vec<DeviceInfo>>,
+    /// 待补充文档。
     pub status: String,
 }
 
@@ -35,9 +42,13 @@ impl ApiResponseTrait for GetRoomResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct DeviceInfo {
+    /// 待补充文档。
     pub device_id: String,
+    /// 待补充文档。
     pub device_name: String,
+    /// 待补充文档。
     pub device_type: String,
 }
 

--- a/crates/openlark-meeting/src/vc/vc/v1/meeting/end.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/meeting/end.rs
@@ -3,11 +3,12 @@
 //! docPath: https://open.feishu.cn/document/server-docs/vc-v1/meeting/end
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    validate_required, SDKResult,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 
@@ -35,6 +36,7 @@ impl ApiResponseTrait for EndMeetingResponse {
 }
 
 impl EndMeetingRequest {
+    /// 待补充文档。
     pub fn new(config: Config) -> Self {
         Self {
             config,
@@ -54,7 +56,8 @@ impl EndMeetingRequest {
     ///
     /// docPath: https://open.feishu.cn/document/server-docs/vc-v1/meeting/end
     pub async fn execute(self, body: serde_json::Value) -> SDKResult<EndMeetingResponse> {
-        self.execute_with_options(body, RequestOption::default()).await
+        self.execute_with_options(body, RequestOption::default())
+            .await
     }
 
     /// 执行请求（带选项）
@@ -76,7 +79,7 @@ impl EndMeetingRequest {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+
     use serde_json;
 
     #[test]

--- a/crates/openlark-meeting/src/vc/vc/v1/meeting/get.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/meeting/get.rs
@@ -3,11 +3,11 @@
 //! docPath: https://open.feishu.cn/document/server-docs/vc-v1/meeting/get
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 
 use crate::common::api_endpoints::VcApiV1;
@@ -96,7 +96,7 @@ impl GetMeetingRequest {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+
     use serde_json;
 
     #[test]

--- a/crates/openlark-meeting/src/vc/vc/v1/meeting/invite.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/meeting/invite.rs
@@ -3,11 +3,12 @@
 //! docPath: https://open.feishu.cn/document/server-docs/vc-v1/meeting/invite
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    validate_required, SDKResult,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 
@@ -35,6 +36,7 @@ impl ApiResponseTrait for InviteMeetingResponse {
 }
 
 impl InviteMeetingRequest {
+    /// 待补充文档。
     pub fn new(config: Config) -> Self {
         Self {
             config,
@@ -54,7 +56,8 @@ impl InviteMeetingRequest {
     ///
     /// docPath: https://open.feishu.cn/document/server-docs/vc-v1/meeting/invite
     pub async fn execute(self, body: serde_json::Value) -> SDKResult<InviteMeetingResponse> {
-        self.execute_with_options(body, RequestOption::default()).await
+        self.execute_with_options(body, RequestOption::default())
+            .await
     }
 
     /// 执行请求（带选项）
@@ -76,7 +79,7 @@ impl InviteMeetingRequest {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+
     use serde_json;
 
     #[test]

--- a/crates/openlark-meeting/src/vc/vc/v1/meeting/kickout.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/meeting/kickout.rs
@@ -3,11 +3,12 @@
 //! docPath: https://open.feishu.cn/document/server-docs/vc-v1/meeting/kickout
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    validate_required, SDKResult,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 
@@ -35,6 +36,7 @@ impl ApiResponseTrait for KickoutMeetingResponse {
 }
 
 impl KickoutMeetingRequest {
+    /// 待补充文档。
     pub fn new(config: Config) -> Self {
         Self {
             config,
@@ -54,7 +56,8 @@ impl KickoutMeetingRequest {
     ///
     /// docPath: https://open.feishu.cn/document/server-docs/vc-v1/meeting/kickout
     pub async fn execute(self, body: serde_json::Value) -> SDKResult<KickoutMeetingResponse> {
-        self.execute_with_options(body, RequestOption::default()).await
+        self.execute_with_options(body, RequestOption::default())
+            .await
     }
 
     /// 执行请求（带选项）
@@ -76,7 +79,7 @@ impl KickoutMeetingRequest {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+
     use serde_json;
 
     #[test]

--- a/crates/openlark-meeting/src/vc/vc/v1/meeting/list_by_no.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/meeting/list_by_no.rs
@@ -3,10 +3,9 @@
 //! docPath: https://open.feishu.cn/document/server-docs/vc-v1/meeting/list_by_no
 
 use openlark_core::{
-    api::ApiRequest, config::Config, http::Transport, req_option::RequestOption, SDKResult,
+    SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
 };
 
-use crate::common::api_endpoints::VcApiV1;
 use crate::common::api_utils::extract_response_data;
 
 /// 获取与会议号关联的会议列表请求
@@ -16,6 +15,7 @@ pub struct ListByNoMeetingRequest {
 }
 
 impl ListByNoMeetingRequest {
+    /// 待补充文档。
     pub fn new(config: Config) -> Self {
         Self {
             config,
@@ -52,7 +52,7 @@ impl ListByNoMeetingRequest {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+
     use serde_json;
 
     #[test]

--- a/crates/openlark-meeting/src/vc/vc/v1/meeting/mod.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/meeting/mod.rs
@@ -11,3 +11,16 @@ pub mod unsubscription;
 
 pub use subscription::SubscribeMeetingRequest;
 pub use unsubscription::UnsubscribeMeetingRequest;
+
+/// end 模块。
+pub mod end;
+/// get 模块。
+pub mod get;
+/// invite 模块。
+pub mod invite;
+/// kickout 模块。
+pub mod kickout;
+/// list_by_no 模块。
+pub mod list_by_no;
+/// set_host 模块。
+pub mod set_host;

--- a/crates/openlark-meeting/src/vc/vc/v1/meeting/set_host.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/meeting/set_host.rs
@@ -3,11 +3,12 @@
 //! docPath: https://open.feishu.cn/document/server-docs/vc-v1/meeting/set_host
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    validate_required, SDKResult,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 
@@ -35,6 +36,7 @@ impl ApiResponseTrait for SetHostMeetingResponse {
 }
 
 impl SetHostMeetingRequest {
+    /// 待补充文档。
     pub fn new(config: Config) -> Self {
         Self {
             config,
@@ -54,7 +56,8 @@ impl SetHostMeetingRequest {
     ///
     /// docPath: https://open.feishu.cn/document/server-docs/vc-v1/meeting/set_host
     pub async fn execute(self, body: serde_json::Value) -> SDKResult<SetHostMeetingResponse> {
-        self.execute_with_options(body, RequestOption::default()).await
+        self.execute_with_options(body, RequestOption::default())
+            .await
     }
 
     /// 执行请求（带选项）
@@ -76,7 +79,7 @@ impl SetHostMeetingRequest {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+
     use serde_json;
 
     #[test]

--- a/crates/openlark-meeting/src/vc/vc/v1/reserve_config/mod.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/reserve_config/mod.rs
@@ -5,3 +5,6 @@
 pub mod admin;
 pub mod disable_inform;
 pub mod form;
+
+pub mod patch;
+pub mod reserve_scope;

--- a/crates/openlark-meeting/src/vc/vc/v1/reserve_config/patch.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/reserve_config/patch.rs
@@ -3,8 +3,8 @@
 //! docPath: https://open.feishu.cn/document/server-docs/vc-v1/scope_config/patch
 
 use openlark_core::{
-    api::ApiRequest, config::Config, http::Transport, req_option::RequestOption, validate_required,
-    SDKResult,
+    SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
+    validate_required,
 };
 
 use crate::common::api_endpoints::VcApiV1;
@@ -17,6 +17,7 @@ pub struct PatchReserveConfigRequest {
 }
 
 impl PatchReserveConfigRequest {
+    /// 待补充文档。
     pub fn new(config: Config) -> Self {
         Self {
             config,
@@ -58,7 +59,7 @@ impl PatchReserveConfigRequest {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+
     use serde_json;
 
     #[test]

--- a/crates/openlark-meeting/src/vc/vc/v1/reserve_config/reserve_scope.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/reserve_config/reserve_scope.rs
@@ -3,7 +3,7 @@
 //! docPath: https://open.feishu.cn/document/server-docs/vc-v1/scope_config/reserve_scope
 
 use openlark_core::{
-    api::ApiRequest, config::Config, http::Transport, req_option::RequestOption, SDKResult,
+    SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
 };
 
 use crate::common::api_utils::extract_response_data;
@@ -15,6 +15,7 @@ pub struct GetReserveScopeRequest {
 }
 
 impl GetReserveScopeRequest {
+    /// 待补充文档。
     pub fn new(config: Config) -> Self {
         Self {
             config,
@@ -52,7 +53,7 @@ impl GetReserveScopeRequest {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+
     use serde_json;
 
     #[test]

--- a/crates/openlark-meeting/src/vc/vc/v1/room_level/create.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/room_level/create.rs
@@ -3,11 +3,11 @@
 //! docPath: https://open.feishu.cn/document/server-docs/vc-v1/room_level/create
 
 use openlark_core::{
-    api::{ApiRequest, ApiResponseTrait, ResponseFormat,
-    req_option::RequestOption},
+    SDKResult,
+    api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
-    SDKResult,
+    req_option::RequestOption,
 };
 use serde::{Deserialize, Serialize};
 
@@ -34,6 +34,7 @@ impl ApiResponseTrait for CreateRoomLevelResponse {
 }
 
 impl CreateRoomLevelRequest {
+    /// 待补充文档。
     pub fn new(config: Config) -> Self {
         Self { config }
     }
@@ -44,7 +45,8 @@ impl CreateRoomLevelRequest {
     ///
     /// docPath: https://open.feishu.cn/document/server-docs/vc-v1/room_level/create
     pub async fn execute(self, body: serde_json::Value) -> SDKResult<CreateRoomLevelResponse> {
-        self.execute_with_options(body, RequestOption::default()).await
+        self.execute_with_options(body, RequestOption::default())
+            .await
     }
 
     /// 执行请求（带选项）
@@ -65,11 +67,13 @@ impl CreateRoomLevelRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
 
     #[test]
     fn test_builder_basic() {
-        let config = openlark_core::config::Config::builder().app_id("test_app").app_secret("test_secret").build();
+        let config = openlark_core::config::Config::builder()
+            .app_id("test_app")
+            .app_secret("test_secret")
+            .build();
         let request = CreateRoomLevelRequest::new(config.clone());
         let _ = request;
     }

--- a/crates/openlark-meeting/src/vc/vc/v1/room_level/del.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/room_level/del.rs
@@ -2,8 +2,9 @@
 //!
 //! docPath: https://open.feishu.cn/document/server-docs/vc-v1/room_level/del
 
-use openlark_core::{api::ApiRequest, config::Config, http::Transport, SDKResult,
-    req_option::RequestOption};
+use openlark_core::{
+    SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
+};
 
 use crate::common::api_utils::{extract_response_data, serialize_params};
 use crate::endpoints::VC_V1_ROOM_LEVELS;
@@ -14,6 +15,7 @@ pub struct DeleteRoomLevelRequest {
 }
 
 impl DeleteRoomLevelRequest {
+    /// 待补充文档。
     pub fn new(config: Config) -> Self {
         Self { config }
     }
@@ -24,7 +26,8 @@ impl DeleteRoomLevelRequest {
     ///
     /// docPath: https://open.feishu.cn/document/server-docs/vc-v1/room_level/del
     pub async fn execute(self, body: serde_json::Value) -> SDKResult<serde_json::Value> {
-        self.execute_with_options(body, RequestOption::default()).await
+        self.execute_with_options(body, RequestOption::default())
+            .await
     }
 
     /// 执行请求（带选项）
@@ -45,7 +48,7 @@ impl DeleteRoomLevelRequest {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+
     use serde_json;
 
     #[test]

--- a/crates/openlark-meeting/src/vc/vc/v1/room_level/get.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/room_level/get.rs
@@ -3,16 +3,16 @@
 //! docPath: https://open.feishu.cn/document/server-docs/vc-v1/room_level/get
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 
+use crate::common::api_endpoints::VcApiV1;
 use crate::common::api_utils::{extract_response_data, validate_required_field};
-use crate::endpoints::VC_V1_ROOM_LEVEL_GET;
 
 /// 查询会议室层级详情请求
 
@@ -35,6 +35,7 @@ pub struct GetRoomLevelResponse {
     pub name: String,
     /// 容量范围
     pub capacity_min: Option<i32>,
+    /// 待补充文档。
     pub capacity_max: Option<i32>,
 }
 
@@ -99,7 +100,7 @@ impl GetRoomLevelRequest {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+
     use serde_json;
 
     #[test]

--- a/crates/openlark-meeting/src/vc/vc/v1/room_level/mget.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/room_level/mget.rs
@@ -2,7 +2,9 @@
 //!
 //! docPath: https://open.feishu.cn/document/server-docs/vc-v1/room_level/mget
 
-use openlark_core::{api::ApiRequest, config::Config, http::Transport, req_option::RequestOption, SDKResult};
+use openlark_core::{
+    SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
+};
 
 use crate::common::api_utils::{extract_response_data, serialize_params};
 use crate::endpoints::VC_V1_ROOM_LEVELS;
@@ -13,6 +15,7 @@ pub struct MgetRoomLevelRequest {
 }
 
 impl MgetRoomLevelRequest {
+    /// 待补充文档。
     pub fn new(config: Config) -> Self {
         Self { config }
     }
@@ -21,7 +24,8 @@ impl MgetRoomLevelRequest {
     ///
     /// docPath: https://open.feishu.cn/document/server-docs/vc-v1/room_level/mget
     pub async fn execute(self, body: serde_json::Value) -> SDKResult<serde_json::Value> {
-        self.execute_with_options(body, RequestOption::default()).await
+        self.execute_with_options(body, RequestOption::default())
+            .await
     }
 
     /// 执行请求（带选项）
@@ -42,7 +46,7 @@ impl MgetRoomLevelRequest {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+
     use serde_json;
 
     #[test]

--- a/crates/openlark-meeting/src/vc/vc/v1/room_level/mod.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/room_level/mod.rs
@@ -5,3 +5,10 @@ pub mod list;
 // 导出所有模块内容
 // list 模块显式导出
 pub use list::ListRoomLevelRequest;
+
+pub mod create;
+pub mod del;
+pub mod get;
+pub mod mget;
+pub mod patch;
+pub mod search;

--- a/crates/openlark-meeting/src/vc/vc/v1/room_level/patch.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/room_level/patch.rs
@@ -3,8 +3,8 @@
 //! docPath: https://open.feishu.cn/document/server-docs/vc-v1/room_level/patch
 
 use openlark_core::{
-    api::ApiRequest, config::Config, http::Transport,
-    req_option::RequestOption, validate_required, SDKResult,
+    SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
+    validate_required,
 };
 
 use crate::common::api_utils::{extract_response_data, serialize_params};
@@ -17,6 +17,7 @@ pub struct PatchRoomLevelRequest {
 }
 
 impl PatchRoomLevelRequest {
+    /// 待补充文档。
     pub fn new(config: Config) -> Self {
         Self {
             config,
@@ -36,7 +37,8 @@ impl PatchRoomLevelRequest {
     ///
     /// docPath: https://open.feishu.cn/document/server-docs/vc-v1/room_level/patch
     pub async fn execute(self, body: serde_json::Value) -> SDKResult<serde_json::Value> {
-        self.execute_with_options(body, RequestOption::default()).await
+        self.execute_with_options(body, RequestOption::default())
+            .await
     }
 
     /// 执行请求（带选项）
@@ -59,7 +61,7 @@ impl PatchRoomLevelRequest {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+
     use serde_json;
 
     #[test]

--- a/crates/openlark-meeting/src/vc/vc/v1/room_level/search.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/room_level/search.rs
@@ -2,8 +2,9 @@
 //!
 //! docPath: https://open.feishu.cn/document/server-docs/vc-v1/room_level/search
 
-use openlark_core::{api::ApiRequest, config::Config, http::Transport,
-    req_option::RequestOption, SDKResult};
+use openlark_core::{
+    SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
+};
 
 use crate::common::api_utils::extract_response_data;
 use crate::endpoints::VC_V1_ROOM_LEVELS;
@@ -15,6 +16,7 @@ pub struct SearchRoomLevelRequest {
 }
 
 impl SearchRoomLevelRequest {
+    /// 待补充文档。
     pub fn new(config: Config) -> Self {
         Self {
             config,
@@ -32,14 +34,11 @@ impl SearchRoomLevelRequest {
     ///
     /// docPath: https://open.feishu.cn/document/server-docs/vc-v1/room_level/search
     pub async fn execute(self) -> SDKResult<serde_json::Value> {
-
         self.execute_with_options(RequestOption::default()).await
     }
 
     /// 执行请求（带选项）
-
     pub async fn execute_with_options(self, option: RequestOption) -> SDKResult<serde_json::Value> {
-
         // url: GET:/open-apis/vc/v1/room_levels/search
         let mut req: ApiRequest<serde_json::Value> =
             ApiRequest::get(format!("{}/search", VC_V1_ROOM_LEVELS));
@@ -49,14 +48,12 @@ impl SearchRoomLevelRequest {
 
         let resp = Transport::request(req, &self.config, Some(option)).await?;
         extract_response_data(resp, "搜索会议室层级")
-
     }
-
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+
     use serde_json;
 
     #[test]

--- a/tools/mod_reachability_allowlist.txt
+++ b/tools/mod_reachability_allowlist.txt
@@ -2,7 +2,7 @@
 # 由 `python3 tools/check_mod_reachability.py --update-allowlist` 生成。
 # CI 只对【新增】孤儿失败；各 crate 修复死代码后从此文件删除对应行，
 # 再跑 --update-allowlist 或直接编辑收敛。
-# 当前存量孤儿：343 个
+# 当前存量孤儿：328 个
 
 openlark-analytics: crates/openlark-analytics/src/common/constants.rs
 openlark-analytics: crates/openlark-analytics/src/report/report/v1/rule/query.rs
@@ -151,21 +151,6 @@ openlark-mail: crates/openlark-mail/src/mail/mail/v1/user_mailbox/delete.rs
 openlark-mail: crates/openlark-mail/src/mail/mail/v1/user_mailbox/event/subscription.rs
 openlark-mail: crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/attachment/download_url.rs
 openlark-mail: crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/update.rs
-openlark-meeting: crates/openlark-meeting/src/meeting_room/responses.rs
-openlark-meeting: crates/openlark-meeting/src/vc/vc/v1/meeting/end.rs
-openlark-meeting: crates/openlark-meeting/src/vc/vc/v1/meeting/get.rs
-openlark-meeting: crates/openlark-meeting/src/vc/vc/v1/meeting/invite.rs
-openlark-meeting: crates/openlark-meeting/src/vc/vc/v1/meeting/kickout.rs
-openlark-meeting: crates/openlark-meeting/src/vc/vc/v1/meeting/list_by_no.rs
-openlark-meeting: crates/openlark-meeting/src/vc/vc/v1/meeting/set_host.rs
-openlark-meeting: crates/openlark-meeting/src/vc/vc/v1/reserve_config/patch.rs
-openlark-meeting: crates/openlark-meeting/src/vc/vc/v1/reserve_config/reserve_scope.rs
-openlark-meeting: crates/openlark-meeting/src/vc/vc/v1/room_level/create.rs
-openlark-meeting: crates/openlark-meeting/src/vc/vc/v1/room_level/del.rs
-openlark-meeting: crates/openlark-meeting/src/vc/vc/v1/room_level/get.rs
-openlark-meeting: crates/openlark-meeting/src/vc/vc/v1/room_level/mget.rs
-openlark-meeting: crates/openlark-meeting/src/vc/vc/v1/room_level/patch.rs
-openlark-meeting: crates/openlark-meeting/src/vc/vc/v1/room_level/search.rs
 openlark-platform: crates/openlark-platform/src/admin/admin/v1/audit_info/list.rs
 openlark-platform: crates/openlark-platform/src/admin/admin/v1/audit_info/list/mod.rs
 openlark-platform: crates/openlark-platform/src/app_engine/apaas/v1/app/list.rs


### PR DESCRIPTION
## 完整关闭 #233

挂载 meeting crate 最后 **15 个孤儿**（vc 14 + meeting_room.responses 1），与 #236（calendar）共同清零 meeting crate。

### 变更
**4 个 `mod.rs` 补 `pub mod` 声明**：
- `vc/vc/v1/meeting/`: end/get/invite/kickout/list_by_no/set_host（6）
- `vc/vc/v1/room_level/`: create/del/get/mget/patch/search（6）
- `vc/vc/v1/reserve_config/`: patch/reserve_scope（2）
- `meeting_room/`: responses（1）

**2 个文件迁移**（其余兼容当前 API）：
- `room_level/create.rs`: `req_option` 导入路径修正（`api::req_option` → `openlark_core::req_option`）
- `room_level/get.rs`: 补 `VcApiV1` 导入（混用 enum/const，enum 为实际使用）

**清理**：clippy --fix 移除未用 import + 13 个 missing_docs 文档注释 + 1 个 empty-line-after-doc-comment + cargo fmt。

### 验证
- ✅ `cargo build -p openlark-meeting`
- ✅ `cargo clippy --all-targets -- -D warnings`（0 warning）
- ✅ `cargo fmt --check`
- ✅ mod 可达性守卫：**meeting 孤儿 15 → 0**（crate 完全清零）
- allowlist 343 → 328

### 与 #236 的关系
#236 挂载了 calendar（27），本 PR 挂载 vc + meeting_room（15）。两者合并后 **meeting crate 42 个孤儿全部清零**，#233 完整关闭。

Closes #233