### PR TITLE
refactor(meeting): 砍 chain.rs 7 空壳 + 修文档谎言（#353，ADR 0001 阶段1 重灾区）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+- **openlark-meeting 砍 chain.rs 7 空壳 + 修文档谎言（ADR 0001 阶段1 重灾区）**（#353）：
+  `common/chain.rs` 的 `CalendarClient`/`CalendarV4Client`/`CalendarResourceClient`/`MeetingRoomClient`
+  + `VcRoomResourceClient`/`VcMeetingResourceClient`/`VcReserveResourceClient` 7 个纯转发空壳
+  （承诺资源却零方法——字段暗示 room/meeting/reserve/calendar API 却未接线，真实 builder 经 strict 路径
+  `crate::vc::vc::v1::<resource>::*` / `crate::calendar::*` 访问）全砍。`MeetingClient.calendar`/`.meeting_room`
+  + `VcV1Client.room`/`.meeting`/`.reserve` 字段移除。保留唯一接线的 `VcNoteResourceClient`（get/subscribe/unsubscribe）。
+  修文档谎言：`client.meeting.vc.v1.room.create()`（`VcRoomResourceClient` 空壳无 create）→ 实际可达的 `note.get()`。
+  Config 内部 Arc-wrapped（clone O(1)，非深拷贝），无需改 Arc。**breaking**：移除 pub 字段 + 7 空壳 struct。
+  **迁移**：仓内零外部引用（仅 client/tests.rs 测 note.*，照过）；leaf builder + VcNote API 不变。
+
 - **openlark-bot 删 `Bot`/`V4`/`BotResource` 3 纯转发壳 + `search_bot()` 直达 leaf**（#354，ADR 0001 阶段1）：
   4 层壳包裹唯一 1 个 API（search），`service.bot().v4().bot().search()` 段名重复 4 跳 → `service.search_bot()` 1 跳。
   删 `Bot`/`V4`/`BotResource` struct（保 `pub mod` 模块树维持 leaf 路径）；`BotService` 加 `search_bot()` 直达

--- a/crates/openlark-client/docs/meta-api-style.md
+++ b/crates/openlark-client/docs/meta-api-style.md
@@ -95,9 +95,9 @@ use serde_json::json;
 async fn main() -> Result<()> {
     let client = Client::from_env()?;
 
-    // 会议：字段链式入口（Room 资源提供 Builder）
-    let req = client.meeting.vc.v1.room.create().build();
-    let _resp = req.execute(json!({"name": "demo"})).await?;
+    // 会议：字段链式入口（note 资源已接线；room/meeting/reserve 经 strict 路径访问）
+    let req = client.meeting.vc.v1.note.get("note_id");
+    let _resp = req.execute().await?;
 
     Ok(())
 }

