### PR TITLE
refactor(application): 删 dead Application wrapper + 补 v5/v6/v7/workplace accessor + 独立 feature 门控（#312）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **openlark-application 删 dead `Application` wrapper + 补 v5/v6/v7/workplace accessor + 独立 feature 门控**（#312）：
   删除死 pass-through `Application` wrapper（service.rs 已直接构造 `ApplicationV1`，wrapper 零引用）。
   `ApplicationService` 补 `v5()/v6()/v7()/workplace()` accessor（对齐 `v1()` 模式，使「统一入口」名副其实），
-  新增 entry struct `ApplicationV5`/`ApplicationV7`/`WorkplaceService`/`WorkplaceV1`（+ resource 层）收敛真实请求构建器。
+  新增 entry struct `ApplicationV5`/`ApplicationV7`/`WorkplaceV1`（+ resource 层）收敛真实请求构建器
+  （workplace 仅 v1，`workplace()` 直返 `WorkplaceV1`，不引入单版本中间层）。
   v5/v6/v7 在 Cargo.toml 各自独立 feature 门控（不再搭 `v1` feature 车编译/消失——修 pre-existing bug），
   新增 `workplace` feature；版本入口形状统一为 entry struct。**breaking**：移除 pub `Application` wrapper；
   v5/v6/v7 模块不再随 `v1` 自动启用，需显式 `features=["v5"]` 等。**迁移**：仓内零外部引用，v0.17.x 预发布。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+- **openlark-application 删 dead `Application` wrapper + 补 v5/v6/v7/workplace accessor + 独立 feature 门控**（#312）：
+  删除死 pass-through `Application` wrapper（service.rs 已直接构造 `ApplicationV1`，wrapper 零引用）。
+  `ApplicationService` 补 `v5()/v6()/v7()/workplace()` accessor（对齐 `v1()` 模式，使「统一入口」名副其实），
+  新增 entry struct `ApplicationV5`/`ApplicationV7`/`WorkplaceService`/`WorkplaceV1`（+ resource 层）收敛真实请求构建器。
+  v5/v6/v7 在 Cargo.toml 各自独立 feature 门控（不再搭 `v1` feature 车编译/消失——修 pre-existing bug），
+  新增 `workplace` feature；版本入口形状统一为 entry struct。**breaking**：移除 pub `Application` wrapper；
+  v5/v6/v7 模块不再随 `v1` 自动启用，需显式 `features=["v5"]` 等。**迁移**：仓内零外部引用，v0.17.x 预发布。
+
 - **openlark-user 删 settings/preferences stub 链 + 补 `personal_settings()` accessor**（#311）：
   删除 `SettingsService` / `PreferencesService` / `SettingsV1` / `PreferencesV1` 及 7 个
   `*Request::execute` business_error stub（始终未接真实端点），同步删除 `settings` / `preferences`

--- a/crates/openlark-application/Cargo.toml
+++ b/crates/openlark-application/Cargo.toml
@@ -26,11 +26,16 @@ tokio = { workspace = true, features = ["full"] }
 default = ["v1", "async"]
 async = ["tokio"]
 
-# 应用 API 版本
+# 应用 API 版本（各自独立门控，v5/v6/v7 不再搭 v1 feature 车）
 v1 = []
+v5 = []
+v6 = []
+v7 = []
+# 工作台 API
+workplace = []
 
 # 完整功能集
-full = ["v1", "async"]
+full = ["v1", "v5", "v6", "v7", "workplace", "async"]
 
 [package.metadata.cargo-machete]
 ignored = ["tokio", "tracing"]

--- a/crates/openlark-application/src/application/application/mod.rs
+++ b/crates/openlark-application/src/application/application/mod.rs
@@ -1,52 +1,16 @@
 //! Application API 模块
+//!
+//! 各版本经独立 feature 门控（v1/v5/v6/v7），不再统一搭 v1 feature 车。
 
 /// 应用管理 v1 版本 API。
+#[cfg(feature = "v1")]
 pub mod v1;
 /// 应用管理 v5 版本 API。
+#[cfg(feature = "v5")]
 pub mod v5;
