### PR TITLE
refactor(hr/okr): okr/v2 content/notes 深嵌套字段 typed 化（ContentBlock，#339）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   一致收敛到「可导航 + typed」。**breaking**：公开 API 源码级返回类型变更，消费方需改接收类型
   （`Value` → `GetObjectiveResponse` 等）。**迁移**：okr/v2 为零外部引用的导航终点（#327/#328
   已确认），v0.17.x 预发布，影响可控；外部若有消费按新 typed Response 改类型即可。深嵌套字段
-  （富文本/备注）仍暂留 `Option<Value>` + TODO，#339 另行收尾。
+  （富文本/备注）的 typed 化见下条 #339。
+
+- **okr/v2 `content` / `notes` 深嵌套字段 `Value` → typed `ContentBlock`**（#339）：`Objective.content` /
+  `Objective.notes` / `KeyResult.content` / `KeyResultProgress.content` / `Progress.content` 共 5 个
+  `Option<serde_json::Value>` + TODO 字段改为 `Option<ContentBlock>`。`ContentBlock`（14 struct 树：
+  blocks → paragraph|gallery → textRun|docsLink|mention → style/color/link/...）从飞书 apiSchema
+  `objectName=content_block` 派生，定义在 `common/models.rs` 被 5 字段共享（#336 消重所赐，改一处）。
+  判别联合 tag 用 `String`（非 enum）容忍飞书未来新增 block 类型。**breaking**：公开 Response 字段
+  类型变更（`Option<Value>` → `Option<ContentBlock>`），消费方读这些字段需改类型。**迁移**：okr/v2
+  仓内零外部引用，v0.17.x 预发布，影响可控。至此 okr/v2 grep `Option<serde_json::Value>` 残留为 0。
 
 - **okr/v2 跨叶共享 domain struct 路径统一到 `common::models`**（#336）：`Objective`/`ObjectiveOwner`、
   `Indicator`/`IndicatorOwner`/`IndicatorUnit`、`KeyResult`/`KeyResultOwner`、`Alignment`/`AlignmentOwner`

