### PR TITLE
refactor(analytics): 砍 Search/SearchV2/search() deprecated 死链（ADR 0001 阶段2 扁平收口）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+- **openlark-analytics 删 deprecated `Search`/`SearchV2`/`search()` 死链（ADR 0001 阶段2 扁平收口）**：
+  `AnalyticsService::search()` → `Search` → `SearchV2` 三层 `Arc<Config>` 纯转发死胡同（`SearchV2` 仅持 `_config`
+  无任何 accessor；真实 search API 经直路径 `crate::search::search::v2::<resource>::XxxRequest::new(Arc<Config>)`
+  访问）。收口为方案 B 扁平：删 pub `Search`/`SearchV2` struct + `AnalyticsService::search()` accessor（#308 已铺
+  `#[deprecated]`，本次落地删除）。**breaking**：移除 pub `Search`/`SearchV2` + `search()`。**迁移**：仓内零外部引用
+  （client/tests.rs 的 `.search()` 属 workflow tasklist，非本 crate）；`v2::*` leaf builder API 与模块树不变。
+
 - **openlark-helpdesk 砍 `Helpdesk` 域层转发壳 + 统一 v1() accessor（ADR 0001 阶段2）**：
   `Helpdesk`（helpdesk/helpdesk/mod.rs）纯转发壳（仅 `v1()`，全仓零调用者）砍除。`HelpdeskService` 移除
   `helpdesk()`（→Helpdesk 壳）+ `ticket()` 单独快捷（11 资源中仅 1 个有快捷，访问深度不一致），统一为

--- a/crates/openlark-analytics/src/search/search/mod.rs
+++ b/crates/openlark-analytics/src/search/search/mod.rs
@@ -2,32 +2,6 @@
 
 pub mod v2;
 
-use openlark_core::config::Config;
-use std::sync::Arc;
-
-/// Search API 入口
-#[deprecated(
-    note = "analytics Search 导航死胡同；直接用 v2 子模块的 XxxRequest::new(Arc<Config>)，如 crate::search::search::v2::query::SearchRequest / v2::user::SearchUserRequest"
-)]
-#[derive(Clone)]
-pub struct Search {
-    config: Arc<Config>,
-}
-
-#[allow(deprecated)]
-impl Search {
-    /// 创建新的 Search API 入口。
-    pub fn new(config: Arc<Config>) -> Self {
-        Self { config }
-    }
-
-    /// 访问 v2 版本搜索 API。
-    #[allow(deprecated)]
-    pub fn v2(&self) -> v2::SearchV2 {
-        v2::SearchV2::new(self.config.clone())
-    }
-}
-
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {

--- a/crates/openlark-analytics/src/search/search/v2.rs
+++ b/crates/openlark-analytics/src/search/search/v2.rs
@@ -1,27 +1,7 @@
 //! 搜索服务 V2 API
 //!
-//! 提供搜索服务 V2 版本的 API 访问
-
-use crate::AnalyticsConfig;
-use std::sync::Arc;
-
-/// 搜索服务 V2 API
-#[deprecated(
-    note = "SearchV2 导航壳；直接用其子模块的 XxxRequest::new(Arc<Config>)，如 query::SearchRequest / user::SearchUserRequest / data_source::* / app::* / doc_wiki / schema / message"
-)]
-#[derive(Debug, Clone)]
-pub struct SearchV2 {
-    // reserved：query()/user() deprecated 存根移除后无读取者（analytics search 导航缺口，后续补访问器）
-    _config: Arc<AnalyticsConfig>,
-}
-
-#[allow(deprecated)]
-impl SearchV2 {
-    /// 创建新的搜索服务 V2 实例
-    pub fn new(config: Arc<AnalyticsConfig>) -> Self {
-        Self { _config: config }
-    }
-}
+//! 提供搜索服务 V2 版本的 API 访问（ADR 0001：扁平收口，无 `SearchV2` 导航壳；
+//! 各资源经 `crate::search::search::v2::<resource>::XxxRequest::new(Arc<Config>)` 直路径访问）。
 
 pub mod app;
 pub mod data_source;

