### PR TITLE
feat(user,helpdesk,analytics): 挂载 3 个小 crate 死代码（#235 部分）

### DIFF
--- a/crates/openlark-analytics/src/common/mod.rs
+++ b/crates/openlark-analytics/src/common/mod.rs
@@ -47,3 +47,5 @@ mod tests {
         assert_eq!(value["field"], "data");
     }
 }
+
+pub mod constants;

--- a/crates/openlark-analytics/src/lib.rs
+++ b/crates/openlark-analytics/src/lib.rs
@@ -41,6 +41,8 @@ mod service;
 
 // 通用模块
 pub mod common;
+/// 报告模块。
+pub mod report;
 
 // 业务域模块
 #[cfg(feature = "search")]

--- a/crates/openlark-analytics/src/report/mod.rs
+++ b/crates/openlark-analytics/src/report/mod.rs
@@ -1,0 +1,5 @@
+//! Report 模块
+
+#![allow(clippy::module_inception)]
+
+pub mod report;

--- a/crates/openlark-analytics/src/report/report/mod.rs
+++ b/crates/openlark-analytics/src/report/report/mod.rs
@@ -1,0 +1,5 @@
+//! report v1（biztag 嵌套层）
+
+#![allow(clippy::module_inception)]
+
+pub mod v1;

--- a/crates/openlark-analytics/src/report/report/v1/mod.rs
+++ b/crates/openlark-analytics/src/report/report/v1/mod.rs
@@ -1,0 +1,4 @@
+//! v1 资源模块
+
+pub mod rule;
+pub mod task;

--- a/crates/openlark-analytics/src/report/report/v1/rule/mod.rs
+++ b/crates/openlark-analytics/src/report/report/v1/rule/mod.rs
@@ -1,0 +1,4 @@
+//! rule 资源模块
+
+pub mod query;
+pub mod view;

--- a/crates/openlark-analytics/src/report/report/v1/rule/query.rs
+++ b/crates/openlark-analytics/src/report/report/v1/rule/query.rs
@@ -2,11 +2,11 @@
 //! docPath: https://open.feishu.cn/document/server-docs/report-v1/rule/query
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -44,9 +44,8 @@ impl QueryReportRuleRequest {
         let req: ApiRequest<QueryReportRuleResponse> = ApiRequest::get(&path);
 
         let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("查询规则", "响应数据为空")
-        })
+        resp.data
+            .ok_or_else(|| openlark_core::error::validation_error("查询规则", "响应数据为空"))
     }
 }
 

--- a/crates/openlark-analytics/src/report/report/v1/rule/view/mod.rs
+++ b/crates/openlark-analytics/src/report/report/v1/rule/view/mod.rs
@@ -1,0 +1,3 @@
+//! view 资源模块
+
+pub mod remove;

--- a/crates/openlark-analytics/src/report/report/v1/rule/view/remove.rs
+++ b/crates/openlark-analytics/src/report/report/v1/rule/view/remove.rs
@@ -1,11 +1,11 @@
 //! 移除规则看板
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -43,9 +43,8 @@ impl RemoveReportRuleViewRequest {
         let req: ApiRequest<RemoveReportRuleViewResponse> = ApiRequest::post(&path);
 
         let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("移除规则看板", "响应数据为空")
-        })
+        resp.data
+            .ok_or_else(|| openlark_core::error::validation_error("移除规则看板", "响应数据为空"))
     }
 }
 

--- a/crates/openlark-analytics/src/report/report/v1/task/mod.rs
+++ b/crates/openlark-analytics/src/report/report/v1/task/mod.rs
@@ -1,0 +1,3 @@
+//! task 资源模块
+
+pub mod query;

