### PR TITLE
feat(application): v1/app 补齐 4 个声明却未接线的端点（ADR 0001 阶段4）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **application v1/app 补齐 4 个声明却未接线的端点（ADR 0001 阶段4）**：
+  `application/application/v1/app/mod.rs` 声明了 `create`/`delete`/`list`/`patch` 4 个 `pub mod`
+  （leaf builder 已存在）但 `App` struct 只暴露 `get()`。补 `App::create()`/`delete()`/`list()`/`patch()`
+  accessor，对齐 `get()` 形态（`new(Arc<Config>)`）。**非 breaking**：纯 additive accessor，leaf 不变。
+
 - **platform `mdm`/`tenant`/`trust_party` 宣布 flat-by-design（ADR 0001 阶段2 facade 缺口收口）**：
   这 3 个域叶子 `new(Config)` 无路径参数（对照 spark `SparkAppService.patch(app_id)` 路径参数绑定，ADR
   判定 #3），加 Service 层会是纯转发 shell（反 ADR）。照 analytics 裁决宣布 flat：直路径访问

--- a/crates/openlark-application/src/application/application/v1/app/mod.rs
+++ b/crates/openlark-application/src/application/application/v1/app/mod.rs
@@ -21,6 +21,26 @@ impl App {
     pub fn get(&self) -> get::GetAppRequest {
         get::GetAppRequest::new(self.config.clone())
     }
+
+    /// 返回创建应用请求构建器。
+    pub fn create(&self) -> create::CreateAppRequest {
+        create::CreateAppRequest::new(self.config.clone())
+    }
+
+    /// 返回删除应用请求构建器。
+    pub fn delete(&self) -> delete::DeleteAppRequest {
+        delete::DeleteAppRequest::new(self.config.clone())
+    }
+
+    /// 返回查询应用列表请求构建器。
+    pub fn list(&self) -> list::ListAppRequest {
+        list::ListAppRequest::new(self.config.clone())
+    }
+
+    /// 返回更新应用请求构建器。
+    pub fn patch(&self) -> patch::PatchAppRequest {
+        patch::PatchAppRequest::new(self.config.clone())
+    }
 }
 
 pub use get::GetAppRequest;


### PR DESCRIPTION
## 背景

ADR 0001 阶段4 application：\`v1/app/mod.rs\` 声明了 \`create\`/\`delete\`/\`list\`/\`patch\` 4 个 \`pub mod\`（leaf builder 已存在），但 \`App\` struct 只暴露 \`get()\`——声明却未接线。

## 改动（+25/−0，2 文件，纯 additive）

补 4 个 accessor 对齐 \`get()\` 形态（leaf 构造器均 \`new(Arc<Config>)\`）：

\`\`\`rust
pub fn create(&self) -> create::CreateAppRequest
pub fn delete(&self) -> delete::DeleteAppRequest
pub fn list(&self) -> list::ListAppRequest
pub fn patch(&self) -> patch::PatchAppRequest
\`\`\`

\`App\` 现为完整 5 端点资源（get/create/delete/list/patch）。

## 非范围

- \`v1/mod.rs\` 的 \`ApplicationV1\` 仅暴露 \`app()\`，另有 14 个 \`pub mod\`（app_badge/application/collaborator/...）未接 accessor —— 这是 flat 直路径 vs accessor 的另一个问题，**不在 ADR 阶段4 application 范围**（ADR 明示「仅补 v1/app」），留作后续。

## 验证

- \`cargo fmt --check\` ✅
- \`cargo clippy -p openlark-application --all-targets --all-features -- -Dwarnings\` ✅
- \`cargo clippy -p openlark-application --all-targets --no-default-features -- -Dwarnings\` ✅
- \`cargo doc -p openlark-application --all-features -Dwarnings\` ✅

ref: ADR 0001 阶段4 application