### PR TITLE
refactor: webhook 统一发送管道 + WebhookClient 改薄 wrapper（#310）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+- **webhook 统一发送管道 + `WebhookClient` 改薄 wrapper**（#310）：提取共享 `post_payload`
+  helper（validate / sign / POST / deserialize），消除 `SendWebhookMessageRequest::execute` 与
+  `WebhookClient::send` 的 ~40 行逐字重复。`SendWebhookMessageRequest` 增 `.raw(Value)` +
+  `.with_client(reqwest::Client)`（解除 shared_client 限制）。`WebhookClient` 改为 Request 的薄
+  wrapper（`send` 委托 `Request::raw + with_client + execute`）。**breaking**：移除 `WebhookClient`
+  的 5 个 inline-json 构造器（`send_text` / `send_post` / `send_image` / `send_file` / `send_card`）。
+  **迁移**：`client.send_text(url, text)` → `SendWebhookMessageRequest::new(url).text(text).execute()`
+  或 `client.send(url, json!({"msg_type":"text","content":{"text":text}}))`。
+
 - **移除 `trait_system` 死 seam 及三处复制宏**（#301 死码清理，归 #277/#299 系列）：
   `openlark-core::trait_system`（`Service` + `ExecutableBuilder` trait）及 `impl_executable_builder!` /
   `impl_executable_builder_owned!` / `impl_full_service!` 等 `#[macro_export]` 宏，全仓**零调用零实现**

