### PR TITLE
refactor(bot): 删 Bot/V4/BotResource 3 纯转发壳，search_bot() 直达 leaf（#354，ADR 0001 阶段1）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+- **openlark-bot 删 `Bot`/`V4`/`BotResource` 3 纯转发壳 + `search_bot()` 直达 leaf**（#354，ADR 0001 阶段1）：
+  4 层壳包裹唯一 1 个 API（search），`service.bot().v4().bot().search()` 段名重复 4 跳 → `service.search_bot()` 1 跳。
+  删 `Bot`/`V4`/`BotResource` struct（保 `pub mod` 模块树维持 leaf 路径）；`BotService` 加 `search_bot()` 直达
+  `SearchBotRequest`（保留 `feature=v4` 门控）。**breaking**：移除 pub `Bot`/`V4`/`BotResource`。**迁移**：仓内零外部引用，
+  leaf `SearchBotRequest` API 不变（strict-path 用户零影响），v0.17.x 预发布。
+
 - **`serialize_params` / `extract_response_data` / `ensure_success` 下沉 `openlark_core::api`（canonical）+ ai common 私有化 + `api_url!` 去 macro_export**（#330）：
   通用 HTTP 管道 helper 此前在 10 个业务 crate 各有一份 `common/api_utils.rs`（locality 失守），
   现统一到 `openlark_core::api::{serialize_params, extract_response_data, ensure_success}`（rich 诊断：

--- a/crates/openlark-bot/src/bot/bot/mod.rs
+++ b/crates/openlark-bot/src/bot/bot/mod.rs
@@ -1,24 +1,3 @@
-//! bot 资源模块
+//! bot 资源模块（ADR 0001：Bot 转发壳已删，仅保留模块树维持 leaf 路径）。
 
 pub mod v4;
-
-use openlark_core::config::Config;
-use std::sync::Arc;
-
-/// Bot：机器人资源入口
-#[derive(Clone)]
-pub struct Bot {
-    config: Arc<Config>,
-}
-
-impl Bot {
-    /// 创建新的实例。
-    pub fn new(config: Arc<Config>) -> Self {
-        Self { config }
-    }
-
-    /// 访问 v4 API。
-    pub fn v4(&self) -> v4::V4 {
-        v4::V4::new(self.config.clone())
-    }
-}

--- a/crates/openlark-bot/src/bot/bot/v4/bot/mod.rs
+++ b/crates/openlark-bot/src/bot/bot/v4/bot/mod.rs
@@ -1,24 +1,3 @@
-//! bot 资源 v4
+//! bot 资源 v4（ADR 0001：BotResource 转发壳已删，仅保留 search leaf 路径）。
 
 pub mod search;
-
-use openlark_core::config::Config;
-use std::sync::Arc;
-
-/// BotResource：机器人资源
-#[derive(Clone)]
-pub struct BotResource {
-    config: Arc<Config>,
-}
-
-impl BotResource {
-    /// 创建新的实例。
-    pub fn new(config: Arc<Config>) -> Self {
-        Self { config }
-    }
-
-    /// 创建搜索机器人请求。
-    pub fn search(&self) -> search::SearchBotRequest {
-        search::SearchBotRequest::new(self.config.clone())
-    }
-}

--- a/crates/openlark-bot/src/bot/bot/v4/mod.rs
+++ b/crates/openlark-bot/src/bot/bot/v4/mod.rs
@@ -1,24 +1,3 @@
-//! Bot v4 模块
+//! Bot v4 模块（ADR 0001：V4 转发壳已删，仅保留模块树）。
 
 pub mod bot;
-
-use openlark_core::config::Config;
-use std::sync::Arc;
-
-/// V4：机器人 v4 版本入口
-#[derive(Clone)]
-pub struct V4 {
-    config: Arc<Config>,
-}
-
-impl V4 {
-    /// 创建新的实例。
-    pub fn new(config: Arc<Config>) -> Self {
-        Self { config }
-    }
-
-    /// 访问 bot 资源。
-    pub fn bot(&self) -> bot::BotResource {
-        bot::BotResource::new(self.config.clone())
-    }
-}

--- a/crates/openlark-bot/src/service.rs
+++ b/crates/openlark-bot/src/service.rs
@@ -3,10 +3,10 @@ use std::sync::Arc;
 
 /// BotService：机器人服务的统一入口
 ///
-/// 提供对机器人 API v4 的访问能力
+/// 提供对机器人搜索 API（v4）的访问能力。
 #[derive(Clone)]
 pub struct BotService {
-    // config 仅在 v4 feature 开启时被 bot() accessor 读取；feature 关闭时受控标注为预期死代码。
+    // config 仅在 v4 feature 开启时被 search_bot() accessor 读取；feature 关闭时受控标注为预期死代码。
     #[cfg_attr(not(feature = "v4"), expect(dead_code))]
     config: Arc<Config>,
 }
@@ -19,10 +19,14 @@ impl BotService {
         }
     }
 
+    /// 搜索机器人请求构建器（直达 leaf）。
+    ///
+    /// ADR 0001：消除 `Bot` / `V4` / `BotResource` 3 层纯转发壳
+    /// （原 `service.bot().v4().bot().search()` 4 跳 → `service.search_bot()` 1 跳）。
+    /// leaf `SearchBotRequest` API 不变。
     #[cfg(feature = "v4")]
-    /// 访问机器人 API。
-    pub fn bot(&self) -> crate::bot::bot::Bot {
-        crate::bot::bot::Bot::new(self.config.clone())
+    pub fn search_bot(&self) -> crate::bot::bot::v4::bot::search::SearchBotRequest {
+        crate::bot::bot::v4::bot::search::SearchBotRequest::new(self.config.clone())
     }
 }
 


### PR DESCRIPTION
## What

ADR 0001（PR #352，混合方案）**阶段 1 范式验证**——#347 点名、最快验证 5 项判定规则。

bot crate `BotService → Bot → V4 → BotResource` 4 层壳包裹唯一 1 个 API（search），`Bot`/`V4`/`BotResource` **全 0 命中 5 项保留判定 → 砍**。`service.bot().v4().bot().search()` 段名重复 4 跳 → `service.search_bot()` 1 跳。

## 改动

- 删 3 纯转发壳 struct（`Bot`/`V4`/`BotResource`，~72 行），保 `pub mod` 模块树维持 leaf 路径（strict-path 用户零影响）
- `BotService::search_bot()` 直达 `SearchBotRequest`（保留 `#[cfg(feature = "v4")]` 门控）
- **leaf `SearchBotRequest` API 100% 冻结**（ADR 硬约束，未改 search.rs）
- `module_inception` allow 保留（`bot::bot` 重复段名仍在，leaf 路径冻结的代价）

## 验证（CI 三连 + clippy 矩阵，本地预跑）

- `cargo test -p openlark-bot`：6 passed / 0 failed
- clippy 矩阵（default/`--no-default-features`/`--all-features`，全 `-Dwarnings`）干净
- fmt + CI 三连（machete / `cargo doc -D`）全过；workspace build 无回归；Cargo.lock 未变（msrv --locked 不受影响）

## ADR 0001 判定复核

bot 三壳全 0 命中（feature门控/版本路由/路径参数/扇出≥3/真实helper）→ 砍 ✓。本 PR 是 ADR 5 项判定规则的首次实战验证（`BotService` 命中 feature 门控 → 留）。

close #354