--- a/crates/openlark-hr/src/okr/okr/v2/common/models.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/common/models.rs
@@ -20,17 +20,15 @@ pub struct Objective {
     pub cycle_id: String,
     /// 目标的序号：从 1 开始计数。
     pub position: i32,
-    /// 目标的内容。
-    // TODO: 飞书文档 block 深度嵌套结构暂留 Value，后续可单独抽取 typed 模型。
+    /// 目标的内容（文档 block 结构，见 [`ContentBlock`]）。
     #[serde(default)]
-    pub content: Option<serde_json::Value>,
+    pub content: Option<ContentBlock>,
     /// 目标的分数：\[0,1\]，支持一位小数。
     #[serde(default)]
     pub score: Option<f64>,
-    /// 目标的备注。
-    // TODO: 飞书文档 block 深度嵌套结构暂留 Value，后续可单独抽取 typed 模型。
+    /// 目标的备注（文档 block 结构，见 [`ContentBlock`]）。
     #[serde(default)]
-    pub notes: Option<serde_json::Value>,
+    pub notes: Option<ContentBlock>,
     /// 目标的权重：\[0,1\]，支持三位小数。
     #[serde(default)]
     pub weight: Option<f64>,
@@ -122,10 +120,9 @@ pub struct KeyResult {
     pub objective_id: String,
     /// 关键结果的序号：从 1 开始计数。
     pub position: i32,
-    /// 关键结果的内容。
-    // TODO: 飞书文档 block 深度嵌套结构暂留 Value，后续可单独抽取 typed 模型。
+    /// 关键结果的内容（文档 block 结构，见 [`ContentBlock`]）。
     #[serde(default)]
-    pub content: Option<serde_json::Value>,
+    pub content: Option<ContentBlock>,
     /// 关键结果的分数：\[0,1\]，支持一位小数。
     #[serde(default)]
     pub score: Option<f64>,
@@ -178,4 +175,270 @@ pub struct AlignmentOwner {
     /// 员工 ID。
     #[serde(default)]
     pub user_id: Option<String>,
+}
+
+// === OKR 文档内容块（content / notes 字段共享）===
+//
+// 源：飞书 apiSchema objectName=content_block（objective/get、key_result/get、
+// key_result/progress/list、objective/progress/list 等的 content/notes 字段共用）。
+// 判别联合：block_element_type（paragraph|gallery）+ paragraph_element_type（textRun|docsLink|mention）。
+// tag 用 String（非 enum）以容忍飞书未来新增 block/element 类型，未知类型反序列化不报错。
+
+/// OKR 文档内容块（objective/key_result 的 content/notes、progress 的 content）。
+#[derive(Debug, Clone, Deserialize)]
+pub struct ContentBlock {
+    /// 文档结构按行排列，每行内容是一个 Block。
+    #[serde(default)]
+    pub blocks: Vec<ContentBlockElement>,
+}
+
+/// 文档块元素（判别联合，由 `block_element_type` 区分）。
+#[derive(Debug, Clone, Deserialize)]
+pub struct ContentBlockElement {
+    /// 文档元素类型（`"paragraph"` | `"gallery"`）。
+    #[serde(default)]
+    pub block_element_type: Option<String>,
+    /// 文本段落（`block_element_type = paragraph` 时存在）。
+    #[serde(default)]
+    pub paragraph: Option<ContentParagraph>,
+    /// 图片画廊（`block_element_type = gallery` 时存在）。
+    #[serde(default)]
+    pub gallery: Option<ContentGallery>,
+}
+
+/// 文本段落。
+#[derive(Debug, Clone, Deserialize)]
+pub struct ContentParagraph {
+    /// 段落样式。
+    #[serde(default)]
+    pub style: Option<ContentParagraphStyle>,
+    /// 段落元素列表。
+    #[serde(default)]
+    pub elements: Vec<ContentParagraphElement>,
+}
+
+/// 段落样式。
+#[derive(Debug, Clone, Deserialize)]
+pub struct ContentParagraphStyle {
+    /// 列表样式（有序 / 无序 / 任务列表）。
+    #[serde(default)]
+    pub list: Option<ContentList>,
+}
+
+/// 列表样式。
+#[derive(Debug, Clone, Deserialize)]
+pub struct ContentList {
+    /// 列表类型（`"number"` | `"bullet"` | `"checkBox"` | `"checkedBox"` | `"indent"`）。
+    #[serde(default)]
+    pub list_type: Option<String>,
+    /// 缩进层级。
+    #[serde(default)]
+    pub indent_level: Option<i32>,
+    /// 有序列表序号。
+    #[serde(default)]
+    pub number: Option<i32>,
+}
+
+/// 段落元素（判别联合，由 `paragraph_element_type` 区分）。
+#[derive(Debug, Clone, Deserialize)]
+pub struct ContentParagraphElement {
+    /// 段落元素类型（`"textRun"` | `"docsLink"` | `"mention"`）。
+    #[serde(default)]
+    pub paragraph_element_type: Option<String>,
+    /// 文本串（`type = textRun`）。
+    #[serde(default)]
+    pub text_run: Option<ContentTextRun>,
+    /// 文档链接（`type = docsLink`）。
+    #[serde(default)]
+    pub docs_link: Option<ContentDocsLink>,
+    /// @提及（`type = mention`）。
+    #[serde(default)]
+    pub mention: Option<ContentMention>,
+}
+
+/// 文本串。
+#[derive(Debug, Clone, Deserialize)]
+pub struct ContentTextRun {
+    /// 文本内容。
+    #[serde(default)]
+    pub text: Option<String>,
+    /// 文本样式。
+    #[serde(default)]
+    pub style: Option<ContentTextStyle>,
+}
+
+/// 文本样式。
+#[derive(Debug, Clone, Deserialize)]
+pub struct ContentTextStyle {
+    /// 加粗。
+    #[serde(default)]
+    pub bold: Option<bool>,
+    /// 删除线。
+    #[serde(default)]
+    pub strike_through: Option<bool>,
+    /// 背景色。
+    #[serde(default)]
+    pub back_color: Option<ContentColor>,
+    /// 文本色。
+    #[serde(default)]
+    pub text_color: Option<ContentColor>,
+    /// 超链接。
+    #[serde(default)]
+    pub link: Option<ContentLink>,
+}
+
+/// RGBA 颜色。
+#[derive(Debug, Clone, Deserialize)]
+pub struct ContentColor {
+    /// 红色通道。
+    #[serde(default)]
+    pub red: Option<i32>,
+    /// 绿色通道。
+    #[serde(default)]
+    pub green: Option<i32>,
+    /// 蓝色通道。
+    #[serde(default)]
+    pub blue: Option<i32>,
+    /// 透明度。
+    #[serde(default)]
+    pub alpha: Option<f64>,
+}
+
+/// 超链接（文本串 style.link）。
+#[derive(Debug, Clone, Deserialize)]
+pub struct ContentLink {
+    /// 链接 URL。
+    #[serde(default)]
+    pub url: Option<String>,
+}
+
+/// 文档链接（段落元素 docs_link）。
+#[derive(Debug, Clone, Deserialize)]
+pub struct ContentDocsLink {
+    /// 链接 URL。
+    #[serde(default)]
+    pub url: Option<String>,
+    /// 标题。
+    #[serde(default)]
+    pub title: Option<String>,
+}
+
+/// @提及（段落元素 mention）。
+#[derive(Debug, Clone, Deserialize)]
+pub struct ContentMention {
+    /// 用户 ID。
+    #[serde(default)]
+    pub user_id: Option<String>,
+}
+
+/// 图片画廊（block_element_type = gallery）。
+#[derive(Debug, Clone, Deserialize)]
+pub struct ContentGallery {
+    /// 图片元素列表。
+    #[serde(default)]
+    pub images: Vec<ContentImageItem>,
+}
+
+/// 图片项。
+#[derive(Debug, Clone, Deserialize)]
+pub struct ContentImageItem {
+    /// 图片 token（不支持编辑）。
+    #[serde(default)]
+    pub file_token: Option<String>,
+    /// 图片源。
+    #[serde(default)]
+    pub src: Option<String>,
+    /// 宽度。
+    #[serde(default)]
+    pub width: Option<f64>,
+    /// 高度。
+    #[serde(default)]
+    pub height: Option<f64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn content_block_deserialize_paragraph_and_gallery() {
+        // 覆盖两类 block + 段落元素判别联合（textRun/docsLink/mention）+ 列表样式 + 图片。
+        let json = serde_json::json!({
+            "blocks": [
+                {
+                    "block_element_type": "paragraph",
+                    "paragraph": {
+                        "style": { "list": { "list_type": "bullet", "indent_level": 1 } },
+                        "elements": [
+                            {
+                                "paragraph_element_type": "textRun",
+                                "text_run": {
+                                    "text": "Q3 目标",
+                                    "style": {
+                                        "bold": true,
+                                        "text_color": { "red": 255, "green": 0, "blue": 0, "alpha": 1.0 }
+                                    }
+                                }
+                            },
+                            {
+                                "paragraph_element_type": "docsLink",
+                                "docs_link": { "url": "https://example.feishu.cn/docs/x", "title": "周报" }
+                            },
+                            {
+                                "paragraph_element_type": "mention",
+                                "mention": { "user_id": "ou_abc" }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "block_element_type": "gallery",
+                    "gallery": {
+                        "images": [
+                            { "file_token": "boxcnOj88GDkmWGm2zsTyCBqoLb", "src": "x", "width": 100.0, "height": 50.0 }
+                        ]
+                    }
+                }
+            ]
+        });
+        let block: ContentBlock = serde_json::from_value(json).expect("反序列化失败");
+        assert_eq!(block.blocks.len(), 2);
+
+        let para = block.blocks[0].paragraph.as_ref().expect("paragraph");
+        assert_eq!(para.elements.len(), 3);
+        assert_eq!(
+            para.style
+                .as_ref()
+                .and_then(|s| s.list.as_ref())
+                .and_then(|l| l.list_type.as_deref()),
+            Some("bullet")
+        );
+        let run = para.elements[0].text_run.as_ref().expect("text_run");
+        assert_eq!(run.text.as_deref(), Some("Q3 目标"));
+        assert_eq!(run.style.as_ref().and_then(|s| s.bold), Some(true));
+
+        let gal = block.blocks[1].gallery.as_ref().expect("gallery");
+        assert_eq!(gal.images.len(), 1);
+        assert_eq!(gal.images[0].width, Some(100.0));
+    }
+
+    #[test]
+    fn content_block_tolerance_unknown_type_and_empty() {
+        // 未知 block_element_type / 缺字段 / 空 blocks 均不报错（向前兼容）。
+        let json = serde_json::json!({
+            "blocks": [
+                { "block_element_type": "futureBlockType", "paragraph": null, "gallery": null }
+            ]
+        });
+        let block: ContentBlock = serde_json::from_value(json).expect("未知类型应容忍");
+        assert_eq!(
+            block.blocks[0].block_element_type.as_deref(),
+            Some("futureBlockType")
+        );
+        assert!(block.blocks[0].paragraph.is_none());
+
+        let empty: ContentBlock =
+            serde_json::from_value(serde_json::json!({})).expect("空对象应容忍");
+        assert!(empty.blocks.is_empty());
+    }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/common/models.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/common/models.rs
@@ -179,10 +179,14 @@ pub struct AlignmentOwner {
 
 // === OKR 文档内容块（content / notes 字段共享）===
 //
-// 源：飞书 apiSchema objectName=content_block（objective/get、key_result/get、
-// key_result/progress/list、objective/progress/list 等的 content/notes 字段共用）。
+// 源：飞书 apiSchema objectName=content_block（objective/get api_id=7644764969658567628 的
+// data.objective.content / .notes；key_result/get、key_result/progress/list、
+// objective/progress/list 等的同名字段共用同一 objectName）。
+// 复现：`python3 tools/schema_cache/cache.py` 或 dump_samples.py 取该 api_id 的
+// responses.200.content.application/json.schema.properties.data.objective.content。
 // 判别联合：block_element_type（paragraph|gallery）+ paragraph_element_type（textRun|docsLink|mention）。
-// tag 用 String（非 enum）以容忍飞书未来新增 block/element 类型，未知类型反序列化不报错。
+// tag 用 String（非 enum）以容忍飞书未来新增 block/element 类型，未知类型反序列化不报错
+// （见测试 content_block_tolerance_unknown_type_and_empty）。
 
 /// OKR 文档内容块（objective/key_result 的 content/notes、progress 的 content）。
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/openlark-hr/src/okr/okr/v2/key_result/progress/list.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/key_result/progress/list.rs
@@ -14,6 +14,7 @@ use serde::Deserialize;
 use std::sync::Arc;
 
 use crate::common::api_endpoints::OkrApiV2;
+use crate::okr::okr::v2::common::models::ContentBlock;
 
 /// 获取关键结果下的进展记录请求。
 #[derive(Debug, Clone)]
@@ -92,10 +93,9 @@ pub struct KeyResultProgress {
     pub entity_type: i32,
     /// 进展所属的实体 ID。
     pub entity_id: String,
-    /// 进展的内容。
-    // TODO: 飞书文档 block 深度嵌套结构暂留 Value，后续可单独抽取 typed 模型。
+    /// 进展的内容（文档 block 结构，见 [`ContentBlock`]）。
     #[serde(default)]
-    pub content: Option<serde_json::Value>,
+    pub content: Option<ContentBlock>,
     /// 进展的进度。
     #[serde(default)]
     pub progress_rate: Option<KeyResultProgressRate>,

--- a/crates/openlark-hr/src/okr/okr/v2/objective/progress/list.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/objective/progress/list.rs
@@ -14,6 +14,7 @@ use serde::Deserialize;
 use std::sync::Arc;
 
 use crate::common::api_endpoints::OkrApiV2;
+use crate::okr::okr::v2::common::models::ContentBlock;
 
 /// 获取目标下的进展记录请求。
 #[derive(Debug, Clone)]
@@ -92,10 +93,9 @@ pub struct Progress {
     pub entity_type: i32,
     /// 进展所属的实体 ID。
     pub entity_id: String,
-    /// 进展的内容。
-    // TODO: 飞书文档 block 深度嵌套结构暂留 Value，后续可单独抽取 typed 模型。
+    /// 进展的内容（文档 block 结构，见 [`ContentBlock`]）。
     #[serde(default)]
-    pub content: Option<serde_json::Value>,
+    pub content: Option<ContentBlock>,
     /// 进展的进度。
     #[serde(default)]
     pub progress_rate: Option<ProgressRate>,


### PR DESCRIPTION
## What

issue #339：把 okr/v2 的 5 个 `Option<serde_json::Value>` + TODO 深嵌套字段 typed 化为 `Option<ContentBlock>`：

| 字段 | 位置 |
|---|---|
| `Objective.content` | common/models.rs |
| `Objective.notes` | common/models.rs |
| `KeyResult.content` | common/models.rs |
| `KeyResultProgress.content` | key_result/progress/list.rs |
| `Progress.content` | objective/progress/list.rs |

issue 说「8 叶」，实际残留 `Option<Value>` 只在 5 字段（6 叶通过 #336 共享 `Objective`/`KeyResult` 自动覆盖 + 2 progress 叶直接改 = 8 叶），无遗漏。

## ContentBlock（14 struct 树，apiSchema 派生）

从飞书 apiSchema `objectName=content_block` 派生（objective/get api_id=`7644764969658567628` 的 `data.objective.content`，注释里给了复现方法）。结构：

```
ContentBlock { blocks: Vec<ContentBlockElement> }
ContentBlockElement { block_element_type: "paragraph"|"gallery", paragraph?, gallery? }  // 判别联合
  ContentParagraph { style{list}, elements[] }
    ContentParagraphElement { paragraph_element_type: "textRun"|"docsLink"|"mention", text_run?/docs_link?/mention? }
      ContentTextRun { text, style{bold/strike/color/link} }
  ContentGallery { images[] {file_token,src,width,height} }
```

判别联合 tag 用 `String`（非 enum）**容忍飞书未来新增 block 类型**（测试覆盖 `futureBlockType` + 空对象不报错）。#336 消重所赐，定义在 `common/models.rs` 一处，5 字段共享。

## 验证（本轮新鲜证据）

- `cargo test -p openlark-hr --all-features`：2427 passed / 0 failed（+2 新 ContentBlock deserialize 测试）
- `cargo clippy -p openlark-hr --all-features --all-targets`：零警告
- `cargo fmt --check`：通过
- `cargo build --workspace --all-features`：通过（跨 crate 无回归）
- `grep -rc "Option<serde_json::Value>" okr/v2/`：**0**
- `grep TODO.*block okr/v2/`：**0**

## code-review（/implement 流程）

`/code-review` 两轴审查：
- **Standards**：通过，无硬违反。14 struct 非 Speculative Generality（逐字段映射 apiSchema）；tag 用 String 是合理前向兼容让步。
- **Spec**：通过，8 叶覆盖成立、无 scope creep、验收全过。建议 apiSchema 派生可追溯——已补 api_id 注释（可复现 fetch）。

## Breaking（v0.18 窗口）

5 个公开 Response 字段类型 `Option<Value>` → `Option<ContentBlock>`，源码级 breaking。已在 CHANGELOG v0.18 Breaking Changes 补条目（okr/v2 仓内零外部引用，影响可控）。

close #339
