### PR TITLE
fix(communication): 为 event 模块补 feature gate（#246）

### DIFF
--- a/crates/openlark-communication/Cargo.toml
+++ b/crates/openlark-communication/Cargo.toml
@@ -26,13 +26,14 @@ tokio = { workspace = true }
 insta = { workspace = true }
 
 [features]
-default = ["im", "contact", "moments", "aily"]
-full = ["im", "contact", "moments", "aily"]
+default = ["im", "contact", "moments", "aily", "event"]
+full = ["im", "contact", "moments", "aily", "event"]
 
 im = []
 contact = []
 moments = []
 aily = []
+event = []
 
 [package.metadata.cargo-machete]
 ignored = ["reqwest", "tracing"]

--- a/crates/openlark-communication/src/lib.rs
+++ b/crates/openlark-communication/src/lib.rs
@@ -65,6 +65,7 @@ pub mod common;
 pub mod endpoints;
 
 // Event（事件系统）模块 - 事件订阅、出口 IP、长连接在线数量等
+#[cfg(feature = "event")]
 pub mod event;
 
 // AILY 模块


### PR DESCRIPTION
## 修复 #246

`event` 模块此前在 `openlark-communication` 无条件编译（`lib.rs` 无 `#[cfg]`），与同 crate 的 `im`/`contact`/`moments`/`aily`（均 feature-gated）不一致，导致 `default-features = false` 的用户无法排除 event，违反 crate「按需编译与功能组合」约定。

来源：#228 决策审查的附带发现（[#228 评论](https://github.com/foxzool/openlark/issues/228#issuecomment-4795562532)）。

## 改动（2 文件，向后兼容）

- `crates/openlark-communication/Cargo.toml`：`default`/`full` 加入 `"event"`，新增空 flag `event = []`
- `crates/openlark-communication/src/lib.rs`：`pub mod event;` 加 `#[cfg(feature = "event")]`

默认行为不变（event 仍在 `default` 启用，下游根 crate 与 openlark-client 均未禁用 communication 默认 feature），仅让按需编译的用户可排除 event。

## 验证

| 检查 | 结果 |
|------|------|
| `cargo build -p openlark-communication`（默认，event 开） | ✅ |
| `cargo build -p openlark-communication --no-default-features --features im`（event 排除） | ✅ gate 生效 |
| `cargo build -p openlark-communication --no-default-features --features event` | ✅ |
| `cargo fmt --check` | ✅ |
| `cargo build --workspace --all-features`（`just build`） | ✅ |
| `cargo test -p openlark-communication --all-features` | ✅ 7 passed / 0 failed |

> 注：`cargo clippy --workspace --all-targets --all-features`（`just lint`）当前在 main 上即红，12 个错误均为 `unused import: super::*`（lib test 上下文），分布在 `openlark-platform`/`meeting`/`docs`/`hr` 等**本 PR 未触及**的 crate（已在未改动的 `openlark-hr` 上单独复现同一错误），与本改动无关。

Closes #246
