### PR TITLE
refactor(mail): 砍 Mail 域层转发壳 + 统一 v1() accessor（ADR 0001 阶段2）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+- **openlark-mail 砍 `Mail` 域层转发壳 + 统一 v1() accessor（ADR 0001 阶段2）**：
+  `Mail`（mail/mail/mod.rs）纯转发壳（仅 `v1()`，全仓零调用者）砍除。`MailService` 移除 `mail()`（→Mail 壳）
+  + `mailgroup()` 单独快捷（5 资源中仅 1 个有快捷，访问深度不一致），统一为 `v1()` → `MailV1`（mailgroup/
+  public_mailbox/user/user_mailbox/multi_entity 扇出 5）。原 `service.mail().v1().mailgroup()` /
+  `service.mailgroup()` → `service.v1().mailgroup()`。**breaking**：移除 pub `Mail` + `mail()`/`mailgroup()`
+  accessor。**迁移**：仓内零外部引用；`MailV1` + leaf builder API 不变。
+
 - **openlark-meeting 砍 chain.rs 7 空壳 + 修文档谎言（ADR 0001 阶段1 重灾区）**（#353）：
   `common/chain.rs` 的 `CalendarClient`/`CalendarV4Client`/`CalendarResourceClient`/`MeetingRoomClient`
   + `VcRoomResourceClient`/`VcMeetingResourceClient`/`VcReserveResourceClient` 7 个纯转发空壳

--- a/crates/openlark-mail/src/lib.rs
+++ b/crates/openlark-mail/src/lib.rs
@@ -25,6 +25,7 @@
 //!
 //! // 创建邮件组
 //! let result = mail_service
+//!     .v1()
 //!     .mailgroup()
 //!     .create()
 //!     .mail_group_id("team@example.com")

--- a/crates/openlark-mail/src/mail/mail/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/mod.rs
@@ -1,45 +1,4 @@
-//! Mail API 模块
+//! Mail API 模块（ADR 0001：Mail 域层转发壳已砍，仅保留 v1 模块树）。
 
 /// Mail v1 模块。
 pub mod v1;
-
-use openlark_core::config::Config;
-use std::sync::Arc;
-
-/// Mail API 入口
-#[derive(Clone)]
-pub struct Mail {
-    config: Arc<Config>,
-}
-
-impl Mail {
-    /// 创建新的 Mail API 入口。
-    pub fn new(config: Arc<Config>) -> Self {
-        Self { config }
-    }
-
-    /// 访问 v1 版本 API
-    pub fn v1(&self) -> v1::MailV1 {
-        v1::MailV1::new(self.config.clone())
-    }
-}
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-mail/src/service.rs
+++ b/crates/openlark-mail/src/service.rs
@@ -19,16 +19,14 @@ impl MailService {
         }
     }
 
+    /// 访问 v1 邮件 API（mailgroup / public_mailbox / user / user_mailbox / multi_entity）。
+    ///
+    /// ADR 0001：消除 `Mail` 域层转发壳 + 单独 `mailgroup()` 快捷（深度不一致），
+    /// 统一经 `v1()` 到 `MailV1` 扇出层。原 `service.mail().v1().mailgroup()` /
+    /// `service.mailgroup()` → `service.v1().mailgroup()`。
     #[cfg(feature = "v1")]
-    /// 访问邮件 API。
-    pub fn mail(&self) -> crate::mail::mail::Mail {
-        crate::mail::mail::Mail::new(self.config.clone())
-    }
-
-    #[cfg(feature = "v1")]
-    /// 访问邮件组 API。
-    pub fn mailgroup(&self) -> crate::mail::mail::v1::mailgroup::MailGroup {
-        crate::mail::mail::v1::mailgroup::MailGroup::new(self.config.clone())
+    pub fn v1(&self) -> crate::mail::mail::v1::MailV1 {
+        crate::mail::mail::v1::MailV1::new(self.config.clone())
     }
 }
 


### PR DESCRIPTION
## What

ADR 0001（PR #352）**阶段 2 死壳清理**——mail crate `Mail` 域层转发壳砍除。

## 改动

`Mail`（mail/mail/mod.rs，纯转发壳：仅 `v1()`，全仓零调用者）**0 命中 5 项判定 → 砍**。

`MailService` 统一 accessor：
- 移除 `mail()`（→ Mail 壳，冗余）
- 移除 `mailgroup()`（5 资源中仅此 1 个有快捷，访问深度不一致——违 ADR「统一」原则）
- 新增 `v1()` → `MailV1`（mailgroup/public_mailbox/user/user_mailbox/multi_entity 扇出 5）

原 `service.mail().v1().mailgroup()` / `service.mailgroup()` → **`service.v1().mailgroup()`**（统一深度）。

## 验证（CI 三连 + clippy 矩阵，本地预跑）

- `cargo test -p openlark-mail`：214 passed / 0 failed（含 doctest 修复）
- clippy 矩阵（default/`--no-default-features`/`--all-features`，全 `-Dwarnings`）干净
- fmt + CI 三连（machete / `cargo doc -D`）全过；workspace build 无回归；Cargo.lock 未变

## ADR 判定

Mail 域层 0 命中 → 砍 ✓；MailV1 扇出 5（命中(4)）→ 留 ✓；leaf builder API 不变。「全关」快捷策略（统一经 v1()）。

close ADR 0001 阶段2 mail 项
