### PR TITLE
refactor(cardkit): 合并双导航树——砍死 strict 树 + 解决 CardElementResource 命名碰撞（ADR 0001 阶段3）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+- **openlark-cardkit 合并双导航树：砍死 strict 树 + 解决 CardElementResource 命名碰撞（ADR 0001 阶段3）**：
+  cardkit 有两套并行导航树——门面链（common/chain.rs：`CardkitClient → CardkitV1Client → CardResource →
+  CardElementResource`，`Arc<Config>` + async helpers）和 strict 死树（cardkit/cardkit/v1：`CardkitV1Service →
+  CardService → strict CardElementResource`，`Config` by-value）。strict 树根 `CardkitV1Service::new()` 全仓零调用，
+  门面直接调 leaf Request，strict 树是自封闭死循环。砍 strict 树 3 壳（`CardkitV1Service`/`CardService`/
+  strict `CardElementResource`）+ `CardElementService` 别名；保门面 twin（disjoint 模块路径，rustc 层面从未碰撞，
+  无需 rename）。门面目标链 `client.cardkit.v1.card.create(body)` 100% 保留。**breaking**：移除 pub
+  `CardkitV1Service`/`CardService`/strict `CardElementResource`/`CardElementService` alias——全仓零外部引用
+ （多 agent 勘察 + 双对抗 reviewer 共识 SOUND）；leaf builder（`*Request*`）+ 模块树不变。
+
 - **openlark-docs 砍 5 个 config-holder 子客户端（ADR 0001 阶段3 扁平收口）**：
   `CcmClient`/`BaseClient`/`BitableClient`/`BaikeClient`/`MinutesClient`（common/chain.rs）是纯 config-holder
   （仅 `config()`，BaseClient 多一个 `bitable()` 路由），与 `DocsClient::config()` 等价冗余。砍 5 struct +

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/mod.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/mod.rs
@@ -35,54 +35,6 @@ pub use update::{
     UpdateCardElementBody, UpdateCardElementRequest, UpdateCardElementRequestBuilder,
 };
 