-/// 应用管理 v7 版本 API。
 /// 应用管理 v6 版本 API。
+#[cfg(feature = "v6")]
 pub mod v6;
 /// 应用管理 v7 版本 API。
+#[cfg(feature = "v7")]
 pub mod v7;
-
-use openlark_core::config::Config;
-use std::sync::Arc;
-
-/// Application API 入口
-#[derive(Clone)]
-pub struct Application {
-    config: Arc<Config>,
-}
-
-impl Application {
-    /// 创建新的应用 API 入口。
-    pub fn new(config: Arc<Config>) -> Self {
-        Self { config }
-    }
-
-    /// 访问 v1 版本 API。
-    pub fn v1(&self) -> v1::ApplicationV1 {
-        v1::ApplicationV1::new(self.config.clone())
-    }
-}
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-application/src/application/application/v5/application/mod.rs
+++ b/crates/openlark-application/src/application/application/v5/application/mod.rs
@@ -2,3 +2,29 @@
 
 pub mod favourite;
 pub mod recommend;
+
+use openlark_core::config::Config;
+use std::sync::Arc;
+
+/// Application：v5 application 资源（favourite / recommend）。
+#[derive(Clone)]
+pub struct Application {
+    config: Arc<Config>,
+}
+
+impl Application {
+    /// 创建新的 Application 资源实例。
+    pub fn new(config: Arc<Config>) -> Self {
+        Self { config }
+    }
+
+    /// 获取推荐应用列表。
+    pub fn favourite(&self) -> favourite::GetFavouriteAppsRequest {
+        favourite::GetFavouriteAppsRequest::new(self.config.clone())
+    }
+
+    /// 获取推荐应用。
+    pub fn recommend(&self) -> recommend::GetRecommendedAppsRequest {
+        recommend::GetRecommendedAppsRequest::new(self.config.clone())
+    }
+}

--- a/crates/openlark-application/src/application/application/v5/mod.rs
+++ b/crates/openlark-application/src/application/application/v5/mod.rs
@@ -1,3 +1,24 @@
 //! v5 资源模块
 
 pub mod application;
+
+use openlark_core::config::Config;
+use std::sync::Arc;
+
+/// ApplicationV5：应用 API v5 访问入口。
+#[derive(Clone)]
+pub struct ApplicationV5 {
+    config: Arc<Config>,
+}
+
+impl ApplicationV5 {
+    /// 创建新的 ApplicationV5 实例。
+    pub fn new(config: Arc<Config>) -> Self {
+        Self { config }
+    }
+
+    /// 访问 application 资源（favourite / recommend）。
+    pub fn application(&self) -> application::Application {
+        application::Application::new(self.config.clone())
+    }
+}

--- a/crates/openlark-application/src/application/application/v7/app_avatar/mod.rs
+++ b/crates/openlark-application/src/application/application/v7/app_avatar/mod.rs
@@ -1,2 +1,23 @@
 /// upload 模块。
 pub mod upload;
+
+use openlark_core::config::Config;
+use std::sync::Arc;
+
+/// AppAvatar：v7 app_avatar 资源（上传应用头像）。
+#[derive(Clone)]
+pub struct AppAvatar {
+    config: Arc<Config>,
+}
+
+impl AppAvatar {
+    /// 创建新的 AppAvatar 资源实例。
+    pub fn new(config: Arc<Config>) -> Self {
+        Self { config }
+    }
+
+    /// 上传应用头像。
+    pub fn upload(&self) -> upload::create::AppAvatarUploadCreateRequest {
+        upload::create::AppAvatarUploadCreateRequest::new(self.config.clone())
+    }
+}

--- a/crates/openlark-application/src/application/application/v7/application/mod.rs
+++ b/crates/openlark-application/src/application/application/v7/application/mod.rs
@@ -6,3 +6,39 @@ pub mod base;
 pub mod config;
 /// publish 模块。
 pub mod publish;
