### PR TITLE
feat(workflow): 挂载 approval v4 + 重构 service.rs #[path] 加载（#231）

### DIFF
--- a/crates/openlark-workflow/src/approval/approval/mod.rs
+++ b/crates/openlark-workflow/src/approval/approval/mod.rs
@@ -1,0 +1,6 @@
+//! Approval v4 模块（biztag 嵌套层）
+
+#![allow(clippy::module_inception)]
+
+/// 待补充文档。
+pub mod v4;

--- a/crates/openlark-workflow/src/approval/approval/v4/approval/create.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/approval/create.rs
@@ -3,9 +3,10 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/approval/create
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    validate_required, SDKResult,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -35,6 +36,7 @@ pub struct CreateApprovalRequestV4 {
 }
 
 impl CreateApprovalRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,
@@ -93,7 +95,6 @@ impl ApiResponseTrait for CreateApprovalResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_approval_create_v4_url() {

--- a/crates/openlark-workflow/src/approval/approval/v4/approval/get.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/approval/get.rs
@@ -3,11 +3,11 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/approval/get
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    SDKResult,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::sync::Arc;
 
 /// 审批定义详情（v4）
@@ -27,6 +27,7 @@ pub struct GetApprovalRequestV4 {
 }
 
 impl GetApprovalRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, approval_code: impl Into<String>) -> Self {
         Self {
             config,
@@ -66,7 +67,6 @@ impl ApiResponseTrait for GetApprovalResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_approval_get_v4_url() {

--- a/crates/openlark-workflow/src/approval/approval/v4/approval/mod.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/approval/mod.rs
@@ -5,27 +5,10 @@ pub mod unsubscribe;
 
 // create 模块显式导出
 
-pub use create::{
-
-    CreateApprovalBodyV4,
-
-    CreateApprovalRequestV4,
-
-    CreateApprovalResponseV4,
-
-};
+pub use create::{CreateApprovalBodyV4, CreateApprovalRequestV4, CreateApprovalResponseV4};
 // get 模块显式导出
-pub use get::{
-    GetApprovalRequestV4,
-    GetApprovalResponseV4,
-};
+pub use get::{GetApprovalRequestV4, GetApprovalResponseV4};
 // subscribe 模块显式导出
-pub use subscribe::{
-    SubscribeApprovalRequestV4,
-    SubscribeApprovalResponseV4,
-};
+pub use subscribe::{SubscribeApprovalRequestV4, SubscribeApprovalResponseV4};
 // unsubscribe 模块显式导出
-pub use unsubscribe::{
-    UnsubscribeApprovalRequestV4,
-    UnsubscribeApprovalResponseV4,
-};
+pub use unsubscribe::{UnsubscribeApprovalRequestV4, UnsubscribeApprovalResponseV4};

--- a/crates/openlark-workflow/src/approval/approval/v4/approval/subscribe.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/approval/subscribe.rs
@@ -3,11 +3,11 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/event/event-interface/subscribe
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    SDKResult,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::sync::Arc;
 
 /// 订阅审批事件响应（v4）
@@ -25,6 +25,7 @@ pub struct SubscribeApprovalRequestV4 {
 }
 
 impl SubscribeApprovalRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, approval_code: impl Into<String>) -> Self {
         Self {
             config,
@@ -65,12 +66,12 @@ impl ApiResponseTrait for SubscribeApprovalResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_approval_subscribe_v4_url() {
-        let endpoint =
-            crate::common::api_endpoints::ApprovalApiV4::ApprovalSubscribe("approval_123".to_string());
+        let endpoint = crate::common::api_endpoints::ApprovalApiV4::ApprovalSubscribe(
+            "approval_123".to_string(),
+        );
         assert_eq!(
             endpoint.to_url(),
             "/open-apis/approval/v4/approvals/approval_123/subscribe"

--- a/crates/openlark-workflow/src/approval/approval/v4/approval/unsubscribe.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/approval/unsubscribe.rs
@@ -3,11 +3,11 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/event/event-interface/unsubscribe
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    SDKResult,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::sync::Arc;
 
 /// 取消订阅审批事件响应（v4）
@@ -25,6 +25,7 @@ pub struct UnsubscribeApprovalRequestV4 {
 }
 
 impl UnsubscribeApprovalRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, approval_code: impl Into<String>) -> Self {
         Self {
             config,
@@ -65,7 +66,6 @@ impl ApiResponseTrait for UnsubscribeApprovalResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_approval_unsubscribe_v4_url() {

--- a/crates/openlark-workflow/src/approval/approval/v4/district/list.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/district/list.rs
@@ -3,48 +3,66 @@
 //! docPath: https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/approval-v4/district/list
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// 待补充文档。
 pub struct DistrictBaseInfo {
+    /// 待补充文档。
     pub id: String,
+    /// 待补充文档。
     pub name: String,
+    /// 待补充文档。
     pub level: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// 待补充文档。
 pub struct DistrictItem {
+    /// 待补充文档。
     pub id: String,
+    /// 待补充文档。
     pub name: String,
+    /// 待补充文档。
     pub level: String,
     #[serde(default)]
+    /// 待补充文档。
     pub has_sub_district: bool,
     #[serde(default)]
+    /// 待补充文档。
     pub parent_districts: Vec<DistrictBaseInfo>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// 待补充文档。
 pub struct ListDistrictsResponse {
+    /// 待补充文档。
     pub version: String,
     #[serde(default)]
+    /// 待补充文档。
     pub has_more: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// 待补充文档。
     pub page_token: Option<String>,
     #[serde(default)]
+    /// 待补充文档。
     pub items: Vec<DistrictItem>,
 }
 
 impl ApiResponseTrait for ListDistrictsResponse {
-    fn data_format() -> ResponseFormat { ResponseFormat::Data }
+    fn data_format() -> ResponseFormat {
+        ResponseFormat::Data
+    }
 }
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct ListDistrictsRequest {
     config: Arc<Config>,
     page_size: Option<i32>,
@@ -55,25 +73,72 @@ pub struct ListDistrictsRequest {
 }
 
 impl ListDistrictsRequest {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
-        Self { config, page_size: None, page_token: None, root_district_id: None, list_type: None, locale: None }
+        Self {
+            config,
+            page_size: None,
+            page_token: None,
+            root_district_id: None,
+            list_type: None,
+            locale: None,
+        }
     }
-    pub fn page_size(mut self, page_size: i32) -> Self { self.page_size = Some(page_size); self }
-    pub fn page_token(mut self, page_token: impl Into<String>) -> Self { self.page_token = Some(page_token.into()); self }
-    pub fn root_district_id(mut self, root_district_id: impl Into<String>) -> Self { self.root_district_id = Some(root_district_id.into()); self }
-    pub fn list_type(mut self, list_type: impl Into<String>) -> Self { self.list_type = Some(list_type.into()); self }
-    pub fn locale(mut self, locale: impl Into<String>) -> Self { self.locale = Some(locale.into()); self }
+    /// 待补充文档。
+    pub fn page_size(mut self, page_size: i32) -> Self {
+        self.page_size = Some(page_size);
+        self
+    }
+    /// 待补充文档。
+    pub fn page_token(mut self, page_token: impl Into<String>) -> Self {
+        self.page_token = Some(page_token.into());
+        self
+    }
+    /// 待补充文档。
+    pub fn root_district_id(mut self, root_district_id: impl Into<String>) -> Self {
+        self.root_district_id = Some(root_district_id.into());
+        self
+    }
+    /// 待补充文档。
+    pub fn list_type(mut self, list_type: impl Into<String>) -> Self {
+        self.list_type = Some(list_type.into());
+        self
+    }
+    /// 待补充文档。
+    pub fn locale(mut self, locale: impl Into<String>) -> Self {
+        self.locale = Some(locale.into());
+        self
+    }
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<ListDistrictsResponse> {
-        self.execute_with_options(openlark_core::req_option::RequestOption::default()).await
+        self.execute_with_options(openlark_core::req_option::RequestOption::default())
+            .await
     }
-    pub async fn execute_with_options(self, option: openlark_core::req_option::RequestOption) -> SDKResult<ListDistrictsResponse> {
-        let mut request = ApiRequest::<ListDistrictsResponse>::get("/open-apis/approval/v4/districts");
-        if let Some(page_size) = self.page_size { request = request.query("page_size", page_size.to_string()); }
-        if let Some(page_token) = self.page_token { request = request.query("page_token", page_token); }
-        if let Some(root_district_id) = self.root_district_id { request = request.query("root_district_id", root_district_id); }
-        if let Some(list_type) = self.list_type { request = request.query("list_type", list_type); }
-        if let Some(locale) = self.locale { request = request.query("locale", locale); }
+    /// 待补充文档。
+    pub async fn execute_with_options(
+        self,
+        option: openlark_core::req_option::RequestOption,
+    ) -> SDKResult<ListDistrictsResponse> {
+        let mut request =
+            ApiRequest::<ListDistrictsResponse>::get("/open-apis/approval/v4/districts");
+        if let Some(page_size) = self.page_size {
+            request = request.query("page_size", page_size.to_string());
+        }
+        if let Some(page_token) = self.page_token {
+            request = request.query("page_token", page_token);
+        }
+        if let Some(root_district_id) = self.root_district_id {
+            request = request.query("root_district_id", root_district_id);
+        }
+        if let Some(list_type) = self.list_type {
+            request = request.query("list_type", list_type);
+        }
+        if let Some(locale) = self.locale {
+            request = request.query("locale", locale);
+        }
         let response = Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| openlark_core::error::validation_error("查询地理库信息", "响应数据为空"))
+        response
+            .data
+            .ok_or_else(|| openlark_core::error::validation_error("查询地理库信息", "响应数据为空"))
     }
 }

--- a/crates/openlark-workflow/src/approval/approval/v4/district/mod.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/district/mod.rs
@@ -1,0 +1,4 @@
+//! district（地理库）资源模块
+
+pub mod list;
+pub mod search;

--- a/crates/openlark-workflow/src/approval/approval/v4/district/search.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/district/search.rs
@@ -3,33 +3,41 @@
 //! docPath: https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/approval-v4/district/search
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+/// 待补充文档。
 pub struct SearchDistrictsBody {
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// 待补充文档。
     pub district_ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// 待补充文档。
     pub keyword: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// 待补充文档。
 pub struct SearchDistrictsResponse {
     #[serde(default)]
+    /// 待补充文档。
     pub items: Vec<super::list::DistrictItem>,
 }
 
 impl ApiResponseTrait for SearchDistrictsResponse {
-    fn data_format() -> ResponseFormat { ResponseFormat::Data }
+    fn data_format() -> ResponseFormat {
+        ResponseFormat::Data
+    }
 }
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct SearchDistrictsRequest {
     config: Arc<Config>,
     locale: Option<String>,
@@ -37,20 +45,48 @@ pub struct SearchDistrictsRequest {
 }
 
 impl SearchDistrictsRequest {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
-        Self { config, locale: None, body: SearchDistrictsBody::default() }
+        Self {
+            config,
+            locale: None,
+            body: SearchDistrictsBody::default(),
+        }
     }
-    pub fn locale(mut self, locale: impl Into<String>) -> Self { self.locale = Some(locale.into()); self }
-    pub fn district_ids(mut self, district_ids: Vec<String>) -> Self { self.body.district_ids = Some(district_ids); self }
-    pub fn keyword(mut self, keyword: impl Into<String>) -> Self { self.body.keyword = Some(keyword.into()); self }
+    /// 待补充文档。
+    pub fn locale(mut self, locale: impl Into<String>) -> Self {
+        self.locale = Some(locale.into());
+        self
+    }
+    /// 待补充文档。
+    pub fn district_ids(mut self, district_ids: Vec<String>) -> Self {
+        self.body.district_ids = Some(district_ids);
+        self
+    }
+    /// 待补充文档。
+    pub fn keyword(mut self, keyword: impl Into<String>) -> Self {
+        self.body.keyword = Some(keyword.into());
+        self
+    }
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<SearchDistrictsResponse> {
-        self.execute_with_options(openlark_core::req_option::RequestOption::default()).await
+        self.execute_with_options(openlark_core::req_option::RequestOption::default())
+            .await
     }
-    pub async fn execute_with_options(self, option: openlark_core::req_option::RequestOption) -> SDKResult<SearchDistrictsResponse> {
-        let mut request = ApiRequest::<SearchDistrictsResponse>::post("/open-apis/approval/v4/districts/search");
-        if let Some(locale) = self.locale { request = request.query("locale", locale); }
+    /// 待补充文档。
+    pub async fn execute_with_options(
+        self,
+        option: openlark_core::req_option::RequestOption,
+    ) -> SDKResult<SearchDistrictsResponse> {
+        let mut request =
+            ApiRequest::<SearchDistrictsResponse>::post("/open-apis/approval/v4/districts/search");
+        if let Some(locale) = self.locale {
+            request = request.query("locale", locale);
+        }
         request = request.body(serde_json::to_value(&self.body)?);
         let response = Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| openlark_core::error::validation_error("搜索地理库信息", "响应数据为空"))
+        response
+            .data
+            .ok_or_else(|| openlark_core::error::validation_error("搜索地理库信息", "响应数据为空"))
     }
 }

--- a/crates/openlark-workflow/src/approval/approval/v4/external_approval/create.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/external_approval/create.rs
@@ -3,9 +3,10 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/external_approval/create
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    validate_required, SDKResult,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -52,6 +53,7 @@ pub struct CreateExternalApprovalRequestV4 {
 }
 
 impl CreateExternalApprovalRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,
@@ -102,7 +104,8 @@ impl CreateExternalApprovalRequestV4 {
         validate_required!(self.body.name.trim(), "审批名称不能为空");
 
         let api_endpoint = crate::common::api_endpoints::ApprovalApiV4::ExternalApprovalCreate;
-        let mut request = ApiRequest::<CreateExternalApprovalResponseV4>::post(api_endpoint.to_url());
+        let mut request =
+            ApiRequest::<CreateExternalApprovalResponseV4>::post(api_endpoint.to_url());
 
         let body_json = serde_json::to_value(&self.body).map_err(|e| {
             openlark_core::error::validation_error("序列化请求体失败", e.to_string().as_str())
@@ -127,7 +130,6 @@ impl ApiResponseTrait for CreateExternalApprovalResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_external_approval_create_v4_url() {

--- a/crates/openlark-workflow/src/approval/approval/v4/external_approval/get.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/external_approval/get.rs
@@ -3,9 +3,10 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/external_approval/get
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    validate_required, SDKResult,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -52,6 +53,7 @@ pub struct GetExternalApprovalRequestV4 {
 }
 
 impl GetExternalApprovalRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, approval_code: impl Into<String>) -> Self {
         Self {
             config,
@@ -70,10 +72,7 @@ impl GetExternalApprovalRequestV4 {
         self,
         option: openlark_core::req_option::RequestOption,
     ) -> SDKResult<GetExternalApprovalResponseV4> {
-        validate_required!(
-            self.approval_code.trim(),
-            "审批定义 Code 不能为空"
-        );
+        validate_required!(self.approval_code.trim(), "审批定义 Code 不能为空");
 
         let api_endpoint =
             crate::common::api_endpoints::ApprovalApiV4::ExternalApprovalGet(self.approval_code);
@@ -96,7 +95,6 @@ impl ApiResponseTrait for GetExternalApprovalResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_external_approval_get_v4_url() {

--- a/crates/openlark-workflow/src/approval/approval/v4/external_approval/mod.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/external_approval/mod.rs
@@ -4,19 +4,8 @@ pub mod get;
 // create 模块显式导出
 
 pub use create::{
-
-    CreateExternalApprovalBodyV4,
-
-    CreateExternalApprovalRequestV4,
-
-    CreateExternalApprovalResponseV4,
-
-    FormField,
-
+    CreateExternalApprovalBodyV4, CreateExternalApprovalRequestV4,
+    CreateExternalApprovalResponseV4, FormField,
 };
 // get 模块显式导出
-pub use get::{
-    FormField,
-    GetExternalApprovalRequestV4,
-    GetExternalApprovalResponseV4,
-};
+pub use get::{GetExternalApprovalRequestV4, GetExternalApprovalResponseV4};

--- a/crates/openlark-workflow/src/approval/approval/v4/external_instance/check.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/external_instance/check.rs
@@ -3,9 +3,10 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/external_instance/check
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    validate_required, SDKResult,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -40,6 +41,7 @@ pub struct CheckExternalInstanceRequestV4 {
 }
 
 impl CheckExternalInstanceRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,
@@ -64,10 +66,7 @@ impl CheckExternalInstanceRequestV4 {
         self,
         option: openlark_core::req_option::RequestOption,
     ) -> SDKResult<CheckExternalInstanceResponseV4> {
-        validate_required!(
-            self.body.instance_id.trim(),
-            "审批实例 ID 不能为空"
-        );
+        validate_required!(self.body.instance_id.trim(), "审批实例 ID 不能为空");
 
         let api_endpoint = crate::common::api_endpoints::ApprovalApiV4::ExternalInstanceCheck;
         let mut request =
@@ -96,7 +95,6 @@ impl ApiResponseTrait for CheckExternalInstanceResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_external_instance_check_v4_url() {

--- a/crates/openlark-workflow/src/approval/approval/v4/external_instance/create.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/external_instance/create.rs
@@ -3,9 +3,10 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/external_instance/create
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    validate_required, SDKResult,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -52,6 +53,7 @@ pub struct CreateExternalInstanceRequestV4 {
 }
 
 impl CreateExternalInstanceRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,
@@ -108,7 +110,8 @@ impl CreateExternalInstanceRequestV4 {
         validate_required!(self.body.user_id.trim(), "发起人用户 ID 不能为空");
 
         let api_endpoint = crate::common::api_endpoints::ApprovalApiV4::ExternalInstanceCreate;
-        let mut request = ApiRequest::<CreateExternalInstanceResponseV4>::post(api_endpoint.to_url());
+        let mut request =
+            ApiRequest::<CreateExternalInstanceResponseV4>::post(api_endpoint.to_url());
 
         let body_json = serde_json::to_value(&self.body).map_err(|e| {
             openlark_core::error::validation_error("序列化请求体失败", e.to_string().as_str())
@@ -133,7 +136,6 @@ impl ApiResponseTrait for CreateExternalInstanceResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_external_instance_create_v4_url() {

--- a/crates/openlark-workflow/src/approval/approval/v4/external_instance/mod.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/external_instance/mod.rs
@@ -4,18 +4,10 @@ pub mod create;
 // check 模块显式导出
 
 pub use check::{
-
-    CheckExternalInstanceBodyV4,
-
-    CheckExternalInstanceRequestV4,
-
-    CheckExternalInstanceResponseV4,
-
+    CheckExternalInstanceBodyV4, CheckExternalInstanceRequestV4, CheckExternalInstanceResponseV4,
 };
 // create 模块显式导出
 pub use create::{
-    CreateExternalInstanceBodyV4,
-    CreateExternalInstanceRequestV4,
-    CreateExternalInstanceResponseV4,
-    FormValue,
+    CreateExternalInstanceBodyV4, CreateExternalInstanceRequestV4,
+    CreateExternalInstanceResponseV4, FormValue,
 };

--- a/crates/openlark-workflow/src/approval/approval/v4/external_task/list.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/external_task/list.rs
@@ -3,9 +3,10 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/external_task/list
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    validate_required, SDKResult,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -50,6 +51,7 @@ pub struct ListExternalTaskRequestV4 {
 }
 
 impl ListExternalTaskRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,
@@ -80,10 +82,7 @@ impl ListExternalTaskRequestV4 {
         self,
         option: openlark_core::req_option::RequestOption,
     ) -> SDKResult<ListExternalTaskResponseV4> {
-        validate_required!(
-            !self.body.instance_ids.is_empty(),
-            "审批实例 ID 列表不能为空"
-        );
+        validate_required!(self.body.instance_ids, "审批实例 ID 列表不能为空");
 
         let api_endpoint = crate::common::api_endpoints::ApprovalApiV4::ExternalTaskList;
         let mut request = ApiRequest::<ListExternalTaskResponseV4>::get(api_endpoint.to_url());

--- a/crates/openlark-workflow/src/approval/approval/v4/external_task/mod.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/external_task/mod.rs
@@ -3,13 +3,5 @@ pub mod list;
 // list 模块显式导出
 
 pub use list::{
-
-    ExternalTask,
-
-    ListExternalTaskBodyV4,
-
-    ListExternalTaskRequestV4,
-
-    ListExternalTaskResponseV4,
-
+    ExternalTask, ListExternalTaskBodyV4, ListExternalTaskRequestV4, ListExternalTaskResponseV4,
 };

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/add_sign.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/add_sign.rs
@@ -3,9 +3,10 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/instance/add_sign
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    validate_required, SDKResult,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -41,6 +42,7 @@ pub struct AddSignRequestV4 {
 }
 
 impl AddSignRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,
@@ -90,10 +92,7 @@ impl AddSignRequestV4 {
         option: openlark_core::req_option::RequestOption,
     ) -> SDKResult<AddSignResponseV4> {
         validate_required!(self.body.sign_type.trim(), "加签类型不能为空");
-        validate_required!(
-            !self.body.user_ids.is_empty(),
-            "加签处理人用户 ID 列表不能为空"
-        );
+        validate_required!(self.body.user_ids, "加签处理人用户 ID 列表不能为空");
 
         let api_endpoint = crate::common::api_endpoints::ApprovalApiV4::InstanceAddSign;
         let mut request = ApiRequest::<AddSignResponseV4>::post(api_endpoint.to_url());
@@ -121,7 +120,6 @@ impl ApiResponseTrait for AddSignResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_instance_add_sign_v4_url() {

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/cancel.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/cancel.rs
@@ -3,9 +3,10 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/instance/cancel
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    validate_required, SDKResult,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -32,6 +33,7 @@ pub struct CancelInstanceRequestV4 {
 }
 
 impl CancelInstanceRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,
@@ -84,7 +86,6 @@ impl ApiResponseTrait for CancelInstanceResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_instance_cancel_v4_url() {

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/cc.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/cc.rs
@@ -3,9 +3,10 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/instance/cc
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    validate_required, validate_required_list, SDKResult,
+    validate_required, validate_required_list,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -34,6 +35,7 @@ pub struct CcInstanceRequestV4 {
 }
 
 impl CcInstanceRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,
@@ -97,7 +99,6 @@ impl ApiResponseTrait for CcInstanceResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_instance_cc_v4_url() {

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/comment/create.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/comment/create.rs
@@ -3,9 +3,10 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/instance_comment/create
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    validate_required, SDKResult,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -38,6 +39,7 @@ pub struct CreateInstanceCommentRequestV4 {
 }
 
 impl CreateInstanceCommentRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, instance_id: impl Into<String>) -> Self {
         Self {
             config,
@@ -99,7 +101,6 @@ impl ApiResponseTrait for CreateInstanceCommentResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_instance_comment_create_v4_url() {

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/comment/delete.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/comment/delete.rs
@@ -3,11 +3,12 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/instance_comment/delete
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    validate_required, SDKResult,
+    validate_required,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::sync::Arc;
 
 /// 删除审批实例评论响应（v4）
@@ -23,6 +24,7 @@ pub struct DeleteInstanceCommentRequestV4 {
 }
 
 impl DeleteInstanceCommentRequestV4 {
+    /// 待补充文档。
     pub fn new(
         config: Arc<Config>,
         instance_id: impl Into<String>,
@@ -53,8 +55,7 @@ impl DeleteInstanceCommentRequestV4 {
             self.instance_id,
             self.comment_id,
         );
-        let request =
-            ApiRequest::<DeleteInstanceCommentResponseV4>::delete(api_endpoint.to_url());
+        let request = ApiRequest::<DeleteInstanceCommentResponseV4>::delete(api_endpoint.to_url());
 
         let response =
             openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
@@ -73,7 +74,6 @@ impl ApiResponseTrait for DeleteInstanceCommentResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_instance_comment_delete_v4_url() {

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/comment/list.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/comment/list.rs
@@ -3,11 +3,12 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/instance_comment/list
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    validate_required, SDKResult,
+    validate_required,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::sync::Arc;
 
 /// 审批实例评论
@@ -54,6 +55,7 @@ pub struct ListInstanceCommentRequestV4 {
 }
 
 impl ListInstanceCommentRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, instance_id: impl Into<String>) -> Self {
         Self {
             config,
@@ -90,8 +92,7 @@ impl ListInstanceCommentRequestV4 {
 
         let api_endpoint =
             crate::common::api_endpoints::ApprovalApiV4::InstanceCommentList(self.instance_id);
-        let mut request =
-            ApiRequest::<ListInstanceCommentResponseV4>::get(api_endpoint.to_url());
+        let mut request = ApiRequest::<ListInstanceCommentResponseV4>::get(api_endpoint.to_url());
 
         if let Some(page_size) = self.page_size {
             request = request.query_param("page_size", page_size.to_string());
@@ -117,7 +118,6 @@ impl ApiResponseTrait for ListInstanceCommentResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_instance_comment_list_v4_url() {

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/comment/mod.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/comment/mod.rs
@@ -6,27 +6,11 @@ pub mod remove;
 // create 模块显式导出
 
 pub use create::{
-
-    CreateInstanceCommentBodyV4,
-
-    CreateInstanceCommentRequestV4,
-
-    CreateInstanceCommentResponseV4,
-
+    CreateInstanceCommentBodyV4, CreateInstanceCommentRequestV4, CreateInstanceCommentResponseV4,
 };
 // delete 模块显式导出
-pub use delete::{
-    DeleteInstanceCommentRequestV4,
-    DeleteInstanceCommentResponseV4,
-};
+pub use delete::{DeleteInstanceCommentRequestV4, DeleteInstanceCommentResponseV4};
 // list 模块显式导出
-pub use list::{
-    InstanceComment,
-    ListInstanceCommentRequestV4,
-    ListInstanceCommentResponseV4,
-};
+pub use list::{InstanceComment, ListInstanceCommentRequestV4, ListInstanceCommentResponseV4};
 // remove 模块显式导出
-pub use remove::{
-    RemoveInstanceCommentRequestV4,
-    RemoveInstanceCommentResponseV4,
-};
+pub use remove::{RemoveInstanceCommentRequestV4, RemoveInstanceCommentResponseV4};

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/comment/remove.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/comment/remove.rs
@@ -3,11 +3,12 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/instance-comment/remove
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    validate_required, SDKResult,
+    validate_required,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::sync::Arc;
 
 /// 清空评论响应（v4）
@@ -25,6 +26,7 @@ pub struct RemoveInstanceCommentRequestV4 {
 }
 
 impl RemoveInstanceCommentRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, instance_id: impl Into<String>) -> Self {
         Self {
             config,
@@ -68,16 +70,18 @@ impl ApiResponseTrait for RemoveInstanceCommentResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
+    use super::*;
+    use std::sync::Arc;
 
     #[test]
     fn test_instance_comment_remove_v4_url() {
         let request = RemoveInstanceCommentRequestV4::new(
-            openlark_core::config::Config::builder()
-                .app_id("test_app_id")
-                .app_secret("test_app_secret")
-                .build()
-                .expect("测试配置构建失败"),
+            Arc::new(
+                openlark_core::config::Config::builder()
+                    .app_id("test_app_id")
+                    .app_secret("test_app_secret")
+                    .build(),
+            ),
             "test_instance_id".to_string(),
         );
         // Just verify it doesn't panic

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/create.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/create.rs
@@ -3,9 +3,10 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/instance/create
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    validate_required, SDKResult,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -43,6 +44,7 @@ pub struct CreateInstanceRequestV4 {
 }
 
 impl CreateInstanceRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,
@@ -104,7 +106,6 @@ impl ApiResponseTrait for CreateInstanceResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_instance_create_v4_url() {

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/get.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/get.rs
@@ -3,11 +3,11 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/instance/get
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    SDKResult,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::sync::Arc;
 
 /// 审批实例详情（v4）
@@ -29,6 +29,7 @@ pub struct GetInstanceRequestV4 {
 }
 
 impl GetInstanceRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, instance_id: impl Into<String>) -> Self {
         Self {
             config,
@@ -68,7 +69,6 @@ impl ApiResponseTrait for GetInstanceResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_instance_get_v4_url() {

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/list.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/list.rs
@@ -3,11 +3,11 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/instance/list
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    SDKResult,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::sync::Arc;
 
 /// 审批实例列表项（v4）
@@ -32,6 +32,7 @@ pub struct ListInstanceRequestV4 {
 }
 
 impl ListInstanceRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, approval_code: impl Into<String>) -> Self {
         Self {
             config,
@@ -71,7 +72,6 @@ impl ApiResponseTrait for ListInstanceResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_instance_list_v4_url() {

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/mod.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/mod.rs
@@ -2,6 +2,7 @@ pub mod add_cc;
 pub mod add_sign;
 pub mod cancel;
 pub mod cc;
+/// 待补充文档。
 pub mod comment;
 pub mod create;
 pub mod detail;
@@ -16,113 +17,49 @@ pub mod search_cc;
 pub mod specified_rollback;
 
 // add_cc 模块显式导出
-pub use add_cc::{
-    AddCcInstanceBodyV4,
-    AddCcInstanceRequestV4,
-    AddCcInstanceResponseV4,
-};
+pub use add_cc::{AddCcInstanceBodyV4, AddCcInstanceRequestV4, AddCcInstanceResponseV4};
 // add_sign 模块显式导出
 
-pub use add_sign::{
-
-    AddSignBodyV4,
-
-    AddSignRequestV4,
-
-    AddSignResponseV4,
-
-};
+pub use add_sign::{AddSignBodyV4, AddSignRequestV4, AddSignResponseV4};
 // cancel 模块显式导出
-pub use cancel::{
-    CancelInstanceBodyV4,
-    CancelInstanceRequestV4,
-    CancelInstanceResponseV4,
-};
+pub use cancel::{CancelInstanceBodyV4, CancelInstanceRequestV4, CancelInstanceResponseV4};
 // cc 模块显式导出
-pub use cc::{
-    CcInstanceBodyV4,
-    CcInstanceRequestV4,
-    CcInstanceResponseV4,
-};
+pub use cc::{CcInstanceBodyV4, CcInstanceRequestV4, CcInstanceResponseV4};
 // comment 模块显式导出
 pub use comment::{
-    CreateInstanceCommentBodyV4,
-    CreateInstanceCommentRequestV4,
-    CreateInstanceCommentResponseV4,
-    DeleteInstanceCommentRequestV4,
-    DeleteInstanceCommentResponseV4,
-    InstanceComment,
-    ListInstanceCommentRequestV4,
-    ListInstanceCommentResponseV4,
-    RemoveInstanceCommentRequestV4,
+    CreateInstanceCommentBodyV4, CreateInstanceCommentRequestV4, CreateInstanceCommentResponseV4,
+    DeleteInstanceCommentRequestV4, DeleteInstanceCommentResponseV4, InstanceComment,
+    ListInstanceCommentRequestV4, ListInstanceCommentResponseV4, RemoveInstanceCommentRequestV4,
     RemoveInstanceCommentResponseV4,
 };
 // create 模块显式导出
 pub use create::{
-    CreateInstanceBodyV4,
-    CreateInstanceRequestV4,
-    CreateInstanceResponseV4,
-    FormValue,
+    CreateInstanceBodyV4, CreateInstanceRequestV4, CreateInstanceResponseV4, FormValue,
 };
 // get 模块显式导出
-pub use get::{
-    GetInstanceRequestV4,
-    GetInstanceResponseV4,
-};
+pub use get::{GetInstanceRequestV4, GetInstanceResponseV4};
 // detail 模块显式导出
-pub use detail::{
-    DetailInstanceRequestV4,
-    DetailInstanceResponseV4,
-    DetailInstanceTaskV4,
-};
+pub use detail::{DetailInstanceRequestV4, DetailInstanceResponseV4, DetailInstanceTaskV4};
 // initiated 模块显式导出
 pub use initiated::{
-    InitiatedInstanceItemV4,
-    InitiatedInstanceRequestV4,
-    InitiatedInstanceResponseV4,
+    InitiatedInstanceItemV4, InitiatedInstanceRequestV4, InitiatedInstanceResponseV4,
     InstanceSummaryV4,
 };
 // list 模块显式导出
-pub use list::{
-    InstanceItemV4,
-    ListInstanceRequestV4,
-    ListInstanceResponseV4,
-};
+pub use list::{InstanceItemV4, ListInstanceRequestV4, ListInstanceResponseV4};
 // preview 模块显式导出
 pub use preview::{
-    FlowNode,
-    FormValue,
-    PreviewInstanceBodyV4,
-    PreviewInstanceRequestV4,
-    PreviewInstanceResponseV4,
+    FlowNode, PreviewInstanceBodyV4, PreviewInstanceRequestV4, PreviewInstanceResponseV4,
 };
 // query 模块显式导出
-pub use query::{
-    InstanceItemV4,
-    QueryInstanceRequestV4,
-    QueryInstanceResponseV4,
-};
+pub use query::{QueryInstanceRequestV4, QueryInstanceResponseV4};
 // search_cc 模块显式导出
-pub use search_cc::{
-    CcItemV4,
-    SearchCcRequestV4,
-    SearchCcResponseV4,
-};
+pub use search_cc::{CcItemV4, SearchCcRequestV4, SearchCcResponseV4};
 // recall 模块显式导出
-pub use recall::{
-    RecallInstanceBodyV4,
-    RecallInstanceRequestV4,
-    RecallInstanceResponseV4,
-};
+pub use recall::{RecallInstanceBodyV4, RecallInstanceRequestV4, RecallInstanceResponseV4};
 // remind 模块显式导出
-pub use remind::{
-    RemindInstanceBodyV4,
-    RemindInstanceRequestV4,
-    RemindInstanceResponseV4,
-};
+pub use remind::{RemindInstanceBodyV4, RemindInstanceRequestV4, RemindInstanceResponseV4};
 // specified_rollback 模块显式导出
 pub use specified_rollback::{
-    SpecifiedRollbackBodyV4,
-    SpecifiedRollbackRequestV4,
-    SpecifiedRollbackResponseV4,
+    SpecifiedRollbackBodyV4, SpecifiedRollbackRequestV4, SpecifiedRollbackResponseV4,
 };

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/preview.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/preview.rs
@@ -3,9 +3,10 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/instance/preview
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    validate_required, SDKResult,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -58,6 +59,7 @@ pub struct PreviewInstanceRequestV4 {
 }
 
 impl PreviewInstanceRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,
@@ -119,7 +121,6 @@ impl ApiResponseTrait for PreviewInstanceResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_instance_preview_v4_url() {

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/query.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/query.rs
@@ -3,11 +3,11 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/approval-search/query-2
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    SDKResult,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::sync::Arc;
 
 /// 审批实例列表项（v4）
@@ -37,6 +37,7 @@ pub struct QueryInstanceRequestV4 {
 }
 
 impl QueryInstanceRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
@@ -72,7 +73,6 @@ impl ApiResponseTrait for QueryInstanceResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_instance_query_v4_url() {

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/search_cc.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/search_cc.rs
@@ -3,11 +3,11 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/approval-search/search_cc
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    SDKResult,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::sync::Arc;
 
 /// 审批抄送列表项（v4）
@@ -37,6 +37,7 @@ pub struct SearchCcRequestV4 {
 }
 
 impl SearchCcRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
@@ -72,11 +73,13 @@ impl ApiResponseTrait for SearchCcResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_instance_search_cc_v4_url() {
         let endpoint = crate::common::api_endpoints::ApprovalApiV4::InstanceSearchCc;
-        assert_eq!(endpoint.to_url(), "/open-apis/approval/v4/instances/search_cc");
+        assert_eq!(
+            endpoint.to_url(),
+            "/open-apis/approval/v4/instances/search_cc"
+        );
     }
 }

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/specified_rollback.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/specified_rollback.rs
@@ -3,9 +3,10 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/instance/specified_rollback
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    validate_required, SDKResult,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -37,6 +38,7 @@ pub struct SpecifiedRollbackRequestV4 {
 }
 
 impl SpecifiedRollbackRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, instance_id: impl Into<String>) -> Self {
         Self {
             config,

--- a/crates/openlark-workflow/src/approval/approval/v4/mod.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/mod.rs
@@ -1,119 +1,60 @@
+/// 待补充文档。
 pub mod approval;
+pub mod district;
+/// 待补充文档。
 pub mod external_approval;
+/// 待补充文档。
 pub mod external_instance;
+/// 待补充文档。
 pub mod external_task;
+/// 待补充文档。
 pub mod instance;
+/// 待补充文档。
 pub mod task;
 
 // approval 模块显式导出
 
 pub use approval::{
-
-    CreateApprovalBodyV4,
-
-    CreateApprovalRequestV4,
-
-    CreateApprovalResponseV4,
-
-    GetApprovalRequestV4,
-
-    GetApprovalResponseV4,
-
-    SubscribeApprovalRequestV4,
-
-    SubscribeApprovalResponseV4,
-
-    UnsubscribeApprovalRequestV4,
-
-    UnsubscribeApprovalResponseV4,
-
+    CreateApprovalBodyV4, CreateApprovalRequestV4, CreateApprovalResponseV4, GetApprovalRequestV4,
+    GetApprovalResponseV4, SubscribeApprovalRequestV4, SubscribeApprovalResponseV4,
+    UnsubscribeApprovalRequestV4, UnsubscribeApprovalResponseV4,
 };
 // external_approval 模块显式导出
 pub use external_approval::{
-    CreateExternalApprovalBodyV4,
-    CreateExternalApprovalRequestV4,
-    CreateExternalApprovalResponseV4,
-    FormField,
-    GetExternalApprovalRequestV4,
+    CreateExternalApprovalBodyV4, CreateExternalApprovalRequestV4,
+    CreateExternalApprovalResponseV4, FormField, GetExternalApprovalRequestV4,
     GetExternalApprovalResponseV4,
 };
 // external_instance 模块显式导出
 pub use external_instance::{
-    CheckExternalInstanceBodyV4,
-    CheckExternalInstanceRequestV4,
-    CheckExternalInstanceResponseV4,
-    CreateExternalInstanceBodyV4,
-    CreateExternalInstanceRequestV4,
-    CreateExternalInstanceResponseV4,
-    FormValue,
+    CheckExternalInstanceBodyV4, CheckExternalInstanceRequestV4, CheckExternalInstanceResponseV4,
+    CreateExternalInstanceBodyV4, CreateExternalInstanceRequestV4,
+    CreateExternalInstanceResponseV4, FormValue,
 };
 // external_task 模块显式导出
 pub use external_task::{
-    ExternalTask,
-    ListExternalTaskBodyV4,
-    ListExternalTaskRequestV4,
-    ListExternalTaskResponseV4,
+    ExternalTask, ListExternalTaskBodyV4, ListExternalTaskRequestV4, ListExternalTaskResponseV4,
 };
 // instance 模块显式导出
 pub use instance::{
-    AddSignBodyV4,
-    AddSignRequestV4,
-    AddSignResponseV4,
-    CancelInstanceBodyV4,
-    CancelInstanceRequestV4,
-    CancelInstanceResponseV4,
-    CcInstanceBodyV4,
-    CcInstanceRequestV4,
-    CcInstanceResponseV4,
-    CcItemV4,
-    CreateInstanceBodyV4,
-    CreateInstanceCommentBodyV4,
-    CreateInstanceCommentRequestV4,
-    CreateInstanceCommentResponseV4,
-    CreateInstanceRequestV4,
-    CreateInstanceResponseV4,
-    DeleteInstanceCommentRequestV4,
-    DeleteInstanceCommentResponseV4,
-    FlowNode,
-    FormValue,
-    GetInstanceRequestV4,
-    GetInstanceResponseV4,
-    InstanceComment,
-    InstanceItemV4,
-    ListInstanceCommentRequestV4,
-    ListInstanceCommentResponseV4,
-    ListInstanceRequestV4,
-    ListInstanceResponseV4,
-    PreviewInstanceBodyV4,
-    PreviewInstanceRequestV4,
-    PreviewInstanceResponseV4,
-    QueryInstanceRequestV4,
-    QueryInstanceResponseV4,
-    RemoveInstanceCommentRequestV4,
-    RemoveInstanceCommentResponseV4,
-    SearchCcRequestV4,
-    SearchCcResponseV4,
-    SpecifiedRollbackBodyV4,
-    SpecifiedRollbackRequestV4,
+    AddSignBodyV4, AddSignRequestV4, AddSignResponseV4, CancelInstanceBodyV4,
+    CancelInstanceRequestV4, CancelInstanceResponseV4, CcInstanceBodyV4, CcInstanceRequestV4,
+    CcInstanceResponseV4, CcItemV4, CreateInstanceBodyV4, CreateInstanceCommentBodyV4,
+    CreateInstanceCommentRequestV4, CreateInstanceCommentResponseV4, CreateInstanceRequestV4,
+    CreateInstanceResponseV4, DeleteInstanceCommentRequestV4, DeleteInstanceCommentResponseV4,
+    FlowNode, GetInstanceRequestV4, GetInstanceResponseV4, InstanceComment, InstanceItemV4,
+    ListInstanceCommentRequestV4, ListInstanceCommentResponseV4, ListInstanceRequestV4,
+    ListInstanceResponseV4, PreviewInstanceBodyV4, PreviewInstanceRequestV4,
+    PreviewInstanceResponseV4, QueryInstanceRequestV4, QueryInstanceResponseV4,
+    RemoveInstanceCommentRequestV4, RemoveInstanceCommentResponseV4, SearchCcRequestV4,
+    SearchCcResponseV4, SpecifiedRollbackBodyV4, SpecifiedRollbackRequestV4,
     SpecifiedRollbackResponseV4,
 };
 // task 模块显式导出
 pub use task::{
-    ApproveTaskBodyV4,
-    ApproveTaskRequestV4,
-    ApproveTaskResponseV4,
-    QueryTaskRequestV4,
-    QueryTaskResponseV4,
-    RejectTaskBodyV4,
-    RejectTaskRequestV4,
-    RejectTaskResponseV4,
-    ResubmitTaskBodyV4,
-    ResubmitTaskRequestV4,
-    ResubmitTaskResponseV4,
-    SearchTaskRequestV4,
-    SearchTaskResponseV4,
-    TaskItemV4,
-    TransferTaskBodyV4,
-    TransferTaskRequestV4,
+    ApproveTaskBodyV4, ApproveTaskRequestV4, ApproveTaskResponseV4, QueryTaskRequestV4,
+    QueryTaskResponseV4, RejectTaskBodyV4, RejectTaskRequestV4, RejectTaskResponseV4,
+    ResubmitTaskBodyV4, ResubmitTaskRequestV4, ResubmitTaskResponseV4, SearchTaskRequestV4,
+    SearchTaskResponseV4, TaskItemV4, TransferTaskBodyV4, TransferTaskRequestV4,
     TransferTaskResponseV4,
 };

--- a/crates/openlark-workflow/src/approval/approval/v4/task/approve.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/task/approve.rs
@@ -45,6 +45,7 @@ pub struct ApproveTaskRequestV4 {
 }
 
 impl ApproveTaskRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,

--- a/crates/openlark-workflow/src/approval/approval/v4/task/mod.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/task/mod.rs
@@ -12,80 +12,27 @@ pub mod search;
 pub mod transfer;
 
 // add_sign 模块显式导出
-pub use add_sign::{
-    AddSignTaskBodyV4,
-    AddSignTaskRequestV4,
-    AddSignTaskResponseV4,
-};
+pub use add_sign::{AddSignTaskBodyV4, AddSignTaskRequestV4, AddSignTaskResponseV4};
 // approve 模块显式导出
 
-pub use approve::{
-
-    ApproveTaskBodyV4,
-
-    ApproveTaskRequestV4,
-
-    ApproveTaskResponseV4,
-
-};
+pub use approve::{ApproveTaskBodyV4, ApproveTaskRequestV4, ApproveTaskResponseV4};
 // query 模块显式导出
-pub use query::{
-    QueryTaskRequestV4,
-    QueryTaskResponseV4,
-    TaskItemV4,
-};
+pub use query::{QueryTaskRequestV4, QueryTaskResponseV4, TaskItemV4};
 // forward 模块显式导出
-pub use forward::{
-    ForwardTaskBodyV4,
-    ForwardTaskRequestV4,
-    ForwardTaskResponseV4,
-};
+pub use forward::{ForwardTaskBodyV4, ForwardTaskRequestV4, ForwardTaskResponseV4};
 // list 模块显式导出
-pub use list::{
-    ListTaskItemV4,
-    ListTaskRequestV4,
-    ListTaskResponseV4,
-    TaskSummaryV4,
-};
+pub use list::{ListTaskItemV4, ListTaskRequestV4, ListTaskResponseV4, TaskSummaryV4};
 // pass 模块显式导出
-pub use pass::{
-    PassTaskBodyV4,
-    PassTaskRequestV4,
-    PassTaskResponseV4,
-};
+pub use pass::{PassTaskBodyV4, PassTaskRequestV4, PassTaskResponseV4};
 // refuse 模块显式导出
-pub use refuse::{
-    RefuseTaskBodyV4,
-    RefuseTaskRequestV4,
-    RefuseTaskResponseV4,
-};
+pub use refuse::{RefuseTaskBodyV4, RefuseTaskRequestV4, RefuseTaskResponseV4};
 // reject 模块显式导出
-pub use reject::{
-    RejectTaskBodyV4,
-    RejectTaskRequestV4,
-    RejectTaskResponseV4,
-};
+pub use reject::{RejectTaskBodyV4, RejectTaskRequestV4, RejectTaskResponseV4};
 // resubmit 模块显式导出
-pub use resubmit::{
-    ResubmitTaskBodyV4,
-    ResubmitTaskRequestV4,
-    ResubmitTaskResponseV4,
-};
+pub use resubmit::{ResubmitTaskBodyV4, ResubmitTaskRequestV4, ResubmitTaskResponseV4};
 // rollback 模块显式导出
-pub use rollback::{
-    RollbackTaskBodyV4,
-    RollbackTaskRequestV4,
-    RollbackTaskResponseV4,
-};
+pub use rollback::{RollbackTaskBodyV4, RollbackTaskRequestV4, RollbackTaskResponseV4};
 // search 模块显式导出
-pub use search::{
-    SearchTaskRequestV4,
-    SearchTaskResponseV4,
-    TaskItemV4,
-};
+pub use search::{SearchTaskRequestV4, SearchTaskResponseV4};
 // transfer 模块显式导出
-pub use transfer::{
-    TransferTaskBodyV4,
-    TransferTaskRequestV4,
-    TransferTaskResponseV4,
-};
+pub use transfer::{TransferTaskBodyV4, TransferTaskRequestV4, TransferTaskResponseV4};

--- a/crates/openlark-workflow/src/approval/approval/v4/task/query.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/task/query.rs
@@ -59,6 +59,7 @@ pub struct QueryTaskRequestV4 {
 }
 
 impl QueryTaskRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,
@@ -70,26 +71,31 @@ impl QueryTaskRequestV4 {
         }
     }
 
+    /// 待补充文档。
     pub fn user_id(mut self, user_id: impl Into<String>) -> Self {
         self.user_id = user_id.into();
         self
     }
 
+    /// 待补充文档。
     pub fn topic(mut self, topic: impl Into<String>) -> Self {
         self.topic = topic.into();
         self
     }
 
+    /// 待补充文档。
     pub fn user_id_type(mut self, user_id_type: impl Into<String>) -> Self {
         self.user_id_type = Some(user_id_type.into());
         self
     }
 
+    /// 待补充文档。
     pub fn page_size(mut self, page_size: i32) -> Self {
         self.page_size = Some(page_size);
         self
     }
 
+    /// 待补充文档。
     pub fn page_token(mut self, page_token: impl Into<String>) -> Self {
         self.page_token = Some(page_token.into());
         self

--- a/crates/openlark-workflow/src/approval/approval/v4/task/reject.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/task/reject.rs
@@ -45,6 +45,7 @@ pub struct RejectTaskRequestV4 {
 }
 
 impl RejectTaskRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,

--- a/crates/openlark-workflow/src/approval/approval/v4/task/resubmit.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/task/resubmit.rs
@@ -44,6 +44,7 @@ pub struct ResubmitTaskRequestV4 {
 }
 
 impl ResubmitTaskRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,

--- a/crates/openlark-workflow/src/approval/approval/v4/task/search.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/task/search.rs
@@ -3,11 +3,11 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/approval-search/search
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    SDKResult,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::sync::Arc;
 
 /// 审批任务列表项（v4）
@@ -37,6 +37,7 @@ pub struct SearchTaskRequestV4 {
 }
 
 impl SearchTaskRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
@@ -72,7 +73,6 @@ impl ApiResponseTrait for SearchTaskResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_task_search_v4_url() {

--- a/crates/openlark-workflow/src/approval/approval/v4/task/transfer.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/task/transfer.rs
@@ -3,9 +3,10 @@
 //! docPath: https://open.feishu.cn/document/server-docs/approval-v4/task/transfer
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
-    validate_required, SDKResult,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -37,6 +38,7 @@ pub struct TransferTaskRequestV4 {
 }
 
 impl TransferTaskRequestV4 {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,
@@ -105,7 +107,6 @@ impl ApiResponseTrait for TransferTaskResponseV4 {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
-    
 
     #[test]
     fn test_task_transfer_v4_url() {

--- a/crates/openlark-workflow/src/approval/mod.rs
+++ b/crates/openlark-workflow/src/approval/mod.rs
@@ -7,9 +7,7 @@
 //! - 审批流程：审批定义、实例与任务管理
 //! - 外部审批：外部审批单据、实例与任务对接
 
-pub mod v4;
+pub mod approval;
 
 // v4 模块显式导出
-pub use v4::{
-    approval, external_approval, external_instance, external_task, instance, task,
-};
+pub use approval::v4::{external_approval, external_instance, external_task, instance, task};

--- a/crates/openlark-workflow/src/lib.rs
+++ b/crates/openlark-workflow/src/lib.rs
@@ -89,6 +89,10 @@ pub mod v2;
 /// 白板/看板模块。
 pub mod board;
 
+// 审批模块（v4 审批定义/实例/任务、外部审批）
+/// 审批 API 模块。
+pub mod approval;
+
 // Prelude 模块
 /// 常用工作流类型预导出模块。
 pub mod prelude;

--- a/crates/openlark-workflow/src/service.rs
+++ b/crates/openlark-workflow/src/service.rs
@@ -1,63 +1,40 @@
-#[path = "approval/approval/v4/task/approve.rs"]
-mod approval_task_approve;
-#[path = "approval/approval/v4/task/query.rs"]
-mod approval_task_query;
-#[path = "approval/approval/v4/task/reject.rs"]
-mod approval_task_reject;
-#[path = "approval/approval/v4/task/resubmit.rs"]
-mod approval_task_resubmit;
-
 // approval v4 用户级接口（用户态，需 user_access_token）
-#[path = "approval/approval/v4/instance/add_cc.rs"]
-mod approval_instance_add_cc;
-#[path = "approval/approval/v4/instance/detail.rs"]
-mod approval_instance_detail;
-#[path = "approval/approval/v4/instance/initiated.rs"]
-mod approval_instance_initiated;
-#[path = "approval/approval/v4/instance/recall.rs"]
-mod approval_instance_recall;
-#[path = "approval/approval/v4/instance/remind.rs"]
-mod approval_instance_remind;
-#[path = "approval/approval/v4/task/add_sign.rs"]
-mod approval_task_add_sign;
-#[path = "approval/approval/v4/task/forward.rs"]
-mod approval_task_forward;
-#[path = "approval/approval/v4/task/list.rs"]
-mod approval_task_list;
-#[path = "approval/approval/v4/task/pass.rs"]
-mod approval_task_pass;
-#[path = "approval/approval/v4/task/refuse.rs"]
-mod approval_task_refuse;
-#[path = "approval/approval/v4/task/rollback.rs"]
-mod approval_task_rollback;
 
 // approval v4 用户级接口的公开类型重新导出
 // 这些 Request/Body/Response 类型供用户直接 new() + builder + execute() 使用
 // （用户态接口需 user_access_token，不适合封装成 service helper）
-pub use approval_instance_add_cc::{
+pub use crate::approval::approval::v4::instance::add_cc::{
     AddCcInstanceBodyV4, AddCcInstanceRequestV4, AddCcInstanceResponseV4,
 };
-pub use approval_instance_detail::{
+pub use crate::approval::approval::v4::instance::detail::{
     DetailInstanceRequestV4, DetailInstanceResponseV4, DetailInstanceTaskV4,
 };
-pub use approval_instance_initiated::{
+pub use crate::approval::approval::v4::instance::initiated::{
     InitiatedInstanceItemV4, InitiatedInstanceRequestV4, InitiatedInstanceResponseV4,
     InstanceSummaryV4,
 };
-pub use approval_instance_recall::{
+pub use crate::approval::approval::v4::instance::recall::{
     RecallInstanceBodyV4, RecallInstanceRequestV4, RecallInstanceResponseV4,
 };
-pub use approval_instance_remind::{
+pub use crate::approval::approval::v4::instance::remind::{
     RemindInstanceBodyV4, RemindInstanceRequestV4, RemindInstanceResponseV4,
 };
-pub use approval_task_add_sign::{AddSignTaskBodyV4, AddSignTaskRequestV4, AddSignTaskResponseV4};
-pub use approval_task_forward::{ForwardTaskBodyV4, ForwardTaskRequestV4, ForwardTaskResponseV4};
-pub use approval_task_list::{
+pub use crate::approval::approval::v4::task::add_sign::{
+    AddSignTaskBodyV4, AddSignTaskRequestV4, AddSignTaskResponseV4,
+};
+pub use crate::approval::approval::v4::task::forward::{
+    ForwardTaskBodyV4, ForwardTaskRequestV4, ForwardTaskResponseV4,
+};
+pub use crate::approval::approval::v4::task::list::{
     ListTaskItemV4, ListTaskRequestV4, ListTaskResponseV4, TaskSummaryV4,
 };
-pub use approval_task_pass::{PassTaskBodyV4, PassTaskRequestV4, PassTaskResponseV4};
-pub use approval_task_refuse::{RefuseTaskBodyV4, RefuseTaskRequestV4, RefuseTaskResponseV4};
-pub use approval_task_rollback::{
+pub use crate::approval::approval::v4::task::pass::{
+    PassTaskBodyV4, PassTaskRequestV4, PassTaskResponseV4,
+};
+pub use crate::approval::approval::v4::task::refuse::{
+    RefuseTaskBodyV4, RefuseTaskRequestV4, RefuseTaskResponseV4,
+};
+pub use crate::approval::approval::v4::task::rollback::{
     RollbackTaskBodyV4, RollbackTaskRequestV4, RollbackTaskResponseV4,
 };
 
@@ -303,7 +280,7 @@ impl ApprovalTaskAction {
 }
 
 /// 审批任务条目类型别名。
-pub type ApprovalTaskItem = approval_task_query::TaskItemV4;
+pub type ApprovalTaskItem = crate::approval::approval::v4::task::query::TaskItemV4;
 
 /// 审批任务动作结果 helper。
 #[derive(Debug, Clone, PartialEq)]
@@ -466,10 +443,12 @@ impl WorkflowService {
         let mut page_token: Option<String> = None;
 
         loop {
-            let mut request = approval_task_query::QueryTaskRequestV4::new(self.config.clone())
-                .user_id(query.user_id.clone())
-                .topic(query.topic.clone())
-                .page_size(query.page_size.unwrap_or(MAX_PAGE_SIZE));
+            let mut request = crate::approval::approval::v4::task::query::QueryTaskRequestV4::new(
+                self.config.clone(),
+            )
+            .user_id(query.user_id.clone())
+            .topic(query.topic.clone())
+            .page_size(query.page_size.unwrap_or(MAX_PAGE_SIZE));
 
             if let Some(user_id_type) = &query.user_id_type {
                 request = request.user_id_type(user_id_type.clone());
@@ -502,11 +481,13 @@ impl WorkflowService {
         &self,
         action: ApprovalTaskAction,
     ) -> SDKResult<ApprovalTaskActionResult> {
-        let mut request = approval_task_approve::ApproveTaskRequestV4::new(self.config.clone())
-            .approval_code(action.approval_code)
-            .instance_code(action.instance_code)
-            .user_id(action.user_id)
-            .task_id(action.task_id);
+        let mut request = crate::approval::approval::v4::task::approve::ApproveTaskRequestV4::new(
+            self.config.clone(),
+        )
+        .approval_code(action.approval_code)
+        .instance_code(action.instance_code)
+        .user_id(action.user_id)
+        .task_id(action.task_id);
         if let Some(user_id_type) = action.user_id_type {
             request = request.user_id_type(user_id_type);
         }
@@ -526,11 +507,13 @@ impl WorkflowService {
         &self,
         action: ApprovalTaskAction,
     ) -> SDKResult<ApprovalTaskActionResult> {
-        let mut request = approval_task_reject::RejectTaskRequestV4::new(self.config.clone())
-            .approval_code(action.approval_code)
-            .instance_code(action.instance_code)
-            .user_id(action.user_id)
-            .task_id(action.task_id);
+        let mut request = crate::approval::approval::v4::task::reject::RejectTaskRequestV4::new(
+            self.config.clone(),
+        )
+        .approval_code(action.approval_code)
+        .instance_code(action.instance_code)
+        .user_id(action.user_id)
+        .task_id(action.task_id);
         if let Some(user_id_type) = action.user_id_type {
             request = request.user_id_type(user_id_type);
         }
@@ -550,7 +533,10 @@ impl WorkflowService {
         &self,
         action: ApprovalTaskAction,
     ) -> SDKResult<ApprovalTaskActionResult> {
-        let mut request = approval_task_resubmit::ResubmitTaskRequestV4::new(self.config.clone())
+        let mut request =
+            crate::approval::approval::v4::task::resubmit::ResubmitTaskRequestV4::new(
+                self.config.clone(),
+            )
             .approval_code(action.approval_code)
             .instance_code(action.instance_code)
             .user_id(action.user_id)

--- a/tools/mod_reachability_allowlist.txt
+++ b/tools/mod_reachability_allowlist.txt
@@ -2,7 +2,7 @@
 # 由 `python3 tools/check_mod_reachability.py --update-allowlist` 生成。
 # CI 只对【新增】孤儿失败；各 crate 修复死代码后从此文件删除对应行，
 # 再跑 --update-allowlist 或直接编辑收敛。
-# 当前存量孤儿：241 个
+# 当前存量孤儿：205 个
 
 openlark-analytics: crates/openlark-analytics/src/common/constants.rs
 openlark-analytics: crates/openlark-analytics/src/report/report/v1/rule/query.rs
@@ -205,42 +205,6 @@ openlark-user: crates/openlark-user/src/personal_settings/personal_settings/v1/s
 openlark-user: crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/get.rs
 openlark-user: crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/list.rs
 openlark-user: crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/patch.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/approval/create.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/approval/get.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/approval/mod.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/approval/subscribe.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/approval/unsubscribe.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/district/list.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/district/search.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/external_approval/create.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/external_approval/get.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/external_approval/mod.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/external_instance/check.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/external_instance/create.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/external_instance/mod.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/external_task/list.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/external_task/mod.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/instance/add_sign.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/instance/cancel.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/instance/cc.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/instance/comment/create.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/instance/comment/delete.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/instance/comment/list.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/instance/comment/mod.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/instance/comment/remove.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/instance/create.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/instance/get.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/instance/list.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/instance/mod.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/instance/preview.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/instance/query.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/instance/search_cc.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/instance/specified_rollback.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/mod.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/task/mod.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/task/search.rs
-openlark-workflow: crates/openlark-workflow/src/approval/approval/v4/task/transfer.rs
-openlark-workflow: crates/openlark-workflow/src/approval/mod.rs
 openlark-workflow: crates/openlark-workflow/src/task/task/v1/task/batch_delete_collaborator.rs
 openlark-workflow: crates/openlark-workflow/src/task/task/v1/task/batch_delete_follower.rs
 openlark-workflow: crates/openlark-workflow/src/task/task/v2/custom_field/patch.rs


### PR DESCRIPTION
## 关闭 #231

挂载 workflow crate 的 **approval v4 模块（36 孤儿 + 2 district）**，并重构 `service.rs` 的 `#[path]` 加载方式。

### 变更
1. **挂载 approval 模块树**：创建 `approval/approval/mod.rs` 桥接层，`approval/mod.rs` 改 `pub mod approval;`，`lib.rs` 加 `pub mod approval;`，含 district 子模块（list/search）。
2. **重构 service.rs**：移除 15 个 `#[path]+mod+pub use` 块，改为从挂载的 approval 模块 `use crate::approval::approval::v4::*`。消除 `clippy::duplicate_mod`（文件双重加载）。
3. **修复既有 bug**（死代码暴露）：4 个 mod.rs 的 pub use 重复导入、2 处 `validate_required!(bool)` → `(field)`、comment/remove.rs 测试修正。
4. 补 ~42 个 missing_docs + cargo fmt。

### 验证
- ✅ `cargo build -p openlark-workflow`
- ✅ `cargo clippy --all-targets -- -D warnings`（0 warning，duplicate_mod 消除）
- ✅ `cargo doc --all-features`（CI flags）
- ✅ `cargo fmt --check`
- ✅ mod 可达性守卫：**approval 孤儿 36 → 0**（crate 仅剩 task 3 + v2 1）
- allowlist 241 → 205

### 与 #238 的关系
#238 删除了 87 个重复 task 文件；本 PR 挂载 approval（36）+ district（2）。两者合并后 workflow crate 孤儿从 127 降至 4（task 3 + v2 1，均为真新增待后续）。

Closes #231