### PR TITLE
refactor(platform)!: 修 PlatformService::new 误导签名（#350 P9 platform 子项）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+- **openlark-platform 修 `PlatformService::new` 误导签名（#350 P9 platform 子项）**：
+  签名 `SDKResult<Self>` 但函数体永远 `Ok(...)`（接口撒谎——调用方据 `Result` 写的错误分支永不达）→ 改为 `Self`
+ （非 `Result`，同 user #360 `UserService::new` 修正方向）。**breaking**：`PlatformService::new` 返回类型
+ `SDKResult<Self>` → `Self`。**迁移**：`openlark-client` facade（`PlatformClient::new(...)?` → 去 `?`）+ 本 crate
+ doctest / 6 个 unit test（`.unwrap()` → 去）已改；仓内零外部残留。
+
 - **openlark-platform 折叠 3 个 module_inception（spark/admin/directory，ADR 0001 #367）**：
   `spark::spark`/`admin::admin`/`directory::directory` 三个同名 inception hop（各 3 行 `pub mod v1;`）折叠：
   `x/x/v1/` 上移到 `x/v1/`，删 inception hop + 空目录。路径 `crate::spark::spark::v1::*` → `crate::spark::v1::*`

--- a/crates/openlark-client/src/client.rs
+++ b/crates/openlark-client/src/client.rs
@@ -123,7 +123,7 @@ declare_client! {
         ty: crate::PlatformClient,
         doc: "Platform meta 调用链入口：client.platform.app_engine... ...",
         init: |_core_config, _base_core_config| {
-            crate::PlatformClient::new(_core_config.clone())?
+            crate::PlatformClient::new(_core_config.clone())
         },
     },
     {

--- a/crates/openlark-platform/src/lib.rs
+++ b/crates/openlark-platform/src/lib.rs
@@ -29,7 +29,7 @@
 //!     .app_secret("app_secret")
 //!     .build();
 //!
-//! let platform_service = PlatformService::new(config)?;
+//! let platform_service = PlatformService::new(config);
 //!
 //! // 具体功能请参考各个子模块的文档
 //! # Ok(())
@@ -112,14 +112,14 @@ mod service_tests {
     #[test]
     fn test_platform_service_creation() {
         let config = create_test_config();
-        let service = PlatformService::new(config).unwrap();
+        let service = PlatformService::new(config);
         assert!(service.config().app_id() == "test_app");
     }
 
     #[test]
     fn test_platform_service_clone() {
         let config = create_test_config();
-        let service = PlatformService::new(config).unwrap();
+        let service = PlatformService::new(config);
         let cloned = service.clone();
         assert!(cloned.config().app_id() == "test_app");
     }
@@ -137,7 +137,7 @@ mod service_tests {
     #[test]
     fn test_platform_service_app_engine() {
         let config = create_test_config();
-        let service = PlatformService::new(config).unwrap();
+        let service = PlatformService::new(config);
         let _app_engine = service.app_engine();
     }
 
@@ -145,7 +145,7 @@ mod service_tests {
     #[test]
     fn test_platform_service_directory() {
         let config = create_test_config();
-        let service = PlatformService::new(config).unwrap();
+        let service = PlatformService::new(config);
         let _directory = service.directory();
     }
 
@@ -153,7 +153,7 @@ mod service_tests {
     #[test]
     fn test_platform_service_admin() {
         let config = create_test_config();
-        let service = PlatformService::new(config).unwrap();
+        let service = PlatformService::new(config);
         let _admin = service.admin();
     }
 
@@ -161,7 +161,7 @@ mod service_tests {
     #[test]
     fn test_platform_service_spark() {
         let config = create_test_config();
-        let service = PlatformService::new(config).unwrap();
+        let service = PlatformService::new(config);
         let _request = service.spark().v1().directory().user().id_convert();
     }
 }

--- a/crates/openlark-platform/src/service.rs
+++ b/crates/openlark-platform/src/service.rs
@@ -3,7 +3,6 @@
 //! 提供平台管理相关的服务入口
 
 use crate::PlatformConfig;
-use openlark_core::SDKResult;
 use std::sync::Arc;
 
 /// 平台服务
@@ -21,14 +20,10 @@ impl PlatformService {
     /// # 参数
     ///
     /// * `config` - 平台服务配置
-    ///
-    /// # 返回
-    ///
-    /// 返回平台服务实例或错误
-    pub fn new(config: PlatformConfig) -> SDKResult<Self> {
-        Ok(Self {
+    pub fn new(config: PlatformConfig) -> Self {
+        Self {
             config: Arc::new(config),
-        })
+        }
     }
 
     /// 获取客户端配置
@@ -79,7 +74,6 @@ mod tests {
             .app_id("test_app_id")
             .app_secret("test_app_secret")
             .build();
-        let service = PlatformService::new(config);
-        assert!(service.is_ok());
+        let _service = PlatformService::new(config);
     }
 }


### PR DESCRIPTION
## 背景

**#350 P9 接口撒谎** platform 子项：\`PlatformService::new\` 签名 \`SDKResult<Self>\` 但函数体永远 \`Ok(...)\`——调用方据 \`Result\` 写的错误分支永不达（接口撒谎）。

## 改动（+18/−18，4 文件）

\`PlatformService::new\` 返回类型 \`SDKResult<Self>\` → \`Self\`（同 user #360 \`UserService::new\` 修正方向）：

- \`service.rs\`：\`new\` 签名 + 去 \`Ok\` 包裹 + 删 unused \`use openlark_core::SDKResult\` + test \`is_ok()\` → 构造
- \`lib.rs\`：doctest \`new(config)?\` → 去 \`?\`；6 个 unit test \`.unwrap()\` → 去（replace_all）
- \`client.rs\` facade：\`PlatformClient::new(...)?\` → 去 \`?\`
- \`CHANGELOG.md\`：breaking 条目

## #350 进度

| 子项 | 状态 |
|---|---|
| analytics \`execute()\` 恒 Err | ✅ #359（删 Search 死链顺带解决） |
| user \`UserService::new\` 签名 | ✅ #360（ADR 阶段2 顺带） |
| **platform \`PlatformService::new\` 签名** | ✅ **本 PR** |
| workflow 丢弃响应/bool 恒真 | ⏳ 另案（需勘察具体 lie） |
| user setter 死值 | ⏳ 另案（需勘察具体 builder） |

## 验证

- \`cargo fmt --check\` ✅
- \`cargo build/clippy -p openlark-platform --all-targets --all-features -- -Dwarnings\` ✅
- \`cargo clippy -p openlark-platform --all-targets --no-default-features -- -Dwarnings\` ✅
- \`cargo test -p openlark-platform\`（默认 features，225+13+1 全过）✅
- \`cargo doc --workspace --all-features -Dwarnings\`（跨 crate intra-doc，clean）✅
- \`cargo clippy -p openlark-client --all-features -- -Dwarnings\`（facade）✅
- \`cargo machete\` ✅

ref: #350 P9 platform 子项