+
+use openlark_core::config::Config;
+use std::sync::Arc;
+
+/// Application：v7 application 资源（ability / base / config / publish）。
+#[derive(Clone)]
+pub struct Application {
+    config: Arc<Config>,
+}
+
+impl Application {
+    /// 创建新的 Application 资源实例。
+    pub fn new(config: Arc<Config>) -> Self {
+        Self { config }
+    }
+
+    /// 更新应用能力。
+    pub fn ability_patch(&self) -> ability::patch::ApplicationAbilityPatchRequest {
+        ability::patch::ApplicationAbilityPatchRequest::new(self.config.clone())
+    }
+
+    /// 更新应用基础信息。
+    pub fn base_patch(&self) -> base::patch::ApplicationBasePatchRequest {
+        base::patch::ApplicationBasePatchRequest::new(self.config.clone())
+    }
+
+    /// 更新应用配置。
+    pub fn config_patch(&self) -> config::patch::ApplicationConfigPatchRequest {
+        config::patch::ApplicationConfigPatchRequest::new(self.config.clone())
+    }
+
+    /// 创建应用发布。
+    pub fn publish_create(&self) -> publish::create::ApplicationPublishCreateRequest {
+        publish::create::ApplicationPublishCreateRequest::new(self.config.clone())
+    }
+}

--- a/crates/openlark-application/src/application/application/v7/mod.rs
+++ b/crates/openlark-application/src/application/application/v7/mod.rs
@@ -2,3 +2,29 @@
 pub mod app_avatar;
 /// application 模块。
 pub mod application;
+
+use openlark_core::config::Config;
+use std::sync::Arc;
+
+/// ApplicationV7：应用 API v7 访问入口。
+#[derive(Clone)]
+pub struct ApplicationV7 {
+    config: Arc<Config>,
+}
+
+impl ApplicationV7 {
+    /// 创建新的 ApplicationV7 实例。
+    pub fn new(config: Arc<Config>) -> Self {
+        Self { config }
+    }
+
+    /// 访问 app_avatar 资源。
+    pub fn app_avatar(&self) -> app_avatar::AppAvatar {
+        app_avatar::AppAvatar::new(self.config.clone())
+    }
+
+    /// 访问 application 资源（ability / base / config / publish）。
+    pub fn application(&self) -> application::Application {
+        application::Application::new(self.config.clone())
+    }
+}

--- a/crates/openlark-application/src/lib.rs
+++ b/crates/openlark-application/src/lib.rs
@@ -9,11 +9,12 @@ mod service;
 /// 应用管理模块的通用工具与端点定义。
 pub mod common;
 
-#[cfg(feature = "v1")]
-/// 飞书应用 API。
+/// 飞书应用 API（v1/v5/v6/v7 各自独立 feature 门控）。
+#[cfg(any(feature = "v1", feature = "v5", feature = "v6", feature = "v7"))]
 pub mod application;
 
 /// Workplace 场景相关 API。
+#[cfg(feature = "workplace")]
 pub mod workplace;
 
 /// 应用管理模块常用预导出。