-use openlark_core::config::Config;
-
-/// card.element 资源服务
-#[derive(Debug, Clone)]
-pub struct CardElementResource {
-    config: Config,
-}
-
-/// 兼容历史命名：card.element 服务
-pub type CardElementService = CardElementResource;
-
-impl CardElementResource {
-    /// 创建新的实例。
-    pub fn new(config: Config) -> Self {
-        Self { config }
-    }
-
-    /// 返回配置引用。
-    pub fn config(&self) -> &Config {
-        &self.config
-    }
-
-    /// 创建卡片组件
-    pub fn create(&self) -> create::CreateCardElementRequestBuilder {
-        create::CreateCardElementRequestBuilder::new(self.config.clone())
-    }
-
-    /// 更新组件
-    pub fn update(&self) -> update::UpdateCardElementRequestBuilder {
-        update::UpdateCardElementRequestBuilder::new(self.config.clone())
-    }
-
-    /// 补丁组件
-    pub fn patch(&self) -> patch::PatchCardElementRequestBuilder {
-        patch::PatchCardElementRequestBuilder::new(self.config.clone())
-    }
-
-    /// 流式更新文本
-    pub fn content(&self) -> content::UpdateCardElementContentRequestBuilder {
-        content::UpdateCardElementContentRequestBuilder::new(self.config.clone())
-    }
-
-    /// 删除组件
-    pub fn delete(&self) -> delete::DeleteCardElementRequestBuilder {
-        delete::DeleteCardElementRequestBuilder::new(self.config.clone())
-    }
-}
-
 #[cfg(test)]
 mod tests {
 

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/mod.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/mod.rs
@@ -14,51 +14,6 @@ pub mod update;
 
 pub mod element;
 
-use openlark_core::config::Config;
-
-/// card 资源服务
-#[derive(Debug, Clone)]
-pub struct CardService {
-    config: Config,
-}
-
-impl CardService {
-    /// 创建新的实例。
-    pub fn new(config: Config) -> Self {
-        Self { config }
-    }
-
-    /// 创建卡片实体
-    pub fn create(&self) -> create::CreateCardRequest {
-        create::CreateCardRequest::new(self.config.clone())
-    }
-
-    /// 全量更新卡片实体
-    pub fn update(&self) -> update::UpdateCardRequest {
-        update::UpdateCardRequest::new(self.config.clone())
-    }
-
-    /// 局部更新卡片实体
-    pub fn batch_update(&self) -> batch_update::BatchUpdateCardRequest {
-        batch_update::BatchUpdateCardRequest::new(self.config.clone())
-    }
-
-    /// 更新卡片实体配置
-    pub fn settings(&self) -> settings::UpdateCardSettingsRequest {
-        settings::UpdateCardSettingsRequest::new(self.config.clone())
-    }
-
-    /// 转换卡片 ID
-    pub fn id_convert(&self) -> id_convert::ConvertCardIdRequest {
-        id_convert::ConvertCardIdRequest::new(self.config.clone())
-    }
-
-    /// 卡片组件相关
-    pub fn element(&self) -> element::CardElementService {
-        element::CardElementService::new(self.config.clone())
-    }
-}
-
 #[cfg(test)]
 mod tests {
 

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/mod.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/mod.rs
@@ -2,26 +2,6 @@
 
 pub mod card;
 
-use openlark_core::config::Config;
-
-/// cardkit v1 服务
-#[derive(Debug, Clone)]
-pub struct CardkitV1Service {
-    config: Config,
-}
-
-impl CardkitV1Service {
-    /// 创建新的实例。
-    pub fn new(config: Config) -> Self {
-        Self { config }
-    }
-
-    /// 访问 card 资源。
-    pub fn card(&self) -> card::CardService {
-        card::CardService::new(self.config.clone())
-    }
-}
-
 #[cfg(test)]
 mod tests {
 


### PR DESCRIPTION
## 背景

ADR 0001 阶段3 cardkit（标「最易出错」）：双导航树并存 + \`CardElementResource\` 命名碰撞。

## 勘察方法（6-agent workflow，SOUND 共识）

本 PR 的合并计划由一个 6-agent 勘察 workflow 产出（3 并行 mapper → 1 synthesizer → 2 对抗 reviewer），run \`wf_e06915d0-387\`。两位对抗 reviewer 独立 grep 全仓后共识 **SOUND**，零 breakage，零 missed ref。

## 双树实测

| | 门面链（存活） | strict 树（死） |
|---|---|---|
| 路径 | \`common/chain.rs\` | \`cardkit/cardkit/v1\` |
| 链 | \`CardkitClient → CardkitV1Client → CardResource → CardElementResource\` | \`CardkitV1Service → CardService → strict CardElementResource\` |
| Config 持有 | \`Arc<Config>\` + async helpers | \`Config\` by-value |
| 外部可达 | ✅ \`client.cardkit\` 挂载，产 ADR 目标链 | ❌ 根 \`CardkitV1Service::new()\` 全仓零调用，门面直接调 leaf Request，自封闭死循环 |

## 改动（+10/−113，4 文件，纯删壳）

砍 strict 树 3 壳 + 别名 + 3 orphan \`use Config\`；保全部 \`pub mod\` + leaf re-export + cfg(test)：

- \`cardkit/cardkit/v1/mod.rs\`：删 \`CardkitV1Service\` + impl + \`use Config\`（保 \`pub mod card;\`）
- \`cardkit/cardkit/v1/card/mod.rs\`：删 \`CardService\` + impl + \`use Config\`（保 \`pub mod *\` + \`pub use self::models::*;\`）
- \`cardkit/cardkit/v1/card/element/mod.rs\`：删 strict \`CardElementResource\` + \`CardElementService\` 别名 + impl + \`use Config\`（保 \`pub mod *\` + 6 组 leaf re-export）

**碰撞解决**：两 \`CardElementResource\` 在 disjoint 模块路径（\`crate::common::chain\` vs \`crate::cardkit::cardkit::v1::card::element\`），rustc 层面从未真碰撞（只对读者歧义）。删 strict twin 后全仓仅剩门面 twin，名唯一，**无需 rename**。

## ADR 硬约束

- ✅ leaf builder API 100% 冻结（\`*Request*\` / \`*Builder*\` / Response models 全不动）
- ✅ 模块树不重组（\`cardkit::cardkit::v1::*\` 路径保留；\`#![allow(clippy::module_inception)]\` 保留）
- ✅ 门面 async helpers + path-param（\`client.cardkit.v1.card.create(body)\`）保留

## 验证

- \`cargo fmt --check\` ✅
- \`cargo build/clippy -p openlark-cardkit --all-targets --all-features -- -Dwarnings\` ✅
- \`cargo clippy -p openlark-cardkit --all-targets --no-default-features -- -Dwarnings\` ✅（orphan \`use Config\` 已清）
- \`cargo test -p openlark-cardkit --all-features\`：**36 unit + 38 card_tests + 51 element_tests 全过** ✅
- \`cargo doc --workspace --all-features -Dwarnings\`（跨 crate intra-doc，clean）✅
- \`cargo clippy -p openlark-client --all-features -- -Dwarnings\`（facade，cardkit 挂载）✅
- \`cargo machete\` ✅

## 非范围（workflow 标注，另案）

- \`.agents/skills/openlark-naming/SKILL.md\` 引用已删类型（line 85/88/89/94/149-153）—— 非阻塞 doc 跟进
- 门面 \`(*self.config).clone()\` per-call 深拷贝（性能 bug，orthogonal，leaf \`Request::new(Config)\` 冻结，另案）

ref: ADR 0001 阶段3 cardkit