### PR TITLE
refactor(user): 砍 PersonalSettingsResource 中间层 + 修 UserService::new 误导签名（ADR 0001 阶段2）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+- **openlark-user 砍 `PersonalSettingsResource` 中间层 + 修 `UserService::new` 误导签名（ADR 0001 阶段2）**：
+  `PersonalSettingsResource`（personal_settings/mod.rs）是 1:1 单转发壳（仅 `system_status()` 一子资源，
+  全仓零调用者）砍除；`UserService` 新增 `system_status()` 直达 `SystemStatusResource`（7 个真实构建器）。
+  原 `service.personal_settings().system_status().list()` → `service.system_status().list()`。
+  同时修 `UserService::new` 误导签名：签名 `SDKResult<Self>` 但函数体永远 `Ok(...)`（#350 P9 接口撒谎）→
+  改为 `Self`（非 Result）。**breaking**：移除 pub `PersonalSettingsResource` + `personal_settings()` accessor；
+  `UserService::new` 返回类型 `SDKResult<Self>` → `Self`。**迁移**：仓内仅 `openlark-client` facade
+  （`UserClient::new(...)?` → 去 `?`）+ 本 crate doctest/test 受影响；`SystemStatusResource` + 7 leaf builder 不变。
+
 - **openlark-analytics 删 deprecated `Search`/`SearchV2`/`search()` 死链（ADR 0001 阶段2 扁平收口）**：
   `AnalyticsService::search()` → `Search` → `SearchV2` 三层 `Arc<Config>` 纯转发死胡同（`SearchV2` 仅持 `_config`
   无任何 accessor；真实 search API 经直路径 `crate::search::search::v2::<resource>::XxxRequest::new(Arc<Config>)`