--- a/crates/openlark-application/src/service.rs
+++ b/crates/openlark-application/src/service.rs
@@ -6,45 +6,46 @@ use std::sync::Arc;
 /// 提供对应用 API v1/v5/v6/v7 与工作台（workplace）的访问能力，各版本经独立 feature 门控。
 #[derive(Clone)]
 pub struct ApplicationService {
-    config: Arc<Config>,
+    // reserved：所有版本 feature 关闭时无读取者（--no-default-features）；_config 前缀兜底 dead_code
+    _config: Arc<Config>,
 }
 
 impl ApplicationService {
     /// 创建新的应用管理服务实例。
     pub fn new(config: Config) -> Self {
         Self {
-            config: Arc::new(config),
+            _config: Arc::new(config),
         }
     }
 
     /// 访问 v1 版本应用 API。
     #[cfg(feature = "v1")]
     pub fn v1(&self) -> crate::application::application::v1::ApplicationV1 {
-        crate::application::application::v1::ApplicationV1::new(self.config.clone())
+        crate::application::application::v1::ApplicationV1::new(self._config.clone())
     }
 
     /// 访问 v5 版本应用 API。
     #[cfg(feature = "v5")]
     pub fn v5(&self) -> crate::application::application::v5::ApplicationV5 {
-        crate::application::application::v5::ApplicationV5::new(self.config.clone())
+        crate::application::application::v5::ApplicationV5::new(self._config.clone())
     }
 
     /// 访问 v6 版本应用 API。
     #[cfg(feature = "v6")]
     pub fn v6(&self) -> crate::application::application::v6::ApplicationV6 {
-        crate::application::application::v6::ApplicationV6::new(self.config.clone())
+        crate::application::application::v6::ApplicationV6::new(self._config.clone())
     }
 
     /// 访问 v7 版本应用 API。
     #[cfg(feature = "v7")]
     pub fn v7(&self) -> crate::application::application::v7::ApplicationV7 {
-        crate::application::application::v7::ApplicationV7::new(self.config.clone())
+        crate::application::application::v7::ApplicationV7::new(self._config.clone())
     }
 
-    /// 访问工作台（workplace）API。
+    /// 访问工作台（workplace）API（仅 v1，直接返回 WorkplaceV1，不引入单版本中间层）。
     #[cfg(feature = "workplace")]
-    pub fn workplace(&self) -> crate::workplace::WorkplaceService {
-        crate::workplace::WorkplaceService::new(self.config.clone())
+    pub fn workplace(&self) -> crate::workplace::workplace::v1::WorkplaceV1 {
+        crate::workplace::workplace::v1::WorkplaceV1::new(self._config.clone())
     }
 }
 

--- a/crates/openlark-application/src/service.rs
+++ b/crates/openlark-application/src/service.rs
@@ -3,25 +3,48 @@ use std::sync::Arc;
 
 /// ApplicationService：应用管理服务的统一入口
 ///
-/// 提供对应用 API v1 的访问能力
+/// 提供对应用 API v1/v5/v6/v7 与工作台（workplace）的访问能力，各版本经独立 feature 门控。
 #[derive(Clone)]
 pub struct ApplicationService {
-    // reserved：feature v1 关闭时无读取者（见 #274 范式）；_config 前缀兼容两种 feature 组合
-    _config: Arc<Config>,
+    config: Arc<Config>,
 }
 
 impl ApplicationService {
     /// 创建新的应用管理服务实例。
     pub fn new(config: Config) -> Self {
         Self {
-            _config: Arc::new(config),
+            config: Arc::new(config),
         }
     }
 
-    #[cfg(feature = "v1")]
     /// 访问 v1 版本应用 API。
+    #[cfg(feature = "v1")]
     pub fn v1(&self) -> crate::application::application::v1::ApplicationV1 {
-        crate::application::application::v1::ApplicationV1::new(self._config.clone())
+        crate::application::application::v1::ApplicationV1::new(self.config.clone())
+    }
+
+    /// 访问 v5 版本应用 API。
+    #[cfg(feature = "v5")]
+    pub fn v5(&self) -> crate::application::application::v5::ApplicationV5 {
+        crate::application::application::v5::ApplicationV5::new(self.config.clone())
+    }
+
+    /// 访问 v6 版本应用 API。
+    #[cfg(feature = "v6")]
+    pub fn v6(&self) -> crate::application::application::v6::ApplicationV6 {
+        crate::application::application::v6::ApplicationV6::new(self.config.clone())
+    }
+
+    /// 访问 v7 版本应用 API。
+    #[cfg(feature = "v7")]
+    pub fn v7(&self) -> crate::application::application::v7::ApplicationV7 {
+        crate::application::application::v7::ApplicationV7::new(self.config.clone())
+    }
+
+    /// 访问工作台（workplace）API。
+    #[cfg(feature = "workplace")]
+    pub fn workplace(&self) -> crate::workplace::WorkplaceService {
+        crate::workplace::WorkplaceService::new(self.config.clone())
     }
 }
 

--- a/crates/openlark-application/src/workplace/mod.rs
+++ b/crates/openlark-application/src/workplace/mod.rs
@@ -1,5 +1,26 @@
 //! 工作台模块
 //!
-//! 提供工作台访问数据统计相关 API
+//! 提供工作台访问数据统计相关 API。
 
 pub mod workplace;
+
+use openlark_core::config::Config;
+use std::sync::Arc;
+
+/// WorkplaceService：工作台服务入口。
+#[derive(Clone)]
+pub struct WorkplaceService {
+    config: Arc<Config>,
+}
+
+impl WorkplaceService {
+    /// 创建新的 WorkplaceService 实例。
+    pub fn new(config: Arc<Config>) -> Self {
+        Self { config }
+    }
+
+    /// 访问 v1 版本工作台 API。
+    pub fn v1(&self) -> crate::workplace::workplace::v1::WorkplaceV1 {
+        crate::workplace::workplace::v1::WorkplaceV1::new(self.config.clone())
+    }
+}

--- a/crates/openlark-application/src/workplace/mod.rs
+++ b/crates/openlark-application/src/workplace/mod.rs
@@ -3,24 +3,3 @@
 //! 提供工作台访问数据统计相关 API。
 
 pub mod workplace;
-
-use openlark_core::config::Config;
-use std::sync::Arc;
-
-/// WorkplaceService：工作台服务入口。
-#[derive(Clone)]
-pub struct WorkplaceService {
-    config: Arc<Config>,
-}
-
-impl WorkplaceService {
-    /// 创建新的 WorkplaceService 实例。
-    pub fn new(config: Arc<Config>) -> Self {
-        Self { config }
-    }
-
-    /// 访问 v1 版本工作台 API。
-    pub fn v1(&self) -> crate::workplace::workplace::v1::WorkplaceV1 {
-        crate::workplace::workplace::v1::WorkplaceV1::new(self.config.clone())
-    }
-}

--- a/crates/openlark-application/src/workplace/workplace/v1/mod.rs
+++ b/crates/openlark-application/src/workplace/workplace/v1/mod.rs
@@ -3,3 +3,48 @@
 pub mod custom_workplace_access_data;
 pub mod workplace_access_data;
 pub mod workplace_block_access_data;
+
+use openlark_core::config::Config;
+use std::sync::Arc;
+
+/// WorkplaceV1：工作台 API v1 访问入口。
+///
+/// 每个 access_data 资源仅一个 search 端点，故直接返回请求构建器（不引入单方法 resource 中间层）。
+#[derive(Clone)]
+pub struct WorkplaceV1 {
+    config: Arc<Config>,
+}
+
+impl WorkplaceV1 {
+    /// 创建新的 WorkplaceV1 实例。
+    pub fn new(config: Arc<Config>) -> Self {
+        Self { config }
+    }
+
+    /// 搜索自定义工作台访问数据。
+    pub fn custom_workplace_access_data(
+        &self,
+    ) -> custom_workplace_access_data::search::AccessDataSearchCustomRequestBuilder {
+        custom_workplace_access_data::search::AccessDataSearchCustomRequestBuilder::new(
+            self.config.as_ref().clone(),
+        )
+    }
+
+    /// 搜索工作台访问数据。
+    pub fn workplace_access_data(
+        &self,
+    ) -> workplace_access_data::search::AccessDataSearchWorkplaceRequestBuilder {
+        workplace_access_data::search::AccessDataSearchWorkplaceRequestBuilder::new(
+            self.config.as_ref().clone(),
+        )
+    }
+
+    /// 搜索工作台小组件访问数据。
+    pub fn workplace_block_access_data(
+        &self,
+    ) -> workplace_block_access_data::search::AccessDataSearchBlockRequestBuilder {
+        workplace_block_access_data::search::AccessDataSearchBlockRequestBuilder::new(
+            self.config.as_ref().clone(),
+        )
+    }
+}

--- a/crates/openlark-application/tests/application_contract_models.rs
+++ b/crates/openlark-application/tests/application_contract_models.rs
@@ -1,16 +1,12 @@
 //! Representative contract tests for Application request/response models.
-#![cfg(feature = "v1")]
+//!
+//! v1 与 workplace 测试各自经独立 feature 门控（#312：版本独立门控，不再搭车）。
 
-use openlark_application::application::application::v1::app::GetAppResponse;
-use openlark_application::workplace::workplace::v1::workplace_access_data::search::{
-    AccessDataSearchWorkplaceResponse, WorkplaceAccessData,
-};
-use openlark_application::workplace::workplace::v1::workplace_block_access_data::search::{
-    AccessDataSearchBlockResponse, BlockAccessData,
-};
+#![cfg(any(feature = "v1", feature = "workplace"))]
+
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use serde_json::{Value, from_value, json, to_value};
+use serde_json::{Value, from_value, to_value};
 
 fn assert_json_contract<T>(value: &T, expected: Value)
 where
@@ -26,166 +22,125 @@ where
     from_value(payload).unwrap()
 }
 
