### PR TITLE
docs(skills): 优化项目 skill 准确性与一致性（修复过时引用/事实错误/补 CI 约定）

### DIFF
--- a/.agents/skills/openlark-api-field-verify/SKILL.md
+++ b/.agents/skills/openlark-api-field-verify/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: openlark-api-field-verify
 description: OpenLark API 字段核对技能。用于新增/重构飞书 API 后，核对 Rust 实现的请求体/响应体字段是否与飞书官方文档一致。通过 playwright 渲染飞书 SPA 文档页面，提取真实的请求/响应字段定义，对比代码实现找出不符项。触发关键词：字段核对、字段验证、字段不符、文档核对、核对请求字段、核对响应字段、飞书文档字段、推断字段、user 级接口、用户级接口字段
-allowed-tools: Bash, Read, Edit, Write
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 ---
 
 # OpenLark API 字段核对技能
@@ -120,6 +120,7 @@ node .agents/skills/openlark-api-field-verify/scripts/fetch_doc.js \
 
 ```bash
 # 快速模式：全仓代码自检（秒级，不抓文档）
+# 无参数裸跑 = 扫描整个 crates，生成 reports/api_field_verify/all.md
 python3 tools/verify_api_fields.py
 
 # 快速模式：单个 crate

--- a/.agents/skills/openlark-api-field-verify/scripts/fetch_doc.js
+++ b/.agents/skills/openlark-api-field-verify/scripts/fetch_doc.js
@@ -25,23 +25,27 @@
 const fs = require('fs');
 const path = require('path');
 
-// 尝试加载 playwright（兼容多种安装位置）
+// 尝试加载 playwright（不依赖个人本机绝对路径）
+// 1) 优先用当前 NODE_PATH / 本地已装的 playwright
+// 2) 失败则查 npm 全局 node_modules 根（等价于 npx 全局缓存解析到的位置）
+// 这样在任何机器上都能跑，不写死作者本机的 npx 缓存路径。
 let chromium;
-const candidates = [
-  'playwright',
-  '/Users/zool/.npm/_npx/9833c18b2d85bc59/node_modules/playwright',
-];
-for (const c of candidates) {
+try {
+  ({ chromium } = require('playwright'));
+} catch (e) {
+  let resolved = null;
   try {
-    ({ chromium } = require(c));
-    break;
-  } catch (e) {
-    // 继续尝试下一个
+    const { execSync } = require('child_process');
+    const globalRoot = execSync('npm root -g', { encoding: 'utf8' }).trim();
+    resolved = require('path').join(globalRoot, 'playwright');
+    ({ chromium } = require(resolved));
+  } catch (e2) {
+    resolved = null;
   }
-}
-if (!chromium) {
-  console.error('❌ 找不到 playwright 模块。请先安装：npm i -g playwright && npx playwright install chromium');
-  process.exit(1);
+  if (!chromium) {
+    console.error('❌ 找不到 playwright 模块。请先安装：npm i -g playwright && npx playwright install chromium');
+    process.exit(1);
+  }
 }
 
 const DOC_BASE = 'https://open.feishu.cn';

--- a/.agents/skills/openlark-api-validation/SKILL.md
+++ b/.agents/skills/openlark-api-validation/SKILL.md
@@ -61,15 +61,17 @@ python3 tools/validate_apis.py --crate openlark-meeting
 python3 tools/validate_apis.py --list-crates
 ```
 
-**示例输出：**
+**示例输出（以实际 `--list-crates` 输出为准）：**
 ```
 📄 映射文件: tools/api_coverage.toml
 
 - openlark-analytics: src=crates/openlark-analytics/src biz_tags=[search, report]
-- openlark-api: src=crates/openlark-api/src biz_tags=[auth, passport]
-- openlark-application: src=crates/openlark-application/src biz_tags=[application]
+- openlark-application: src=crates/openlark-application/src biz_tags=[application, workplace]
+- openlark-auth: src=crates/openlark-auth/src biz_tags=[auth, passport, verification_information, human_authentication]
 ...
 ```
+
+> 映射共 **15 个 crate**（核对自 `tools/api_coverage.toml`）。新增 crate 时，在 `tools/api_coverage.toml` 追加 `[crates.<name>]` 段（`src` + `biz_tags`，可选 `dashboard_groups`）即自动纳入 `--crate`/`--all-crates`/`--list-crates`，无需改脚本。
 
 ### 3. 自定义验证范围
 
@@ -88,12 +90,17 @@ python3 tools/validate_apis.py --crate openlark-docs --include-old
 ### 4. 验证所有 crates（批量）
 
 ```bash
-# 验证所有 crate 并生成报告
-for crate in openlark-docs openlark-communication openlark-meeting openlark-hr; do
-  echo "验证 $crate..."
-  python3 tools/validate_apis.py --crate $crate
-done
+# 一条命令验证映射里的全部 crate，并生成汇总报告 + 仪表盘
+python3 tools/validate_apis.py --all-crates
+
+# 等价的日常快捷命令（just recipe）
+just api-coverage
 ```
+
+`--all-crates` 会遍历 `tools/api_coverage.toml` 中映射的 15 个 crate，逐个生成 `reports/api_validation/<crate>.md`，再产出：
+
+- `reports/api_validation/summary.md` / `summary.json` —— 全仓汇总
+- `reports/api_validation/dashboards/<group>.{md,json}` —— 按 `dashboard_groups` 分组（如 `core_business`）
 
 ## 📊 报告解读
 
@@ -125,6 +132,8 @@ done
 按模块分组列出所有已实现的 API。
 
 ### 示例报告片段
+
+> 以下数字仅为格式示意，**以实际生成的报告为准**，请勿当作覆盖率基线。
 
 ```markdown
 ## 一、总体统计
@@ -162,8 +171,22 @@ biz_tags = ["bizTag1", "bizTag2", ...]
 
 **添加新 crate 映射：**
 1. 编辑 `tools/api_coverage.toml`
-2. 在 `[crates]` 下添加新条目
+2. 追加 `[crates.<name>]` 段（`src` + `biz_tags`，可选 `dashboard_groups`）
 3. 运行 `--list-crates` 验证配置
+
+### tools/api_priority.toml
+
+缺失 API 的**业务优先级模型**，把“有多少 API 没实现”升级为“缺口按价值怎么排序”。
+
+- **综合分公式**（核对自 `tools/validate_apis.py` 的 `priority_formula()`）：
+
+  `综合分 = 业务价值×0.50 + 高频场景×0.30 + (6 - 实现复杂度)×0.20`
+
+  三个维度均取 1–5（`[defaults]` 默认各为 3），实现复杂度在综合分里**反向计入**（越难分越低）。
+- **评分来源**：`[defaults]` 基线 + `[[rules]]` 覆盖（按声明顺序匹配，后面的更具体规则覆盖前面的；可按 `biz_tags` / `expected_file_prefixes` / `methods` / `name_prefixes` 命中）。
+- **分层**：`[[priority_tiers]]` 定义 P0/P1/P2/P3 阈值（如 `min_score = 4.4` → P0）。
+- **覆盖路径**：脚本默认 `--priority-config tools/api_priority.toml`（见 `tools/validate_apis.py` 参数定义）；如需切换模型可用该参数指向别的 toml。
+- **输出条件**：仅当该 crate **存在缺失 API** 时，才在报告里写「缺失 API 优先级清单」段（含综合分、P 级、判定规则）；无缺口则不输出。
 
 ## 🚨 常见问题
 
@@ -197,6 +220,20 @@ biz_tags = ["bizTag1", "bizTag2", ...]
 - 更新 CSV 文件
 - 检查是否需要更新 `tools/api_coverage.toml` 映射
 
+### 4. 「额外文件」白名单（预期，非缺陷）
+
+**现象：** 报告「额外的实现文件」段里反复出现一批非 API 文件，完成率看着偏低。
+
+**说明：** 以下文件是 crate 的组织骨架/聚合层/测试，**本就不对应任何 CSV 中的 API**，不计入 API 覆盖，出现属预期：
+
+- `prelude.rs`、`mod.rs` —— 模块聚合 / 导出预导出
+- `versions.rs` —— 版本聚合入口
+- `models.rs`、`models/` —— Serde 模型集中存放
+- `services.rs`、`service.rs` —— Service/Client 注册表
+- `tests.rs`、`tests/` —— 测试
+
+只有当「额外文件」里出现**疑似真实 API 落盘但命名不匹配 CSV**（例如拼错 bizTag / version / resource）时，才需要按命名规范排查。
+
 ## 📝 命名规范
 
 API 文件路径严格遵循以下规范：
@@ -225,33 +262,20 @@ src/{bizTag}/{project}/{version}/{resource}/{name}.rs
 
 ## 📚 工作流集成
 
-### CI/CD 集成
+### CI/CD 接线（已存在，勿重复造）
 
-在 CI 中添加 API 覆盖率检查：
+仓库**没有** `.github/workflows/api-validation.yml`，也**没有** pre-commit hook 跑覆盖率。真实接线分布在两个 workflow：
 
-```yaml
-# .github/workflows/api-validation.yml
-name: API Validation
-on: [push, pull_request]
+- **release.yml**（`.github/workflows/release.yml:70`）—— 打 tag 发版时，`github-release` job 执行 `python3 tools/validate_apis.py --all-crates`，生成全仓覆盖率汇总。
+- **pre-release-compatibility.yml**（`.github/workflows/pre-release-compatibility.yml`）—— 当 `tools/validate_apis.py`（以及 release.yml、相关 docs/scripts、`src/lib.rs`）改动时触发；它调用 `scripts/check-pre-release-compatibility.sh`，并上传 `reports/api_validation/{summary.json,summary.md,dashboards/core_business.json,dashboards/core_business.md}` 作为 artifact（`pre-release-compatibility-report`）。
 
