### PR TITLE
feat(helpdesk): 补 ticket_customized_field accessor (#307)

### DIFF
--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/mod.rs
@@ -20,6 +20,8 @@ pub mod faq;
 pub mod notification;
 /// 工单接口。
 pub mod ticket;
+/// 工单自定义字段接口。
+pub mod ticket_customized_field;
 
 use openlark_core::config::Config;
 use std::sync::Arc;
@@ -39,6 +41,11 @@ impl HelpdeskV1 {
     /// 访问工单 API。
     pub fn ticket(&self) -> ticket::Ticket {
         ticket::Ticket::new(self.config.clone())
+    }
+
+    /// 访问工单自定义字段 API。
+    pub fn ticket_customized_field(&self) -> ticket_customized_field::TicketCustomizedField {
+        ticket_customized_field::TicketCustomizedField::new(self.config.clone())
     }
 
     /// agent。
@@ -106,5 +113,3 @@ mod tests {
         assert_eq!(value["field"], "data");
     }
 }
-
-pub mod ticket_customized_field;


### PR DESCRIPTION
## What

补 `HelpdeskV1` 的 `ticket_customized_field` fluent accessor（#307），恢复聚合器 11/11 parity。该 5-API 深模块此前只通过双重全限定路径可达。

## Changes

- `pub mod ticket_customized_field` 上移到兄弟位置（字母序 + 中文 doc）
- `HelpdeskV1` impl 加 `ticket_customized_field()` accessor，返回 `TicketCustomizedField`，沿用既有 accessor 模式

纯增量，零风险。1 file, +7/-2。

## Verification

fmt ✓ / build ✓ / clippy ✓ / test 21 passed ✓

Closes #307