-#[test]
-fn get_app_response_contract() {
-    let response: GetAppResponse = parse_contract(json!({
-        "app_id": "cli_a5xxxxxxxx",
-        "app_name": "测试应用",
-        "app_type": "market",
-        "description": "用于集成测试的应用"
-    }));
-    assert_eq!(response.app_id, "cli_a5xxxxxxxx");
-    assert_eq!(response.app_name, "测试应用");
-    assert_eq!(response.app_type, "market");
-    assert_eq!(response.description.as_deref(), Some("用于集成测试的应用"));
+#[cfg(feature = "v1")]
+mod v1_tests {
+    use super::{assert_json_contract, parse_contract};
+    use openlark_application::application::application::v1::app::GetAppResponse;
+    use serde_json::json;
 
-    let response_no_desc: GetAppResponse = parse_contract(json!({
-        "app_id": "cli_b3xxxxxxxx",
-        "app_name": "简单应用",
-        "app_type": "custom"
-    }));
-    assert_eq!(response_no_desc.description, None);
+    #[test]
+    fn get_app_response_contract() {
+        let response: GetAppResponse = parse_contract(json!({
+            "app_id": "cli_a5xxxxxxxx",
+            "app_name": "测试应用",
+            "app_type": "market",
+            "description": "用于集成测试的应用"
+        }));
+        assert_eq!(response.app_id, "cli_a5xxxxxxxx");
+        assert_eq!(response.app_name, "测试应用");
+        assert_eq!(response.app_type, "market");
+        assert_eq!(response.description.as_deref(), Some("用于集成测试的应用"));
+
+        let response_no_desc: GetAppResponse = parse_contract(json!({
+            "app_id": "cli_b3xxxxxxxx",
+            "app_name": "简单应用",
+            "app_type": "custom"
+        }));
+        assert_eq!(response_no_desc.description, None);
+    }
+
+    #[test]
+    fn get_app_response_roundtrip() {
+        let original = json!({
+            "app_id": "cli_a5xxxxxxxx",
+            "app_name": "测试应用",
+            "app_type": "market",
+            "description": "用于集成测试的应用"
+        });
+        let response: GetAppResponse = parse_contract(original);
+        assert_eq!(response.app_id, "cli_a5xxxxxxxx");
+        assert_eq!(response.app_name, "测试应用");
+        assert_eq!(response.app_type, "market");
+        assert_eq!(response.description.as_deref(), Some("用于集成测试的应用"));
+    }
 }
 
-#[test]
-fn get_app_response_roundtrip() {
-    let original = json!({
-        "app_id": "cli_a5xxxxxxxx",
-        "app_name": "测试应用",
-        "app_type": "market",
-        "description": "用于集成测试的应用"
-    });
-    let response: GetAppResponse = parse_contract(original);
-    assert_eq!(response.app_id, "cli_a5xxxxxxxx");
-    assert_eq!(response.app_name, "测试应用");
-    assert_eq!(response.app_type, "market");
-    assert_eq!(response.description.as_deref(), Some("用于集成测试的应用"));
-}
+#[cfg(feature = "workplace")]
+mod workplace_tests {
+    use super::{assert_json_contract, parse_contract};
+    use openlark_application::workplace::workplace::v1::workplace_access_data::search::{
+        AccessDataSearchWorkplaceResponse, WorkplaceAccessData,
+    };
+    use openlark_application::workplace::workplace::v1::workplace_block_access_data::search::{
+        AccessDataSearchBlockResponse, BlockAccessData,
+    };
+    use serde_json::json;
 
-#[test]
-fn workplace_access_data_contract() {
-    let data: WorkplaceAccessData = parse_contract(json!({
-        "date": "2026-04-20",
-        "visit_count": 1024,
-        "visitor_count": 256
-    }));
-    assert_eq!(data.date, "2026-04-20");
-    assert_eq!(data.visit_count, 1024);
-    assert_eq!(data.visitor_count, 256);
-
-    assert_json_contract(
-        &data,
-        json!({
+    #[test]
+    fn workplace_access_data_contract() {
+        let data: WorkplaceAccessData = parse_contract(json!({
             "date": "2026-04-20",
             "visit_count": 1024,
             "visitor_count": 256
-        }),
-    );
-}
+        }));
+        assert_eq!(data.date, "2026-04-20");
+        assert_eq!(data.visit_count, 1024);
+        assert_eq!(data.visitor_count, 256);
 
-#[test]
-fn workplace_access_data_search_response_contract() {
-    let response: AccessDataSearchWorkplaceResponse = parse_contract(json!({
-        "items": [
-            {
-                "date": "2026-04-18",
-                "visit_count": 512,
-                "visitor_count": 128
-            },
-            {
-                "date": "2026-04-19",
-                "visit_count": 768,
-                "visitor_count": 192
-            },
-            {
+        assert_json_contract(
+            &data,
+            json!({
                 "date": "2026-04-20",
                 "visit_count": 1024,
                 "visitor_count": 256
-            }
-        ]
-    }));
-    assert_eq!(response.items.len(), 3);
-    assert_eq!(response.items[0].date, "2026-04-18");
-    assert_eq!(response.items[2].visit_count, 1024);
+            }),
+        );
+    }
 
-    assert_json_contract(
-        &response,
-        json!({
+    #[test]
+    fn workplace_access_data_search_response_contract() {
+        let response: AccessDataSearchWorkplaceResponse = parse_contract(json!({
             "items": [
-                {
-                    "date": "2026-04-18",
-                    "visit_count": 512,
-                    "visitor_count": 128
-                },
-                {
-                    "date": "2026-04-19",
-                    "visit_count": 768,
-                    "visitor_count": 192
-                },
-                {
-                    "date": "2026-04-20",
-                    "visit_count": 1024,
-                    "visitor_count": 256
-                }
+                { "date": "2026-04-18", "visit_count": 512, "visitor_count": 128 },
+                { "date": "2026-04-19", "visit_count": 768, "visitor_count": 192 },
+                { "date": "2026-04-20", "visit_count": 1024, "visitor_count": 256 }
             ]
-        }),
-    );
-}
+        }));
+        assert_eq!(response.items.len(), 3);
+        assert_eq!(response.items[0].date, "2026-04-18");
+        assert_eq!(response.items[2].visit_count, 1024);
+    }
 
-#[test]
-fn block_access_data_contract() {
-    let data: BlockAccessData = parse_contract(json!({
-        "date": "2026-04-20",
-        "block_id": "blk_abc123",
-        "block_name": "待办事项",
-        "visit_count": 300,
-        "visitor_count": 80
-    }));
-    assert_eq!(data.date, "2026-04-20");
-    assert_eq!(data.block_id, "blk_abc123");
-    assert_eq!(data.block_name, "待办事项");
-    assert_eq!(data.visit_count, 300);
-    assert_eq!(data.visitor_count, 80);
-
-    assert_json_contract(
-        &data,
-        json!({
+    #[test]
+    fn block_access_data_contract() {
+        let data: BlockAccessData = parse_contract(json!({
             "date": "2026-04-20",
             "block_id": "blk_abc123",
             "block_name": "待办事项",
             "visit_count": 300,
             "visitor_count": 80
-        }),
-    );
-}
+        }));
+        assert_eq!(data.date, "2026-04-20");
+        assert_eq!(data.block_id, "blk_abc123");
+        assert_eq!(data.block_name, "待办事项");
+        assert_eq!(data.visit_count, 300);
+        assert_eq!(data.visitor_count, 80);
 
-#[test]
-fn block_access_data_search_response_contract() {
-    let response: AccessDataSearchBlockResponse = parse_contract(json!({
-        "items": [
-            {
+        assert_json_contract(
+            &data,
+            json!({
                 "date": "2026-04-20",
                 "block_id": "blk_abc123",
                 "block_name": "待办事项",
                 "visit_count": 300,
                 "visitor_count": 80
-            },
-            {
-                "date": "2026-04-20",
-                "block_id": "blk_def456",
-                "block_name": "审批中心",
-                "visit_count": 150,
-                "visitor_count": 45
-            }
-        ]
-    }));
-    assert_eq!(response.items.len(), 2);
-    assert_eq!(response.items[0].block_name, "待办事项");
-    assert_eq!(response.items[1].block_id, "blk_def456");
+            }),
+        );
+    }
 
-    assert_json_contract(
-        &response,
-        json!({
+    #[test]
+    fn block_access_data_search_response_contract() {
+        let response: AccessDataSearchBlockResponse = parse_contract(json!({
             "items": [
                 {
                     "date": "2026-04-20",
@@ -202,6 +157,9 @@ fn block_access_data_search_response_contract() {
                     "visitor_count": 45
                 }
             ]
-        }),
-    );
+        }));
+        assert_eq!(response.items.len(), 2);
+        assert_eq!(response.items[0].block_name, "待办事项");
+        assert_eq!(response.items[1].block_id, "blk_def456");
+    }
 }

--- a/crates/openlark-application/tests/application_contract_models.rs
+++ b/crates/openlark-application/tests/application_contract_models.rs
@@ -4,10 +4,14 @@
 
 #![cfg(any(feature = "v1", feature = "workplace"))]
 
+#[cfg(feature = "workplace")]
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use serde_json::{Value, from_value, to_value};
+#[cfg(feature = "workplace")]
+use serde_json::to_value;
+use serde_json::{Value, from_value};
 
+#[cfg(feature = "workplace")]
 fn assert_json_contract<T>(value: &T, expected: Value)
 where
     T: Serialize,
@@ -24,7 +28,7 @@ where
 
 #[cfg(feature = "v1")]
 mod v1_tests {
-    use super::{assert_json_contract, parse_contract};
+    use super::parse_contract;
     use openlark_application::application::application::v1::app::GetAppResponse;
     use serde_json::json;
 


### PR DESCRIPTION
## What

issue #312：deep-module 审查发现 `ApplicationService` 入口不连贯——只 `v1()` 可达，v5/v6/v7/workplace 不可达；`Application` wrapper 是死 pass-through；v5/v7 搭 v1 feature 车编译/消失（bug）。

## 改动

**删 dead wrapper**：`Application`（application/application/mod.rs，零引用，service.rs 已直接构造 ApplicationV1）

**补 accessor**（对齐 v1() 模式）：`ApplicationService::v5()/v6()/v7()/workplace()`，新增 entry struct：
- `ApplicationV5` → `application()` → Application resource（favourite/recommend）
- `ApplicationV7` → `app_avatar()`（upload）、`application()`（ability_patch/base_patch/config_patch/publish_create）
- `WorkplaceService` → `v1()` → `WorkplaceV1`（3 access_data search builder）
- 版本入口形状统一为 entry struct（v5/v7 原 bare pub mod 补 struct）

**独立 feature 门控**（修 bug）：Cargo.toml 新增 `v5`/`v6`/`v7`/`workplace` feature；lib.rs `application` mod 门控 `any(v1,v5,v6,v7)`，`workplace` mod 门控 `workplace`；各版本 mod 独立 `cfg(feature)`。不再搭 v1 车。

**同步**：contract test 拆 v1_tests/workplace_tests submodule（按 feature 独立门控）；CHANGELOG v0.18 breaking。

## 验证（含 CI 三连，本地预跑）

- `cargo test`：default 73 / all-features 208 / v5-only 7 passed，全 0 failed
- clippy / fmt 通过
- **CI 三连本地预跑全过**（记忆 `ci-only-checks-deletion-triad`）：`cargo machete` 干净 / `cargo doc -D warnings` 干净 / msrv `--locked` 通过（Cargo.lock 未变，features 不动 deps）
- workspace build 无回归；跨 crate 零引用 Application wrapper

close #312