-jobs:
-  validate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Validate API Coverage
-        run: |
-          python3 tools/validate_apis.py --crate openlark-docs
-          python3 tools/validate_apis.py --crate openlark-communication
-```
-
-### Pre-commit Hook
+### 日常本地
 
 ```bash
-# .git/hooks/pre-commit
-#!/bin/bash
-python3 tools/validate_apis.py --crate openlark-docs --output reports/api_validation/pre-commit.md
+just api-coverage   # 等价 python3 tools/validate_apis.py --all-crates
 ```
+
+> 仓库未配置 pre-commit hook，本地验证靠 `just api-coverage` 或直接跑脚本。
 
 ## 🎓 最佳实践
 

--- a/.agents/skills/openlark-api/SKILL.md
+++ b/.agents/skills/openlark-api/SKILL.md
@@ -42,7 +42,7 @@ allowed-tools: Bash, Read, Grep, Glob, Edit
 
 > 这些是仓库**唯一规范**，违反任何一条都会导致接口不统一/调用失败。完整正确模板见 `references/standard-example.md`。
 
-1. **`Config` 用 owned，不用 `Arc<Config>`**。`openlark_core::Config` 内部已 `Arc<ConfigInner>`，clone 廉价。`Request`/`Service` 字段一律 `config: Config`，构造用 `Config::build()`（直接返回 `Config`，**不要** `.unwrap()`）。真实 crate（communication/auth/docs）全是 owned；§2.1 的 `Arc<Config>` 示例仅作 docs crate 的旧参考，**以本条为准**。
+1. **新代码默认 `config: Config`（owned）；现有 `Arc<Config>` 的 Service/Client 保持现状，勿为统一所有权单独重构**。`openlark_core::Config` 内部已 `Arc<ConfigInner>`，clone 廉价。新 Request/Service 默认用 `config: Config`，构造用 `Config::build()`（直接返回 `Config`，**不要** `.unwrap()`）。但仓库现有 573+ 文件仍用 `Arc<Config>`（如 `openlark-docs` 的 `DocsClient`/`BaseClient`/`CcmClient`，见 `crates/openlark-docs/src/common/chain.rs:611-629`）——这些保持现状，**不为统一所有权单独重构**。两种形态都不持 HTTP client，"走 Transport"是硬约束。
 
 2. **`R`（`ApiRequest<R>` 泛型）是响应 `data` 字段的内容类型，不是包装层**。`Transport::request` 返回 `ApiResponse<R> = {code,msg,data: R,...}`，`resp.data: Option<R>`。
    - 无 schema/透传：`R = serde_json::Value`，`execute` 返回 `SDKResult<serde_json::Value>`。
@@ -65,7 +65,11 @@ allowed-tools: Bash, Read, Grep, Glob, Edit
    - **必须支持 RequestOption**：用于 `user_access_token` / `tenant_key` / 自定义 header
 5) **补导出**：在 `mod.rs` 中 `pub mod ...` / `pub use ...`
 6) **补链路**：在约定入口补齐链式调用（默认 `service.rs`，但 `openlark-docs` 例外，见 §2）
-7) **验证**：`just fmt && just lint && just test`
+7) **验证**：
+   - 新增 API 所属 crate feature 已在 `Cargo.toml [features]` 声明；
+   - 涉及该 feature 的测试用 `#[cfg(test)]` 模块内 `#![cfg(feature = "...")]`（或模块级 `#[cfg(feature)]`）门控；
+   - 若新增 `examples/` 示例，须在 `Cargo.toml [[example]]` 声明 `required-features`；
+   - 跑 `just fmt && just lint && just test`，其中 `just lint` 须含 `--all-targets`（覆盖 examples + tests）。
 
 ## 1. Feature Crate ↔ bizTag
 
@@ -87,6 +91,8 @@ python3 tools/validate_apis.py --crate openlark-docs
 
 ### 2.1 实现侧：service.rs
 
+> **event/webhook 类 P2 模块不进统一 `service.rs` 链路**：这类模块（如长连接回调、事件订阅）的入口形态与普通 CRUD API 不同，放在各自独立入口，**不强行塞进** `client.<biz>.service()...` 链。
+
 目标：让 `openlark-client` 能走 `client.<biz>.service().<project>().<version>()...<api>()`
 
 - 若 crate 已有 `src/service.rs`：在顶层 service 新增 `pub fn {bizTag}(&self) -> ...`
@@ -95,10 +101,8 @@ python3 tools/validate_apis.py --crate openlark-docs
 
 #### ⚠️ Service 层标准模式
 
-> 注：这是 `openlark-docs` crate 的真实写法（用 `Arc<Config>`）。**核心契约 1 规定
-> `Config` 用 owned**——新 crate / 重构优先 owned（`config: Config`）；docs crate 因
-> 历史原因用 `Arc<Config>`，二者都**不持 HTTP client**，这点是硬约束。写法区别只是
-> Config 的所有权形态，不影响"走 Transport"这条核心规则。
+> 注：这是 `openlark-docs` crate 的真实写法（用 `Arc<Config>`，见 `crates/openlark-docs/src/common/chain.rs:611-629` 的 `DocsClient`）。
+> **核心契约 1 已放宽**：新代码默认 owned（`config: Config`），现有 `Arc<Config>` 的 Service/Client 保持现状、勿为统一所有权单独重构。两种形态都**不持 HTTP client**，这点是硬约束。
 
 **正确示例**（参考 `openlark-docs/src/common/chain.rs`）：
 
