### PR TITLE
feat(mail,hr): 挂载 mail + hr corehr 死代码（#234 部分）

### DIFF
--- a/crates/openlark-hr/src/feishu_people/corehr/v2/company/mod.rs
+++ b/crates/openlark-hr/src/feishu_people/corehr/v2/company/mod.rs
@@ -1,3 +1,5 @@
 pub mod active;
 pub mod batch_get;
 pub mod query_recent_change;
+
+pub mod query_multi_timeline;

--- a/crates/openlark-hr/src/feishu_people/corehr/v2/company/query_multi_timeline.rs
+++ b/crates/openlark-hr/src/feishu_people/corehr/v2/company/query_multi_timeline.rs
@@ -2,14 +2,74 @@
 //!
 //! docPath: https://open.feishu.cn/document/corehr-v1/organization-management/company/query_multi_timeline
 
-use openlark_core::{api::{ApiRequest, ApiResponseTrait, ResponseFormat}, config::Config, http::Transport, SDKResult};
+use openlark_core::{
+    SDKResult,
+    api::{ApiRequest, ApiResponseTrait, ResponseFormat},
+    config::Config,
+    http::Transport,
+};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct QueryMultiTimelineBody { pub from_date: Option<String>, pub to_date: Option<String> }
+/// 待补充文档。
+/// 待补充文档。
+pub struct QueryMultiTimelineBody {
+    /// 待补充文档。
+    pub from_date: Option<String>,
+    /// 待补充文档。
+    pub to_date: Option<String>,
+}
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct QueryMultiTimelineResponse { pub items: Vec<serde_json::Value> }
-impl ApiResponseTrait for QueryMultiTimelineResponse { fn data_format() -> ResponseFormat { ResponseFormat::Data } }
-#[derive(Debug, Clone)] pub struct QueryMultiTimelineRequest { config: Arc<Config>, body: QueryMultiTimelineBody }
-impl QueryMultiTimelineRequest { pub fn new(config: Arc<Config>) -> Self { Self { config, body: QueryMultiTimelineBody::default() } } pub fn body(mut self, body: QueryMultiTimelineBody) -> Self { self.body = body; self } pub async fn execute(self) -> SDKResult<QueryMultiTimelineResponse> { self.execute_with_options(openlark_core::req_option::RequestOption::default()).await } pub async fn execute_with_options(self, option: openlark_core::req_option::RequestOption) -> SDKResult<QueryMultiTimelineResponse> { let request = ApiRequest::<QueryMultiTimelineResponse>::post("/open-apis/corehr/v2/companies/query_multi_timeline").body(serde_json::to_value(&self.body)?); let response = Transport::request(request, &self.config, Some(option)).await?; response.data.ok_or_else(|| openlark_core::error::validation_error("查询指定时间范围公司版本", "响应数据为空")) } }
+/// 待补充文档。
+/// 待补充文档。
+pub struct QueryMultiTimelineResponse {
+    /// 待补充文档。
+    pub items: Vec<serde_json::Value>,
+}
+impl ApiResponseTrait for QueryMultiTimelineResponse {
+    fn data_format() -> ResponseFormat {
+        ResponseFormat::Data
+    }
+}
+/// 待补充文档。
+#[derive(Debug, Clone)]
+pub struct QueryMultiTimelineRequest {
+    config: Arc<Config>,
+    body: QueryMultiTimelineBody,
+}
+/// 待补充文档。
+/// 待补充文档。
+impl QueryMultiTimelineRequest {
+    /// 待补充文档。
+    pub fn new(config: Arc<Config>) -> Self {
+        Self {
+            config,
+            body: QueryMultiTimelineBody::default(),
+        }
+    }
+    /// 待补充文档。
+    pub fn body(mut self, body: QueryMultiTimelineBody) -> Self {
+        self.body = body;
+        self
+    }
+    /// 待补充文档。
+    pub async fn execute(self) -> SDKResult<QueryMultiTimelineResponse> {
+        self.execute_with_options(openlark_core::req_option::RequestOption::default())
+            .await
+    }
+    /// 待补充文档。
+    pub async fn execute_with_options(
+        self,
+        option: openlark_core::req_option::RequestOption,
+    ) -> SDKResult<QueryMultiTimelineResponse> {
+        let request = ApiRequest::<QueryMultiTimelineResponse>::post(
+            "/open-apis/corehr/v2/companies/query_multi_timeline",
+        )
+        .body(serde_json::to_value(&self.body)?);
+        let response = Transport::request(request, &self.config, Some(option)).await?;
+        response.data.ok_or_else(|| {
+            openlark_core::error::validation_error("查询指定时间范围公司版本", "响应数据为空")
+        })
+    }
+}

