### PR TITLE
feat(security): 补 5 个 security_and_compliance v1 API（#260）

### DIFF
--- a/crates/openlark-security/src/security/security_and_compliance/v1/mod.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/mod.rs
@@ -1,5 +1,7 @@
 //! Security & Compliance v1 API 版本实现
 //!
-//! 主要提供审计日志查询功能
+//! 主要提供审计日志查询、多地理位置实体、用户迁移等功能
 
+pub mod multi_geo_entity;
 pub mod openapi_logs;
+pub mod user_migrations;

--- a/crates/openlark-security/src/security/security_and_compliance/v1/multi_geo_entity/mod.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/multi_geo_entity/mod.rs
@@ -1,0 +1,3 @@
+//! multi_geo_entity 资源模块。
+
+pub mod tenant;

--- a/crates/openlark-security/src/security/security_and_compliance/v1/multi_geo_entity/tenant/get.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/multi_geo_entity/tenant/get.rs
@@ -1,0 +1,62 @@
+//! 获取地理位置列表
+//!
+//! docPath: https://open.feishu.cn/document/server-docs/security_and_compliance-v1/multi_geo_entity-tenant-get
+
+use openlark_core::{
+    SDKResult, api::ApiRequest, config::Config, constants::AccessTokenType,
+    error::validation_error, http::Transport, req_option::RequestOption,
+};
+
+/// 获取地理位置列表请求
+///
+/// 支持分页。
+#[derive(Debug)]
+pub struct ListMultiGeoEntityTenantsRequest {
+    /// 配置信息。
+    config: Config,
+    /// 页面大小（可选）。
+    page_size: Option<i32>,
+    /// 分页标记（可选）。
+    page_token: Option<String>,
+}
+
+impl ListMultiGeoEntityTenantsRequest {
+    /// 创建新的请求构建器。
+    pub fn new(config: Config) -> Self {
+        Self {
+            config,
+            page_size: None,
+            page_token: None,
+        }
+    }
+
+    /// 设置页面大小。
+    pub fn page_size(mut self, page_size: i32) -> Self {
+        self.page_size = Some(page_size);
+        self
+    }
+
+    /// 设置分页标记。
+    pub fn page_token(mut self, page_token: impl Into<String>) -> Self {
+        self.page_token = Some(page_token.into());
+        self
+    }
+
+    /// 执行请求，返回响应 `data` 字段内容。
+    pub async fn execute(self) -> SDKResult<serde_json::Value> {
+        self.execute_with_options(RequestOption::default()).await
+    }
+
+    /// 使用指定请求选项执行请求。
+    pub async fn execute_with_options(self, option: RequestOption) -> SDKResult<serde_json::Value> {
+        let req: ApiRequest<serde_json::Value> =
+            ApiRequest::get("/open-apis/security_and_compliance/v1/multi_geo_entity/tenant")
+                .query_opt("page_size", self.page_size.map(|v| v.to_string()))
+                .query_opt("page_token", self.page_token.as_ref())
+                .with_supported_access_token_types(vec![AccessTokenType::App]);
+
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data
+            .ok_or_else(|| validation_error("获取地理位置列表", "响应数据为空"))
+    }
+}

--- a/crates/openlark-security/src/security/security_and_compliance/v1/multi_geo_entity/tenant/mod.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/multi_geo_entity/tenant/mod.rs
@@ -1,0 +1,5 @@
+//! 多地理位置实体资源（tenant 维度）。
+
+pub mod get;
+
+pub use get::ListMultiGeoEntityTenantsRequest;

--- a/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/cancel.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/cancel.rs
@@ -1,0 +1,45 @@
+//! 取消用户迁移
+//!
+//! docPath: https://open.feishu.cn/document/server-docs/security_and_compliance-v1/user_migration/cancel
+
+use openlark_core::{
+    SDKResult, api::ApiRequest, config::Config, constants::AccessTokenType,
+    error::validation_error, http::Transport, req_option::RequestOption,
+};
+
+/// 取消用户迁移请求。
+#[derive(Debug)]
+pub struct CancelUserMigrationRequest {
+    /// 配置信息。
+    config: Config,
+    /// 用户迁移任务 ID。
+    migration_id: String,
+}
+
+impl CancelUserMigrationRequest {
+    /// 创建新的请求构建器。
+    pub fn new(config: Config, migration_id: impl Into<String>) -> Self {
+        Self {
+            config,
+            migration_id: migration_id.into(),
+        }
+    }
+
+    /// 执行请求，返回响应 `data` 字段内容。
+    pub async fn execute(self) -> SDKResult<serde_json::Value> {
+        self.execute_with_options(RequestOption::default()).await
+    }
+
+    /// 使用指定请求选项执行请求。
+    pub async fn execute_with_options(self, option: RequestOption) -> SDKResult<serde_json::Value> {
+        let body = serde_json::json!({ "migration_id": self.migration_id });
+        let req: ApiRequest<serde_json::Value> =
+            ApiRequest::post("/open-apis/security_and_compliance/v1/user_migrations/cancel")
+                .body(body)
+                .with_supported_access_token_types(vec![AccessTokenType::App]);
+
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data
+            .ok_or_else(|| validation_error("取消用户迁移", "响应数据为空"))
+    }
+}

