### PR TITLE
refactor: 移除 auth 死 feature + 死依赖（#306）

### DIFF
--- a/.github/msrv/Cargo.lock
+++ b/.github/msrv/Cargo.lock
@@ -1565,24 +1565,18 @@ dependencies = [
  "anyhow",
  "base64",
  "chrono",
- "criterion",
  "hex",
- "hmac",
  "mockall",
  "openlark-core",
- "pbkdf2",
  "rand 0.8.6",
  "regex",
- "ring",
  "rstest",
  "serde",
  "serde_json",
- "sha2",
  "thiserror",
  "tokio",
  "tokio-test",
  "tracing",
- "url",
  "urlencoding",
  "uuid",
  "wiremock",
@@ -1934,16 +1928,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest",
- "hmac",
 ]
 
 [[package]]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   自包含于 `crate::models`），从 prelude 与 robot/v1/mod 移除。**迁移**：无需迁移——
   这些类型本就无法发送，零消费方。prelude 移除 3 类型，minor breaking。
 
+- **移除 `openlark-auth` 死 feature + 死依赖**（#306 死码清理）：
+  `[features]` 段 6 feature（cache / encryption / monitoring / oauth / token-management /
+  advanced-cache）门控 0 行代码（auth src 零 `cfg(feature)`），却拉入 ring / sha2 / hmac /
+  pbkdf2 / url / criterion 死依赖。删 `[features]` + 死依赖 + cargo-machete ignored 对应 6 项。
+  cache token_provider 实现保留（不用 `cfg(feature)`）。**迁移**：无需迁移——feature 从未
+  被代码门控，删除 strictly safe。
+
 - **openlark-core 移除 `tracing-init` / `otel` feature 及直接依赖**（#277 inner-attribute 收尾）：
   `openlark-core` 的 `tracing-init` 与 `otel` feature 仅门控已删的 `observability.rs` 死代码（0 引用），移除。
   连带删 4 个直接依赖（`opentelemetry`、`opentelemetry_sdk`、`opentelemetry-otlp`、`tracing-opentelemetry`）

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,24 +1565,18 @@ dependencies = [
  "anyhow",
  "base64",
  "chrono",
- "criterion",
  "hex",
- "hmac",
  "mockall",
  "openlark-core",
- "pbkdf2",
  "rand 0.8.6",
  "regex",
- "ring",
  "rstest",
  "serde",
  "serde_json",
- "sha2",
  "thiserror",
  "tokio",
  "tokio-test",
  "tracing",
- "url",
  "urlencoding",
  "uuid",
  "wiremock",
@@ -1934,16 +1928,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest",
- "hmac",
 ]
 
 [[package]]

--- a/crates/openlark-auth/Cargo.toml
+++ b/crates/openlark-auth/Cargo.toml
@@ -38,14 +38,6 @@ tracing = { workspace = true }
 # UUID
 uuid = { workspace = true, features = ["v4", "serde"] }
 
-# 加密和安全 (可选)
-ring = { version = "0.17", optional = true }
-sha2 = { version = "0.10", optional = true }
-hmac = { version = "0.12", optional = true }
-pbkdf2 = { version = "0.12", optional = true }
-
-url = { workspace = true, optional = true }
-
 # 验证工具
 regex = "1.10"
 base64 = "0.22"
@@ -59,24 +51,5 @@ mockall = "0.12"
 rstest = { workspace = true }
 wiremock = "0.6"
 
-# 性能基准测试的依赖（可选）
-[dependencies.criterion]
-version = "0.5"
-features = ["html_reports"]
-optional = true
-
-[features]
-default = ["token-management", "cache", "oauth"]
-
-# 核心功能模块
-token-management = []
-cache = ["token-management"]
-oauth = ["url"]
-encryption = ["ring", "sha2", "hmac", "pbkdf2"]
-
-# 高级功能
-advanced-cache = ["cache", "encryption"]
-monitoring = []
-
 [package.metadata.cargo-machete]
-ignored = ["anyhow", "base64", "criterion", "hex", "hmac", "pbkdf2", "rand", "regex", "ring", "sha2", "thiserror", "tracing", "url"]
+ignored = ["anyhow", "base64", "hex", "rand", "regex", "thiserror", "tracing"]


### PR DESCRIPTION
## What
移除 `openlark-auth` 的死 `[features]` 段 + 死依赖（#306）。审查确认 6 feature（cache/encryption/monitoring/oauth/token-management/advanced-cache）门控 0 行代码（auth src 零 `cfg(feature)`），却拉入 ring/sha2/hmac/pbkdf2/url/criterion 死依赖。

## Changes（4 files, +7/-67）
- 删 `[features]` 段（含 default）
- 删死可选依赖：ring/sha2/hmac/pbkdf2/url + `[dependencies.criterion]` 整段（无 benches）
- cargo-machete ignored 清对应 6 项
- `Cargo.lock` + `.github/msrv/Cargo.lock` 同步（#244 MSRV lock 教训）
- CHANGELOG breaking-changes 加一条

cache token_provider 实现保留（不用 cfg(feature)，always compile）。

## CI matrix
动态生成（`cargo hack --each-feature` 从 Cargo.toml 读），删 feature 自动反映，**不需手动清 matrix**（auth 子 feature 不像 #277 otel 硬编码）。

## Verification
build ✓ / clippy（--no-default-features）✓ / test（-p auth, 10 passed）✓ / fmt ✓ / auth lock 死依赖 edge 移除 ✓

Closes #306