--- a/crates/openlark-webhook/examples/webhook_client_with_signature.rs
+++ b/crates/openlark-webhook/examples/webhook_client_with_signature.rs
@@ -20,11 +20,11 @@ async fn main() -> Result<()> {
     // Create client with signature
     let client = WebhookClient::new().with_secret(secret);
 
-    // Send text message
+    // Send text message（raw payload；typed 消息用 SendWebhookMessageRequest::text）
     let response = client
-        .send_text(
+        .send(
             &webhook_url,
-            "Hello from WebhookClient with signature!".to_string(),
+            serde_json::json!({"msg_type": "text", "content": {"text": "Hello from WebhookClient with signature!"}}),
         )
         .await?;
 
@@ -34,7 +34,10 @@ async fn main() -> Result<()> {
 
     // Send image message
     let image_response = client
-        .send_image(&webhook_url, "img_abc123".to_string())
+        .send(
+            &webhook_url,
+            serde_json::json!({"msg_type": "image", "content": {"image_key": "img_abc123"}}),
+        )
         .await?;
 
     println!("\nImage message sent!");

--- a/crates/openlark-webhook/src/robot/v1/client.rs
+++ b/crates/openlark-webhook/src/robot/v1/client.rs
@@ -1,10 +1,5 @@
-use crate::common::error::{Result, WebhookError};
-use crate::common::validation;
-use crate::robot::v1::send::SendWebhookMessageResponse;
-use serde_json::json;
-
-#[cfg(feature = "signature")]
-use crate::common::signature;
+use crate::common::error::Result;
+use crate::robot::v1::send::{SendWebhookMessageRequest, SendWebhookMessageResponse};
 
 /// Webhook 客户端。
 ///
@@ -13,6 +8,9 @@ use crate::common::signature;
 ///
 /// 这是 `Transport` 边界的 **by-design 例外**（白名单见 `ARCHITECTURE.md`
 /// 「Transport HTTP 边界」小节，#270）。
+///
+/// `WebhookClient` 是 `SendWebhookMessageRequest` 的薄 wrapper：`send` 委托
+/// `Request::raw + with_client + execute`，复用共享发送管道（#310）。
 #[derive(Debug, Clone)]
 pub struct WebhookClient {
     client: reqwest::Client,
@@ -61,126 +59,24 @@ impl WebhookClient {
 
     /// 发送原始 JSON 负载到指定 webhook。
     ///
-    /// `payload` 需要符合飞书自定义机器人消息协议。
+    /// `payload` 需要符合飞书自定义机器人消息协议。委托 `SendWebhookMessageRequest::raw`
+    /// + `with_client` + `execute`（共享发送管道，#310）。
+    ///
+    /// 如需 typed 消息（text/post/image/file/card），用 `SendWebhookMessageRequest` 的
+    /// `.text()` / `.post()` / `.image()` / `.file()` / `.card()` 构造器。
     pub async fn send(
         &self,
         webhook_url: &str,
         payload: serde_json::Value,
     ) -> Result<SendWebhookMessageResponse> {
-        validation::validate_webhook_url(webhook_url)
-            .map_err(|e| WebhookError::Http(e.to_string()))?;
-
+        let mut req = SendWebhookMessageRequest::new(webhook_url.to_string())
+            .raw(payload)
+            .with_client(self.client.clone());
         #[cfg(feature = "signature")]
-        let request_builder = {
-            let mut rb = self.client.post(webhook_url).json(&payload);
-            if let Some(secret) = &self.secret {
-                let timestamp = signature::current_timestamp();
-                let sign = signature::sign(timestamp, secret);
-                rb = rb
-                    .header("X-Lark-Signature", sign)
-                    .header("X-Lark-Timestamp", timestamp.to_string());
-            }
-            rb
-        };
-
-        #[cfg(not(feature = "signature"))]
-        let request_builder = self.client.post(webhook_url).json(&payload);
-
-        let response = request_builder
-            .send()
-            .await
-            .map_err(|e| WebhookError::Http(e.to_string()))?;
-
-        let status = response.status();
-        if !status.is_success() {
-            return Err(WebhookError::Http(format!("HTTP error: {status}")));
+        if let Some(secret) = &self.secret {
+            req = req.with_secret(secret.clone());
         }
-
-        let body = response
-            .text()
-            .await
-            .map_err(|e| WebhookError::Http(e.to_string()))?;
-
-        let result: SendWebhookMessageResponse = serde_json::from_str(&body)?;
-        Ok(result)
-    }
-
-    /// 发送文本消息。
-    pub async fn send_text(
-        &self,
-        webhook_url: &str,
-        text: String,
-    ) -> Result<SendWebhookMessageResponse> {
-        let payload = json!({
-            "msg_type": "text",
-            "content": {
-                "text": text
-            }
-        });
-        self.send(webhook_url, payload).await
-    }
-
-    /// 发送富文本消息。
-    pub async fn send_post(
-        &self,
-        webhook_url: &str,
-        post: String,
-    ) -> Result<SendWebhookMessageResponse> {
-        let payload = json!({
-            "msg_type": "post",
-            "content": {
-                "post": post
-            }
-        });
-        self.send(webhook_url, payload).await
-    }
-
-    /// 发送图片消息。
-    pub async fn send_image(
-        &self,
-        webhook_url: &str,
-        image_key: String,
-    ) -> Result<SendWebhookMessageResponse> {
-        let payload = json!({
-            "msg_type": "image",
-            "content": {
-                "image_key": image_key
-            }
-        });
-        self.send(webhook_url, payload).await
-    }
-
-    /// 发送文件消息。
-    pub async fn send_file(
-        &self,
-        webhook_url: &str,
-        file_key: String,
-    ) -> Result<SendWebhookMessageResponse> {
-        let payload = json!({
-            "msg_type": "file",
-            "content": {
-                "file_key": file_key
-            }
-        });
-        self.send(webhook_url, payload).await
-    }
-
-    /// 发送交互式卡片消息。
-    ///
-    /// 需要启用 `card` feature。
-    #[cfg(feature = "card")]
-    pub async fn send_card(
-        &self,
-        webhook_url: &str,
-        card: serde_json::Value,
-    ) -> Result<SendWebhookMessageResponse> {
-        let payload = json!({
-            "msg_type": "interactive",
-            "content": {
-                "card": card
-            }
-        });
-        self.send(webhook_url, payload).await
+        req.execute().await
     }
 }
 
@@ -202,10 +98,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_send_text_message_construction() {
+    async fn test_webhook_client_send_construction() {
+        // 验证 send 方法存在且可调用（实际 HTTP 需 mock）
         let client = WebhookClient::new();
-        // Test that the method exists and can be called
-        // (actual HTTP call would require mocking)
         let _client_ref = &client;
     }
 

--- a/crates/openlark-webhook/src/robot/v1/send.rs
+++ b/crates/openlark-webhook/src/robot/v1/send.rs
@@ -29,12 +29,63 @@ pub(super) fn shared_client() -> &'static reqwest::Client {
     CLIENT.get_or_init(reqwest::Client::new)
 }
 
+/// 共享的 validate / sign / POST / deserialize 管道。
+///
+/// `SendWebhookMessageRequest::execute` 与 `WebhookClient::send` 复用此 helper，
+/// 消除两份逐字重复的发送管道（#310）。
+pub(super) async fn post_payload(
+    client: &reqwest::Client,
+    webhook_url: &str,
+    payload: serde_json::Value,
+    #[cfg(feature = "signature")] secret: Option<&str>,
+) -> Result<SendWebhookMessageResponse> {
+    validation::validate_webhook_url(webhook_url).map_err(|e| WebhookError::Http(e.to_string()))?;
+
+    #[cfg(feature = "signature")]
+    let request_builder = {
+        let mut rb = client.post(webhook_url).json(&payload);
+        if let Some(secret) = secret {
+            let timestamp = signature::current_timestamp();
+            let sign = signature::sign(timestamp, secret);
+            rb = rb
+                .header("X-Lark-Signature", sign)
+                .header("X-Lark-Timestamp", timestamp.to_string());
+        }
+        rb
+    };
+
+    #[cfg(not(feature = "signature"))]
+    let request_builder = client.post(webhook_url).json(&payload);
+
+    let response = request_builder
+        .send()
+        .await
+        .map_err(|e| WebhookError::Http(e.to_string()))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err(WebhookError::Http(format!("HTTP error: {status}")));
+    }
+
+    let body = response
+        .text()
+        .await
+        .map_err(|e| WebhookError::Http(e.to_string()))?;
+
+    let result: SendWebhookMessageResponse = serde_json::from_str(&body)?;
+    Ok(result)
+}
+
 /// 发送 Webhook 消息请求构建器。
 #[derive(Debug, Clone)]
 pub struct SendWebhookMessageRequest {
     webhook_url: String,
     msg_type: String,
     content: serde_json::Value,
+    /// raw 模式：直接作为完整 payload 发送（跳过 `{msg_type, content}` 包装）。
+    raw_payload: Option<serde_json::Value>,
+    /// 注入的 HTTP client（None = 用 `shared_client()`）。
+    client: Option<reqwest::Client>,
     #[cfg(feature = "signature")]
     secret: Option<String>,
 }
@@ -46,6 +97,8 @@ impl SendWebhookMessageRequest {
             webhook_url,
             msg_type: "text".to_string(),
             content: json!({}),
+            raw_payload: None,
+            client: None,
             #[cfg(feature = "signature")]
             secret: None,
         }
@@ -55,6 +108,22 @@ impl SendWebhookMessageRequest {
     #[cfg(feature = "signature")]
     pub fn with_secret(mut self, secret: String) -> Self {
         self.secret = Some(secret);
+        self
+    }
+
+    /// 设置原始 payload（跳过 `{msg_type, content}` 包装，直接发送完整 payload）。
+    ///
+    /// 用于 `WebhookClient::send` 等需要完全自定义 payload 的场景。
+    pub fn raw(mut self, payload: serde_json::Value) -> Self {
+        self.raw_payload = Some(payload);
+        self
+    }
+
+    /// 注入自定义 HTTP client（覆盖进程级 `shared_client`）。
+    ///
+    /// 允许配置连接池、超时等。不设置则用 `shared_client()`。
+    pub fn with_client(mut self, client: reqwest::Client) -> Self {
+        self.client = Some(client);
         self
     }
 
@@ -101,48 +170,23 @@ impl SendWebhookMessageRequest {
 
     /// 执行发送请求并返回飞书响应。
     pub async fn execute(self) -> Result<SendWebhookMessageResponse> {
-        validation::validate_webhook_url(&self.webhook_url)
-            .map_err(|e| WebhookError::Http(e.to_string()))?;
-
-        let payload = json!(
-        {
-            "msg_type": self.msg_type,
-            "content": self.content,
-        });
-
-        #[cfg(feature = "signature")]
-        let request_builder = {
-            let mut rb = shared_client().post(&self.webhook_url).json(&payload);
-            if let Some(secret) = &self.secret {
-                let timestamp = signature::current_timestamp();
-                let sign = signature::sign(timestamp, secret);
-                rb = rb
-                    .header("X-Lark-Signature", sign)
-                    .header("X-Lark-Timestamp", timestamp.to_string());
-            }
-            rb
+        let payload = if let Some(raw) = self.raw_payload {
+            raw
+        } else {
+            json!({
+                "msg_type": self.msg_type,
+                "content": self.content,
+            })
         };
-
-        #[cfg(not(feature = "signature"))]
-        let request_builder = shared_client().post(&self.webhook_url).json(&payload);
-
-        let response = request_builder
-            .send()
-            .await
-            .map_err(|e| WebhookError::Http(e.to_string()))?;
-
-        let status = response.status();
-        if !status.is_success() {
-            return Err(WebhookError::Http(format!("HTTP error: {status}")));
+        let client: &reqwest::Client = self.client.as_ref().unwrap_or_else(|| shared_client());
+        #[cfg(feature = "signature")]
+        {
+            post_payload(client, &self.webhook_url, payload, self.secret.as_deref()).await
         }
-
-        let body = response
-            .text()
-            .await
-            .map_err(|e| WebhookError::Http(e.to_string()))?;
-
-        let result: SendWebhookMessageResponse = serde_json::from_str(&body)?;
-        Ok(result)
+        #[cfg(not(feature = "signature"))]
+        {
+            post_payload(client, &self.webhook_url, payload).await
+        }
     }
 }
 

--- a/crates/openlark-webhook/tests/integration_webhook.rs
+++ b/crates/openlark-webhook/tests/integration_webhook.rs
@@ -257,7 +257,10 @@ async fn test_client_send_with_signature_headers() {
     let client = WebhookClient::new().with_secret("test-secret".to_string());
 
     let resp = client
-        .send_text(&webhook_url(&server), "client signed message".to_string())
+        .send(
+            &webhook_url(&server),
+            json!({"msg_type": "text", "content": {"text": "client signed message"}}),
+        )
         .await
         .expect("client signed message should be sent successfully");
 


### PR DESCRIPTION
## What
统一 webhook 两份平行发送管道（#310）。审查确认 `SendWebhookMessageRequest::execute` 与 `WebhookClient::send` 共享 ~40 行逐字重复的 validate/sign/POST/deserialize。

## Changes
- 提取共享 `post_payload(client, url, payload, secret)` helper，两处复用
- `SendWebhookMessageRequest` 增 `.raw(Value)` + `.with_client(reqwest::Client)`
- `WebhookClient::send` 改为委托 `Request::raw + with_client + execute`（薄 wrapper）
- 删除 `WebhookClient` 的 5 个 inline-json 构造器（send_text/send_post/send_image/send_file/send_card）—— **breaking**
- 修正 integration test + signature example（send_text/send_image → send raw）
- CHANGELOG breaking-changes 加一条

## Breaking？
是：移除 `WebhookClient::{send_text, send_post, send_image, send_file, send_card}` 5 个 pub 方法。**迁移**：`client.send_text(url, text)` → `SendWebhookMessageRequest::new(url).text(text).execute()`，或 `client.send(url, json!({"msg_type":"text","content":{"text":text}}))`。

## Verification
build ✓ / clippy（--all-features --all-targets + --no-default-features）✓ / test（--all-features）✓ / fmt ✓。行为不变（post_payload 等价原管道）。

Closes #310