--- a/crates/openlark-client/src/client.rs
+++ b/crates/openlark-client/src/client.rs
@@ -166,9 +166,9 @@ declare_client! {
         feature: "user",
         field: user,
         ty: crate::UserClient,
-        doc: "User meta 调用链入口：client.user.setting... ...",
+        doc: "User meta 调用链入口：client.user.system_status... ...",
         init: |_core_config, _base_core_config| {
-            crate::UserClient::new(_core_config.clone())?
+            crate::UserClient::new(_core_config.clone())
         },
     },
     {

--- a/crates/openlark-user/src/lib.rs
+++ b/crates/openlark-user/src/lib.rs
@@ -9,7 +9,7 @@
 //! ## 模块组织
 //!
 //! 本模块按功能域组织：
-//! - `personal_settings` - 个人设置 system_status API（门面 `UserService::personal_settings()` 收敛）
+//! - `personal_settings` - 个人设置 system_status API（`UserService::system_status()` 直达）
 //!
 //! ## 使用示例
 //!
@@ -22,10 +22,10 @@
 //!     .app_secret("app_secret")
 //!     .build();
 //!
-//! let user_service = UserService::new(config).unwrap();
+//! let user_service = UserService::new(config);
 //!
-//! // 经门面 accessor 获取个人设置服务（system_status 7 个真实构建器）
-//! let system_status = user_service.personal_settings().system_status();
+//! // 经 system_status() 直达（7 个真实构建器）
+//! let system_status = user_service.system_status();
 //! let _list_req = system_status.list();
 //! ```
 

--- a/crates/openlark-user/src/personal_settings/mod.rs
+++ b/crates/openlark-user/src/personal_settings/mod.rs
@@ -1,8 +1,8 @@
 //! Personal Settings 模块
 //!
-//! 门面 `PersonalSettingsResource` 是 `UserService::personal_settings()` 返回的薄 resource，
-//! 收敛 system_status 等真实请求构建器，缩短调用路径（避免写
-//! `personal_settings::personal_settings::v1::system_status::*` 三重嵌套模块全路径）。
+//! `SystemStatusResource` 由 `UserService::system_status()` 直接返回（ADR 0001：砍
+//! `PersonalSettingsResource` 单转发中间层），收敛 system_status 7 个真实请求构建器，
+//! 避免写 `personal_settings::personal_settings::v1::system_status::*` 三重嵌套模块全路径。
 
 pub mod personal_settings;
 
@@ -14,32 +14,6 @@ use crate::personal_settings::personal_settings::v1::system_status::{
     create::SystemStatusCreateRequest, delete::SystemStatusDeleteRequest,
     get::SystemStatusGetRequest, list::SystemStatusListRequest, patch::SystemStatusPatchRequest,
 };
-
-/// 个人设置资源（门面 accessor 返回的薄 resource）。
-///
-/// 经 `UserService::personal_settings()` 获得，提供 system_status 资源入口。
-#[derive(Debug, Clone)]
-pub struct PersonalSettingsResource {
-    /// 客户端配置
-    config: Arc<Config>,
-}
-
-impl PersonalSettingsResource {
-    /// 创建新的个人设置资源实例。
-    pub fn new(config: Arc<Config>) -> Self {
-        Self { config }
-    }
-
-    /// 获取客户端配置。
-    pub fn config(&self) -> Arc<Config> {
-        self.config.clone()
-    }
-
-    /// system_status 资源入口（7 个真实请求构建器）。
-    pub fn system_status(&self) -> SystemStatusResource {
-        SystemStatusResource::new(self.config.clone())
-    }
-}
 
 /// system_status 资源（7 个真实请求构建器）。
 #[derive(Debug, Clone)]

--- a/crates/openlark-user/src/service.rs
+++ b/crates/openlark-user/src/service.rs
@@ -3,12 +3,12 @@
 //! 提供用户设置相关的服务入口
 
 use crate::UserConfig;
-use openlark_core::SDKResult;
 use std::sync::Arc;
 
 /// 用户设置服务
 ///
-/// 提供个人设置（system_status 等）功能的统一入口。
+/// 提供个人设置（system_status）功能的统一入口（ADR 0001：砍 `PersonalSettingsResource`
+/// 单转发中间层，`system_status()` 直达 7 个真实构建器）。
 #[derive(Debug, Clone)]
 pub struct UserService {
     /// 客户端配置
@@ -21,14 +21,10 @@ impl UserService {
     /// # 参数
     ///
     /// * `config` - 用户设置服务配置
-    ///
-    /// # 返回
-    ///
-    /// 返回用户设置服务实例或错误
-    pub fn new(config: UserConfig) -> SDKResult<Self> {
-        Ok(Self {
+    pub fn new(config: UserConfig) -> Self {
+        Self {
             config: Arc::new(config),
-        })
+        }
     }
 
     /// 获取客户端配置。
@@ -36,12 +32,13 @@ impl UserService {
         self.config.clone()
     }
 
-    /// 个人设置（system_status 等真实 API 入口）。
+    /// system_status 资源入口（7 个真实请求构建器）。
     ///
-    /// 收敛 system_status 资源的真实请求构建器，避免三重嵌套模块全路径
-    /// （`personal_settings::personal_settings::v1::system_status::*`）。
-    pub fn personal_settings(&self) -> crate::personal_settings::PersonalSettingsResource {
-        crate::personal_settings::PersonalSettingsResource::new(self.config.clone())
+    /// 直达 `SystemStatusResource`（list / get / create / patch / delete / batch_open /
+    /// batch_close），消除原 `service.personal_settings().system_status()` 中
+    /// `PersonalSettingsResource` 单转发中间层。
+    pub fn system_status(&self) -> crate::personal_settings::SystemStatusResource {
+        crate::personal_settings::SystemStatusResource::new(self.config.clone())
     }
 }
 
@@ -57,7 +54,6 @@ mod tests {
             .app_secret("test_app_secret")
             .build();
 
-        let service = UserService::new(config);
-        assert!(service.is_ok());
+        let _service = UserService::new(config);
     }
 }

--- a/crates/openlark-user/tests/user_contract_models.rs
+++ b/crates/openlark-user/tests/user_contract_models.rs
@@ -2,7 +2,7 @@
 //!
 //! Tests cover:
 //! - `common::UserSetting` / `UserPreference` — core data models
-//! - UserService / PersonalSettingsResource / SystemStatusResource — service access
+//! - UserService / SystemStatusResource — service access
 //! - Version contract
 
 use openlark_user::common::{UserPreference, UserSetting};
@@ -169,8 +169,7 @@ fn user_service_creation_contract() {
         .app_secret("test_secret")
         .build();
 
-    let service = UserService::new(config);
-    assert!(service.is_ok());
+    let _service = UserService::new(config);
 }
 
 #[test]
@@ -183,17 +182,17 @@ fn user_service_config_roundtrip() {
         .app_secret("secret_value")
         .build();
 
-    let service = UserService::new(config).unwrap();
+    let service = UserService::new(config);
     let config_arc = service.config();
     assert_eq!(config_arc.app_id(), "cli_config_test");
 }
 
 // ---------------------------------------------------------------------------
-// Personal settings service access (system_status facade accessor)
+// system_status service access (direct accessor)
 // ---------------------------------------------------------------------------
 
 #[test]
-fn personal_settings_service_access_contract() {
+fn system_status_service_access_contract() {
     use openlark_core::config::Config;
     use openlark_user::UserService;
 
@@ -201,14 +200,13 @@ fn personal_settings_service_access_contract() {
         .app_id("cli_ps_test")
         .app_secret("secret")
         .build();
-    let service = UserService::new(config).unwrap();
+    let service = UserService::new(config);
 
-    // 门面 accessor 缩短 system_status 路径
-    let ps = service.personal_settings();
-    assert_eq!(ps.config().app_id(), "cli_ps_test");
+    // service config 可达
+    assert_eq!(service.config().app_id(), "cli_ps_test");
 
-    // system_status 资源 7 个真实构建器可达
-    let system_status = ps.system_status();
+    // system_status() 直达（7 个真实构建器）
+    let system_status = service.system_status();
     let _list = system_status.list();
     let _get = system_status.get();
     let _create = system_status.create();


### PR DESCRIPTION
## 背景

ADR 0001 阶段2 项6：user crate 的 `PersonalSettingsResource` 是 1:1 单转发壳（仅 `system_status()` 一子资源），且 `UserService::new` 返回 `SDKResult<Self>` 但函数体永远 `Ok(...)`——签名撒谎（#350 P9 子项）。

## 改动（+40/−63，6 文件）

**砍中间层**（5 项判定 `PersonalSettingsResource` 0 命中 → 砍；`SystemStatusResource` 7 builder 命中 #5 → 留）：

- `service.rs`：`personal_settings()` → `system_status()` 直达 `SystemStatusResource`
- `personal_settings/mod.rs`：删 `PersonalSettingsResource` struct + impl（保 `SystemStatusResource` + 内 `pub mod`）

原 `service.personal_settings().system_status().list()` → `service.system_status().list()`。

**修误导签名**（#350 P9）：

- `UserService::new(config) -> SDKResult<Self>`（永远 `Ok`）→ `-> Self`

**连带**：

- `openlark-client/src/client.rs`：facade `UserClient::new(...)?` → 去 `?`（与 helpdesk/mail 一致）
- `lib.rs` doctest + `tests/user_contract_models.rs`：去 `.unwrap()`、`personal_settings()` → `system_status()`，重命名 `personal_settings_service_access_contract` → `system_status_service_access_contract`

## ADR 硬约束遵守

- ✅ leaf builder API 100% 冻结（7 个 system_status `*Request` 全不动）
- ✅ 模块树不重组（`personal_settings::personal_settings::v1::system_status::*` 路径保留）

## 迁移

`PersonalSettingsResource` + `personal_settings()` 全仓零外部引用；`UserService::new` 签名变更仅影响 `openlark-client` facade + 本 crate 测试/doctest（均已改）。

## 验证

- `cargo fmt --check` ✅
- `cargo clippy -p openlark-user --all-targets --all-features -- -Dwarnings` ✅
- `cargo clippy -p openlark-user --all-targets --no-default-features -- -Dwarnings` ✅
- `cargo test -p openlark-user --all-features`（10 passed + 1 doctest）✅
- `cargo clippy -p openlark-client --all-features -- -Dwarnings`（facade）✅
- CI 三元组：`cargo machete`（无 unused dep）/ `cargo doc -Dwarnings`（无 intra-doc 死链）✅

ref: ADR 0001 阶段2 项6；refs #350