### PR TITLE
refactor: analytics Search/SearchV2/search() 标 #[deprecated]（#308）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tools/check_reqwest_boundary.sh` 守卫并接入 just 与 CI lint job 防回归。
   **非 breaking**：不改公开 API（业务 crate 无 re-export reqwest）。
 
+- **analytics Search / SearchV2 / search() 标 `#[deprecated]`**（#308）：三层 `Arc<Config>`
+  导航死胡同（Search → SearchV2 无真实 API 落地）标记 deprecated，note 指明替代路径
+  （v2 子模块的 `XxxRequest::new`，如 `query::SearchRequest` / `user::SearchUserRequest`）。
+  配合 v0.18 deprecated 清理节奏，下个 breaking 窗口删除。**非 breaking**：仅 deprecation
+  warning，旧调用仍可编译。
+
 ### Breaking Changes
 
 - **移除 `trait_system` 死 seam 及三处复制宏**（#301 死码清理，归 #277/#299 系列）：

--- a/crates/openlark-analytics/src/search/search/mod.rs
+++ b/crates/openlark-analytics/src/search/search/mod.rs
@@ -6,11 +6,15 @@ use openlark_core::config::Config;
 use std::sync::Arc;
 
 /// Search API 入口
+#[deprecated(
+    note = "analytics Search 导航死胡同；直接用 v2 子模块的 XxxRequest::new(Arc<Config>)，如 crate::search::search::v2::query::SearchRequest / v2::user::SearchUserRequest"
+)]
 #[derive(Clone)]
 pub struct Search {
     config: Arc<Config>,
 }
 
+#[allow(deprecated)]
 impl Search {
     /// 创建新的 Search API 入口。
     pub fn new(config: Arc<Config>) -> Self {
@@ -18,6 +22,7 @@ impl Search {
     }
 
     /// 访问 v2 版本搜索 API。
+    #[allow(deprecated)]
     pub fn v2(&self) -> v2::SearchV2 {
         v2::SearchV2::new(self.config.clone())
     }

--- a/crates/openlark-analytics/src/search/search/v2.rs
+++ b/crates/openlark-analytics/src/search/search/v2.rs
@@ -6,12 +6,16 @@ use crate::AnalyticsConfig;
 use std::sync::Arc;
 
 /// 搜索服务 V2 API
+#[deprecated(
+    note = "SearchV2 导航壳；直接用其子模块的 XxxRequest::new(Arc<Config>)，如 query::SearchRequest / user::SearchUserRequest / data_source::* / app::* / doc_wiki / schema / message"
+)]
 #[derive(Debug, Clone)]
 pub struct SearchV2 {
     // reserved：query()/user() deprecated 存根移除后无读取者（analytics search 导航缺口，后续补访问器）
     _config: Arc<AnalyticsConfig>,
 }
 
+#[allow(deprecated)]
 impl SearchV2 {
     /// 创建新的搜索服务 V2 实例
     pub fn new(config: Arc<AnalyticsConfig>) -> Self {

--- a/crates/openlark-analytics/src/service.rs
+++ b/crates/openlark-analytics/src/service.rs
@@ -39,7 +39,11 @@ impl AnalyticsService {
     /// 搜索服务
     ///
     /// 提供全文搜索、智能搜索等功能。
+    #[deprecated(
+        note = "search() 导航死胡同；直接用 crate::search::search::v2 子模块的 XxxRequest::new(config)，如 v2::query::SearchRequest / v2::user::SearchUserRequest"
+    )]
     #[cfg(feature = "search")]
+    #[allow(deprecated)]
     pub fn search(&self) -> crate::search::search::Search {
         crate::search::search::Search::new(self.config.clone())
     }


### PR DESCRIPTION
## What
给 analytics 的 Search / SearchV2 / AnalyticsService::search() 标 `#[deprecated]`（#308）。审查确认 Search → SearchV2 是三层 `Arc<Config>` 转发死胡同（SearchV2 无真实 API 落地）。

本 issue **只做 deprecated 标注**，删除留下个 breaking 窗口（配合 v0.18 deprecated 清理节奏）。

## Changes
- `Search` struct + `SearchV2` struct + `AnalyticsService::search()` 加 `#[deprecated(note="...替代路径...")]`
- `impl Search` / `impl SearchV2` 块 + `search()` 加 `#[allow(deprecated)]`（抑制 analytics 自身 warning，外部调用仍见 deprecation）
- CHANGELOG ### Changed 段记一条（非 breaking）

## Verification
fmt ✓ / build --all-features **0 warning**（impl 块 allow 生效）✓ / clippy（--no-default-features）✓

Closes #308