### PR TITLE
ci: no-default-features + 矩阵 clippy 升级 --all-targets（#250 deferred）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
           python3 -m unittest tools.tests.test_check_mod_reachability
           python3 tools/check_mod_reachability.py
       - name: Run clippy (no default features)
-        run: cargo clippy --workspace --lib --no-default-features -- -D warnings
+        run: cargo clippy --workspace --all-targets --no-default-features -- -D warnings
 
   # Feature combination testing for issue #47
   feature-combinations:
@@ -214,9 +214,9 @@ jobs:
       - name: Run clippy with feature combination
         run: |
           if [ -z "${{ matrix.features }}" ]; then
-            cargo clippy --no-default-features --lib -- -D warnings
+            cargo clippy --no-default-features --all-targets -- -D warnings
           else
-            cargo clippy --no-default-features --features "${{ matrix.features }}" --lib -- -D warnings
+            cargo clippy --no-default-features --features "${{ matrix.features }}" --all-targets -- -D warnings
           fi
 
   # MSRV 检查 (Minimum Supported Rust Version)


### PR DESCRIPTION
## 完成 #250 deferred（最后一步）

把 `ci.yml` 里剩余两处 `--lib` clippy 升级到 `--all-targets`，让 CI 在 **no-default-features + 各 feature 组合**维度也覆盖 test target。

- `lint` job 的 no-default-features clippy（line 116）
- `feature-combinations` 矩阵的两处 clippy（空 features + 带 features 各一）

## 为何现在安全

#251 已让 `cargo clippy --workspace --all-targets --no-default-features -- -D warnings` 通过（tests/examples 全部 feature 门控修复 + examples 改 `required-features`）。本 PR 就是 #250 当初因「历史遗留测试门控」延后的那部分。

## 验证

| 检查 | 结果 |
|------|------|
| `cargo clippy --workspace --all-targets --no-default-features -- -D warnings`（line 116 命令） | ✅ exit 0（#251 验证 + 本地复测） |
| 矩阵代表性组合 `--all-targets`：hr / docs / communication / webhook / helpdesk | ✅ 全 exit 0 |
| diff 仅 3 行（`--lib` → `--all-targets`） | ✅ |

CI 的 feature-combinations job 会在所有 ~100 个组合上以 `--all-targets` 跑一遍，作为全矩阵最终验证。

至此整条链路（#228 → #251）彻底闭环：CI 在 all-features、no-default-features、各组合三个维度都覆盖 test target。