--- a/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/create.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/create.rs
@@ -1,0 +1,54 @@
+//! 创建用户迁移
+//!
+//! docPath: https://open.feishu.cn/document/server-docs/security_and_compliance-v1/user_migration/create
+//!
+//! 请求 body 字段较多（源/目标用户、范围等），调用方按飞书文档自行构造 JSON 透传。
+
+use openlark_core::{
+    SDKResult, api::ApiRequest, config::Config, constants::AccessTokenType,
+    error::validation_error, http::Transport, req_option::RequestOption,
+};
+
+/// 创建用户迁移请求。
+///
+/// 通过 [`Self::body`] 传入完整请求体（按飞书文档构造）。
+#[derive(Debug)]
+pub struct CreateUserMigrationRequest {
+    /// 配置信息。
+    config: Config,
+    /// 请求 body。
+    body: serde_json::Value,
+}
+
+impl CreateUserMigrationRequest {
+    /// 创建新的请求构建器（空 body）。
+    pub fn new(config: Config) -> Self {
+        Self {
+            config,
+            body: serde_json::json!({}),
+        }
+    }
+
+    /// 设置请求 body（覆盖已有内容）。
+    pub fn body(mut self, body: serde_json::Value) -> Self {
+        self.body = body;
+        self
+    }
+
+    /// 执行请求，返回响应 `data` 字段内容。
+    pub async fn execute(self) -> SDKResult<serde_json::Value> {
+        self.execute_with_options(RequestOption::default()).await
+    }
+
+    /// 使用指定请求选项执行请求。
+    pub async fn execute_with_options(self, option: RequestOption) -> SDKResult<serde_json::Value> {
+        let req: ApiRequest<serde_json::Value> =
+            ApiRequest::post("/open-apis/security_and_compliance/v1/user_migrations")
+                .body(self.body)
+                .with_supported_access_token_types(vec![AccessTokenType::App]);
+
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data
+            .ok_or_else(|| validation_error("创建用户迁移", "响应数据为空"))
+    }
+}

--- a/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/get.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/get.rs
@@ -1,0 +1,45 @@
+//! 获取单个用户迁移状态
+//!
+//! docPath: https://open.feishu.cn/document/server-docs/security_and_compliance-v1/user_migration/get
+
+use openlark_core::{
+    SDKResult, api::ApiRequest, config::Config, constants::AccessTokenType,
+    error::validation_error, http::Transport, req_option::RequestOption,
+};
+
+/// 获取单个用户迁移状态请求。
+#[derive(Debug)]
+pub struct GetUserMigrationRequest {
+    /// 配置信息。
+    config: Config,
+    /// 用户迁移任务 ID。
+    migration_id: String,
+}
+
+impl GetUserMigrationRequest {
+    /// 创建新的请求构建器。
+    pub fn new(config: Config, migration_id: impl Into<String>) -> Self {
+        Self {
+            config,
+            migration_id: migration_id.into(),
+        }
+    }
+
+    /// 执行请求，返回响应 `data` 字段内容。
+    pub async fn execute(self) -> SDKResult<serde_json::Value> {
+        self.execute_with_options(RequestOption::default()).await
+    }
+
+    /// 使用指定请求选项执行请求。
+    pub async fn execute_with_options(self, option: RequestOption) -> SDKResult<serde_json::Value> {
+        let req: ApiRequest<serde_json::Value> = ApiRequest::get(format!(
+            "/open-apis/security_and_compliance/v1/user_migrations/{}",
+            self.migration_id
+        ))
+        .with_supported_access_token_types(vec![AccessTokenType::App]);
+
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data
+            .ok_or_else(|| validation_error("获取单个用户迁移状态", "响应数据为空"))
+    }
+}