@@ -251,12 +255,13 @@ impl {Name}Request {
 - [ ] **核心契约 5**：端点用常量/enum（禁手写 URL）；必填字段用 `validate_required!`
 - [ ] `execute_with_options(..., RequestOption)` 已提供并透传到 Transport
 - [ ] `mod.rs` 已导出；`service.rs`/链式入口已补
-- [ ] `just fmt && just lint && just test` 通过
+- [ ] 新增 feature 已在 `Cargo.toml [features]` 声明；测试/示例的 `#[cfg(feature)]` 与 `[[example]] required-features` 已补
+- [ ] `just fmt && just lint --all-targets && just test` 通过
 
 ## 5. docPath 网页读取
 
 ```bash
-python3 .claude/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --format md --out /tmp/doc.md
+python3 .agents/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --format md --out /tmp/doc.md
 ```
 
 ## 6. References

--- a/.agents/skills/openlark-api/references/README.md
+++ b/.agents/skills/openlark-api/references/README.md
@@ -10,7 +10,7 @@
 
 ## docPath 抓取脚本
 
-- 在线抓取（需要网络）：`python3 .claude/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --format md --out /tmp/doc.md`
+- 在线抓取（需要网络）：`python3 .agents/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --format md --out /tmp/doc.md`
 - 离线解析（无网络/受限环境）：先把页面保存为 HTML，再用 `--html-file` 解析：
-  - `python3 .claude/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --html-file /path/to/page.html --format md --out /tmp/doc.md`
-  - 或直接从 stdin 输入 HTML：`cat /path/to/page.html | python3 .claude/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --stdin --format md`
+  - `python3 .agents/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --html-file /path/to/page.html --format md --out /tmp/doc.md`
+  - 或直接从 stdin 输入 HTML：`cat /path/to/page.html | python3 .agents/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --stdin --format md`

--- a/.agents/skills/openlark-api/references/standard-example.md
+++ b/.agents/skills/openlark-api/references/standard-example.md
@@ -47,7 +47,18 @@ impl CreateMessageRequest {
         self
     }
 
+    /// 执行请求（转调 execute_with_options，传 RequestOption::default()）
     pub async fn execute(self, body: CreateMessageBody) -> SDKResult<serde_json::Value> {
+        self.execute_with_options(body, openlark_core::req_option::RequestOption::default())
+            .await
+    }
+
+    /// 使用指定请求选项执行（option 透传到 Transport::request 的 Some(option)）
+    pub async fn execute_with_options(
+        self,
+        body: CreateMessageBody,
+        option: openlark_core::req_option::RequestOption,
+    ) -> SDKResult<serde_json::Value> {
         validate_required!(body.receive_id, "receive_id 不能为空");
         validate_required!(body.msg_type, "msg_type 不能为空");
         validate_required!(body.content, "content 不能为空");
@@ -60,14 +71,14 @@ impl CreateMessageRequest {
             .query("receive_id_type", receive_id_type)
             .body(serialize_params(&body, "发送消息")?);
 
-        let resp = Transport::request(req, &self.config, None).await?;
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
         extract_response_data(resp, "发送消息")
     }
 }
 ```
 
 补充约定（新增/重构时统一）：
-- 若该 API 可能需要用户态 token / request_id / 自定义 header：在 builder 上提供 `execute_with_options(..., RequestOption)`，并将 `option` 透传到 `Transport::request(..., Some(option))`
+- **每个 Request 必须提供 `execute_with_options(..., RequestOption)` 并把 option 透传到 `Transport::request(..., Some(option))`**；`execute` 只是无 option 版本的转调（`execute_with_options(.., RequestOption::default())`）。见核心契约 5。
 - 不要只调用 `ApiRequest::request_option(...)`：当前实现仅合并 header，token 推断/注入需要走 `Transport` 的 `option` 参数
 
 ## B) enum 端点 + typed response + ApiResponseTrait
@@ -127,7 +138,17 @@ impl Create {
     pub fn role_name(mut self, v: impl Into<String>) -> Self { self.req.role_name = v.into(); self }
     pub fn table_roles(mut self, v: Vec<serde_json::Value>) -> Self { self.req.table_roles = v; self }
 
-    pub async fn send(self) -> SDKResult<CreateResp> {
+    /// 使用默认请求选项执行（转调 execute_with_options）
+    pub async fn execute(self) -> SDKResult<CreateResp> {
+        self.execute_with_options(openlark_core::req_option::RequestOption::default())
+            .await
+    }
+
+    /// 使用指定请求选项执行（option 透传到 Transport::request 的 Some(option)）
+    pub async fn execute_with_options(
+        self,
+        option: openlark_core::req_option::RequestOption,
+    ) -> SDKResult<CreateResp> {
         validate_required!(self.app_token, "app_token 不能为空");
         validate_required!(self.req.role_name, "role_name 不能为空");
 
@@ -135,14 +156,14 @@ impl Create {
         let api_request: ApiRequest<CreateResp> = ApiRequest::post(&api_endpoint.to_url())
             .body(serialize_params(&self.req, "新增自定义角色")?);
 
-        let response = Transport::request(api_request, &self.config, None).await?;
+        let response = Transport::request(api_request, &self.config, Some(option)).await?;
         extract_response_data(response, "新增自定义角色")
     }
 }
 ```
 
 补充约定（新增/重构时统一）：
-- 若保留 `send()`：建议额外提供 `send_with_options(option: RequestOption)`（或改为 `send(self, option: Option<RequestOption>)`），并将 option 透传到 `Transport::request(...)`
+- 与 A 范式一致：每个 Request 必须提供 `execute_with_options(..., RequestOption)` 并透传 `Some(option)`；`execute()` 只是无 option 版本的转调。
 
 ## 最小导出约定（mod.rs）
 
@@ -154,31 +175,40 @@ pub mod get;
 pub mod models;
 ```
 
-## service.rs 链式调用（给 openlark-client 调用）
+## DocsClient / 链式入口（openlark-docs 真实形态）
 
-`openlark-client` 推荐以“薄包装 + raw 透传”的方式复用各 feature crate 的 service 链路。
+> ⚠️ **历史纠错**：旧版文档曾给出 `client.docs.service().base().v2().app().role().create()`
+> 这样的深层链式调用——**这些 `service()`/`base()`/`v2()` 方法与 `DocsService`/`BaseService`
+> 类型在仓库中均不存在**。核实 `crates/openlark-docs/src/common/chain.rs:609-651`：`DocsClient`
+> 只暴露 `ccm`/`base`/`baike`/`minutes` 公开字段（按 feature 裁剪）和 `config()` 方法，
+> 没有 `service()` 方法，也没有逐层 `.base().v2().app().role()` 的 Service 链。
 
-### 示例：openlark-docs 的链式结构（真实存在）
+`openlark-docs` 的真实调用形态是**两段式**：
 
-入口：
-- `openlark-client`：`client.docs.service() ...`
-- `feature crate`：`openlark_docs::service::DocsService::new(config) ...`
+1. 用 `DocsClient::new(config)` 拿到 client，再取 `docs.base.config().clone()`（或对应子 client 的 `.config()`）得到 `Config`；
+2. 用户自己 `CreateRole::new(config)...execute()` 直接构造 Builder 调用，**不存在统一的深层 Service 链**。
 
 ```rust
-// 统一调用形态（方案 1）：client.<biz>.service()...<api>() -> Builder
-client.docs.service().base().v2().app().role().create()
+use openlark_docs::DocsClient;
+use openlark_docs::base::base::v2::app::role::create::Create;
+
+// 1) 拿到 Config（DocsClient 内部 Arc<Config>，clone 廉价）
+let docs = DocsClient::new(config);
+let config = docs.base.config().clone();   // crates/openlark-docs/src/common/chain.rs:1080-1091
+
+// 2) 用户直接构造 Builder 调用 API
+let resp = Create::new(config)
+    .app_token("bascn...")
+    .role_name("角色名")
+    .table_roles(vec![...])
+    .execute()
+    .await?;
 ```
 
-其中：
-- `service()` 在 `DocsClient` 上提供：`crates/openlark-docs/src/common/chain.rs`
-- `base()`（bizTag）在 `DocsService` 上提供：`crates/openlark-docs/src/service.rs`
-- `v2()`（meta.Version）在 `BaseService` 上提供：`crates/openlark-docs/src/base/service.rs`
-- `app().role()`（meta.Project/meta.Resource）在各层 `*Service` 上提供
-- `create()`（meta.Name）在 `RoleService` 上提供：`crates/openlark-docs/src/base/base/v2/app/role/mod.rs`
+### 对新 API 的要求
 
-### 对新 API 的要求（建议照此落地）
+`openlark-docs` crate 新增 API 时：
+- 在对应 `mod.rs` 导出 Builder（如 `Create`）即可，**不需要**补任何 `service.rs` / 深层 Service 链；
+- Builder 必须实现 `execute` + `execute_with_options`（见上方 A/B 范式），不依赖外层 Service。
 
-当你新增 `crates/{feature-crate}/src/{bizTag}/{meta.Project}/{meta.Version}/.../{meta.Name}.rs` 时：
-- 确保能从 `crates/{feature-crate}/src/service.rs` 逐层链式访问到该 API builder
-- 并确保 `client.<biz>` 的链式入口提供 `service()`，让调用侧统一走 `client.<biz>.service()...`
-- 每一层 service 只做“路由/分组”，最后一层返回具体 API builder（其上再 `.send()`/`.execute()`）
+其他 crate（非 docs）若已有 `src/service.rs` 链式入口，按该 crate 现有结构补链路即可；event/webhook 类 P2 模块不进统一 `service.rs` 链路。

--- a/.agents/skills/openlark-api/scripts/fetch_docpath.py
+++ b/.agents/skills/openlark-api/scripts/fetch_docpath.py
@@ -7,12 +7,12 @@
 - 输出可直接粘贴到上下文的 Markdown，辅助生成 Rust Request/Response 字段
 
 用法：
-  python3 .claude/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --format md --out /tmp/doc.md
-  python3 .claude/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --format json
+  python3 .agents/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --format md --out /tmp/doc.md
+  python3 .agents/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --format json
 
 离线模式（无网络/受限环境）：
-  python3 .claude/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --html-file /path/to/page.html --format md
-  cat /path/to/page.html | python3 .claude/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --stdin --format md
+  python3 .agents/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --html-file /path/to/page.html --format md
+  cat /path/to/page.html | python3 .agents/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --stdin --format md
 """
 
 from __future__ import annotations

--- a/.agents/skills/openlark-code-standards/SKILL.md
+++ b/.agents/skills/openlark-code-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openlark-code-standards
-description: OpenLark 项目代码规范检查技能。用于快速审查仓库内的架构一致性、API 实现套路、参数校验、命名与导出规范，并输出可执行检查清单与证据路径。
+description: OpenLark 项目代码规范检查技能。用于快速审查仓库内的架构一致性、API 实现套路、参数校验、命名与导出规范，并输出可执行检查清单与证据路径。Triggers: code review / consistency check / architecture audit / 规范检查 / 风格一致性 / 体检 / 对齐约定。项目锚点见 AGENTS.md#CONVENTIONS 与 AGENTS.md#ANTI-PATTERNS。
 argument-hint: "[crate-name|path]"
 allowed-tools: Read, Grep, Glob, Bash
 ---
@@ -25,14 +25,11 @@ allowed-tools: Read, Grep, Glob, Bash
 
 ## 检查范围
 
-优先覆盖：
+覆盖全部 `crates/openlark-*`（按 `AGENTS.md#STRUCTURE` 有 18 个业务/基础设施 crate）。
 
-- `crates/openlark-core`
-- `crates/openlark-client`
-- `crates/openlark-docs`
-- `crates/openlark-communication`
-
-可按参数缩小为某个 crate 或目录。
+- 重点核审：核心基础设施（`openlark-core`、`openlark-client`、`openlark-protocol`）与高频业务 crate（`openlark-docs`、`openlark-communication`、`openlark-hr`）。
+- Client 命名（`XxxClient`）权威映射表见 `docs/CLIENT_NAMING_CONVENTION.md` 的「当前映射」，命名核审以此为准。
+- 可按参数缩小为某个 crate 或目录（如 `openlark-mail`、`crates/openlark-hr/src/`）。
 
 ## 核心检查项
 
@@ -43,10 +40,11 @@ allowed-tools: Read, Grep, Glob, Bash
 - 是否通过 `Transport::request(...)` 发送请求
 
 **🔴 硬规则（grep 命中即 P0 违规）：**
-- 业务 crate（除 `openlark-core`）**不得出现 `reqwest::Client::new()`**——一旦命中，说明有端点绕过了 `Transport`，必为不一致源头。检查命令：
+- 业务 crate（除 `openlark-core` 与 **`openlark-webhook`**）**不得出现 `reqwest::Client::new()`**——一旦命中，说明有端点绕过了 `Transport`，必为不一致源头。检查命令：
   ```bash
-  rg "reqwest::Client::new" crates/ --type rust -g '!openlark-core/**'
+  rg "reqwest::Client::new" crates/ --type rust -g '!openlark-core/**' -g '!openlark-webhook/**'
   ```
+- **白名单说明：`openlark-webhook` 是有意例外**——自定义机器人不是飞书开放平台 API（目标 URL 为用户配置的绝对地址、用 URL 携带签名密钥鉴权、响应体为非标准 `{code,msg}`），不适用 `Transport` 的 `/open-apis/` 基址与 token 注入，故保留独立 reqwest 路径（见 issue #214 调研结论，注释位于 `crates/openlark-webhook/src/robot/v1/send.rs:13-26`）。**勿改 webhook 的 reqwest 用法**。
 - **不得手工 `Authorization` 头 / `get_app_token`**（token 由 `Transport` 自动注入）
 - **`Service`/`Request` 不得持有 HTTP client 字段**（只持 `Config`）
 
@@ -57,9 +55,12 @@ allowed-tools: Read, Grep, Glob, Bash
 
 ### 2) 端点定义规范
 
-- 是否使用 `ApiEndpoint` 枚举/端点常量
-- 是否避免手写业务 URL
-- 是否通过 `to_url()` 或统一端点入口生成路径
+- 是否使用 **per-crate 类型安全端点枚举**：每个 crate 在 `src/common/api_endpoints.rs` 定义各自的 `<Domain>ApiV1` 枚举，并实现 `pub fn to_url(&self) -> String`（注意 `to_url()` 返回的是相对路径 `String`，形如 `/open-apis/mail/v1/...`，不带基址）。
+- 是否避免手写业务 URL（统一走枚举 `to_url()`）
+- 命名注意：枚举名是 `<Domain>ApiV1`，`Domain` **通常但并非总是**等于 crate 名——以现况为准：
+  - 与 crate 同名：`MailApiV1`（`crates/openlark-mail/src/common/api_endpoints.rs:5`）、`DocsApiV1`（`crates/openlark-docs/src/common/api_endpoints.rs:440`）、`HelpdeskApiV1`、`AppApiV1`（application）。
+  - 与 crate 名不同：`VcApiV1`（meeting，`crates/openlark-meeting/src/common/api_endpoints.rs:224`）、`TaskApiV1`/`BoardApiV1`（workflow）、`AdminApiV1`（platform）、`AuthenApiV1`（auth）、HR 多枚举（`AttendanceApiV1`/`HireApiV1`/`OkrApiV1`/...）、Docs 多枚举（`BitableApiV1`/`WikiApiV1`/`DocxApiV1`/`MinutesApiV1`/...）。
+- 新增端点时改枚举与 `to_url()` match 分支，不要在 Request/Builder 里手写 URL 字面量。
 
 ### 3) 参数校验规范
 
@@ -70,6 +71,11 @@ allowed-tools: Read, Grep, Glob, Bash
 **🟡 Token 类型与 Config 形态：**
 - 应用级接口（文档要求 `tenant_access_token`/`app_access_token`）是否显式 `.with_supported_access_token_types(vec![AccessTokenType::App])`——`ApiRequest` 默认 `[User, Tenant]`，漏设会导致飞书拒绝。
 - `Request`/`Service` 是否用 owned `Config`（非 `Arc<Config>`）——新代码与重构以 owned 为准（`openlark-docs` 历史用 `Arc` 属例外）。
+
+**🟡 `RequestOption`（单数）vs `RequestOptions`（复数）切勿混用：**
+- `openlark_core::req_option::RequestOption`（**单数**，`crates/openlark-core/src/req_option.rs:7`）——`Transport`/`execute_with_options` 实际接受的类型（token、tenant_key、file_upload/download 等运行时请求控制），业务 crate 调用 `execute_with_options(RequestOption::default())`。
+- `openlark_client::types::client::RequestOptions`（**复数**，`crates/openlark-client/src/types/client.rs:180`）——高级客户端的 timeout/retry_count/headers 构造参数，语义不同。
+- 二者字段集合完全不同，**不得互相替代或导出混名**；业务 crate 写 Builder 时用单数 `RequestOption`。
 
 ### 4) 命名与公开 API 表达
 
@@ -82,6 +88,15 @@ allowed-tools: Read, Grep, Glob, Bash
 - `mod.rs` 与 `prelude` 是否完整导出新增 API
 - `Cargo.toml` feature 与 `#[cfg(feature = "...")]` 是否对齐
 - 是否存在导出但不可编译或不可访问路径
+
+### 6) CI 与测试门控（#228 审核闭环）
+
+> 详细背景见 `docs/CI_TEST_TARGET_COVERAGE.md`（相关 issue：#228 / #246 / #248 / #250 / #251；PR：#247 / #249 / #252 / #253 / #254）。
+
+- **测试/`#[cfg(test)]` 改动后必跑 `just lint`**：`just lint` = `cargo clippy --workspace --all-targets --all-features`（justfile:12-14）。CI 在 **all-features / no-default-features / 各 feature 组合** 三个维度都用 `--all-targets`，因此 `#[cfg(test)]` 类 lint 回归（如 #248 的未用 `use super::*`）会被 CI 直接拦住，不只依赖本地。
+- **`tests/*.rs` feature 门控约定**（#251）：文件引用 feature-gated 模块时，文件顶部加 `#![cfg(feature = "...")]`；且 **`//!` 模块文档必须在 `#![cfg]` 之上**（顺序反了会触发 clippy `missing_docs`）。
+- **`examples/*.rs` 禁用 `#![cfg]`**（#251）：feature 门控走 `Cargo.toml` 的 `[[example]] required-features`。example 里写 `#![cfg]` 会把文件清空成无 `main`，报 **`E0601`**。
+- **event 模块（`openlark-communication`）不违规**：event 在 `tools/api_priority.toml` 标为 **P2**（非 P0 核心业务），按基础设施类对待（与 WebSocket `LarkWsClient` 同类），**有意不经统一 client `declare_client!` re-export**（#228 决策）。审查时勿把它当作「漏 re-export 的违规」上报。
 
 ## 输出模板（必须）
 

--- a/.agents/skills/openlark-design-review/SKILL.md
+++ b/.agents/skills/openlark-design-review/SKILL.md
@@ -142,8 +142,10 @@ PY
 
 特征：
 - Builder 只拼 Request
-- `ExecutableBuilder`/trait_system 统一 execute
+- 统一 execute 由 `openlark_core::trait_system::ExecutableBuilder` 提供（trait 定义在 `crates/openlark-core/src/trait_system/executable_builder.rs:11`，业务 crate 通过宏批量 impl，例如 `crates/openlark-meeting/src/common/macros.rs` 的 `impl_executable_builder!`/`impl_executable_builder_owned!`）
 - Service 持有 Config，并负责实际请求发送
+
+> ⚠️ trait 名核实：现码中 trait 名是 **`ExecutableBuilder`**（不是单字母 `n`）。引用时写完整路径 `openlark_core::trait_system::ExecutableBuilder`，不要写成 `trait_system::n`。
 
 **规则**：同一个 project/version 内不得同时出现 A+B；若历史原因混用，必须定义清晰的迁移路线。
 
@@ -155,6 +157,7 @@ PY
 - 是否存在“占位/空实现”的 public API（例如 builder setter 不生效）？
 - re-export 是否稳定、是否引入 `ambiguous_glob_reexports` 需要大量 allow？
 - `prelude` 是否只导出“高频且稳定”的类型，避免把内部实现细节暴露出去？
+- **event/回调类不进统一 Client ServiceRegistry**：event 模块在业务优先级模型中属 **P2**（非 P0 核心业务），按**基础设施类**对待（与 WebSocket `LarkWsClient` 同类），仅在所属业务 crate（如 `openlark-communication`）暴露，**不进** `declare_client!`/`ServiceRegistry` 注册表（统一 client 仅注册 P0/P1 资源客户端）。详见 `docs/CI_TEST_TARGET_COVERAGE.md`（#228 决策）。
 
 ### 2.2 Feature gating 一致性（Cargo.toml ↔ cfg）
 
@@ -188,17 +191,21 @@ PY
 **正确模式**（参考 `openlark-docs/src/common/chain.rs`）：
 - ✅ Service 只持有 `Arc<Config>`
 - ✅ 子 Service 通过 `new(Arc<Config>)` 透传配置
-- ✅ HTTP 传输统一由 `openlark_core::Transport` 处理
+- ✅ HTTP 传输统一由 `openlark_core::http::Transport`（`pub struct Transport<T>`，`http.rs:23`，prelude 导出于 `lib.rs:93`）处理
 - ✅ `Config::build()` 直接返回 `Config`，不需要 `.unwrap()`
 
 **检查点**：
 ```bash
 # 搜索错误的 LarkClient 用法
+# 注：本仓已历史清零（无命中），此命令作“回归守卫”——命中即 P0。
 rg "LarkClient::new" crates/
 
 # 搜索错误的 Config::build().unwrap() 用法
+# 注：本仓已历史清零（无命中），此命令作“回归守卫”——命中即 P0。
 rg "Config::builder\(\).*\.build\(\)\.unwrap\(\)" crates/
 ```
+
+> Transport 精确路径：HTTP 传输统一走 `openlark_core::http::Transport`（`pub struct Transport<T>`，定义在 `crates/openlark-core/src/http.rs:23`，由 `crates/openlark-core/src/lib.rs:93` 的 prelude 导出）。
 
 ### 2.5 错误处理与类型边界
 
@@ -211,6 +218,30 @@ rg "Config::builder\(\).*\.build\(\)\.unwrap\(\)" crates/
 - `cargo check --all-features` 是否无 warning？（deprecated/unused 要么修，要么显式 allow）
 - 单元测试是否只验证“构建正确”，避免依赖真实网络？
 - 文档示例是否可 `compile`（必要时 `no_run/ignore` 但要有理由）
+
+### 2.7 CI/测试门控一致性（#251 后约定）
+
+> 背景：CI clippy 三个维度（all-features / no-default-features / 各 feature 组合）统一加 `--all-targets`（#250/#254），把 test/bench target 纳入 lint；门控写法不当会直接被 CI 拦或触发 `E0601`/`missing_docs`。详见 `docs/CI_TEST_TARGET_COVERAGE.md`。
+
+检查点：
+
+1. **example 必须在 `Cargo.toml [[example]]` 声明 `required-features`**（CI clippy 跑 `--all-targets` 会编译 example）。
+   - example **不要**用 `#![cfg(feature="...")]`（会把 example 清空成无 `main`，报 `E0601`）。
+   - 现码范例：`crates/openlark-docs/Cargo.toml` 的 `required-features = ["baike", "bitable", "ccm-core"]`。
+
+2. **feature 契约测试文件结构约定**：`//! 文档注释` 在前 + `#![cfg(feature="x")]` 紧随其后。
+   - 文件首行必须是 `//! ...` 文档；`#![cfg(...)]` 放第 2 行（顺序反了会触发 clippy `missing_docs`）。
+   - **不要**用 `#[cfg]` 包整文件，**不要**把 `#![cfg]` 放在 `//!` 之前。
+   - 现码范例：`crates/openlark-application/tests/application_contract_models.rs:1-2`（`//!` 在第 1 行，`#![cfg(feature = "v1")]` 在第 2 行）。
+
+3. **检查命令**：
+   ```bash
+   # 测试文件门控写法（确认 //! 在前、#![cfg(feature)] 紧随）
+   rg -n '^#!\[cfg\(feature' crates/<crate>/tests/
+
+   # example 是否声明 required-features
+   rg -n 'required-features' crates/<crate>/Cargo.toml
+   ```
 
 ## 3. 常见整改套路（建议）
 

--- a/.agents/skills/openlark-design-review/references/design-review-report-template.md
+++ b/.agents/skills/openlark-design-review/references/design-review-report-template.md
@@ -85,7 +85,8 @@
 - 核心规范：
   - Builder 只拼 Request，不做网络
   - Service 持有 Config，统一执行与注入点
-  - 使用 `trait_system::ExecutableBuilder`（如仓库已有统一约定）
+  - 使用 `openlark_core::trait_system::ExecutableBuilder`（trait 定义在 `crates/openlark-core/src/trait_system/executable_builder.rs:11`；业务 crate 通过宏 impl，如 `crates/openlark-meeting/src/common/macros.rs`）
+  - ⚠️ trait 名是 `ExecutableBuilder`（非单字母 `n`），引用写完整路径
 - 迁移策略：
   - 第 1 步：`<试点模块>`
   - 第 2 步：`<逐步迁移>`

--- a/.agents/skills/openlark-naming/SKILL.md
+++ b/.agents/skills/openlark-naming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openlark-naming
-description: OpenLark Rust SDK 命名与对外 API 表达规范（Client/Service/Resource/Request/Builder）。用于新增/重构公开类型、设计 meta 调用链、调整模块导出与 prelude、或排查类似 openlark-docs 中 DocsService 重名/语义混乱与调用风格不一致的问题。触发关键词：命名规范、Client vs Service、Resource、重命名、meta 调用链、公开 API
+description: OpenLark Rust SDK 命名与对外 API 表达规范（Client/Service/Resource/Request/Builder）。用于新增/重构公开类型、设计 meta 调用链、调整模块导出与 prelude、或排查 *Service 同名/语义错配/V{N}Service 版本层错位、*Resource 与 *Service 同类型两名、以及 Client/Service/Resource 调用风格不一致的问题。触发关键词：命名规范、Client vs Service、Resource、重命名、V1Service 版本层、meta 调用链、公开 API
 argument-hint: "[module|type-name|path]"
 allowed-tools: Bash, Read, Grep, Glob, Edit
 ---
@@ -54,6 +54,17 @@ allowed-tools: Bash, Read, Grep, Glob, Edit
   - 很少直接实现业务方法（除非规模很小且能保持一致）
 - 建议放置：`common/chain.rs`（避免被 API 实现校验脚本当成 endpoint 实现文件）
 
+### 两种合法实现（XxxClient 的落盘方式）
+
+每个业务 crate 必须导出一个 `XxxClient` 类型作为主入口，有两种合法实现方式，按 crate 规模/复杂度二选一：
+
+| 方式 | 写法 | 适用 | 现码实例（核实） |
+|------|------|------|------------------|
+| **A. 单 facade type alias** | `pub type XxxClient = XxxService;`（写在 `lib.rs`） | crate 规模小、内部仅一个 Service、无需多层链式入口 | `crates/openlark-workflow/src/lib.rs:121` `pub type WorkflowClient = WorkflowService;`；同类还有 bot/application/platform/mail/helpdesk/analytics/user 等 |
+| **B. 分层调用链 struct** | `pub struct XxxClient { ... }`（写在 `common/chain.rs`，经 `lib.rs` re-export） | crate 含多 bizTag/project、需要 `client.xxx.v1.yyy` 链式入口 | `crates/openlark-docs/src/common/chain.rs` → `lib.rs:125` `DocsClient`；同类有 cardkit/communication/meeting/ai |
+
+> **权威映射表**：各 crate 当前采用 A 还是 B、内部类型与导出名对照，以 `docs/CLIENT_NAMING_CONVENTION.md` 的「当前映射」表为准；新增/切换实现方式时同步更新该表，勿仅凭记忆判断。
+
 ## 2) `*Service` 命名规则
 
 - 语义：**能力载体**；需要能回答“这个类型里提供了一组可执行 API/操作”。
@@ -61,9 +72,21 @@ allowed-tools: Bash, Read, Grep, Glob, Edit
 
 ## 3) 版本层命名（强制：避免同名灾难）
 
-- 版本对象必须显式：`DriveV1Service`、`DocsV2Service`
+- 版本对象必须显式带版本号：`*V1Service` / `*V2Service`（或 `*V1Client`，按下方双轨约定选择）
 - 禁止：外层 `DocsService`，内层 `v1::DocsService` 也叫 `DocsService`
   - 会导致 `use` 歧义、re-export 冲突、文档示例难以写清
+
+### 双轨约定（执行 Service 侧 vs chain.rs facade 侧）
+
+同一个版本层在 crate 内会同时出现两个名字，分别承担不同职责，**二者都必须带版本号**且语义不混：
+
+| 侧 | 命名 | 职责 | 典型位置（现码核实） |
+|----|------|------|----------------------|
+| **执行 Service 侧** | `*V{N}Service` | 能力载体，承接 trait（`Service`/`ExecutableBuilder`），提供一组可执行 API | `crates/openlark-cardkit/src/service.rs:27` 返回 `CardkitV1Service`；`crates/openlark-meeting/src/calendar/service.rs:26` 定义 `CalendarV4Service` |
+| **chain.rs facade 侧** | `*V{N}Client` | 门面/链式入口节点，持有 `Arc<Config>` + 暴露资源字段链 | `crates/openlark-cardkit/src/common/chain.rs:37` `pub struct CardkitV1Client` |
+
+- 两层之间由 facade 构造并返回 Service（如 `service.rs` 的 `v1()` 返回 `CardkitV1Service`）
+- 命名上务必成对出现：`CardkitV1Client`（facade）↔ `CardkitV1Service`（执行），版本号一致，**不可一侧带版本号、另一侧不带**
 
 ## 4) `*Resource` 命名规则（meta 调用链中间层）
 
@@ -91,24 +114,54 @@ allowed-tools: Bash, Read, Grep, Glob, Edit
 - 模块叫 `permission`，类型不要叫 `DriveService`
 - 类型名应能让读者大致推断它在哪个 bizTag/project/version/resource 下（至少不会“指向错误模块”）
 
-## 7) openlark-docs 的典型反例（用于触发重命名）
+## 6.5) 事件/回调类（P2）命名与归属
 
-### 7.1 多处 `DocsService` 同名但语义不同
+事件（event）、回调（callback）、webhook 推送这类**被动接收**能力，命名与归属规则与主动调用的业务 API 不同：
 
-- `crates/openlark-docs/src/ccm/docs/mod.rs:8`：`ccm::docs` 的服务入口也叫 `DocsService`
-- `crates/openlark-docs/src/ccm/docs/v1/mod.rs:25`：`ccm::docs::v1` 的版本服务也叫 `DocsService`
-- `crates/openlark-docs/src/ccm/doc/mod.rs:65`：模块叫 `doc`，但类型依然叫 `DocsService`（语义错配）
+- **独立 P2 crate，不进统一门面**：webhook/event 类能力放在独立 crate（`openlark-webhook`），**不注册进 `openlark-client` 的 ServiceRegistry 统一门面**。
+  - 现码核实：`openlark-webhook` 是独立 crate，其入口 `WebhookClient` 由 `crates/openlark-webhook/src/lib.rs:60` re-export（`pub use robot::v1::client::WebhookClient;`）；在 `crates/openlark-client/src/` 下搜索 `webhook` 无任何注册项。
+- **命名**：沿用 `*Client` 作为该 crate 的对外入口（如 `WebhookClient`），但**不要求**与 `openlark-client::Client` 形成 `client.xxx` 链式段，因为它不属于主动 API 调用链。
+- **构造差异**：webhook 类常不需要 `Config`/app_id，构造可能为 `WebhookClient::new()`（无参）或仅传 webhook URL/secret，与业务 `*Client::new(config)` 不同；命名上仍叫 `*Client`，但归属与生命周期独立。
+- **判断要点**：新增一个“接收推送/回调”的能力时，优先问“它是否被动触发？”——是，则归独立 P2 crate，不要塞进 `openlark-client`。
 
-### 7.2 推荐的“立即可落地”改名模板（不考虑兼容）
+## 7) 已治理案例与现存反例
 
-- 版本层显式化：
-  - `ccm::docs::v1::DocsService` → `DocsV1Service`
-- 模块名与类型名对齐（尤其是 `doc`/`docs` 这种高风险词）：
-  - `ccm::doc::DocsService` → `DocService`（如是旧版 API，可用 `LegacyDocService`）
+### 7.1 已治理：openlark-docs 的 `DocsService` 重名问题
+
+历史问题：`openlark-docs` 曾出现多处 `DocsService` 同名但语义不同（`ccm::docs` 入口、`ccm::docs::v1` 版本层、`ccm::doc` 模块错配），是本技能最初触发的典型案例。
+
+**治理结论**（已落地，作为同类问题的参考样板）：
+- 全 crate 统一以 **`DocsClient` 作为唯一对外入口**，prelude 注释明确记载：
+  - `crates/openlark-docs/src/prelude.rs:16` — `// 已移除 Service 的 prelude 导出，统一使用 DocsClient 作为唯一入口`
+- `DocsClient` 由分层调用链实现，定义于 `crates/openlark-docs/src/common/chain.rs`，经 `crates/openlark-docs/src/lib.rs:125` re-export（`pub use common::chain::DocsClient;`）
+- `*Service` 类型（`CcmService`/`BaseService`/`BitableService` 等）保留为内部执行层，不再进 prelude，仅在需要时通过完整路径访问
+- **启示**：当某 crate 的 `*Service` 泛名泛滥、re-export 冲突难收敛时，优先收敛为单一 `*Client` 门面 + 内部 Service 分层，而非逐个改名 `*Service`
+
+> 现码核实：上述 prelude.rs:16 与 lib.rs:125 的 file:line 均有效；旧的 `ccm/docs/mod.rs:8`、`ccm/docs/v1/mod.rs:25`、`ccm/doc/mod.rs:65` 三处引用已全部失效，勿再引用。
+
+### 7.2 现存反例：同一类型同时挂两个名字（Resource + Service）
+
+现码中仍存在“同一结构体同时暴露 `*Resource` 与 `*Service` 两个名字”的兼容残留，是典型的待收敛反例：
+
+- `crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/mod.rs:47`
+  ```rust
+  /// 兼容历史命名：card.element 服务
+  pub type CardElementService = CardElementResource;
+  ```
+  - 真实结构体是 `CardElementResource`（mod.rs:42，资源节点语义），却又 `pub type` 出一个 `CardElementService` 别名。
+  - 问题：违反 §0/§4 的职责-命名对应（资源节点不应叫 `*Service`），造成“读者不知道哪里能 execute”的同名泛滥；别名仅为兼容历史调用而存在。
+  - 收敛方向：评估调用方迁移后移除 `CardElementService` 别名，统一只保留 `CardElementResource`。
+
+> 排查方法：`rg -n "pub type .*Service = .*Resource" crates/` 可一次性找出所有此类“同类型两名”残留。
 
 ## 8) 改名 review 清单（提交前逐条过一遍）
 
 - 目录/模块路径是否能从类型名推断（至少到 bizTag/project/version/resource）
-- `prelude`/re-export 是否引入同名冲突（尤其是 `DocsService` 这种泛名）
+- `prelude`/re-export 是否引入同名冲突（尤其是 `*Service` 这种泛名；已治理的 `DocsService` 勿再复现）
 - `*Client` / `*Service` / `*Resource` 的职责是否清晰，调用方式是否一致
-- 版本层是否统一采用 `*V{N}Service`（或 `*V{N}Client`），避免重复 `*Service`
+- 版本层是否统一采用 `*V{N}Service`（或 `*V{N}Client`），避免重复 `*Service`；facade 侧 `*V{N}Client` 与执行侧 `*V{N}Service` 版本号是否成对一致
+- 同一类型是否同时挂了 `*Resource` 与 `*Service` 两个名字（`rg "pub type .*Service = .*Resource"` 应无新增）
+- 事件/回调类是否误被塞进 `openlark-client` 门面（webhook/event 应在独立 P2 crate）
+- **改名后跑 `just lint`**：等价于 `cargo clippy --workspace --all-targets --all-features -- -Dwarnings -A missing_docs`（justfile:14），务必带 `--all-targets` 以覆盖 examples/tests/benches，确保改名未漏掉非 lib 目标
+- **移动/新建 example 时补 `[[example]] required-features`**：根 `Cargo.toml` 每个 `[[example]]` 需声明所依赖的 feature（如 `required-features = ["communication", "websocket"]`，见 Cargo.toml:248+）；example 引用的类型若位于 feature-gated 模块，缺声明会导致 `--all-features` 之外编译失败
+- **测试文件保持 `//!` 在 `#![cfg(feature)]` 之上**：契约测试/集成测试文件开头顺序固定为「文件级文档注释 `//!` 在前、`#![cfg(feature = "...")]` 属性在后」，再 `use`（正例：`crates/openlark-client/tests/docs_feature_contract.rs:1-6`）；改名时勿颠倒顺序，否则 inner attribute 报错

--- a/.agents/skills/openlark-validation-style/SKILL.md
+++ b/.agents/skills/openlark-validation-style/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: openlark-validation-style
-description: OpenLark Rust SDK 的 feature-crate 参数校验规范（必填校验）。当需要统一/评审 `validate()` 写法，或用户询问 `openlark_core::validate_required`（函数）与 `openlark_core::validate_required!`（宏）的区别、是否需要宏、空白字符串处理等问题时使用。
+description: OpenLark Rust SDK 的 validate() 写法规范（必填校验 / 空白字符串处理）。当需要统一或评审 feature crate 中 validate(&self) -> SDKResult<()> 的实现、确定何时用 validate_required! 宏、空白字符串是否视为空、列表字段同时校验非空与限长等问题时使用。
 argument-hint: "[crate-name|path|request-file]"
 allowed-tools: Read, Grep
 ---
+
+> 权威源：`crates/openlark-core/AGENTS.md`，本文件与之冲突时以它为准。
 
 # OpenLark Validation Style
 
@@ -11,9 +13,9 @@ allowed-tools: Read, Grep
 
 **本技能适用场景：**
 - 需要统一/评审 `validate()` 方法写法
-- 不确定使用 `validate_required!`（宏）还是 `validate_required()`（函数）
-- 需要处理空白字符串校验
-- 需要聚合多条校验错误
+- 不确定字符串字段是否要 `.trim()`、空白字符串算不算空
+- 列表字段需要同时校验“非空 + 最大长度”
+- 多条校验如何组织（连续宏快速失败 / 用构建器聚合）
 
 **其他技能：**
 - 项目级代码规范检查（架构/API/导出/校验一体）→ `Skill(openlark-code-standards)`
@@ -22,7 +24,7 @@ allowed-tools: Read, Grep
 
 ### 关键词触发映射
 
-- validate、必填校验、validate_required、空白字符串、校验聚合 → `openlark-validation-style`
+- validate、必填校验、validate_required、validate_required_list、空白字符串、校验聚合 → `openlark-validation-style`
 - 代码规范、规范检查、风格一致性、体检 → `openlark-code-standards`
 - 架构设计、public API、收敛方案、feature gating、兼容策略 → `openlark-design-review`
 - 新增 API、重构 API、Builder、Request/Response、mod.rs 导出 → `openlark-api`
@@ -45,23 +47,28 @@ allowed-tools: Read, Grep
 
 ## 规则
 
-### 1) 默认：在 `validate()` 内使用 `openlark_core::validate_required!`（宏）快速失败
+### 1) 字符串字段默认用 `validate_required!` 宏——字符串已自动 trim，传 `self.field` 即可
 
-适用场景：必填校验失败就应该立即返回 `Err(...)`。
+`validate_required!` 宏内部调用 `Validatable::is_empty_trimmed`（`crates/openlark-core/src/lib.rs:53-59`）。
+对 `&str` / `String` 的实现是 `self.trim().is_empty()`（`crates/openlark-core/src/validation/validatable.rs:7-17`，提交 `6fe4a6ca6`）。
 
-注意：该宏内部用 `.is_empty()` 判空，不会自动 `trim()`。
+也就是说：**字符串字段会自动 `trim`，纯空白字符串视为空。直接传 `self.field`，不要再额外 `.trim()`。**
 
-字符串字段一律传入 `.trim()` 结果，保证空白字符串也视为缺失：
+适用场景：必填校验失败就应该立即返回 `Err(...)`（快速失败）。
 
 ```rust
 fn validate(&self) -> openlark_core::SDKResult<()> {
-    openlark_core::validate_required!(self.app_token.trim(), "app_token 不能为空");
-    openlark_core::validate_required!(self.table_id.trim(), "table_id 不能为空");
+    // 字符串字段：自动 trim，空白算空，直接传字段本身
+    openlark_core::validate_required!(self.app_token, "app_token 不能为空");
+    openlark_core::validate_required!(self.table_id, "table_id 不能为空");
     Ok(())
 }
 ```
 
-非字符串容器（如 `Vec<T>`）可直接传字段（按“长度是否为 0”判空）：
+> 现码惯例一致，例如 `crates/openlark-ai/src/ai/document_ai/v1/bank_card/recognize.rs:30`
+> `validate_required!(self.file, "file 不能为空");` —— 字符串字段未手动 `.trim()`。
+
+非字符串容器（如 `Vec<T>` / `&[T]`）的 `is_empty_trimmed` 退化为“长度是否为 0”（`validatable.rs:25-35`），同样直接传字段即可：
 
 ```rust
 fn validate(&self) -> openlark_core::SDKResult<()> {
@@ -70,30 +77,73 @@ fn validate(&self) -> openlark_core::SDKResult<()> {
 }
 ```
 
-### 2) 需要自定义控制流（不立刻 return / 聚合多条错误）时，使用 `openlark_core::validation::validate_required`（函数）
+> 若列表字段还需要“最大长度”限制，应改用下面的 `validate_required_list!`，不要在 `validate_required!` 之外再手写长度判断。
 
-适用场景：
+### 2) 列表字段用 `validate_required_list!` 同时校验非空 + 最大长度
 
-- 需要做多条校验后统一返回（例如收集多个错误）
-- 需要明确的 `trim()` 语义（函数内部 `trim()` 后判空）
-
-注意：函数只返回 `bool`，你需要自己决定错误消息与返回时机：
+`validate_required_list!(field, max_len, msg)` 一次完成两项检查：先判空、再判是否超过 `max_len`，任一失败即快速返回（`crates/openlark-core/src/lib.rs:72-82`）。msg 用于两种失败场景，建议写明两条约束。
 
 ```rust
 fn validate(&self) -> openlark_core::SDKResult<()> {
-    if !openlark_core::validation::validate_required(&self.name, "name") {
-        return Err(openlark_core::CoreError::validation_msg("name 不能为空"));
-    }
+    openlark_core::validate_required_list!(self.user_ids, 50, "user_ids 不能为空且不能超过 50 个");
     Ok(())
 }
 ```
 
-### 3) 禁止在 feature crate 内重复定义 `validate_required!`（或同语义宏）
+> 广泛使用于 hr/docs/ai/workflow/mail/communication/user 等，例如
+> `crates/openlark-ai/src/ai/translation/v1/text/translate.rs:32`
+> `validate_required_list!(self.texts, 50, "texts 不能为空且不能超过 50 个");`，
+> `crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_update.rs:114`
+> `validate_required_list!(self.records, 1000, "records 不能为空且单次最多 1000 条");`。
 
-统一复用 `openlark_core::validate_required!`，避免各 crate 的判空规则/错误类型不一致。
+### 3) 多条校验：连续写多个宏（遇首个失败即 return），或用 `DefaultValidateBuilder` 聚合
+
+项目**没有统一的“聚合多错误”宏**。两种推荐写法：
+
+**a) 连续宏——快速失败（绝大多数场景首选）**
+
+宏在失败时直接 `return Err(...)`，因此按字段顺序连续书写即可；首个失败字段处返回。
+
+```rust
+fn validate(&self) -> openlark_core::SDKResult<()> {
+    openlark_core::validate_required!(self.app_token, "app_token 不能为空");
+    openlark_core::validate_required!(self.table_id, "table_id 不能为空");
+    openlark_core::validate_required_list!(self.records, 1000, "records 不能为空且单次最多 1000 条");
+    Ok(())
+}
+```
+
+**b) 需要收集多个错误一次性返回——用 `DefaultValidateBuilder`**
+
+`openlark_core::validation::DefaultValidateBuilder` 实现 `ValidateBuilder` trait，链式 `required` / `length` / `custom` 累积错误，`build()` 返回 `Result<String, Vec<String>>`（`crates/openlark-core/src/validation/core.rs:154-266`）。
+
+```rust
+use openlark_core::validation::{DefaultValidateBuilder, ValidateBuilder};
+
+fn validate(&self) -> openlark_core::SDKResult<()> {
+    let result = DefaultValidateBuilder::new()
+        .required(Some(self.name.clone()), "name")
+        .length(self.code.clone(), 1, 32, "code")
+        .build();
+    match result {
+        Ok(_) => Ok(()),
+        Err(errs) => Err(openlark_core::CoreError::validation_msg(errs.join("; "))),
+    }
+}
+```
+
+> 注意：`DefaultValidateBuilder` 当前仅在 core 内定义与使用，feature crate 的现码一律采用方式 (a) 的连续宏写法。优先沿用 (a)；确有聚合需求时再评估 (b)。
+
+### 4) 禁止在 feature crate 内重复定义 `validate_required!` / `validate_required_list!`（或同语义宏）
+
+统一复用 `openlark_core::validate_required!` 与 `openlark_core::validate_required_list!`，避免各 crate 的判空规则/错误类型不一致。
+
+> 同步约束：`openlark_core::validation::validate_required`（函数）**已删除**，不要引用或照抄旧文档里的函数写法，否则编译失败（见 `crates/openlark-core/AGENTS.md:91,125` 反模式）。
 
 ## 速查
 