--- a/crates/openlark-analytics/src/service.rs
+++ b/crates/openlark-analytics/src/service.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 /// 数据分析服务
 ///
-/// 提供搜索、数据分析等功能的统一入口。
+/// 数据分析服务的统一入口（search API 经 `crate::search::search::v2::*` 直路径访问，ADR 0001 扁平收口）。
 #[derive(Debug, Clone)]
 pub struct AnalyticsService {
     /// 客户端配置
@@ -34,18 +34,6 @@ impl AnalyticsService {
     /// 获取客户端配置
     pub fn config(&self) -> Arc<AnalyticsConfig> {
         self.config.clone()
-    }
-
-    /// 搜索服务
-    ///
-    /// 提供全文搜索、智能搜索等功能。
-    #[deprecated(
-        note = "search() 导航死胡同；直接用 crate::search::search::v2 子模块的 XxxRequest::new(config)，如 v2::query::SearchRequest / v2::user::SearchUserRequest"
-    )]
-    #[cfg(feature = "search")]
-    #[allow(deprecated)]
-    pub fn search(&self) -> crate::search::search::Search {
-        crate::search::search::Search::new(self.config.clone())
     }
 }
 


### PR DESCRIPTION
## 背景

ADR 0001 阶段2 项5：analytics crate 的 `Search`/`SearchV2`/`search()` 是三层 `Arc<Config>` 纯转发死胡同。#308 已为它们铺 `#[deprecated]`，本 PR 在 v0.18 breaking 窗口落地删除，正式收口为方案 B 扁平。

## 死链结构（已核实）

```
AnalyticsService::search()  →  Search  →  SearchV2 (仅持 _config，零 accessor)
```

`SearchV2` 无任何业务方法，真实 search API 早已经直路径访问：

```rust
crate::search::search::v2::query::SearchRequest::new(Arc<Config>)
crate::search::search::v2::data_source::get::GetDataSourceRequest::new(Arc<Config>, id)
```

## 改动（+10/−61，4 文件）

- `service.rs`：删 `AnalyticsService::search()`（+ deprecated/cfg/allow）；struct doc 改为不再承诺 search 入口
- `search/search/mod.rs`：删 `Search` struct + impl（保 `pub mod v2;`）
- `search/search/v2.rs`：删 `SearchV2` struct + impl（保 7 个 `pub mod` 真实 leaf 资源）
- `CHANGELOG.md`：Breaking Changes 顶部加 analytics 条目

## ADR 硬约束遵守

- ✅ leaf builder API 100% 冻结（`v2::*::XxxRequest` 全不动）
- ✅ 模块树不重组（`search::search::v2::*` 路径保留；`#![allow(clippy::module_inception)]` 保留）
- ✅ 只裁壳、不动 leaf

## 迁移

仓内零外部引用（`client/tests.rs` 的 `.search()` 属 workflow tasklist，非本 crate）。blast radius 仅限「走 `service.search()` 深链」的调用方——已确认零调用者。

## 验证

- `cargo fmt --check` ✅
- `cargo build -p openlark-analytics --all-features` / `--no-default-features` ✅
- `cargo clippy -p openlark-analytics --all-targets --all-features -- -Dwarnings` ✅
- `cargo clippy -p openlark-analytics --all-targets --no-default-features -- -Dwarnings` ✅
- `cargo test -p openlark-analytics --all-features`（10 passed + 1 doctest）✅
- CI 三元组：`cargo machete`（无 unused dep）/ `cargo doc -Dwarnings`（无 intra-doc 死链）✅
- `cargo build -p openlark-client --all-features`（facade 转发层）✅

ref: ADR 0001 阶段2 项5；closes #308