### PR TITLE
refactor(helpdesk): 砍 Helpdesk 域层转发壳 + 统一 v1() accessor（ADR 0001 阶段2）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+- **openlark-helpdesk 砍 `Helpdesk` 域层转发壳 + 统一 v1() accessor（ADR 0001 阶段2）**：
+  `Helpdesk`（helpdesk/helpdesk/mod.rs）纯转发壳（仅 `v1()`，全仓零调用者）砍除。`HelpdeskService` 移除
+  `helpdesk()`（→Helpdesk 壳）+ `ticket()` 单独快捷（11 资源中仅 1 个有快捷，访问深度不一致），统一为
+  `v1()` → `HelpdeskV1`（ticket/agent/category/faq 等 11 资源扇出）。原 `service.helpdesk().v1().ticket()` /
+  `service.ticket()` → `service.v1().ticket()`。**breaking**：移除 pub `Helpdesk` + `helpdesk()`/`ticket()`
+  accessor。**迁移**：仓内零外部引用；`HelpdeskV1` + leaf builder API 不变。
+
 - **openlark-mail 砍 `Mail` 域层转发壳 + 统一 v1() accessor（ADR 0001 阶段2）**：
   `Mail`（mail/mail/mod.rs）纯转发壳（仅 `v1()`，全仓零调用者）砍除。`MailService` 移除 `mail()`（→Mail 壳）
   + `mailgroup()` 单独快捷（5 资源中仅 1 个有快捷，访问深度不一致），统一为 `v1()` → `MailV1`（mailgroup/

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/mod.rs
@@ -1,45 +1,4 @@
-//! Helpdesk API 模块
+//! Helpdesk API 模块（ADR 0001：Helpdesk 域层转发壳已砍，仅保留 v1 模块树）。
 
 /// Helpdesk v1 模块。
 pub mod v1;
-
-use openlark_core::config::Config;
-use std::sync::Arc;
-
-/// Helpdesk API 入口
-#[derive(Clone)]
-pub struct Helpdesk {
-    config: Arc<Config>,
-}
-
-impl Helpdesk {
-    /// 创建新的 Helpdesk API 入口。
-    pub fn new(config: Arc<Config>) -> Self {
-        Self { config }
-    }
-
-    /// 访问 v1 版本 API
-    pub fn v1(&self) -> v1::HelpdeskV1 {
-        v1::HelpdeskV1::new(self.config.clone())
-    }
-}
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-helpdesk/src/service.rs
+++ b/crates/openlark-helpdesk/src/service.rs
@@ -16,16 +16,14 @@ impl HelpdeskService {
         }
     }
 
-    /// 访问帮助台 API。
+    /// 访问 v1 帮助台 API（ticket / agent / category / faq 等 11 资源扇出）。
+    ///
+    /// ADR 0001：消除 `Helpdesk` 域层转发壳 + 单独 `ticket()` 快捷（11 资源中仅 1 个有快捷，
+    /// 深度不一致），统一经 `v1()` 到 `HelpdeskV1` 扇出层。
+    /// 原 `service.helpdesk().v1().ticket()` / `service.ticket()` → `service.v1().ticket()`。
     #[cfg(feature = "v1")]
-    pub fn helpdesk(&self) -> crate::helpdesk::helpdesk::Helpdesk {
-        crate::helpdesk::helpdesk::Helpdesk::new(self._config.clone())
-    }
-
-    /// 访问工单 API。
-    #[cfg(feature = "v1")]
-    pub fn ticket(&self) -> crate::helpdesk::helpdesk::v1::ticket::Ticket {
-        crate::helpdesk::helpdesk::v1::ticket::Ticket::new(self._config.clone())
+    pub fn v1(&self) -> crate::helpdesk::helpdesk::v1::HelpdeskV1 {
+        crate::helpdesk::helpdesk::v1::HelpdeskV1::new(self._config.clone())
     }
 }
 


### PR DESCRIPTION
## What

ADR 0001 **阶段 2 死壳清理**——helpdesk crate `Helpdesk` 域层转发壳砍除（同 mail 模式）。

## 改动

`Helpdesk`（纯转发壳：仅 `v1()`，全仓零调用者）**0 命中 5 项判定 → 砍**。

`HelpdeskService` 统一 accessor：
- 移除 `helpdesk()`（→ Helpdesk 壳，冗余）
- 移除 `ticket()`（11 资源中仅此 1 个有快捷，深度不一致）
- 新增 `v1()` → `HelpdeskV1`（ticket/agent/category/faq/notification/event/bot 等 11 资源扇出）

原 `service.helpdesk().v1().ticket()` / `service.ticket()` → **`service.v1().ticket()`**。

## 验证（CI 三连 + clippy 矩阵，本地预跑）

- `cargo test -p openlark-helpdesk`：164 passed / 0 failed
- clippy 矩阵（default/`--no-default-features`/`--all-features`，全 `-Dwarnings`）干净
- fmt + CI 三连（machete / `cargo doc -D`）全过；workspace build 无回归；Cargo.lock 未变

## ADR 判定

Helpdesk 域层 0 命中 → 砍 ✓；HelpdeskV1 扇出 11（命中(4)）→ 留 ✓；leaf builder API 不变。

close ADR 0001 阶段2 helpdesk 项