--- a/crates/openlark-analytics/src/report/report/v1/task/query.rs
+++ b/crates/openlark-analytics/src/report/report/v1/task/query.rs
@@ -2,11 +2,11 @@
 //! docPath: https://open.feishu.cn/document/server-docs/report-v1/task/query
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -44,9 +44,8 @@ impl QueryReportTaskRequest {
         let req: ApiRequest<QueryReportTaskResponse> = ApiRequest::post(&path);
 
         let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("查询任务", "响应数据为空")
-        })
+        resp.data
+            .ok_or_else(|| openlark_core::error::validation_error("查询任务", "响应数据为空"))
     }
 }
 

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/mod.rs
@@ -106,3 +106,5 @@ mod tests {
         assert_eq!(value["field"], "data");
     }
 }
+
+pub mod ticket_customized_field;

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/create.rs
@@ -5,11 +5,7 @@
 //! docPath: https://open.feishu.cn/document/server-docs/helpdesk-v1/ticket_customized_field/create
 
 use openlark_core::{
-    api::ApiRequest,
-    config::Config,
-    http::Transport,
-    req_option::RequestOption,
-    SDKResult,
+    SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
     validate_required,
 };
 use serde::{Deserialize, Serialize};
@@ -73,8 +69,12 @@ impl CreateTicketCustomizedFieldRequest {
     }
 
     /// 执行创建工单自定义字段请求