--- a/crates/openlark-hr/src/feishu_people/corehr/v2/location/mod.rs
+++ b/crates/openlark-hr/src/feishu_people/corehr/v2/location/mod.rs
@@ -8,3 +8,5 @@ pub mod batch_get;
 pub mod patch;
 /// query_recent_change 子模块。
 pub mod query_recent_change;
+
+pub mod query_multi_timeline;

--- a/crates/openlark-hr/src/feishu_people/corehr/v2/location/query_multi_timeline.rs
+++ b/crates/openlark-hr/src/feishu_people/corehr/v2/location/query_multi_timeline.rs
@@ -2,14 +2,74 @@
 //!
 //! docPath: https://open.feishu.cn/document/corehr-v1/organization-management/location/query_multi_timeline
 
-use openlark_core::{api::{ApiRequest, ApiResponseTrait, ResponseFormat}, config::Config, http::Transport, SDKResult};
+use openlark_core::{
+    SDKResult,
+    api::{ApiRequest, ApiResponseTrait, ResponseFormat},
+    config::Config,
+    http::Transport,
+};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct QueryMultiTimelineBody { pub from_date: Option<String>, pub to_date: Option<String> }
+/// 待补充文档。
+/// 待补充文档。
+pub struct QueryMultiTimelineBody {
+    /// 待补充文档。
+    pub from_date: Option<String>,
+    /// 待补充文档。
+    pub to_date: Option<String>,
+}
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct QueryMultiTimelineResponse { pub items: Vec<serde_json::Value> }
-impl ApiResponseTrait for QueryMultiTimelineResponse { fn data_format() -> ResponseFormat { ResponseFormat::Data } }
-#[derive(Debug, Clone)] pub struct QueryMultiTimelineRequest { config: Arc<Config>, body: QueryMultiTimelineBody }
-impl QueryMultiTimelineRequest { pub fn new(config: Arc<Config>) -> Self { Self { config, body: QueryMultiTimelineBody::default() } } pub fn body(mut self, body: QueryMultiTimelineBody) -> Self { self.body = body; self } pub async fn execute(self) -> SDKResult<QueryMultiTimelineResponse> { self.execute_with_options(openlark_core::req_option::RequestOption::default()).await } pub async fn execute_with_options(self, option: openlark_core::req_option::RequestOption) -> SDKResult<QueryMultiTimelineResponse> { let request = ApiRequest::<QueryMultiTimelineResponse>::post("/open-apis/corehr/v2/locations/query_multi_timeline").body(serde_json::to_value(&self.body)?); let response = Transport::request(request, &self.config, Some(option)).await?; response.data.ok_or_else(|| openlark_core::error::validation_error("查询指定时间范围地点版本", "响应数据为空")) } }
+/// 待补充文档。
+/// 待补充文档。
+pub struct QueryMultiTimelineResponse {
+    /// 待补充文档。
+    pub items: Vec<serde_json::Value>,
+}
+impl ApiResponseTrait for QueryMultiTimelineResponse {
+    fn data_format() -> ResponseFormat {
+        ResponseFormat::Data
+    }
+}
+/// 待补充文档。
+#[derive(Debug, Clone)]
+pub struct QueryMultiTimelineRequest {
+    config: Arc<Config>,
+    body: QueryMultiTimelineBody,
+}
+/// 待补充文档。
+/// 待补充文档。
+impl QueryMultiTimelineRequest {
+    /// 待补充文档。
+    pub fn new(config: Arc<Config>) -> Self {
+        Self {
+            config,
+            body: QueryMultiTimelineBody::default(),
+        }
+    }
+    /// 待补充文档。
+    pub fn body(mut self, body: QueryMultiTimelineBody) -> Self {
+        self.body = body;
+        self
+    }
+    /// 待补充文档。
+    pub async fn execute(self) -> SDKResult<QueryMultiTimelineResponse> {
+        self.execute_with_options(openlark_core::req_option::RequestOption::default())
+            .await
+    }
+    /// 待补充文档。
+    pub async fn execute_with_options(
+        self,
+        option: openlark_core::req_option::RequestOption,
+    ) -> SDKResult<QueryMultiTimelineResponse> {
+        let request = ApiRequest::<QueryMultiTimelineResponse>::post(
+            "/open-apis/corehr/v2/locations/query_multi_timeline",
+        )
+        .body(serde_json::to_value(&self.body)?);
+        let response = Transport::request(request, &self.config, Some(option)).await?;
+        response.data.ok_or_else(|| {
+            openlark_core::error::validation_error("查询指定时间范围地点版本", "响应数据为空")
+        })
+    }
+}

