### PR TITLE
docs(agents): triage-labels 补 category 角色映射

### DIFF
--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -13,3 +13,18 @@ The skills speak in terms of five canonical triage roles. This file maps those r
 When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
 
 Edit the right-hand column to match whatever vocabulary you actually use.
+
+## Category roles
+
+The `triage` skill also speaks in terms of two **category** roles — `bug` (something is broken) and `enhancement` (new feature or improvement). Every triaged issue should carry exactly one category role **and** one state role.
+
+This repo expresses category through its existing `type:` taxonomy rather than the canonical `bug` / `enhancement` names, keeping category orthogonal to the state machine above and consistent with the project's conventions:
+
+| Canonical category | This repo's label | When to use |
+| --- | --- | --- |
+| `bug` | `bug` | 缺陷修复（仓库已有 `bug` label） |
+| `enhancement` | `type:feat` | 新功能或公开 API 增强（如补 accessor） |
+| `enhancement` | `type:refactor` | 重构、清理、死码移除 |
+| `enhancement` | `type:docs` / `type:test` / `type:ci` / `type:policy` | 文档 / 测试 / CI / 策略类改进 |
+
+当 skill 提到 "apply a category role" 时，按上表选 `type:` 标签（`bug` 类用独立 `bug` label）。state 与 category 正交：一个 issue 同时带一个 state（最上面的表）+ 一个 category（本表）。


### PR DESCRIPTION
## 背景

`/setup-matt-pocock-skills` 生成的 `docs/agents/triage-labels.md` 只映射了 5 个 **state** 角色（needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix），缺 2 个 **category**（bug / enhancement）。本次 `/triage` 处理 #301–314 时暴露此 gap：每个新 issue 都要临时决定 category 用什么 label。

## 变更

固化决策——category 用项目现有 `type:` 分类体系表达（而非 canonical `bug` / `enhancement` 名），与 state 正交，符合项目惯例：

| Canonical category | 本仓库 label | 用途 |
| --- | --- | --- |
| `bug` | `bug` | 缺陷修复 |
| `enhancement` | `type:feat` | 新功能 / 公开 API 增强 |
| `enhancement` | `type:refactor` | 重构、清理、死码移除 |
| `enhancement` | `type:docs` / `type:test` / `type:ci` / `type:policy` | 文档 / 测试 / CI / 策略 |

新增 `## Category roles` 段（+15 行）。未来 triage 直接按表选 `type:` 标签，不再临时决策。

## 关联

实证：#301–314 已按此映射补 category（12 × `type:refactor` + #307 `type:feat` + epic #314）。