-    pub async fn execute(self, body: CreateTicketCustomizedFieldBody) -> SDKResult<CreateTicketCustomizedFieldResponse> {
-        self.execute_with_options(body, RequestOption::default()).await
+    pub async fn execute(
+        self,
+        body: CreateTicketCustomizedFieldBody,
+    ) -> SDKResult<CreateTicketCustomizedFieldResponse> {
+        self.execute_with_options(body, RequestOption::default())
+            .await
     }
 
     /// 执行创建工单自定义字段请求（支持自定义选项）
@@ -146,9 +146,9 @@ impl CreateTicketCustomizedFieldRequestBuilder {
 
     /// 执行请求
     pub async fn execute(&self) -> SDKResult<CreateTicketCustomizedFieldResponse> {
-        let body = self.body().map_err(|reason| {
-            openlark_core::error::validation_error("body", reason)
-        })?;
+        let body = self
+            .body()
+            .map_err(|reason| openlark_core::error::validation_error("body", reason))?;
         let request = CreateTicketCustomizedFieldRequest::new(self.config.clone());
         request.execute(body).await
     }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/delete.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/delete.rs
@@ -5,11 +5,7 @@
 //! docPath: https://open.feishu.cn/document/server-docs/helpdesk-v1/ticket_customized_field/delete
 
 use openlark_core::{
-    api::ApiRequest,
-    config::Config,
-    http::Transport,
-    req_option::RequestOption,
-    SDKResult,
+    SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -58,8 +54,9 @@ impl DeleteTicketCustomizedFieldRequest {
         self,
         option: RequestOption,
     ) -> SDKResult<DeleteTicketCustomizedFieldResponse> {
-        let req: ApiRequest<DeleteTicketCustomizedFieldResponse> =
-            ApiRequest::delete(HelpdeskApiV1::TicketCustomizedFieldDelete(self.id.clone()).to_url());
+        let req: ApiRequest<DeleteTicketCustomizedFieldResponse> = ApiRequest::delete(
+            HelpdeskApiV1::TicketCustomizedFieldDelete(self.id.clone()).to_url(),
+        );
 
         let resp = Transport::request(req, &self.config, Some(option)).await?;
         extract_response_data(resp, "删除工单自定义字段")
@@ -127,7 +124,10 @@ mod tests {
             .app_id("test_app_id")
             .app_secret("test_app_secret")
             .build();
-        let builder = DeleteTicketCustomizedFieldRequestBuilder::new(Arc::new(config), "field_123".to_string());
+        let builder = DeleteTicketCustomizedFieldRequestBuilder::new(
+            Arc::new(config),
+            "field_123".to_string(),
+        );
 
         assert_eq!(builder.id, "field_123");
     }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/get.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/get.rs
@@ -5,10 +5,10 @@
 //! docPath: https://open.feishu.cn/document/server-docs/helpdesk-v1/ticket_customized_field/get
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -62,7 +62,8 @@ impl GetTicketCustomizedFieldRequest {
 
     /// 执行获取指定工单自定义字段请求
     pub async fn execute(self) -> SDKResult<GetTicketCustomizedFieldResponse> {
-        self.execute_with_options(openlark_core::req_option::RequestOption::default()).await
+        self.execute_with_options(openlark_core::req_option::RequestOption::default())
+            .await
     }
 
     /// 使用选项执行请求
@@ -124,7 +125,8 @@ mod tests {
             .app_id("test_app_id")
             .app_secret("test_app_secret")
             .build();
-        let builder = GetTicketCustomizedFieldRequestBuilder::new(Arc::new(config), "field_123".to_string());
+        let builder =
+            GetTicketCustomizedFieldRequestBuilder::new(Arc::new(config), "field_123".to_string());
 
         assert_eq!(builder.id, "field_123");
     }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/list.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/list.rs
@@ -5,10 +5,10 @@
 //! docPath: https://open.feishu.cn/document/server-docs/helpdesk-v1/ticket_customized_field/list
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -61,7 +61,8 @@ impl ListTicketCustomizedFieldRequest {
 
     /// 执行获取工单自定义字段列表请求
     pub async fn execute(self) -> SDKResult<ListTicketCustomizedFieldResponse> {
-        self.execute_with_options(openlark_core::req_option::RequestOption::default()).await
+        self.execute_with_options(openlark_core::req_option::RequestOption::default())
+            .await
     }
 
     /// 使用选项执行请求
@@ -100,7 +101,9 @@ impl ListTicketCustomizedFieldRequestBuilder {
 }
 
 /// 执行获取工单自定义字段列表
-pub async fn list_ticket_customized_fields(config: &Config) -> SDKResult<ListTicketCustomizedFieldResponse> {
+pub async fn list_ticket_customized_fields(
+    config: &Config,
+) -> SDKResult<ListTicketCustomizedFieldResponse> {
     let api_endpoint = HelpdeskApiV1::TicketCustomizedFieldList;
     let request = ApiRequest::<ListTicketCustomizedFieldResponse>::get(api_endpoint.to_url());
 

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/mod.rs
@@ -2,15 +2,15 @@
 //!
 //! 提供工单自定义字段相关的 API。
 
-pub mod list;
 /// 创建接口。
 pub mod create;
-/// 获取接口。
-pub mod get;
-/// 更新接口。
-pub mod patch;
 /// 删除接口。
 pub mod delete;
+/// 获取接口。
+pub mod get;
+pub mod list;
+/// 更新接口。
+pub mod patch;
 
 use openlark_core::config::Config;
 use std::sync::Arc;
@@ -53,11 +53,11 @@ impl TicketCustomizedField {
     }
 }
 
-pub use list::{ListTicketCustomizedFieldRequest, ListTicketCustomizedFieldRequestBuilder};
 pub use create::{CreateTicketCustomizedFieldRequest, CreateTicketCustomizedFieldRequestBuilder};
-pub use get::{GetTicketCustomizedFieldRequest, GetTicketCustomizedFieldRequestBuilder};
-pub use patch::{PatchTicketCustomizedFieldRequest, PatchTicketCustomizedFieldRequestBuilder};
 pub use delete::{DeleteTicketCustomizedFieldRequest, DeleteTicketCustomizedFieldRequestBuilder};
+pub use get::{GetTicketCustomizedFieldRequest, GetTicketCustomizedFieldRequestBuilder};
+pub use list::{ListTicketCustomizedFieldRequest, ListTicketCustomizedFieldRequestBuilder};
+pub use patch::{PatchTicketCustomizedFieldRequest, PatchTicketCustomizedFieldRequestBuilder};
 
 #[cfg(test)]
 #[allow(unused_imports)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/patch.rs
@@ -5,11 +5,7 @@
 //! docPath: https://open.feishu.cn/document/server-docs/helpdesk-v1/ticket_customized_field/patch
 
 use openlark_core::{
-    api::ApiRequest,
-    config::Config,
-    http::Transport,
-    req_option::RequestOption,
-    SDKResult,
+    SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
     validate_required,
 };
 use serde::{Deserialize, Serialize};
@@ -74,8 +70,12 @@ impl PatchTicketCustomizedFieldRequest {
     }
 
     /// 执行更新工单自定义字段请求
-    pub async fn execute(self, body: PatchTicketCustomizedFieldBody) -> SDKResult<PatchTicketCustomizedFieldResponse> {
-        self.execute_with_options(body, RequestOption::default()).await
+    pub async fn execute(
+        self,
+        body: PatchTicketCustomizedFieldBody,
+    ) -> SDKResult<PatchTicketCustomizedFieldResponse> {
+        self.execute_with_options(body, RequestOption::default())
+            .await
     }
 
     /// 执行更新工单自定义字段请求（支持自定义选项）
@@ -217,7 +217,10 @@ mod tests {
             .app_id("test_app_id")
             .app_secret("test_app_secret")
             .build();
-        let builder = PatchTicketCustomizedFieldRequestBuilder::new(Arc::new(config), "field_123".to_string());
+        let builder = PatchTicketCustomizedFieldRequestBuilder::new(
+            Arc::new(config),
+            "field_123".to_string(),
+        );
 
         assert_eq!(builder.id, "field_123");
         assert!(builder.name.is_none());

--- a/crates/openlark-user/src/common/mod.rs
+++ b/crates/openlark-user/src/common/mod.rs
@@ -43,3 +43,5 @@ mod tests {
         assert_eq!(value["field"], "data");
     }
 }
+
+pub mod constants;

--- a/crates/openlark-user/src/lib.rs
+++ b/crates/openlark-user/src/lib.rs
@@ -40,6 +40,8 @@ mod service;
 // 通用模块
 /// 用户设置与偏好共享模型。
 pub mod common;
+/// 个人设置模块。
+pub mod personal_settings;
 
 // 功能域模块
 #[cfg(feature = "settings")]

--- a/crates/openlark-user/src/personal_settings/personal_settings/mod.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/mod.rs
@@ -1,0 +1,5 @@
+//! personal_settings v1（biztag 嵌套层）
+
+#![allow(clippy::module_inception)]
+
+pub mod v1;

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/mod.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/mod.rs
@@ -1,0 +1,3 @@
+//! v1 资源模块
+
+pub mod system_status;

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/batch_close.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/batch_close.rs
@@ -2,16 +2,18 @@
 //! docPath: https://open.feishu.cn/document/server-docs/personal_settings-v1/system_status/batch_close
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    validate_required, validate_required_list, SDKResult,
+    validate_required, validate_required_list,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct BatchCloseSystemStatusRequest {
     config: Arc<Config>,
     status_id: String,
@@ -19,12 +21,16 @@ pub struct BatchCloseSystemStatusRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+/// 待补充文档。
 pub struct BatchCloseSystemStatusBody {
+    /// 待补充文档。
     pub user_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct BatchCloseSystemStatusResponse {
+    /// 待补充文档。
     pub data: Option<serde_json::Value>,
 }
 
@@ -35,6 +41,7 @@ impl ApiResponseTrait for BatchCloseSystemStatusResponse {
 }
 
 impl BatchCloseSystemStatusRequest {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, status_id: impl Into<String>) -> Self {
         Self {
             config,
@@ -43,15 +50,18 @@ impl BatchCloseSystemStatusRequest {
         }
     }
 
+    /// 待补充文档。
     pub fn user_ids(mut self, ids: Vec<String>) -> Self {
         self.body.user_ids = ids;
         self
     }
 
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<BatchCloseSystemStatusResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,
@@ -67,14 +77,12 @@ impl BatchCloseSystemStatusRequest {
             "/open-apis/personal_settings/v1/system_statuses/{}/batch_close",
             self.status_id
         );
-        let req: ApiRequest<BatchCloseSystemStatusResponse> =
-            ApiRequest::post(&path).json(&self.body).map_err(|e| {
-                openlark_core::error::CoreError::Serialization(e.to_string())
-            })?;
-
-        let _resp: openlark_core::api::Response<BatchCloseSystemStatusResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(BatchCloseSystemStatusResponse { data: None })
+        let body = serde_json::to_value(&self.body)?;
+        let req: ApiRequest<BatchCloseSystemStatusResponse> = ApiRequest::post(&path).body(body);
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        Ok(resp
+            .data
+            .unwrap_or(BatchCloseSystemStatusResponse { data: None }))
     }
 }
 

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/batch_open.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/batch_open.rs
@@ -2,33 +2,37 @@
 //! docPath: https://open.feishu.cn/document/server-docs/personal_settings-v1/system_status/batch_open
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
-pub struct SystemStatusBatch_openRequest {
+/// 待补充文档。
+pub struct SystemStatusBatchOpenRequest {
     config: Arc<Config>,
     status_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SystemStatusBatch_openResponse {
+/// 待补充文档。
+pub struct SystemStatusBatchOpenResponse {
+    /// 待补充文档。
     pub data: Option<serde_json::Value>,
 }
 
-impl ApiResponseTrait for SystemStatusBatch_openResponse {
+impl ApiResponseTrait for SystemStatusBatchOpenResponse {
     fn data_format() -> ResponseFormat {
         ResponseFormat::Data
     }
 }
 
-impl SystemStatusBatch_openRequest {
+impl SystemStatusBatchOpenRequest {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>, status_id: impl Into<String>) -> Self {
         Self {
             config,
@@ -36,19 +40,21 @@ impl SystemStatusBatch_openRequest {
         }
     }
 
-    pub async fn execute(self) -> SDKResult<SystemStatusBatch_openResponse> {
+    /// 待补充文档。
+    pub async fn execute(self) -> SDKResult<SystemStatusBatchOpenResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,
-    ) -> SDKResult<SystemStatusBatch_openResponse> {
+    ) -> SDKResult<SystemStatusBatchOpenResponse> {
         let path = format!(
             "/open-apis/personal_settings/v1/system_statuses/{}/batch_open",
             self.status_id
         );
-        let req: ApiRequest<SystemStatusBatch_openResponse> = ApiRequest::post(&path);
+        let req: ApiRequest<SystemStatusBatchOpenResponse> = ApiRequest::post(&path);
 
         let resp = Transport::request(req, &self.config, Some(option)).await?;
         resp.data.ok_or_else(|| {

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/create.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/create.rs
@@ -2,22 +2,25 @@
 //! docPath: https://open.feishu.cn/document/server-docs/personal_settings-v1/system_status/create
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct SystemStatusCreateRequest {
     config: Arc<Config>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct SystemStatusCreateResponse {
+    /// 待补充文档。
     pub data: Option<serde_json::Value>,
 }
 
@@ -28,14 +31,17 @@ impl ApiResponseTrait for SystemStatusCreateResponse {
 }
 
 impl SystemStatusCreateRequest {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
 
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<SystemStatusCreateResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/delete.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/delete.rs
@@ -2,23 +2,27 @@
 //! docPath: https://open.feishu.cn/document/server-docs/personal_settings-v1/system_status/delete
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    validate_required, SDKResult,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct SystemStatusDeleteRequest {
     config: Arc<Config>,
     status_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct SystemStatusDeleteResponse {
+    /// 待补充文档。
     pub data: Option<serde_json::Value>,
 }
 
@@ -29,6 +33,7 @@ impl ApiResponseTrait for SystemStatusDeleteResponse {
 }
 
 impl SystemStatusDeleteRequest {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,
@@ -36,15 +41,18 @@ impl SystemStatusDeleteRequest {
         }
     }
 
+    /// 待补充文档。
     pub fn status_id(mut self, status_id: impl Into<String>) -> Self {
         self.status_id = status_id.into();
         self
     }
 
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<SystemStatusDeleteResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/get.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/get.rs
@@ -1,22 +1,25 @@
 //! system_status get
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct SystemStatusGetRequest {
     config: Arc<Config>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct SystemStatusGetResponse {
+    /// 待补充文档。
     pub data: Option<serde_json::Value>,
 }
 
@@ -27,23 +30,23 @@ impl ApiResponseTrait for SystemStatusGetResponse {
 }
 
 impl SystemStatusGetRequest {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
 
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<SystemStatusGetResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,
     ) -> SDKResult<SystemStatusGetResponse> {
-        let path = "/open-apis/personal-settings/personal-settings/v1/system-status/get"
-            .replace("application", "application")
-            .replace("security", "acs")
-            .replace("personal_settings", "personal_settings");
-        let req: ApiRequest<SystemStatusGetResponse> = ApiRequest::get(&path);
+        let path = "/open-apis/personal-settings/personal-settings/v1/system-status/get";
+        let req: ApiRequest<SystemStatusGetResponse> = ApiRequest::get(path);
 
         let resp = Transport::request(req, &self.config, Some(option)).await?;
         resp.data.ok_or_else(|| {

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/list.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/list.rs
@@ -2,22 +2,25 @@
 //! docPath: https://open.feishu.cn/document/server-docs/personal_settings-v1/system_status/list
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    SDKResult,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct SystemStatusListRequest {
     config: Arc<Config>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct SystemStatusListResponse {
+    /// 待补充文档。
     pub data: Option<serde_json::Value>,
 }
 
@@ -28,14 +31,17 @@ impl ApiResponseTrait for SystemStatusListResponse {
 }
 
 impl SystemStatusListRequest {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self { config }
     }
 
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<SystemStatusListResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/mod.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/mod.rs
@@ -1,0 +1,9 @@
+//! system_status 资源模块
+
+pub mod batch_close;
+pub mod batch_open;
+pub mod create;
+pub mod delete;
+pub mod get;
+pub mod list;
+pub mod patch;

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/patch.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/patch.rs
@@ -2,23 +2,27 @@
 //! docPath: https://open.feishu.cn/document/server-docs/personal_settings-v1/system_status/patch
 
 use openlark_core::{
+    SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     req_option::RequestOption,
-    validate_required, SDKResult,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
+/// 待补充文档。
 pub struct SystemStatusPatchRequest {
     config: Arc<Config>,
     status_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// 待补充文档。
 pub struct SystemStatusPatchResponse {
+    /// 待补充文档。
     pub data: Option<serde_json::Value>,
 }
 
@@ -29,6 +33,7 @@ impl ApiResponseTrait for SystemStatusPatchResponse {
 }
 
 impl SystemStatusPatchRequest {
+    /// 待补充文档。
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,
@@ -36,15 +41,18 @@ impl SystemStatusPatchRequest {
         }
     }
 
+    /// 待补充文档。
     pub fn status_id(mut self, status_id: impl Into<String>) -> Self {
         self.status_id = status_id.into();
         self
     }
 
+    /// 待补充文档。
     pub async fn execute(self) -> SDKResult<SystemStatusPatchResponse> {
         self.execute_with_options(RequestOption::default()).await
     }
 
+    /// 待补充文档。
     pub async fn execute_with_options(
         self,
         option: RequestOption,

--- a/tools/mod_reachability_allowlist.txt
+++ b/tools/mod_reachability_allowlist.txt
@@ -2,12 +2,8 @@
 # 由 `python3 tools/check_mod_reachability.py --update-allowlist` 生成。
 # CI 只对【新增】孤儿失败；各 crate 修复死代码后从此文件删除对应行，
 # 再跑 --update-allowlist 或直接编辑收敛。
-# 当前存量孤儿：97 个
+# 当前存量孤儿：78 个
 
-openlark-analytics: crates/openlark-analytics/src/common/constants.rs
-openlark-analytics: crates/openlark-analytics/src/report/report/v1/rule/query.rs
-openlark-analytics: crates/openlark-analytics/src/report/report/v1/rule/view/remove.rs
-openlark-analytics: crates/openlark-analytics/src/report/report/v1/task/query.rs
 openlark-auth: crates/openlark-auth/src/common/cache.rs
 openlark-auth: crates/openlark-auth/src/common/refresh.rs
 openlark-auth: crates/openlark-auth/src/common/token.rs
@@ -29,12 +25,6 @@ openlark-docs: crates/openlark-docs/src/ccm/export_tasks/models.rs
 openlark-docs: crates/openlark-docs/src/ccm/export_tasks/services.rs
 openlark-docs: crates/openlark-docs/src/ccm/models/mod.rs
 openlark-docs: crates/openlark-docs/src/ccm/sheet/mod.rs
-openlark-helpdesk: crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/create.rs
-openlark-helpdesk: crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/delete.rs
-openlark-helpdesk: crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/get.rs
-openlark-helpdesk: crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/list.rs
-openlark-helpdesk: crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/mod.rs
-openlark-helpdesk: crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/patch.rs
 openlark-hr: crates/openlark-hr/src/feishu_people/corehr/v2/enum/mod.rs
 openlark-hr: crates/openlark-hr/src/feishu_people/corehr/v2/enum/search.rs
 openlark-hr: crates/openlark-hr/src/feishu_people/corehr/v2/process/query_flow_data_template/create.rs
@@ -88,15 +78,6 @@ openlark-security: crates/openlark-security/src/security_and_compliance/security
 openlark-security: crates/openlark-security/src/security_and_compliance/security_and_compliance/v2/device_record/list.rs
 openlark-security: crates/openlark-security/src/security_and_compliance/security_and_compliance/v2/device_record/mine.rs
 openlark-security: crates/openlark-security/src/security_and_compliance/security_and_compliance/v2/device_record/update.rs
-openlark-user: crates/openlark-user/src/common/constants.rs
-openlark-user: crates/openlark-user/src/personal_settings/mod.rs
-openlark-user: crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/batch_close.rs
-openlark-user: crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/batch_open.rs
-openlark-user: crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/create.rs
-openlark-user: crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/delete.rs
-openlark-user: crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/get.rs
-openlark-user: crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/list.rs
-openlark-user: crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/patch.rs
 openlark-workflow: crates/openlark-workflow/src/task/task/v1/task/batch_delete_collaborator.rs
 openlark-workflow: crates/openlark-workflow/src/task/task/v1/task/batch_delete_follower.rs
 openlark-workflow: crates/openlark-workflow/src/task/task/v2/custom_field/patch.rs


### PR DESCRIPTION
## #235 部分（user + helpdesk + analytics）

#235 涉及 8 个小 crate。本 PR 处理其中 3 个可清理的（均 -100%）：

### user (9→0)
`personal_settings/personal_settings/v1/system_status/`（7 文件）+ `common/constants.rs`。补 biz-nest mod.rs + lib.rs 声明。修复 codegen bug：batch_close.rs 旧 API、get.rs no-op .replace、batch_open.rs 非驼峰命名。

### helpdesk (6→0)
`ticket_customized_field/`（5 文件）缺 v1/mod.rs 声明，补齐。

### analytics (4→0)
`report/report/v1/`（rule/task 子模块）补 biz-nest mod.rs + lib.rs 声明。

### 延后/跳过（详见 #235 评论）
- **docs (10)**：ccm/ 子树在 `#[cfg(feature=ccm-core)]` 下（feature-gated，checker 默认 features 误报）
- **communication (2)**：card/im_message 是 stale 代码（引用不存在的 `crate::service`）
- **auth (5)**：common/ 文件引用不存在的 `crate::error`（跨 crate stale）
- **client(3)/core(1)**：tests.rs/mock_server.rs 为 checker 误报（test 模块经 `#[path]` 加载）

### 验证
- ✅ user/helpdesk/analytics `cargo build` / `clippy -D warnings` / `cargo doc` / `fmt` 全绿
- ✅ allowlist 97 → 78（user -9, helpdesk -6, analytics -4）

Refs #235（user+helpdesk+analytics 部分）