### PR TITLE
refactor(workflow): 删 service.task()/tasklist() 冗余双入口（ADR 0001 阶段4）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+- **openlark-workflow 删 `service.task()`/`service.tasklist()` 冗余双入口（ADR 0001 阶段4）**：
+  `WorkflowService::task()`/`tasklist()` 与 `service.v2().task()`/`service.v2().tasklist()` 等价（同
+  `v2::task::Task` / `v2::tasklist::Tasklist` 类型），是绕过版本层的冗余捷径。ADR「双入口二选一，留版本化
+  路径」：删捷径 accessor，统一经 `service.v2()` 版本路由层。原 `service.task().create()` /
+  `service.tasklist().search()` → `service.v2().task().create()` / `service.v2().tasklist().search()`。
+  **breaking**：移除 pub `WorkflowService::task()`/`tasklist()`。**迁移**：仅 `openlark-client` facade
+  test + 本 crate 2 个捷径 test 用到，已改（test 改走 `.v2()` / 捷径 test 删除）；TaskV2 + leaf builder 不变。
+
 - **openlark-user 砍 `PersonalSettingsResource` 中间层 + 修 `UserService::new` 误导签名（ADR 0001 阶段2）**：
   `PersonalSettingsResource`（personal_settings/mod.rs）是 1:1 单转发壳（仅 `system_status()` 一子资源，
   全仓零调用者）砍除；`UserService` 新增 `system_status()` 直达 `SystemStatusResource`（7 个真实构建器）。

--- a/crates/openlark-client/src/client.rs
+++ b/crates/openlark-client/src/client.rs
@@ -112,7 +112,7 @@ declare_client! {
         feature: "workflow",
         field: workflow,
         ty: crate::WorkflowClient,
-        doc: "Workflow meta 调用链入口：client.workflow.task.create() ...",
+        doc: "Workflow meta 调用链入口：client.workflow.v2().task().create() ...",
         init: |_core_config, _base_core_config| {
             crate::WorkflowClient::new(_core_config.clone())
         },

--- a/crates/openlark-client/src/client/tests.rs
+++ b/crates/openlark-client/src/client/tests.rs
@@ -260,7 +260,7 @@ fn test_workflow_task_v2_chain_exists() {
         .build()
         .unwrap();
 
-    let task = client.workflow.task();
+    let task = client.workflow.v2().task();
 
     let _ = task.create();
     let _ = task.update("task_123");
@@ -288,6 +288,7 @@ fn test_workflow_task_v2_chain_exists() {
 
     let _ = client
         .workflow
+        .v2()
         .tasklist()
         .search()
         .page_size(20)

--- a/crates/openlark-workflow/src/lib.rs
+++ b/crates/openlark-workflow/src/lib.rs
@@ -176,20 +176,4 @@ mod service_tests {
         let service = WorkflowService::new(config);
         let _v2 = service.v2();
     }
-
-    #[cfg(feature = "v2")]
-    #[test]
-    fn test_workflow_service_task() {
-        let config = create_test_config();
-        let service = WorkflowService::new(config);
-        let _task = service.task();
-    }
-
-    #[cfg(feature = "v2")]
-    #[test]
-    fn test_workflow_service_tasklist() {
-        let config = create_test_config();
-        let service = WorkflowService::new(config);
-        let _tasklist = service.tasklist();
-    }
 }

--- a/crates/openlark-workflow/src/service.rs
+++ b/crates/openlark-workflow/src/service.rs
@@ -317,18 +317,6 @@ impl WorkflowService {
         crate::v2::TaskV2::new(self.config.clone())
     }
 
-    #[cfg(feature = "v2")]
-    /// 返回 v2 任务资源入口。
-    pub fn task(&self) -> crate::v2::task::Task {
-        crate::v2::task::Task::new(self.config.clone())
-    }
-
-    #[cfg(feature = "v2")]
-    /// 返回 v2 任务清单资源入口。
-    pub fn tasklist(&self) -> crate::v2::tasklist::Tasklist {
-        crate::v2::tasklist::Tasklist::new(self.config.clone())
-    }
-
     /// 列取任务并自动处理分页。
     #[cfg(feature = "v2")]
     pub async fn list_tasks_all(


### PR DESCRIPTION
## 背景

ADR 0001 阶段4 workflow：workflow 是真实深度 facade（648 行 service.rs，含 \`list_tasks_all\` 分页 / \`query_approval_tasks\` 筛选 / 3 个 DTO 等真 helper，非壳）。唯一问题是 \`WorkflowService::task()\` / \`tasklist()\` 与 \`service.v2().task()\` / \`service.v2().tasklist()\` 等价双入口。

## 改动（+11/−30，5 文件）

ADR「双入口二选一，留版本化路径」——删冗余捷径，统一经 \`service.v2()\` 版本路由层：

- \`service.rs\`：删 \`WorkflowService::task()\` + \`tasklist()\`（保 \`v2()\`）
- \`lib.rs\`：删 \`test_workflow_service_task\` / \`test_workflow_service_tasklist\`（捷径专属 test；\`v2()\` 路径已有 \`test_workflow_service_v2\` + TaskV2::task/tasklist test 覆盖）
- \`client/tests.rs\`：\`client.workflow.task()\` → \`.workflow.v2().task()\`；\`client.workflow.tasklist()\` → \`.workflow.v2().tasklist()\`
- \`client.rs\` facade doc：\`client.workflow.task.create()\` → \`client.workflow.v2().task().create()\`

\`TaskV2\`（v2/mod.rs）的 \`.task()\`/\`.tasklist()\` 是版本 struct 自身 accessor，**保留**（非服务层捷径）。

## ADR 硬约束遵守

- ✅ leaf builder API 100% 冻结
- ✅ 真实 helper（\`list_tasks_all\` / \`query_approval_tasks\` / DTO）全保留——只删两个 1:1 转发捷径

## 迁移

仓内仅 \`openlark-client\` facade test + 本 crate 2 个捷径 test 用到，均已改。无外部 caller。

## 验证

- \`cargo fmt --check\` ✅
- \`cargo clippy -p openlark-workflow --all-targets --all-features -- -Dwarnings\` ✅
- \`cargo clippy -p openlark-workflow --all-targets --no-default-features -- -Dwarnings\` ✅
- \`cargo test -p openlark-workflow --all-features\`（含 doctest）✅
- \`cargo clippy -p openlark-client --all-features -- -Dwarnings\`（facade test）✅
- CI 三元组：\`cargo machete\` / \`cargo doc -Dwarnings\` ✅

ref: ADR 0001 阶段4 workflow