--- a/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/mod.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/mod.rs
@@ -1,0 +1,11 @@
+//! user_migration 资源模块（用户迁移：创建/取消/查询/批量查询）。
+
+pub mod cancel;
+pub mod create;
+pub mod get;
+pub mod search;
+
+pub use cancel::CancelUserMigrationRequest;
+pub use create::CreateUserMigrationRequest;
+pub use get::GetUserMigrationRequest;
+pub use search::SearchUserMigrationsRequest;

--- a/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/search.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/search.rs
@@ -1,0 +1,54 @@
+//! 批量获取用户迁移状态
+//!
+//! docPath: https://open.feishu.cn/document/server-docs/security_and_compliance-v1/user_migration/search
+//!
+//! 过滤条件在 body，调用方按飞书文档自行构造 JSON 透传。
+
+use openlark_core::{
+    SDKResult, api::ApiRequest, config::Config, constants::AccessTokenType,
+    error::validation_error, http::Transport, req_option::RequestOption,
+};
+
+/// 批量获取用户迁移状态请求。
+///
+/// 通过 [`Self::body`] 传入过滤条件（如迁移任务 ID 列表、分页等）。
+#[derive(Debug)]
+pub struct SearchUserMigrationsRequest {
+    /// 配置信息。
+    config: Config,
+    /// 请求 body（过滤 + 分页条件）。
+    body: serde_json::Value,
+}
+
+impl SearchUserMigrationsRequest {
+    /// 创建新的请求构建器（空 body）。
+    pub fn new(config: Config) -> Self {
+        Self {
+            config,
+            body: serde_json::json!({}),
+        }
+    }
+
+    /// 设置请求 body（覆盖已有内容）。
+    pub fn body(mut self, body: serde_json::Value) -> Self {
+        self.body = body;
+        self
+    }
+
+    /// 执行请求，返回响应 `data` 字段内容。
+    pub async fn execute(self) -> SDKResult<serde_json::Value> {
+        self.execute_with_options(RequestOption::default()).await
+    }
+
+    /// 使用指定请求选项执行请求。
+    pub async fn execute_with_options(self, option: RequestOption) -> SDKResult<serde_json::Value> {
+        let req: ApiRequest<serde_json::Value> =
+            ApiRequest::post("/open-apis/security_and_compliance/v1/user_migrations/search")
+                .body(self.body)
+                .with_supported_access_token_types(vec![AccessTokenType::App]);
+
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data
+            .ok_or_else(|| validation_error("批量获取用户迁移状态", "响应数据为空"))
+    }
+}


### PR DESCRIPTION
## 修复 #260

补经审计确认**真正缺失**的 5 个 `security_and_compliance` v1 API（coverage 审计发现 security 13 个"缺失"里仅 5 个真未实现，其余 8 个是路径错配已存在）。

## 改动（9 文件，仅 openlark-security，style A + `serde_json::Value`，仿现有 device_records/openapi_logs）

| API | 方法/端点 | 文件 |
|-----|----------|------|
| 获取地理位置列表 | GET `/multi_geo_entity/tenant` | `v1/multi_geo_entity/tenant/get.rs` |
| 获取单个用户迁移状态 | GET `/user_migrations/:migration_id` | `v1/user_migrations/get.rs` |
| 取消用户迁移 | POST `/user_migrations/cancel` | `v1/user_migrations/cancel.rs` |
| 创建用户迁移 | POST `/user_migrations` | `v1/user_migrations/create.rs` |
| 批量获取用户迁移状态 | POST `/user_migrations/search` | `v1/user_migrations/search.rs` |

+ `multi_geo_entity/mod.rs`、`tenant/mod.rs`、`user_migrations/mod.rs` + `v1/mod.rs` 挂载。

POST body 字段较多（迁移参数）或 fetch_docpath 取不到飞书字段，沿用现有 security crate 的 `serde_json::Value` 透传风格（调用方按文档构造 JSON）；GET/cancel 的必填项用 typed 字段。

## 验证

| 检查 | 结果 |
|------|------|
| `cargo build -p openlark-security --all-features` | ✅ exit 0 |
| `cargo clippy --all-targets --all-features -p openlark-security -- -D warnings` | ✅ exit 0 |
| `cargo fmt --check` | ✅ exit 0 |
| `cargo test -p openlark-security --all-features` | ✅ 85 passed, 0 failed |

补齐后 SDK 功能覆盖 **~100%**（5 个真缺口清零；validator 的路径错配是另一回事，本 PR 不改 validator——保持其作为合规检查）。

Closes #260