-- “校验失败立即返回” → `openlark_core::validate_required!(field[.trim()], "...")`
-- “空白也算空” → 字符串传 `.trim()`，或使用函数 `openlark_core::validation::validate_required`
-- “多条校验汇总再返回” → 函数 `validate_required` + 自定义聚合逻辑
+- 字符串必填 → `validate_required!(self.field, "...")`；**自动 trim，空白算空，不要手动 `.trim()`**
+- 列表必填（不限长）→ `validate_required!(self.items, "...")`
+- 列表必填 + 限长 → `validate_required_list!(self.items, max_len, "不能为空且不能超过 N 个")`
+- 多条校验按顺序快速失败 → 连续写多个宏（首个失败即 return）
+- 必须一次性返回全部错误 → `DefaultValidateBuilder`（`openlark_core::validation::DefaultValidateBuilder`），项目无统一聚合宏

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ just release VERSION  # 发布新版本
 
 ## SKILLS
 
-项目内置 6 个领域技能（位于 `.agents/skills/`），Agent 在对应场景下应优先调用。调用权限如需预授权，在各端本地配置中放行（`.claude/settings.json` 已被 `.gitignore` 忽略，不入库）：
+项目内置 7 个领域技能（位于 `.agents/skills/`），Agent 在对应场景下应优先调用。调用权限如需预授权，在各端本地配置中放行（`.claude/settings.json` 已被 `.gitignore` 忽略，不入库）：
 
 | Skill | 用途 | 触发场景 |
 |-------|------|----------|