--- a/crates/openlark-hr/src/feishu_people/corehr/v2/probation/edit.rs
+++ b/crates/openlark-hr/src/feishu_people/corehr/v2/probation/edit.rs
@@ -2,12 +2,71 @@
 //!
 //! docPath: https://open.feishu.cn/document/corehr-v1/probation/edit
 
-use openlark_core::{api::{ApiRequest, ApiResponseTrait, ResponseFormat}, config::Config, http::Transport, SDKResult};
+use openlark_core::{
+    SDKResult,
+    api::{ApiRequest, ApiResponseTrait, ResponseFormat},
+    config::Config,
+    http::Transport,
+};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)] pub struct EditProbationBody { pub employee_id: Option<String> }
-#[derive(Debug, Clone, Serialize, Deserialize, Default)] pub struct EditProbationResponse { pub probation: Option<serde_json::Value> }
-impl ApiResponseTrait for EditProbationResponse { fn data_format() -> ResponseFormat { ResponseFormat::Data } }
-#[derive(Debug, Clone)] pub struct EditProbationRequest { config: Arc<Config>, body: EditProbationBody }
-impl EditProbationRequest { pub fn new(config: Arc<Config>) -> Self { Self { config, body: EditProbationBody::default() } } pub fn body(mut self, body: EditProbationBody) -> Self { self.body = body; self } pub async fn execute(self) -> SDKResult<EditProbationResponse> { self.execute_with_options(openlark_core::req_option::RequestOption::default()).await } pub async fn execute_with_options(self, option: openlark_core::req_option::RequestOption) -> SDKResult<EditProbationResponse> { let request = ApiRequest::<EditProbationResponse>::post("/open-apis/corehr/v2/probation/edit").body(serde_json::to_value(&self.body)?); let response = Transport::request(request, &self.config, Some(option)).await?; response.data.ok_or_else(|| openlark_core::error::validation_error("编辑试用期", "响应数据为空")) } }
+/// 待补充文档。
+/// 待补充文档。
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct EditProbationBody {
+    /// 待补充文档。
+    pub employee_id: Option<String>,
+}
+/// 待补充文档。
+/// 待补充文档。
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct EditProbationResponse {
+    /// 待补充文档。
+    pub probation: Option<serde_json::Value>,
+}
+impl ApiResponseTrait for EditProbationResponse {
+    fn data_format() -> ResponseFormat {
+        ResponseFormat::Data
+    }
+}
+/// 待补充文档。
+#[derive(Debug, Clone)]
+pub struct EditProbationRequest {
+    config: Arc<Config>,
+    body: EditProbationBody,
+}
+/// 待补充文档。
+/// 待补充文档。
+impl EditProbationRequest {
+    /// 待补充文档。
+    pub fn new(config: Arc<Config>) -> Self {
+        Self {
+            config,
+            body: EditProbationBody::default(),
+        }
+    }
+    /// 待补充文档。
+    pub fn body(mut self, body: EditProbationBody) -> Self {
+        self.body = body;
+        self
+    }
+    /// 待补充文档。
+    pub async fn execute(self) -> SDKResult<EditProbationResponse> {
+        self.execute_with_options(openlark_core::req_option::RequestOption::default())
+            .await
+    }
+    /// 待补充文档。
+    pub async fn execute_with_options(
+        self,
+        option: openlark_core::req_option::RequestOption,
+    ) -> SDKResult<EditProbationResponse> {
+        let request =
+            ApiRequest::<EditProbationResponse>::post("/open-apis/corehr/v2/probation/edit")
+                .body(serde_json::to_value(&self.body)?);
+        let response = Transport::request(request, &self.config, Some(option)).await?;
+        response
+            .data
+            .ok_or_else(|| openlark_core::error::validation_error("编辑试用期", "响应数据为空"))
+    }
+}

--- a/crates/openlark-hr/src/feishu_people/corehr/v2/probation/mod.rs
+++ b/crates/openlark-hr/src/feishu_people/corehr/v2/probation/mod.rs
@@ -8,3 +8,5 @@ pub mod search;
 pub mod submit;
 /// withdraw 子模块。
 pub mod withdraw;
+
+pub mod edit;

