### PR TITLE
docs(platform): mdm/tenant/trust_party 宣布 flat-by-design（ADR 0001 阶段2 facade 缺口收口）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **platform `mdm`/`tenant`/`trust_party` 宣布 flat-by-design（ADR 0001 阶段2 facade 缺口收口）**：
+  这 3 个域叶子 `new(Config)` 无路径参数（对照 spark `SparkAppService.patch(app_id)` 路径参数绑定，ADR
+  判定 #3），加 Service 层会是纯转发 shell（反 ADR）。照 analytics 裁决宣布 flat：直路径访问
+  （`crate::mdm::v1::*` 等），`PlatformService` 故意不暴露 accessor。lib.rs 模块文档补齐 7 域清单
+  （原仅列 4 域）+ 3 域 mod.rs 加 flat-by-design 说明。**非 breaking**：纯文档，无 API 变更。
+
 - **auth `AuthTokenProvider` 手搓 HTTP 改委托 Transport-based RequestBuilder**（#309）：
   `fetch_token_via_http`（绕过 `Transport` 直接 `config.http_client().post()` 手搓 reqwest + 手解析
   code/msg/token）改为委托 4 个既有 RequestBuilder（AppAccessTokenInternal/AppAccessToken/

--- a/crates/openlark-platform/src/lib.rs
+++ b/crates/openlark-platform/src/lib.rs
@@ -10,11 +10,11 @@
 //!
 //! ## 模块组织
 //!
-//! 本模块按业务域（bizTag）组织：
-//! - `app_engine` - 应用引擎相关 API (37 APIs)
-//! - `directory` - 目录服务相关 API (21 APIs)
-//! - `admin` - 系统管理相关 API (14 APIs)
-//! - `spark` - 妙搭平台相关 API (1 API)
+//! 本模块按业务域（bizTag）组织，分两类入口（ADR 0001）：
+//! - **Service accessor 入口**（含路径参数绑定层，经 `PlatformService::xxx()`）：
+//!   `app_engine`（37 APIs）、`directory`（21 APIs）、`admin`（14 APIs）、`spark`（1 API）
+//! - **flat-by-design 直路径**（叶子 `new(Config)` 无路径参数，无 Service 壳，同 analytics 裁决）：
+//!   `mdm`、`tenant`、`trust_party`
 //!
 //! ## 使用示例
 //!
@@ -53,6 +53,7 @@ pub mod directory;
 #[cfg(feature = "admin")]
 pub mod admin;
 
+// flat-by-design 域（无 Service 壳，直路径访问，ADR 0001）
 #[cfg(feature = "mdm")]
 pub mod mdm;
 

--- a/crates/openlark-platform/src/mdm/mod.rs
+++ b/crates/openlark-platform/src/mdm/mod.rs
@@ -1,6 +1,8 @@
-//! 主数据管理模块
+//! 主数据管理模块（flat-by-design，ADR 0001）。
 //!
-//! 提供主数据管理相关 API
+//! 叶子 `new(Config)` 无路径参数 → 直路径访问（`crate::mdm::v1::*` / `crate::mdm::v3::*`），
+//! 无 Service 壳。Service 层会是纯转发 shell（反 ADR），同 analytics 裁决；
+//! `PlatformService` 故意不暴露 `mdm()` accessor。
 
 pub mod v1;
 pub mod v3;

--- a/crates/openlark-platform/src/tenant/mod.rs
+++ b/crates/openlark-platform/src/tenant/mod.rs
@@ -1,3 +1,6 @@
-//! 租户服务模块
+//! 租户服务模块（flat-by-design，ADR 0001）。
+//!
+//! 叶子 `new(Config)` 无路径参数 → 直路径访问（`crate::tenant::v2::*`），无 Service 壳
+//! （同 analytics / mdm 裁决）。`PlatformService` 故意不暴露 `tenant()` accessor。
 
 pub mod v2;

--- a/crates/openlark-platform/src/trust_party/mod.rs
+++ b/crates/openlark-platform/src/trust_party/mod.rs
@@ -1,3 +1,6 @@
-//! 关联组织模块
+//! 关联组织模块（flat-by-design，ADR 0001）。
+//!
+//! 叶子 `new(Config)` 无路径参数 → 直路径访问（`crate::trust_party::v1::*`），无 Service 壳
+//! （同 analytics / mdm 裁决）。`PlatformService` 故意不暴露 `trust_party()` accessor。
 
 pub mod v1;


### PR DESCRIPTION
## 背景

ADR 0001 阶段2 platform facade 缺口：`lib.rs` 暴露 `mdm`/`tenant`/`trust_party` 但 `PlatformService` 无对应 accessor。

## 调查发现（为何不加 accessor）

核实这 3 个域的叶子构造器：

\`\`\`
mdm/v1/user_auth_data_relation/bind.rs:25         pub fn new(config: Config) -> Self
trust_party/v1/collaboration_tenant/get.rs:24     pub fn new(config: Config) -> Self
tenant/v2/tenant/product_assign_info/query.rs:25  pub fn new(config: Config) -> Self
\`\`\`

叶子 \`new(Config)\` **无路径参数**——对照 spark \`SparkAppService.patch(app_id: impl Into<String>)\`（路径参数绑定，ADR 判定 #3），这 3 个域加 Service 层会是**纯转发 shell**（反 ADR 0001 核心立场）。

## 决策（user-approved）

照 analytics 裁决宣布 **flat-by-design**：直路径访问 \`crate::mdm::v1::*\` 等，\`PlatformService\` 故意不暴露 accessor。不加 shell。

## 改动（+24/−9，5 文件，纯文档）

- \`lib.rs\` 模块文档补齐 7 域清单（原仅列 app_engine/directory/admin/spark 4 域），分两类入口说明
- \`lib.rs\` \`pub mod\` 块加 flat-by-design 分组注释（mdm/tenant/trust_party 本就连续，未 reorder）
- \`mdm/mod.rs\` / \`tenant/mod.rs\` / \`trust_party/mod.rs\`：扩 doc 声明 flat-by-design + 直路径示例
- \`CHANGELOG.md\`：\`### Changed\` 加条目（非 breaking）

## 非范围

- 4 个 inception 折叠（spark/spark、admin/admin、directory/directory、app_engine/apaas）→ **另案 PR**（user-approved 拆分；涉及模块树重组 + ~9 路径 rewiring，独立评审）

## 验证

- \`cargo fmt --check\` ✅
- \`cargo clippy -p openlark-platform --all-targets --all-features -- -Dwarnings\` ✅
- \`cargo doc -p openlark-platform --all-features -Dwarnings\`（模块文档渲染）✅

ref: ADR 0001 阶段2 platform facade 缺口