### PR DESCRIPTION
## 优化 7 个项目 skill 的准确性与一致性

对 `.agents/skills/` 下全部 7 个 skill 做 codebase 交叉核对，修复事实性错误、过时引用、缺失约定。**仅改 skill 文档 + AGENTS.md，未动业务代码**（12 文件，+350/−135）。

## 改动概览

| Skill | 准确度 | 关键修复 |
|-------|--------|---------|
| **validation-style** | 🔴 low→✅ | 重写：删已废弃的 `validate_required` 函数推荐（照写编译失败）；修正『宏不自动 trim』错误（实际自动 trim）；补 `validate_required_list!`；对齐 core/AGENTS.md |
| **code-standards** | 🟡→✅ | 不存在的 `ApiEndpoint`→per-crate `XxxApiV1` enum+`to_url()`；P0 grep 白名单 webhook（#214）；新增 CI/测试门控 §6；RequestOption vs RequestOptions |
| **api** | 🟡→✅ | 删虚构 docs 深层链式调用（DocsClient 是字段非方法链）；脚本路径 `.claude→.agents`；A 示例补 `execute_with_options`；owned Config 降级 |
| **api-validation** | 🟡→✅ | 4-crate for 循环→`--all-crates`；删虚构 `api-validation.yml`/pre-commit；补 `api_priority.toml` |
| **design-review** | 🟡→✅ | 补 CI/测试门控 §2.7、event P2、Transport 路径、回归守卫标注 |
| **naming** | 🟡→✅ | 重写过时 §7（`DocsService`→`DocsClient`）；补双轨命名、两种 Client 实现、webhook/event P2 |
| **api-field-verify** | 🟢→✅ | 去除 `fetch_doc.js` 硬编码个人 npx 路径；补 Grep/Glob 工具 |

## 一个审查误报（已纠正）

初版审查称 design-review 的 trait 名应是 `n`（high severity）。**实施 agent 核对现码后确认 trait 名就是 `ExecutableBuilder`**（`crates/openlark-core/src/trait_system/executable_builder.rs:11`），拒绝了这个错误重命名——审查本身是误报。

## 跨 skill

- AGENTS.md「6 个领域技能」→「7 个」（实际就是 7 个）。
- 多个 skill 补了本仓库刚确立的 CI `--all-targets` / 测试门控约定（#250/#251，详见 `docs/CI_TEST_TARGET_COVERAGE.md`）。

## 验证

- `rg '\.claude/skills' .agents/skills/` → 0 残留。
- AGENTS.md skill 表 7 行 = 「7 个」。
- diff 仅含 `.agents/skills/` + AGENTS.md，未触业务代码。
- validation-style 不再推荐已删函数；`validate_required_list!` 已覆盖。