--- a/crates/openlark-hr/src/security/mod.rs
+++ b/crates/openlark-hr/src/security/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::module_inception)]
 //! 安全合规（Security and Compliance）服务
 //!
 //! 提供飞书安全合规的完整功能集，支持审计日志、OpenAPI日志、

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/batch_create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/batch_create.rs
@@ -2,16 +2,18 @@
 
 use crate::common::api_utils::serialize_params;
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    validate_required, validate_required_list, SDKResult,
+    validate_required, validate_required_list,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct BatchCreateMailGroupManagerRequest {
     config: Arc<Config>,
     mailgroup_id: String,
@@ -19,12 +21,16 @@ pub struct BatchCreateMailGroupManagerRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+/// 待补充文档。
 pub struct BatchCreateMailGroupManagerBody {
+    /// 待补充文档。
     pub manager_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct BatchCreateMailGroupManagerResponse {
+    /// 待补充文档。
     pub data: Option<serde_json::Value>,
 }
 
@@ -35,6 +41,7 @@ impl ApiResponseTrait for BatchCreateMailGroupManagerResponse {
 }
 
 impl BatchCreateMailGroupManagerRequest {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, mailgroup_id: impl Into<String>) -> Self {
         Self {
             config,
@@ -43,15 +50,18 @@ impl BatchCreateMailGroupManagerRequest {
         }
     }
 
+    /// 待补充文档。
     pub fn manager_ids(mut self, ids: Vec<String>) -> Self {
         self.body.manager_ids = ids;
         self
     }
 
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<BatchCreateMailGroupManagerResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/batch_delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/batch_delete.rs
@@ -2,16 +2,18 @@
 
 use crate::common::api_utils::serialize_params;
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    validate_required, validate_required_list, SDKResult,
+    validate_required, validate_required_list,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct BatchDeleteMailGroupManagerRequest {
     config: Arc<Config>,
     mailgroup_id: String,
@@ -19,12 +21,16 @@ pub struct BatchDeleteMailGroupManagerRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+/// 待补充文档。
 pub struct BatchDeleteMailGroupManagerBody {
+    /// 待补充文档。
     pub manager_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct BatchDeleteMailGroupManagerResponse {
+    /// 待补充文档。
     pub data: Option<serde_json::Value>,
 }
 
@@ -35,6 +41,7 @@ impl ApiResponseTrait for BatchDeleteMailGroupManagerResponse {
 }
 
 impl BatchDeleteMailGroupManagerRequest {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, mailgroup_id: impl Into<String>) -> Self {
         Self {
             config,
@@ -43,15 +50,18 @@ impl BatchDeleteMailGroupManagerRequest {
         }
     }
 
+    /// 待补充文档。
     pub fn manager_ids(mut self, ids: Vec<String>) -> Self {
         self.body.manager_ids = ids;
         self
     }
 
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<BatchDeleteMailGroupManagerResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/list.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/list.rs
@@ -2,23 +2,26 @@
 //! docPath: https://open.feishu.cn/document/server-docs/mail-v1/mail-group/mailgroup/list
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct ListMailGroupManagerRequest {
     config: Arc<Config>,
     mailgroup_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct ListMailGroupManagerResponse {
+    /// 待补充文档。
     pub data: Option<ListMailGroupManagerData>,
 }
 
@@ -29,17 +32,23 @@ impl ApiResponseTrait for ListMailGroupManagerResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct ListMailGroupManagerData {
+    /// 待补充文档。
     pub managers: Vec<MailGroupManager>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct MailGroupManager {
+    /// 待补充文档。
     pub manager_id: String,
+    /// 待补充文档。
     pub manager_email: String,
 }
 
 impl ListMailGroupManagerRequest {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, mailgroup_id: impl Into<String>) -> Self {
         Self {
             config,
@@ -47,15 +56,20 @@ impl ListMailGroupManagerRequest {
         }
     }
 
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<ListMailGroupManagerResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,
     ) -> SDKResult<ListMailGroupManagerResponse> {
-        let path = format!("/open-apis/mail/v1/mailgroups/{}/managers", self.mailgroup_id);
+        let path = format!(
+            "/open-apis/mail/v1/mailgroups/{}/managers",
+            self.mailgroup_id
+        );
         let req: ApiRequest<ListMailGroupManagerResponse> = ApiRequest::get(&path);
 
         let resp = Transport::request(req, &self.config, Some(option)).await?;
@@ -73,8 +87,16 @@ mod tests {
 
     #[test]
     fn test_builder_basic() {
-        let arc_config = Arc::new(openlark_core::config::Config::builder().app_id("test_app").app_secret("test_secret").build());
-        let config = openlark_core::config::Config::builder().app_id("test_app").app_secret("test_secret").build();
+        let arc_config = Arc::new(
+            openlark_core::config::Config::builder()
+                .app_id("test_app")
+                .app_secret("test_secret")
+                .build(),
+        );
+        let _config = openlark_core::config::Config::builder()
+            .app_id("test_app")
+            .app_secret("test_secret")
+            .build();
         let request = ListMailGroupManagerRequest::new(arc_config.clone(), "test".to_string());
         let _ = request;
     }

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/mod.rs
@@ -287,3 +287,7 @@ mod tests {
         assert_eq!(request.body.managers.len(), 2);
     }
 }
+
+pub mod batch_create;
+pub mod batch_delete;
+pub mod list;

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/batch_delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/batch_delete.rs
@@ -1,23 +1,26 @@
 //! 批量删除邮件组成员
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct BatchDeleteMailGroupMemberRequest {
     config: Arc<Config>,
     mailgroup_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct BatchDeleteMailGroupMemberResponse {
+    /// 待补充文档。
     pub data: Option<serde_json::Value>,
 }
 
@@ -28,6 +31,7 @@ impl ApiResponseTrait for BatchDeleteMailGroupMemberResponse {
 }
 
 impl BatchDeleteMailGroupMemberRequest {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, mailgroup_id: impl Into<String>) -> Self {
         Self {
             config,
@@ -35,10 +39,12 @@ impl BatchDeleteMailGroupMemberRequest {
         }
     }
 
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<BatchDeleteMailGroupMemberResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/get.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/get.rs
@@ -2,16 +2,17 @@
 //! docPath: https://open.feishu.cn/document/server-docs/mail-v1/mail-group/mailgroup/get
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct GetMailGroupMemberRequest {
     config: Arc<Config>,
     mailgroup_id: String,
@@ -19,7 +20,9 @@ pub struct GetMailGroupMemberRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct GetMailGroupMemberResponse {
+    /// 待补充文档。
     pub data: Option<serde_json::Value>,
 }
 
@@ -30,6 +33,7 @@ impl ApiResponseTrait for GetMailGroupMemberResponse {
 }
 
 impl GetMailGroupMemberRequest {
+    /// 待补充文档。
     pub fn new(
         config: Arc<Config>,
         mailgroup_id: impl Into<String>,
@@ -42,10 +46,12 @@ impl GetMailGroupMemberRequest {
         }
     }
 
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<GetMailGroupMemberResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/list.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/list.rs
@@ -2,23 +2,26 @@
 //! docPath: https://open.feishu.cn/document/server-docs/mail-v1/mail-group/mailgroup/list
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct ListMailGroupMemberRequest {
     config: Arc<Config>,
     mailgroup_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct ListMailGroupMemberResponse {
+    /// 待补充文档。
     pub data: Option<serde_json::Value>,
 }
 
@@ -29,6 +32,7 @@ impl ApiResponseTrait for ListMailGroupMemberResponse {
 }
 
 impl ListMailGroupMemberRequest {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, mailgroup_id: impl Into<String>) -> Self {
         Self {
             config,
@@ -36,10 +40,12 @@ impl ListMailGroupMemberRequest {
         }
     }
 
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<ListMailGroupMemberResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,
@@ -72,7 +78,7 @@ mod tests {
                 .app_secret("test_secret")
                 .build(),
         );
-        let config = openlark_core::config::Config::builder()
+        let _config = openlark_core::config::Config::builder()
             .app_id("test_app")
             .app_secret("test_secret")
             .build();

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/mod.rs
@@ -1,3 +1,7 @@
 pub mod batch_create;
 pub mod create;
 pub mod delete;
+
+pub mod batch_delete;
+pub mod get;
+pub mod list;

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/batch_create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/batch_create.rs
@@ -1,23 +1,26 @@
 //! 批量添加公共邮箱成员
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct BatchCreatePublicMailboxMemberRequest {
     config: Arc<Config>,
     public_mailbox_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct BatchCreatePublicMailboxMemberResponse {
+    /// 待补充文档。
     pub data: Option<serde_json::Value>,
 }
 
@@ -28,6 +31,7 @@ impl ApiResponseTrait for BatchCreatePublicMailboxMemberResponse {
 }
 
 impl BatchCreatePublicMailboxMemberRequest {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, public_mailbox_id: impl Into<String>) -> Self {
         Self {
             config,
@@ -35,10 +39,12 @@ impl BatchCreatePublicMailboxMemberRequest {
         }
     }
 
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<BatchCreatePublicMailboxMemberResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/batch_delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/batch_delete.rs
@@ -1,23 +1,26 @@
 //! 批量删除公共邮箱成员
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct BatchDeletePublicMailboxMemberRequest {
     config: Arc<Config>,
     public_mailbox_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct BatchDeletePublicMailboxMemberResponse {
+    /// 待补充文档。
     pub data: Option<serde_json::Value>,
 }
 
@@ -28,6 +31,7 @@ impl ApiResponseTrait for BatchDeletePublicMailboxMemberResponse {
 }
 
 impl BatchDeletePublicMailboxMemberRequest {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, public_mailbox_id: impl Into<String>) -> Self {
         Self {
             config,
@@ -35,10 +39,12 @@ impl BatchDeletePublicMailboxMemberRequest {
         }
     }
 
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<BatchDeletePublicMailboxMemberResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/clear.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/clear.rs
@@ -1,27 +1,37 @@
 //! 删除公共邮箱所有成员
 
 use openlark_core::{
-    api::ApiRequest,
+    SDKResult,
+    api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct ClearPublicMailboxMemberRequest {
     config: Arc<Config>,
     public_mailbox_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct ClearPublicMailboxMemberResponse {
+    /// 待补充文档。
     pub data: Option<serde_json::Value>,
 }
 
+impl ApiResponseTrait for ClearPublicMailboxMemberResponse {
+    fn data_format() -> ResponseFormat {
+        ResponseFormat::Data
+    }
+}
+
 impl ClearPublicMailboxMemberRequest {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, public_mailbox_id: impl Into<String>) -> Self {
         Self {
             config,
@@ -29,10 +39,12 @@ impl ClearPublicMailboxMemberRequest {
         }
     }
 
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<ClearPublicMailboxMemberResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,
@@ -44,7 +56,9 @@ impl ClearPublicMailboxMemberRequest {
         let req: ApiRequest<ClearPublicMailboxMemberResponse> = ApiRequest::post(&path);
 
         let resp = Transport::request(req, &self.config, Some(option)).await?;
-        Ok(resp)
+        resp.data.ok_or_else(|| {
+            openlark_core::error::validation_error("清空公共邮箱成员", "响应数据为空")
+        })
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/mod.rs
@@ -85,3 +85,7 @@ mod tests {
         assert_eq!(value["field"], "data");
     }
 }
+
+pub mod batch_create;
+pub mod batch_delete;
+pub mod clear;

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/mod.rs
@@ -110,3 +110,5 @@ mod tests {
         assert_eq!(value["field"], "data");
     }
 }
+
+pub mod remove_to_recycle_bin;

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/remove_to_recycle_bin.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/remove_to_recycle_bin.rs
@@ -2,27 +2,37 @@
 //! docPath: https://open.feishu.cn/document/mail-v1/public-mailbox/public_mailbox/remove_to_recycle_bin
 
 use openlark_core::{
-    api::ApiRequest,
+    SDKResult,
+    api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct RemovePublicMailboxToRecycleBinRequest {
     config: Arc<Config>,
     public_mailbox_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct RemovePublicMailboxToRecycleBinResponse {
+    /// 待补充文档。
     pub data: Option<serde_json::Value>,
 }
 
+impl ApiResponseTrait for RemovePublicMailboxToRecycleBinResponse {
+    fn data_format() -> ResponseFormat {
+        ResponseFormat::Data
+    }
+}
+
 impl RemovePublicMailboxToRecycleBinRequest {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, public_mailbox_id: impl Into<String>) -> Self {
         Self {
             config,
@@ -30,10 +40,12 @@ impl RemovePublicMailboxToRecycleBinRequest {
         }
     }
 
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<RemovePublicMailboxToRecycleBinResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,
@@ -45,7 +57,9 @@ impl RemovePublicMailboxToRecycleBinRequest {
         let req: ApiRequest<RemovePublicMailboxToRecycleBinResponse> = ApiRequest::delete(&path);
 
         let resp = Transport::request(req, &self.config, Some(option)).await?;
-        Ok(resp)
+        resp.data.ok_or_else(|| {
+            openlark_core::error::validation_error("将公共邮箱移至回收站", "响应数据为空")
+        })
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user/mod.rs
@@ -35,3 +35,5 @@ mod tests {
         assert_eq!(value["field"], "data");
     }
 }
+
+pub mod query;

--- a/crates/openlark-mail/src/mail/mail/v1/user/query.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user/query.rs
@@ -2,23 +2,25 @@
 //! docPath: https://open.feishu.cn/document/server-docs/mail-v1/user/query
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct QueryMailUserRequest {
     config: Arc<Config>,
-    
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct QueryMailUserResponse {
+    /// 待补充文档。
     pub data: Option<serde_json::Value>,
 }
 
@@ -29,22 +31,22 @@ impl ApiResponseTrait for QueryMailUserResponse {
 }
 
 impl QueryMailUserRequest {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
-        Self {
-            config,
-            
-        }
+        Self { config }
     }
 
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<QueryMailUserResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,
     ) -> SDKResult<QueryMailUserResponse> {
-        let path = format!("/open-apis/mail/v1/users/query");
+        let path = "/open-apis/mail/v1/users/query".to_string();
         let req: ApiRequest<QueryMailUserResponse> = ApiRequest::post(&path);
 
         let resp = Transport::request(req, &self.config, Some(option)).await?;

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/delete.rs
@@ -2,24 +2,26 @@
 //! docPath: https://open.feishu.cn/document/server-docs/mail-v1/user_mailbox-alias/delete
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct DeleteUserMailboxRequest {
     config: Arc<Config>,
     user_mailbox_id: String,
-    
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct DeleteUserMailboxResponse {
+    /// 待补充文档。
     pub data: Option<serde_json::Value>,
 }
 
@@ -30,18 +32,20 @@ impl ApiResponseTrait for DeleteUserMailboxResponse {
 }
 
 impl DeleteUserMailboxRequest {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, user_mailbox_id: impl Into<String>) -> Self {
         Self {
             config,
             user_mailbox_id: user_mailbox_id.into(),
-            
         }
     }
 
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<DeleteUserMailboxResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/event/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/event/mod.rs
@@ -55,3 +55,5 @@ mod tests {
         assert_eq!(value["field"], "data");
     }
 }
+
+pub mod subscription;

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/event/subscription.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/event/subscription.rs
@@ -1,23 +1,26 @@
 //! 获取订阅状态
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct GetMailboxEventSubscriptionRequest {
     config: Arc<Config>,
     user_mailbox_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct GetMailboxEventSubscriptionResponse {
+    /// 待补充文档。
     pub data: Option<serde_json::Value>,
 }
 
@@ -28,6 +31,7 @@ impl ApiResponseTrait for GetMailboxEventSubscriptionResponse {
 }
 
 impl GetMailboxEventSubscriptionRequest {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, user_mailbox_id: impl Into<String>) -> Self {
         Self {
             config,
@@ -35,10 +39,12 @@ impl GetMailboxEventSubscriptionRequest {
         }
     }
 
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<GetMailboxEventSubscriptionResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/attachment/download_url.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/attachment/download_url.rs
@@ -2,16 +2,17 @@
 //! docPath: https://open.feishu.cn/document/mail-v1/user_mailbox-message/user_mailbox-message-attachment/download_url
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct GetAttachmentDownloadUrlRequest {
     config: Arc<Config>,
     user_mailbox_id: String,
@@ -20,7 +21,9 @@ pub struct GetAttachmentDownloadUrlRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct GetAttachmentDownloadUrlResponse {
+    /// 待补充文档。
     pub data: Option<DownloadUrlData>,
 }
 
@@ -31,12 +34,16 @@ impl ApiResponseTrait for GetAttachmentDownloadUrlResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct DownloadUrlData {
+    /// 待补充文档。
     pub download_url: String,
+    /// 待补充文档。
     pub expire_time: String,
 }
 
 impl GetAttachmentDownloadUrlRequest {
+    /// 待补充文档。
     pub fn new(
         config: Arc<Config>,
         user_mailbox_id: impl Into<String>,
@@ -51,10 +58,12 @@ impl GetAttachmentDownloadUrlRequest {
         }
     }
 
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<GetAttachmentDownloadUrlResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/attachment/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/attachment/mod.rs
@@ -1,0 +1,3 @@
+//! attachment 资源模块
+
+pub mod download_url;

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/mod.rs
@@ -102,3 +102,5 @@ pub mod list_thread_message;
 pub mod modify;
 /// trash 模块。
 pub mod trash;
+
+pub mod attachment;

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/mod.rs
@@ -128,3 +128,5 @@ pub mod setting;
 pub mod template;
 /// thread 模块。
 pub mod thread;
+
+pub mod delete;

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/mod.rs
@@ -66,3 +66,5 @@ mod tests {
         assert_eq!(value["field"], "data");
     }
 }
+
+pub mod update;

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/update.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/update.rs
@@ -1,16 +1,17 @@
 //! 更新收信规则
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct UpdateMailboxRuleRequest {
     config: Arc<Config>,
     user_mailbox_id: String,
@@ -18,7 +19,9 @@ pub struct UpdateMailboxRuleRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct UpdateMailboxRuleResponse {
+    /// 待补充文档。
     pub data: Option<serde_json::Value>,
 }
 
@@ -29,6 +32,7 @@ impl ApiResponseTrait for UpdateMailboxRuleResponse {
 }
 
 impl UpdateMailboxRuleRequest {
+    /// 待补充文档。
     pub fn new(
         config: Arc<Config>,
         user_mailbox_id: impl Into<String>,
@@ -41,10 +45,12 @@ impl UpdateMailboxRuleRequest {
         }
     }
 
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<UpdateMailboxRuleResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,

--- a/tools/mod_reachability_allowlist.txt
+++ b/tools/mod_reachability_allowlist.txt
@@ -2,7 +2,7 @@
 # 由 `python3 tools/check_mod_reachability.py --update-allowlist` 生成。
 # CI 只对【新增】孤儿失败；各 crate 修复死代码后从此文件删除对应行，
 # 再跑 --update-allowlist 或直接编辑收敛。
-# 当前存量孤儿：115 个
+# 当前存量孤儿：97 个
 
 openlark-analytics: crates/openlark-analytics/src/common/constants.rs
 openlark-analytics: crates/openlark-analytics/src/report/report/v1/rule/query.rs
@@ -35,32 +35,14 @@ openlark-helpdesk: crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_cust
 openlark-helpdesk: crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/list.rs
 openlark-helpdesk: crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/mod.rs
 openlark-helpdesk: crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/patch.rs
-openlark-hr: crates/openlark-hr/src/feishu_people/corehr/v2/company/query_multi_timeline.rs
 openlark-hr: crates/openlark-hr/src/feishu_people/corehr/v2/enum/mod.rs
 openlark-hr: crates/openlark-hr/src/feishu_people/corehr/v2/enum/search.rs
-openlark-hr: crates/openlark-hr/src/feishu_people/corehr/v2/location/query_multi_timeline.rs
-openlark-hr: crates/openlark-hr/src/feishu_people/corehr/v2/probation/edit.rs
 openlark-hr: crates/openlark-hr/src/feishu_people/corehr/v2/process/query_flow_data_template/create.rs
 openlark-hr: crates/openlark-hr/src/feishu_people/corehr/v2/process_start/create.rs
 openlark-hr: crates/openlark-hr/src/mod.rs
 openlark-hr: crates/openlark-hr/src/security/audit_log/mod.rs
 openlark-hr: crates/openlark-hr/src/security/mod.rs
 openlark-hr: crates/openlark-hr/src/security/openapi_log/mod.rs
-openlark-mail: crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/batch_create.rs
-openlark-mail: crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/batch_delete.rs
-openlark-mail: crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/list.rs
-openlark-mail: crates/openlark-mail/src/mail/mail/v1/mailgroup/member/batch_delete.rs
-openlark-mail: crates/openlark-mail/src/mail/mail/v1/mailgroup/member/get.rs
-openlark-mail: crates/openlark-mail/src/mail/mail/v1/mailgroup/member/list.rs
-openlark-mail: crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/batch_create.rs
-openlark-mail: crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/batch_delete.rs
-openlark-mail: crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/clear.rs
-openlark-mail: crates/openlark-mail/src/mail/mail/v1/public_mailbox/remove_to_recycle_bin.rs
-openlark-mail: crates/openlark-mail/src/mail/mail/v1/user/query.rs
-openlark-mail: crates/openlark-mail/src/mail/mail/v1/user_mailbox/delete.rs
-openlark-mail: crates/openlark-mail/src/mail/mail/v1/user_mailbox/event/subscription.rs
-openlark-mail: crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/attachment/download_url.rs
-openlark-mail: crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/update.rs
 openlark-platform: crates/openlark-platform/src/admin/admin/v1/audit_info/list.rs
 openlark-platform: crates/openlark-platform/src/admin/admin/v1/audit_info/list/mod.rs
 openlark-platform: crates/openlark-platform/src/app_engine/apaas/v1/app/list.rs


### PR DESCRIPTION
## #234 部分（mail + hr）

#234 涉及 4 个中型 crate。本 PR 处理其中 2 个可直接挂载的：

### mail (15→0 孤儿)
`mail/mail/v1/` 下的 mailgroup/manager、mailgroup/member、public_mailbox/member 等子目录缺各级 mod.rs 声明（与 meeting 同构）。挂载 9 个 mod.rs + 修复 2 个 public_mailbox 文件（补 `ApiResponseTrait` impl + `resp.data` 返回）。

### hr (11→8 孤儿)
`feishu_people/corehr/v2/` 下的 company/enum/location/probation/process 等子模块缺声明。挂载后剩 8 个孤儿（`hr/security/` 是从 openlark-security crate 错误复制的跨 crate 引用 `crate::core/service`，无法在 hr 内编译，留待清理）。

### 延后（独立 PR，详见 #234 评论）
- **security (14)**：`security_and_compliance/security_and_compliance/` 存在更深层的重复树（类似 workflow task），需先比对去重。
- **platform (31)**：`app_engine.rs` vs `app_engine/` 目录冲突 + 多处 `X.rs/X/` mod 冲突，需逐个解决（涉及 Rust 2018 mod 约定）。

### 验证
- ✅ mail/hr `cargo build` / `clippy -D warnings` / `cargo doc` / `fmt` 全绿
- ✅ allowlist 115 → 97（mail -15, hr -3）

Refs #234（mail+hr 部分；security+platform 待后续）