--- a/crates/openlark-client/src/client.rs
+++ b/crates/openlark-client/src/client.rs
@@ -94,7 +94,7 @@ declare_client! {
         feature: "meeting",
         field: meeting,
         ty: openlark_meeting::MeetingClient,
-        doc: "Meeting meta 调用链入口：client.meeting.vc.v1.room.create() ...",
+        doc: "Meeting meta 调用链入口：client.meeting.vc.v1.note.get(...) 等（ADR 0001：room/meeting/reserve 空壳已砍，真实 builder 经 strict 路径）",
         init: |_core_config, _base_core_config| {
             openlark_meeting::MeetingClient::new(_core_config.clone())
         },

--- a/crates/openlark-meeting/src/common/chain.rs
+++ b/crates/openlark-meeting/src/common/chain.rs
@@ -1,110 +1,32 @@
-//! openlark-meeting 链式调用入口（meta 风格）
+//! openlark-meeting 链式调用入口（meta 风格）。
 //!
-//! 说明：
-//! - 本文件放在 `common/` 下，避免被 strict API 校验脚本计入"额外实现文件"。
-//! - 会议模块本身已存在 `service.rs` 的 Builder/Resource 分层，这里提供"字段链式入口"。
-//! - Config 内部已使用 Arc，无需重复包装。
+//! ADR 0001（#353）：砍掉 7 个空壳——`CalendarClient`/`CalendarV4Client`/
+//! `CalendarResourceClient`/`MeetingRoomClient`（承诺资源却零方法）+ `VcRoomResourceClient`/
+//! `VcMeetingResourceClient`/`VcReserveResourceClient`（字段暗示 room/meeting/reserve API
+//! 却未接线，真实 builder 经 strict 路径 `crate::vc::vc::v1::<resource>::*` 访问）。
+//! 保留唯一接线的真实资源 `VcNoteResourceClient`（get/subscribe/unsubscribe）。
+//!
+//! Config 内部 Arc-wrapped，clone O(1)（非深拷贝），无需改 Arc。
 
 use openlark_core::config::Config;
 
-/// 会议链式入口：`meeting.vc.v1.room.create()` 等
+/// 会议链式入口：`client.meeting.vc.v1.note.get()` 等。
 #[derive(Debug, Clone)]
 pub struct MeetingClient {
     config: Config,
-
-    /// 日历客户端入口。
-    #[cfg(feature = "calendar")]
-    pub calendar: CalendarClient,
-
     /// 视频会议客户端入口。
     #[cfg(feature = "vc")]
     pub vc: VcClient,
-
-    /// 会议室客户端入口。
-    #[cfg(feature = "meeting-room")]
-    pub meeting_room: MeetingRoomClient,
 }
 
 impl MeetingClient {
     /// 创建新的实例。
     pub fn new(config: Config) -> Self {
-        let config_cloned = config.clone();
         Self {
-            config: config_cloned,
-            #[cfg(feature = "calendar")]
-            calendar: CalendarClient::new(config.clone()),
+            config: config.clone(),
             #[cfg(feature = "vc")]
-            vc: VcClient::new(config.clone()),
-            #[cfg(feature = "meeting-room")]
-            meeting_room: MeetingRoomClient::new(config),
+            vc: VcClient::new(config),
         }
-    }
-
-    /// 返回配置引用。
-    pub fn config(&self) -> &Config {
-        &self.config
-    }
-}
-
-/// 日历链式调用客户端。
-#[cfg(feature = "calendar")]
-#[derive(Debug, Clone)]
-pub struct CalendarClient {
-    config: Config,
-    /// v4 版本客户端入口。
-    pub v4: CalendarV4Client,
-}
-
-#[cfg(feature = "calendar")]
-impl CalendarClient {
-    fn new(config: Config) -> Self {
-        Self {
-            config: config.clone(),
-            v4: CalendarV4Client::new(config),
-        }
-    }
-
-    /// 返回配置引用。
-    pub fn config(&self) -> &Config {
-        &self.config
-    }
-}
-
-/// 日历 v4 链式调用客户端。
-#[cfg(feature = "calendar")]
-#[derive(Debug, Clone)]
-pub struct CalendarV4Client {
-    config: Config,
-    /// 日历客户端入口。
-    pub calendar: CalendarResourceClient,
-}
-
-#[cfg(feature = "calendar")]
-impl CalendarV4Client {
-    fn new(config: Config) -> Self {
-        Self {
-            config: config.clone(),
-            calendar: CalendarResourceClient::new(config),
-        }
-    }
-
-    /// 返回配置引用。
-    pub fn config(&self) -> &Config {
-        &self.config
-    }
-}
-
-/// 日历资源客户端。
-#[cfg(feature = "calendar")]
-#[derive(Debug, Clone)]
-pub struct CalendarResourceClient {
-    config: Config,
-}
-
-#[cfg(feature = "calendar")]
-impl CalendarResourceClient {
-    fn new(config: Config) -> Self {
-        Self { config }
     }
 
     /// 返回配置引用。
@@ -138,16 +60,13 @@ impl VcClient {
 }
 
 /// 视频会议 v1 链式调用客户端。
+///
+/// 仅 `note` 资源接线（get/subscribe/unsubscribe）；room/meeting/reserve 的真实 builder
+/// 经 strict 路径访问（ADR 0001：不 deepen 空壳）。
 #[cfg(feature = "vc")]
 #[derive(Debug, Clone)]
 pub struct VcV1Client {
     config: Config,
-    /// room 资源入口。
-    pub room: VcRoomResourceClient,
-    /// meeting 资源入口。
-    pub meeting: VcMeetingResourceClient,
-    /// reserve 资源入口。
-    pub reserve: VcReserveResourceClient,
     /// note 资源入口。
     pub note: VcNoteResourceClient,
 }
@@ -157,9 +76,6 @@ impl VcV1Client {
     fn new(config: Config) -> Self {
         Self {
             config: config.clone(),
-            room: VcRoomResourceClient::new(config.clone()),
-            meeting: VcMeetingResourceClient::new(config.clone()),
-            reserve: VcReserveResourceClient::new(config.clone()),
             note: VcNoteResourceClient::new(config),
         }
     }
@@ -170,64 +86,7 @@ impl VcV1Client {
     }
 }
 
-/// 视频会议 room 资源客户端。
-#[cfg(feature = "vc")]
-#[derive(Debug, Clone)]
-pub struct VcRoomResourceClient {
-    config: Config,
-}
-
-#[cfg(feature = "vc")]
-impl VcRoomResourceClient {
-    fn new(config: Config) -> Self {
-        Self { config }
-    }
-
-    /// 返回配置引用。
-    pub fn config(&self) -> &Config {
-        &self.config
-    }
-}
-
-/// 视频会议 meeting 资源客户端。
-#[cfg(feature = "vc")]
-#[derive(Debug, Clone)]
-pub struct VcMeetingResourceClient {
-    config: Config,
-}
-
-#[cfg(feature = "vc")]
-impl VcMeetingResourceClient {
-    fn new(config: Config) -> Self {
-        Self { config }
-    }
-
-    /// 返回配置引用。
-    pub fn config(&self) -> &Config {
-        &self.config
-    }
-}
-
-/// 视频会议 reserve 资源客户端。
-#[cfg(feature = "vc")]
-#[derive(Debug, Clone)]
-pub struct VcReserveResourceClient {
-    config: Config,
-}
-
-#[cfg(feature = "vc")]
-impl VcReserveResourceClient {
-    fn new(config: Config) -> Self {
-        Self { config }
-    }
-
-    /// 返回配置引用。
-    pub fn config(&self) -> &Config {
-        &self.config
-    }
-}
-
-/// 视频会议 note 资源客户端。
+/// 视频会议 note 资源客户端（get/subscribe/unsubscribe）。
 #[cfg(feature = "vc")]
 #[derive(Debug, Clone)]
 pub struct VcNoteResourceClient {
@@ -262,42 +121,11 @@ impl VcNoteResourceClient {
     }
 }
 
-/// 会议室链式调用客户端。
-#[cfg(feature = "meeting-room")]
-#[derive(Debug, Clone)]
-pub struct MeetingRoomClient {
-    config: Config,
-}
-
-#[cfg(feature = "meeting-room")]
-impl MeetingRoomClient {
-    fn new(config: Config) -> Self {
-        Self { config }
-    }
-
-    /// 返回配置引用。
-    pub fn config(&self) -> &Config {
-        &self.config
-    }
-}
-
 #[cfg(test)]
 mod tests {
-
-    use serde_json;
-
     #[test]
     fn test_serialization_roundtrip() {
-        // 基础序列化测试
         let json = r#"{"test": "value"}"#;
         assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
     }
 }

--- a/crates/openlark-meeting/src/lib.rs
+++ b/crates/openlark-meeting/src/lib.rs
@@ -88,20 +88,4 @@ mod tests {
         let client = MeetingClient::new(config);
         let _vc = &client.vc;
     }
-
-    #[cfg(feature = "calendar")]
-    #[test]
-    fn test_meeting_client_calendar() {
-        let config = create_test_config();
-        let client = MeetingClient::new(config);
-        let _calendar = &client.calendar;
-    }
-
-    #[cfg(feature = "meeting-room")]
-    #[test]
-    fn test_meeting_client_meeting_room() {
-        let config = create_test_config();
-        let client = MeetingClient::new(config);
-        let _meeting_room = &client.meeting_room;
-    }
 }


### PR DESCRIPTION
## What

ADR 0001（PR #352）**阶段 1 重灾区**——meeting crate `common/chain.rs` 7 个纯转发空壳砍除。

## 背景

chain.rs 11 个 Client struct 中 7 个是**纯转发空壳**：承诺资源（字段名 room/meeting/reserve/calendar/meeting_room）却零业务方法。真实 builder（vc/v1/room 8 文件、meeting 15、reserve 6；calendar 63）从未被 chain 接线——用户据字段名以为可达，实则只 `note`（VcNoteResourceClient get/subscribe/unsubscribe）接线。

**最严重**：官方文档 `client.meeting.vc.v1.room.create()` 走不通（`VcRoomResourceClient` 空壳无 `create()`）——文档谎言。

## 改动（ADR 0001：砍空壳，不 deepen）

- **砍 7 空壳**：`CalendarClient`/`CalendarV4Client`/`CalendarResourceClient`/`MeetingRoomClient` + `VcRoomResourceClient`/`VcMeetingResourceClient`/`VcReserveResourceClient`
- **移除 pub 字段**：`MeetingClient.calendar`/`.meeting_room`、`VcV1Client.room`/`.meeting`/`.reserve`
- **保留**：`VcNoteResourceClient`（唯一接线真实资源）+ 导航链 `MeetingClient.vc.v1.note`
- **修文档谎言**：`meta-api-style.md` + `client.rs` 的 `room.create()` → 实际可达的 `note.get()`
- **跳过 Config→Arc**：Config 内部 Arc-wrapped（clone O(1)，非深拷贝），leaf 签名又不一致（get: Arc，subscribe/unsubscribe: owned），迁移是零收益 churn（ADR #353 验收的认知修正）
- chain.rs 303 → ~127 行（−176）

## 后果

- `client.meeting.vc.v1.note.get()` 仍可达（VcNote 保留）
- room/meeting/reserve/calendar 真实 builder 改经 **strict 路径**访问（`crate::vc::vc::v1::room::*` / `crate::calendar::*`）——chain 从未接线它们，无功能损失，只是诚实化
- **breaking**：移除 pub 字段 + 7 空壳 struct；仓内零外部引用（client/tests.rs 仅测 note.*）

## 验证（CI 三连 + clippy 矩阵，本地预跑）

- `cargo test`：meeting 264 / client 101 passed，0 failed
- clippy 矩阵（meeting default/`--no-default-features`/`--all-features` + client，全 `-Dwarnings`）干净
- fmt + CI 三连（machete / `cargo doc -D`）全过；workspace build 无回归；Cargo.lock 未变

close #353
