### PR TITLE
test(security): 占位 roundtrip 测试 → wiremock 端到端（#351 pilot）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/openlark-security/src/acs/acs/v1/access_record/access_photo/get.rs
+++ b/crates/openlark-security/src/acs/acs/v1/access_record/access_photo/get.rs
@@ -65,4 +65,46 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("access_record_id"));
     }
+
+    /// 端到端：GET .../access_records/{id}/access_photo + 响应解析。
+    #[tokio::test]
+    async fn test_get_access_photo_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/acs/v1/access_records/rec_001/access_photo"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "code": 0,
+                    "msg": "success",
+                    "data": { "access_record_id": "rec_001", "photo_url": "https://cdn.example.com/p.jpg" }
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = GetAccessPhotoRequest::new(config, "rec_001")
+            .execute()
+            .await
+            .expect("下载开门人脸识别图片应成功");
+        assert_eq!(data["photo_url"], "https://cdn.example.com/p.jpg");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/acs/v1/access_records/rec_001/access_photo"
+        );
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/access_record/list.rs
+++ b/crates/openlark-security/src/acs/acs/v1/access_record/list.rs
@@ -60,3 +60,54 @@ impl ListAccessRecordsRequest {
             .ok_or_else(|| validation_error("获取门禁记录列表", "响应数据为空"))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
+
+    /// 端到端：GET .../access_records + query 拼装 + 响应解析。
+    #[tokio::test]
+    async fn test_list_access_records_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/acs/v1/access_records"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [{ "access_record_id": "rec_001" }],
+                    "page_token": "next_page",
+                    "has_more": false
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListAccessRecordsRequest::new(config)
+            .page_size(50)
+            .page_token("curr_page")
+            .execute()
+            .await
+            .expect("获取门禁记录列表应成功");
+
+        assert_eq!(data["items"].as_array().unwrap().len(), 1);
+        assert_eq!(data["has_more"], false);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let query = received[0].url.query().unwrap_or("");
+        assert!(query.contains("page_size=50"));
+        assert!(query.contains("page_token=curr_page"));
+    }
+}

--- a/crates/openlark-security/src/acs/acs/v1/client_device/get.rs
+++ b/crates/openlark-security/src/acs/acs/v1/client_device/get.rs
@@ -62,4 +62,45 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("device_id"));
     }
+
+    /// 端到端：GET .../client_devices/{id} + 响应解析。
+    #[tokio::test]
+    async fn test_get_client_device_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/acs/v1/client_devices/dev_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "device_id": "dev_001", "cert": "client_cert_token" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = GetClientDeviceRequest::new(config, "dev_001")
+            .execute()
+            .await
+            .expect("获取客户端设备认证信息应成功");
+        assert_eq!(data["device_id"], "dev_001");
+        assert_eq!(data["cert"], "client_cert_token");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/acs/v1/client_devices/dev_001"
+        );
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/device/approve.rs
+++ b/crates/openlark-security/src/acs/acs/v1/device/approve.rs
@@ -77,4 +77,45 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("device_id"));
     }
+
+    /// 端到端：POST .../devices/{id}/approve + body 透传 + 响应解析。
+    #[tokio::test]
+    async fn test_approve_device_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/acs/v1/devices/dev_001/approve"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "device_id": "dev_001", "approved": true }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ApproveDeviceRequest::new(config, "dev_001")
+            .body(json!({ "approve": true }))
+            .execute()
+            .await
+            .expect("审批设备申报应成功");
+        assert_eq!(data["approved"], true);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/acs/v1/devices/dev_001/approve"
+        );
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/device/create.rs
+++ b/crates/openlark-security/src/acs/acs/v1/device/create.rs
@@ -70,4 +70,44 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("body"));
     }
+
+    /// 端到端：POST body 透传 + 响应解析 + 请求体校验。
+    #[tokio::test]
+    async fn test_create_device_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/acs/v1/devices"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "device_id": "dev_new_001" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body = json!({ "device_name": "新门禁机", "device_type": "gate" });
+        let data = CreateDeviceRequest::new(config)
+            .body(body)
+            .execute()
+            .await
+            .expect("新增设备应成功");
+        assert_eq!(data["device_id"], "dev_new_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["device_name"], "新门禁机");
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/device/delete.rs
+++ b/crates/openlark-security/src/acs/acs/v1/device/delete.rs
@@ -62,4 +62,41 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("device_id"));
     }
+
+    /// 端到端：DELETE .../devices/{id} + 响应解析。
+    #[tokio::test]
+    async fn test_delete_device_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/acs/v1/devices/dev_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "device_id": "dev_001" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = DeleteDeviceRequest::new(config, "dev_001")
+            .execute()
+            .await
+            .expect("删除设备应成功");
+        assert_eq!(data["device_id"], "dev_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/acs/v1/devices/dev_001");
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/device/get.rs
+++ b/crates/openlark-security/src/acs/acs/v1/device/get.rs
@@ -62,4 +62,46 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("device_id"));
     }
+
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_get_device_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/acs/v1/devices/dev_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "device_id": "dev_001",
+                    "device_name": "前台门禁机"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = GetDeviceRequest::new(config, "dev_001")
+            .execute()
+            .await
+            .expect("获取设备信息应成功");
+
+        assert_eq!(data["device_id"], "dev_001");
+        assert_eq!(data["device_name"], "前台门禁机");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/acs/v1/devices/dev_001");
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/device/list.rs
+++ b/crates/openlark-security/src/acs/acs/v1/device/list.rs
@@ -69,3 +69,55 @@ impl ListDevicesRequest {
             .ok_or_else(|| validation_error("获取设备列表", "响应数据为空"))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
+
+    /// 端到端：GET + query 参数拼装 + 响应解析。
+    #[tokio::test]
+    async fn test_list_devices_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/acs/v1/devices"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [{ "device_id": "dev_001" }, { "device_id": "dev_002" }],
+                    "page_token": "next_page",
+                    "has_more": true
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListDevicesRequest::new(config)
+            .page_size(10)
+            .device_type("gate")
+            .execute()
+            .await
+            .expect("获取设备列表应成功");
+
+        assert_eq!(data["items"].as_array().unwrap().len(), 2);
+        assert_eq!(data["page_token"], "next_page");
+        assert_eq!(data["has_more"], true);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let query = received[0].url.query().unwrap_or("");
+        assert!(query.contains("page_size=10"));
+        assert!(query.contains("device_type=gate"));
+    }
+}

--- a/crates/openlark-security/src/acs/acs/v1/device/query.rs
+++ b/crates/openlark-security/src/acs/acs/v1/device/query.rs
@@ -62,4 +62,45 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("device_id"));
     }
+
+    /// 端到端：GET .../devices/{id}/query + 响应解析。
+    #[tokio::test]
+    async fn test_query_device_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/acs/v1/devices/dev_001/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "device_id": "dev_001", "status": "online" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryDeviceRequest::new(config, "dev_001")
+            .execute()
+            .await
+            .expect("查询设备信息应成功");
+        assert_eq!(data["device_id"], "dev_001");
+        assert_eq!(data["status"], "online");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/acs/v1/devices/dev_001/query"
+        );
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/device/update.rs
+++ b/crates/openlark-security/src/acs/acs/v1/device/update.rs
@@ -77,4 +77,44 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("device_id"));
     }
+
+    /// 端到端：PUT .../devices/{id} + body 透传 + 响应解析。
+    #[tokio::test]
+    async fn test_update_device_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/acs/v1/devices/dev_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "device_id": "dev_001", "device_name": "更新后门禁机" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = UpdateDeviceRequest::new(config, "dev_001")
+            .body(json!({ "device_name": "更新后门禁机" }))
+            .execute()
+            .await
+            .expect("更新设备应成功");
+        assert_eq!(data["device_name"], "更新后门禁机");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/acs/v1/devices/dev_001");
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["device_name"], "更新后门禁机");
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/face/create.rs
+++ b/crates/openlark-security/src/acs/acs/v1/face/create.rs
@@ -70,4 +70,43 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("body"));
     }
+
+    /// 端到端：POST .../faces + body 透传 + 响应解析。
+    #[tokio::test]
+    async fn test_face_create_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/acs/v1/faces"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "face_id": "face_new_001" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = FaceCreateRequest::new(config)
+            .body(json!({ "user_id": "u_001", "image_base64": "BASE64" }))
+            .execute()
+            .await
+            .expect("创建人脸应成功");
+        assert_eq!(data["face_id"], "face_new_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["user_id"], "u_001");
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/face/delete.rs
+++ b/crates/openlark-security/src/acs/acs/v1/face/delete.rs
@@ -62,4 +62,41 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("face_id"));
     }
+
+    /// 端到端：DELETE .../faces/{id} + 响应解析。
+    #[tokio::test]
+    async fn test_face_delete_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/acs/v1/faces/face_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "face_id": "face_001" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = FaceDeleteRequest::new(config, "face_001")
+            .execute()
+            .await
+            .expect("删除人脸应成功");
+        assert_eq!(data["face_id"], "face_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/acs/v1/faces/face_001");
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/face/get.rs
+++ b/crates/openlark-security/src/acs/acs/v1/face/get.rs
@@ -62,4 +62,42 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("face_id"));
     }
+
+    /// 端到端：GET .../faces/{id} + 响应解析。
+    #[tokio::test]
+    async fn test_face_get_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/acs/v1/faces/face_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "face_id": "face_001", "status": "active" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = FaceGetRequest::new(config, "face_001")
+            .execute()
+            .await
+            .expect("获取人脸信息应成功");
+        assert_eq!(data["face_id"], "face_001");
+        assert_eq!(data["status"], "active");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/acs/v1/faces/face_001");
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/rule_external/create.rs
+++ b/crates/openlark-security/src/acs/acs/v1/rule_external/create.rs
@@ -103,4 +103,47 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("rule"));
     }
+
+    /// 端到端：POST .../rule_external?rule_id= + {"rule": {...}} 包装 + query 拼装。
+    #[tokio::test]
+    async fn test_create_rule_external_returns_data_on_success() {
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/acs/v1/rule_external"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "rule_id": "rule_123" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = CreateRuleExternalRequest::new(config, "rule_123")
+            .user_id_type("open_id")
+            .rule(serde_json::json!({ "name": "前台权限组", "devices": ["dev_001"] }))
+            .execute()
+            .await
+            .expect("创建或更新权限组应成功");
+        assert_eq!(data["rule_id"], "rule_123");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let query = received[0].url.query().unwrap_or("");
+        assert!(query.contains("rule_id=rule_123"));
+        assert!(query.contains("user_id_type=open_id"));
+        // body 应被包装为 {"rule": {...}}
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["rule"]["name"], "前台权限组");
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/rule_external/delete.rs
+++ b/crates/openlark-security/src/acs/acs/v1/rule_external/delete.rs
@@ -66,4 +66,48 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("rule_id"));
     }
+
+    /// 端到端：DELETE .../rule_external?rule_id= + query 拼装（无 body）。
+    #[tokio::test]
+    async fn test_delete_rule_external_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/acs/v1/rule_external"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "rule_id": "rule_123" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = DeleteRuleExternalRequest::new(config, "rule_123")
+            .execute()
+            .await
+            .expect("删除权限组应成功");
+        assert_eq!(data["rule_id"], "rule_123");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/acs/v1/rule_external");
+        assert!(
+            received[0]
+                .url
+                .query()
+                .unwrap_or("")
+                .contains("rule_id=rule_123")
+        );
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/rule_external/device_bind.rs
+++ b/crates/openlark-security/src/acs/acs/v1/rule_external/device_bind.rs
@@ -110,4 +110,45 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("rule_ids"));
     }
+
+    /// 端到端：POST .../rule_external/device_bind + flat body 序列化 + 响应解析。
+    #[tokio::test]
+    async fn test_bind_device_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/acs/v1/rule_external/device_bind"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "device_id": "dev_001" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = BindDeviceToRuleRequest::new(config)
+            .device_id("dev_001")
+            .rule_ids(vec!["rule_123".into(), "rule_456".into()])
+            .execute()
+            .await
+            .expect("设备绑定权限组应成功");
+        assert_eq!(data["device_id"], "dev_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["device_id"], "dev_001");
+        assert_eq!(sent["rule_ids"].as_array().unwrap().len(), 2);
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/rule_external/get.rs
+++ b/crates/openlark-security/src/acs/acs/v1/rule_external/get.rs
@@ -75,4 +75,44 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("device_id"));
     }
+
+    /// 端到端：GET .../rule_external?device_id=&user_id_type= + query 拼装。
+    #[tokio::test]
+    async fn test_get_rule_external_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/acs/v1/rule_external"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "rule_id": "rule_123", "name": "前台权限组" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = GetRuleExternalRequest::new(config, "dev_001")
+            .user_id_type("open_id")
+            .execute()
+            .await
+            .expect("获取权限组信息应成功");
+        assert_eq!(data["rule_id"], "rule_123");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let query = received[0].url.query().unwrap_or("");
+        assert!(query.contains("device_id=dev_001"));
+        assert!(query.contains("user_id_type=open_id"));
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/user/create.rs
+++ b/crates/openlark-security/src/acs/acs/v1/user/create.rs
@@ -71,4 +71,43 @@ mod tests {
         assert!(result.is_err(), "空 body 必须校验失败");
         assert!(result.unwrap_err().to_string().contains("body"));
     }
+
+    /// 端到端：POST .../users + body 透传 + 响应解析。
+    #[tokio::test]
+    async fn test_create_user_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/acs/v1/users"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "user_id": "u_new_001" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = CreateUserRequest::new(config)
+            .body(json!({ "name": "张三", "user_id": "u_new_001" }))
+            .execute()
+            .await
+            .expect("创建用户应成功");
+        assert_eq!(data["user_id"], "u_new_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["name"], "张三");
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/user/delete.rs
+++ b/crates/openlark-security/src/acs/acs/v1/user/delete.rs
@@ -62,4 +62,41 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("user_id"));
     }
+
+    /// 端到端：DELETE .../users/{id} + 响应解析。
+    #[tokio::test]
+    async fn test_delete_user_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/acs/v1/users/u_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "user_id": "u_001" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = DeleteUserRequest::new(config, "u_001")
+            .execute()
+            .await
+            .expect("删除用户应成功");
+        assert_eq!(data["user_id"], "u_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/acs/v1/users/u_001");
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/user/face/get.rs
+++ b/crates/openlark-security/src/acs/acs/v1/user/face/get.rs
@@ -82,4 +82,41 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("user_id"));
     }
+
+    /// 端到端：GET .../users/{id}/face → 强类型 FaceData 反序列化。
+    #[tokio::test]
+    async fn test_get_user_face_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/acs/v1/users/u_001/face"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "face_url": "https://cdn.example.com/face/u_001.jpg" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = GetUserFaceRequest::new(config, "u_001")
+            .execute()
+            .await
+            .expect("下载用户人脸图片应成功");
+        assert_eq!(data.face_url, "https://cdn.example.com/face/u_001.jpg");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/acs/v1/users/u_001/face");
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/user/face/update.rs
+++ b/crates/openlark-security/src/acs/acs/v1/user/face/update.rs
@@ -78,4 +78,44 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("user_id"));
     }
+
+    /// 端到端：PUT .../users/{id}/face + body 透传 + 响应解析。
+    #[tokio::test]
+    async fn test_update_user_face_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/acs/v1/users/u_001/face"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "face_url": "https://cdn.example.com/face/u_001.jpg" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = UpdateUserFaceRequest::new(config, "u_001")
+            .body(json!({ "image_base64": "BASE64_DATA" }))
+            .execute()
+            .await
+            .expect("上传用户人脸图片应成功");
+        assert_eq!(data["face_url"], "https://cdn.example.com/face/u_001.jpg");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/acs/v1/users/u_001/face");
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert!(sent["image_base64"].as_str().unwrap().contains("BASE64"));
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/user/get.rs
+++ b/crates/openlark-security/src/acs/acs/v1/user/get.rs
@@ -77,4 +77,42 @@ mod tests {
         let result = req.execute().await;
         assert!(result.is_err());
     }
+
+    /// 端到端：GET .../users/{id} + 响应解析。
+    #[tokio::test]
+    async fn test_get_user_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/acs/v1/users/u_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "user_id": "u_001", "name": "张三" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = GetUserRequest::new(config, "u_001")
+            .execute()
+            .await
+            .expect("获取用户信息应成功");
+        assert_eq!(data["user_id"], "u_001");
+        assert_eq!(data["name"], "张三");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/acs/v1/users/u_001");
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/user/list.rs
+++ b/crates/openlark-security/src/acs/acs/v1/user/list.rs
@@ -90,3 +90,55 @@ impl ListUsersRequest {
         }))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
+
+    /// 端到端：GET .../users + query 拼装 → 强类型 ListUsersResponse 反序列化。
+    #[tokio::test]
+    async fn test_list_users_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/acs/v1/users"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "has_more": true,
+                    "page_token": "next_page",
+                    "items": [{ "user_id": "u_001" }, { "user_id": "u_002" }]
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = ListUsersRequest::new(config)
+            .page_size(20)
+            .department_id("dept_001")
+            .execute()
+            .await
+            .expect("获取用户列表应成功");
+
+        assert!(resp.has_more);
+        assert_eq!(resp.page_token.as_deref(), Some("next_page"));
+        assert_eq!(resp.items.as_ref().unwrap().len(), 2);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let query = received[0].url.query().unwrap_or("");
+        assert!(query.contains("page_size=20"));
+        assert!(query.contains("department_id=dept_001"));
+    }
+}

--- a/crates/openlark-security/src/acs/acs/v1/user/patch.rs
+++ b/crates/openlark-security/src/acs/acs/v1/user/patch.rs
@@ -77,4 +77,44 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("user_id"));
     }
+
+    /// 端到端：PATCH .../users/{id} + body 透传 + 响应解析。
+    #[tokio::test]
+    async fn test_patch_user_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/acs/v1/users/u_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "user_id": "u_001", "name": "李四" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = PatchUserRequest::new(config, "u_001")
+            .body(json!({ "name": "李四" }))
+            .execute()
+            .await
+            .expect("修改用户信息应成功");
+        assert_eq!(data["name"], "李四");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/acs/v1/users/u_001");
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["name"], "李四");
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/visitor/create.rs
+++ b/crates/openlark-security/src/acs/acs/v1/visitor/create.rs
@@ -70,4 +70,43 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("body"));
     }
+
+    /// 端到端：POST .../visitors + body 透传 + 响应解析。
+    #[tokio::test]
+    async fn test_create_visitor_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/acs/v1/visitors"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "visitor_id": "visitor_new_001" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = CreateVisitorRequest::new(config)
+            .body(json!({ "name": "访客甲", "phone": "13800000000" }))
+            .execute()
+            .await
+            .expect("添加访客应成功");
+        assert_eq!(data["visitor_id"], "visitor_new_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["name"], "访客甲");
+    }
 }

--- a/crates/openlark-security/src/acs/acs/v1/visitor/delete.rs
+++ b/crates/openlark-security/src/acs/acs/v1/visitor/delete.rs
@@ -62,4 +62,44 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("visitor_id"));
     }
+
+    /// 端到端：DELETE .../visitors/{id} + 响应解析。
+    #[tokio::test]
+    async fn test_delete_visitor_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/acs/v1/visitors/visitor_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "visitor_id": "visitor_001" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = DeleteVisitorRequest::new(config, "visitor_001")
+            .execute()
+            .await
+            .expect("删除访客应成功");
+        assert_eq!(data["visitor_id"], "visitor_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/acs/v1/visitors/visitor_001"
+        );
+    }
 }

--- a/crates/openlark-security/src/lib.rs
+++ b/crates/openlark-security/src/lib.rs
@@ -194,22 +194,3 @@ pub mod prelude {
         SecurityAndComplianceV1Service, SecurityAndComplianceV2Service,
     };
 }
-
-#[cfg(test)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-security/src/security/security_and_compliance/v1/multi_geo_entity/tenant/get.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/multi_geo_entity/tenant/get.rs
@@ -60,3 +60,53 @@ impl ListMultiGeoEntityTenantsRequest {
             .ok_or_else(|| validation_error("获取地理位置列表", "响应数据为空"))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
+
+    /// 端到端：GET .../multi_geo_entity/tenant + query 拼装 + 响应解析。
+    #[tokio::test]
+    async fn test_list_multi_geo_entity_tenants_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/security_and_compliance/v1/multi_geo_entity/tenant",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "items": [{ "tenant_id": "t_001" }], "has_more": false }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListMultiGeoEntityTenantsRequest::new(config)
+            .page_size(10)
+            .execute()
+            .await
+            .expect("获取地理位置列表应成功");
+        assert_eq!(data["items"].as_array().unwrap().len(), 1);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert!(
+            received[0]
+                .url
+                .query()
+                .unwrap_or("")
+                .contains("page_size=10")
+        );
+    }
+}

--- a/crates/openlark-security/src/security/security_and_compliance/v1/openapi_logs/list_data.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/openapi_logs/list_data.rs
@@ -100,4 +100,48 @@ mod tests {
         let end = obj["end_time"].as_i64().unwrap();
         assert!(end > start);
     }
+
+    /// 端到端：POST .../openapi_logs/list_data + body 透传 + 响应解析。
+    #[tokio::test]
+    async fn test_list_openapi_logs_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/security_and_compliance/v1/openapi_logs/list_data",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [{ "request_id": "req_001" }],
+                    "has_more": false
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListOpenApiLogsRequest::new(config)
+            .body(json!({ "start_time": 1700000000, "end_time": 1700003600 }))
+            .execute()
+            .await
+            .expect("获取审计日志数据应成功");
+        assert_eq!(data["items"].as_array().unwrap().len(), 1);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["start_time"], 1700000000);
+    }
 }

--- a/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/cancel.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/cancel.rs
@@ -43,3 +43,47 @@ impl CancelUserMigrationRequest {
             .ok_or_else(|| validation_error("取消用户迁移", "响应数据为空"))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
+
+    /// 端到端：POST .../user_migrations/cancel + body {migration_id} + 响应解析。
+    #[tokio::test]
+    async fn test_cancel_user_migration_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/security_and_compliance/v1/user_migrations/cancel",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "migration_id": "mig_001" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = CancelUserMigrationRequest::new(config, "mig_001")
+            .execute()
+            .await
+            .expect("取消用户迁移应成功");
+        assert_eq!(data["migration_id"], "mig_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["migration_id"], "mig_001");
+    }
+}

--- a/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/create.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/create.rs
@@ -52,3 +52,48 @@ impl CreateUserMigrationRequest {
             .ok_or_else(|| validation_error("创建用户迁移", "响应数据为空"))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
+
+    /// 端到端：POST .../user_migrations + body 透传 + 响应解析。
+    #[tokio::test]
+    async fn test_create_user_migration_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/security_and_compliance/v1/user_migrations",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "migration_id": "mig_new_001" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = CreateUserMigrationRequest::new(config)
+            .body(json!({ "source_user_id": "u_old", "target_user_id": "u_new" }))
+            .execute()
+            .await
+            .expect("创建用户迁移应成功");
+        assert_eq!(data["migration_id"], "mig_new_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["source_user_id"], "u_old");
+    }
+}

--- a/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/get.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/get.rs
@@ -43,3 +43,50 @@ impl GetUserMigrationRequest {
             .ok_or_else(|| validation_error("获取单个用户迁移状态", "响应数据为空"))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
+
+    /// 端到端：GET .../user_migrations/{id} + 响应解析。
+    #[tokio::test]
+    async fn test_get_user_migration_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/security_and_compliance/v1/user_migrations/mig_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "migration_id": "mig_001", "status": "processing" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = GetUserMigrationRequest::new(config, "mig_001")
+            .execute()
+            .await
+            .expect("获取用户迁移状态应成功");
+        assert_eq!(data["migration_id"], "mig_001");
+        assert_eq!(data["status"], "processing");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/security_and_compliance/v1/user_migrations/mig_001"
+        );
+    }
+}

--- a/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/search.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/search.rs
@@ -52,3 +52,51 @@ impl SearchUserMigrationsRequest {
             .ok_or_else(|| validation_error("批量获取用户迁移状态", "响应数据为空"))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
+
+    /// 端到端：POST .../user_migrations/search + body 透传 + 响应解析。
+    #[tokio::test]
+    async fn test_search_user_migrations_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/security_and_compliance/v1/user_migrations/search",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [{ "migration_id": "mig_001" }, { "migration_id": "mig_002" }],
+                    "has_more": false
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = SearchUserMigrationsRequest::new(config)
+            .body(json!({ "migration_ids": ["mig_001", "mig_002"] }))
+            .execute()
+            .await
+            .expect("批量获取用户迁移状态应成功");
+        assert_eq!(data["items"].as_array().unwrap().len(), 2);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["migration_ids"].as_array().unwrap().len(), 2);
+    }
+}

--- a/crates/openlark-security/src/security/security_and_compliance/v2/device_apply_records/approve.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v2/device_apply_records/approve.rs
@@ -127,4 +127,52 @@ mod tests {
                 .contains("device_apply_record_id")
         );
     }
+
+    /// 端到端：PUT .../device_apply_records/{id} + body {approved, comment, remark} 序列化。
+    #[tokio::test]
+    async fn test_approve_device_apply_record_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path(
+                "/open-apis/security_and_compliance/v2/device_apply_records/rec_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "device_apply_record_id": "rec_001" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ApproveDeviceApplyRecordRequest::new(config, "rec_001")
+            .approve()
+            .comment("同意")
+            .remark("IT 设备")
+            .execute()
+            .await
+            .expect("审批设备申报应成功");
+        assert_eq!(data["device_apply_record_id"], "rec_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/security_and_compliance/v2/device_apply_records/rec_001"
+        );
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["approved"], true);
+        assert_eq!(sent["comment"], "同意");
+    }
 }

--- a/crates/openlark-security/src/security/security_and_compliance/v2/device_records/create.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v2/device_records/create.rs
@@ -74,4 +74,43 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("body"));
     }
+
+    /// 端到端：POST .../device_records + body 透传 + 响应解析。
+    #[tokio::test]
+    async fn test_create_device_record_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/security_and_compliance/v2/device_records"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "device_record_id": "dr_new_001" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = CreateDeviceRecordRequest::new(config)
+            .body(json!({ "user_id": "u_001", "device_id": "dev_001" }))
+            .execute()
+            .await
+            .expect("新增设备记录应成功");
+        assert_eq!(data["device_record_id"], "dr_new_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["user_id"], "u_001");
+    }
 }

--- a/crates/openlark-security/src/security/security_and_compliance/v2/device_records/delete.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v2/device_records/delete.rs
@@ -65,4 +65,46 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("device_record_id"));
     }
+
+    /// 端到端：DELETE .../device_records/{id} + 响应解析。
+    #[tokio::test]
+    async fn test_delete_device_record_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/security_and_compliance/v2/device_records/dr_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "device_record_id": "dr_001" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = DeleteDeviceRecordRequest::new(config, "dr_001")
+            .execute()
+            .await
+            .expect("删除设备记录应成功");
+        assert_eq!(data["device_record_id"], "dr_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/security_and_compliance/v2/device_records/dr_001"
+        );
+    }
 }

--- a/crates/openlark-security/src/security/security_and_compliance/v2/device_records/get.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v2/device_records/get.rs
@@ -65,4 +65,47 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("device_record_id"));
     }
+
+    /// 端到端：GET .../device_records/{id} + 响应解析。
+    #[tokio::test]
+    async fn test_get_device_record_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/security_and_compliance/v2/device_records/dr_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "device_record_id": "dr_001", "status": "approved" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = GetDeviceRecordRequest::new(config, "dr_001")
+            .execute()
+            .await
+            .expect("获取设备记录应成功");
+        assert_eq!(data["device_record_id"], "dr_001");
+        assert_eq!(data["status"], "approved");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/security_and_compliance/v2/device_records/dr_001"
+        );
+    }
 }

--- a/crates/openlark-security/src/security/security_and_compliance/v2/device_records/list.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v2/device_records/list.rs
@@ -113,3 +113,55 @@ impl ListDeviceRecordsRequest {
             .ok_or_else(|| validation_error("查询设备信息列表", "响应数据为空"))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
+
+    /// 端到端：GET .../device_records + 多个 query 拼装 + 响应解析。
+    #[tokio::test]
+    async fn test_list_device_records_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/security_and_compliance/v2/device_records"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [{ "device_record_id": "dr_001" }],
+                    "page_token": "next",
+                    "has_more": true
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListDeviceRecordsRequest::new(config)
+            .page_size(20)
+            .user_id("u_001")
+            .status("approved")
+            .execute()
+            .await
+            .expect("查询设备信息列表应成功");
+        assert_eq!(data["items"].as_array().unwrap().len(), 1);
+        assert_eq!(data["has_more"], true);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let query = received[0].url.query().unwrap_or("");
+        assert!(query.contains("page_size=20"));
+        assert!(query.contains("user_id=u_001"));
+        assert!(query.contains("status=approved"));
+    }
+}

--- a/crates/openlark-security/src/security/security_and_compliance/v2/device_records/mine.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v2/device_records/mine.rs
@@ -70,3 +70,53 @@ impl GetMyDeviceRecordsRequest {
             .ok_or_else(|| validation_error("获取我的设备认证信息", "响应数据为空"))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
+
+    /// 端到端：GET .../device_records/mine + query 拼装 + 响应解析。
+    #[tokio::test]
+    async fn test_get_my_device_records_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/security_and_compliance/v2/device_records/mine",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [{ "device_record_id": "dr_001" }],
+                    "has_more": false
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = GetMyDeviceRecordsRequest::new(config)
+            .page_size(10)
+            .status("approved")
+            .execute()
+            .await
+            .expect("获取我的设备认证信息应成功");
+        assert_eq!(data["items"].as_array().unwrap().len(), 1);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let query = received[0].url.query().unwrap_or("");
+        assert!(query.contains("page_size=10"));
+        assert!(query.contains("status=approved"));
+    }
+}

--- a/crates/openlark-security/src/security/security_and_compliance/v2/device_records/update.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v2/device_records/update.rs
@@ -80,4 +80,49 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("device_record_id"));
     }
+
+    /// 端到端：PUT .../device_records/{id} + body 透传 + 响应解析。
+    #[tokio::test]
+    async fn test_update_device_record_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path(
+                "/open-apis/security_and_compliance/v2/device_records/dr_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "device_record_id": "dr_001", "status": "approved" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = UpdateDeviceRecordRequest::new(config, "dr_001")
+            .body(json!({ "status": "approved" }))
+            .execute()
+            .await
+            .expect("更新设备记录应成功");
+        assert_eq!(data["status"], "approved");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/security_and_compliance/v2/device_records/dr_001"
+        );
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["status"], "approved");
+    }
 }

--- a/docs/API_E2E_TEST_STRATEGY.md
+++ b/docs/API_E2E_TEST_STRATEGY.md
@@ -1,0 +1,157 @@
+# API 端到端测试策略（占位测试 → 真实 e2e）
+
+> 关联 issue：[#351 — P10: 占位 serde_json roundtrip 测试 → test_runtime 端到端](https://github.com/foxzool/openlark/issues/351)
+> 父 epic：[#314 deep-module](https://github.com/foxzool/openlark/issues/314)
+> 本 PR：策略文档 + pilot crate（`openlark-security`）全量改造。
+
+## 1. 问题：占位测试不验证接口层
+
+业务 crate 的接口层（`src/**/v*/` 下的 API 文件）普遍存在两类**占位测试**，它们都不触发真实的 `Builder → execute → Transport` 路径：
+
+1. **`serde_json` roundtrip 占位**：只测 `Request/Response` 结构体的 `serialize/deserialize`，从不构造请求、不发送。
+2. **`let _ = request.execute().await` 丢弃式占位**（部分 `openlark-docs` 的 `test_runtime` 用法）：调用了 `execute()`，但把结果丢弃，只断言「线程没 panic」。由于 `Config` 指向真实 `open.feishu.cn` 且无凭证，`execute` 实际返回 `Err`，而测试仍「绿」。
+
+结论：**业务 crate 的真实端到端覆盖近似为 0**。`validate_required!` 之类的校验被测到了，但「URL 是否拼对、method/body/query 是否正确、响应是否被正确解析」全部未验证。
+
+## 2. 目标模式：wiremock 端到端（auth 既定模式）
+
+唯一能真正验证 `Builder → execute → Transport → 响应解析` 的模式，是 `openlark-auth` 已落地的 **wiremock + `base_url` 注入**：
+
+1. `wiremock::MockServer::start()` 起一个本地 mock HTTP 服务。
+2. `Mock::given(method + path [+ body])` 挂载期望的请求匹配与响应。
+3. `Config::builder().base_url(server.uri())` 把真实 `Transport` 指向 mock。
+4. `.execute().await` 跑完整链路。
+5. 断言返回的 `data`，并用 `server.received_requests()` 反查**实际发出的 HTTP 请求形状**（method / path / query / body）。
+
+参考实现：
+- 历史范本：`crates/openlark-auth/src/auth/auth/v3/auth/tenant_access_token.rs::test_execute_sends_app_token_tenant_key_and_no_authorization`
+- 本 PR pilot 范本：`crates/openlark-security/src/acs/acs/v1/device/{get,create,list}.rs`
+
+### 2.1 为什么不用 docs 的 `test_runtime` Potemkin 模式
+
+issue 标题写作「→ `test_runtime` 端到端」，但 `test_runtime()` 本身只是 `Tokio Runtime` 的封装（见 `openlark-core/src/testing/mock_context.rs`），**不是一个 mock**。`openlark-docs` 全 crate 有 `wiremock` dev-dep 却 0 处使用，42 处 `execute()` 调用全部是 `let _ = ...execute()` 丢弃式——这正是要消除的反模式，不能作为目标。
+
+目标模式是 **wiremock 端到端**（auth 模式），不是 `test_runtime` 丢弃式。
+
+### 2.2 三个关键细节（避免踩坑）
+
+**① `enable_token_cache(false)`：App/Tenant 类型端点的测试必备**
+
+业务接口多用 `AccessTokenType::App`/`Tenant`。`Config::default()` 的 `enable_token_cache = true`，此时 `Transport` 会调用 `TokenProvider` 去获取 token；默认的 `NoOpTokenProvider` 直接返回 `ConfigurationError`，请求根本到不了 mock。
+
+测试中把 token 注入视为正交关注点（auth crate 已充分覆盖），配置加 `.enable_token_cache(false)`：在 `determine_token_type`（`openlark-core/src/http.rs`）中，缓存关闭 + `App` + 未显式传 token → 退化为 `None`，不发 token 请求、不加 `Authorization` 头，请求直达 mock。
+
+```rust
+let config = Config::builder()
+    .app_id("ci_app_id")
+    .app_secret("ci_app_secret")
+    .base_url(server.uri())
+    .enable_token_cache(false)   // ← 关键：绕过 token 获取，直达 mock
+    .build();
+```
+
+**② 响应信封：`ResponseFormat::Data` → `{"code":0,"data":<值>}`**
+
+业务 crate 的响应类型多为 `serde_json::Value`，其 `ApiResponseTrait` blanket impl 返回 `ResponseFormat::Data`（`openlark-core/src/api/responses.rs:211`）。`execute()` 返回的就是 `data` 字段的**内容**。故 mock body 必须是：
+
+```json
+{ "code": 0, "msg": "success", "data": { ...断言的内容... } }
+```
+
+`code: 0` 表示成功；非 0 会被 `Transport` 当作 API 错误。
+
+**③ wiremock 是 per-crate dev-dependency**
+
+`openlark-core` 的 `TestServer` 封装是 `#[cfg(test)]`，**不能跨 crate 使用**（见 [`TESTSERVER_LIMITATIONS.md`](./TESTSERVER_LIMITATIONS.md)）。业务 crate 必须各自在 `[dev-dependencies]` 加 `wiremock = { workspace = true }`，并在测试内直接 `use wiremock::{Mock, MockServer, ResponseTemplate}`。长期去重方案（独立 `openlark-test-utils` crate）见同文档方案 3，**不在本 PR 范围**。
+
+## 3. 食谱（已验证模板）
+
+### GET + 路径参数
+
+```rust
+#[tokio::test]
+async fn test_get_device_returns_data_on_success() {
+    use serde_json::json;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+    use wiremock::matchers::{method, path};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/open-apis/acs/v1/devices/dev_001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "code": 0, "msg": "success",
+            "data": { "device_id": "dev_001", "device_name": "前台门禁机" }
+        })))
+        .mount(&server).await;
+
+    let config = Config::builder()
+        .app_id("ci_app_id").app_secret("ci_app_secret")
+        .base_url(server.uri()).enable_token_cache(false).build();
+
+    let data = GetDeviceRequest::new(config, "dev_001")
+        .execute().await.expect("获取设备信息应成功");
+    assert_eq!(data["device_id"], "dev_001");
+
+    let received = server.received_requests().await.unwrap_or_default();
+    assert_eq!(received.len(), 1);
+    assert_eq!(received[0].url.path(), "/open-apis/acs/v1/devices/dev_001");
+}
+```
+
+### POST + body（额外校验请求体透传）
+
+```rust
+// mock 用 method+path 匹配（不绑死 body，避免脆性）；响应后反查 received body
+let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+assert_eq!(sent["device_name"], "新门禁机");
+```
+
+### GET + query 参数（校验拼装）
+
+```rust
+let query = received[0].url.query().unwrap_or("");
+assert!(query.contains("page_size=10"));
+assert!(query.contains("device_type=gate"));
+```
+
+> 约定：测试命名 `test_<op>_<resource>_returns_data_on_success`，与既有 `rejects_empty_*` 校验测试并列共存（不替换、不删除校验测试）。
+
+## 4. 各 crate 规模与优先级
+
+按「API 文件数（`fn execute`）」排序，端到端改造的体量与建议批次：
+
+| Crate | API 文件数 | 含 mod tests 文件 | 现状 | 优先级 |
+|-------|-----------|------------------|------|--------|
+| `openlark-security` | 39 | 32 | ✅ **本 PR pilot（全量改造）** | P0 |
+| `openlark-cardkit` | 10 | 18 | 小，适合第 2 批 | P1 |
+| `openlark-user` | 7 | 10 | 小，适合第 2 批 | P1 |
+| `openlark-auth` | 15 | 26 | ✅ 已是 wiremock e2e（范本） | — |
+| `openlark-analytics` | 20 | 25 | 中 | P2 |
+| `openlark-helpdesk` | 57 | 75 | 中（需补 wiremock dev-dep） | P2 |
+| `openlark-application` | 96 | 104 | 大，宜拆子 issue | P3 |
+| `openlark-mail` | 108 | 130 | 大，宜拆子 issue | P3 |
+| `openlark-platform` | 125 | 131 | 大，宜拆子 issue | P3 |
+| `openlark-meeting` | 125 | 134 | 大，宜拆子 issue | P3 |
+| `openlark-workflow` | 132 | 154 | 大，宜拆子 issue | P3 |
+| `openlark-docs` | 172 | 263 | 大 + 既有 Potemkin 需先清理 | P3 |
+| `openlark-communication` | 190 | 227 | 大，宜拆子 issue | P3 |
+| `openlark-hr` | 599 | 625 | 最大，按子域多次拆分 | P4 |
+
+**选型原则**：
+- pilot 选小而全（覆盖 GET/POST/LIST/DELETE/PATCH 等所有形状）的 crate，建立可复制范本 → `openlark-security`。
+- 后续按 crate 分批，**每个 crate 一个子 issue/PR**（issue #351 明确「宜按 crate 分批子 issue」）。大 crate（application/mail/hr…）按子域再拆。
+- 优先改造「响应类型为强类型 struct」的接口（更能捕获反序列化回归）；`serde_json::Value` 透传接口次之。
+
+## 5. 验收
+
+- [x] 测试策略文档（本文件）
+- [x] pilot crate（`openlark-security`）全量替换为 wiremock 端到端（含移除 `src/lib.rs` 中的占位 roundtrip 测试）
+- [x] `cargo test -p openlark-security --all-features` 通过（79 项，含 39 个新增 e2e）
+- [ ] 后续 crate：按上表分批建子 issue
+
+## 6. 相关文档
+
+- [`TESTING.md`](../TESTING.md) — 总测试指南
+- [`docs/TEST_ARCHITECTURE_SUMMARY.md`](./TEST_ARCHITECTURE_SUMMARY.md) — 测试架构与覆盖率门禁
+- [`docs/TESTSERVER_LIMITATIONS.md`](./TESTSERVER_LIMITATIONS.md) — `TestServer` 跨 crate 限制（为何业务 crate 直接用 wiremock）
+- [`docs/TEST_MIGRATION.md`](./TEST_MIGRATION.md) — 向 `TestServer` 迁移（core 内部）


### PR DESCRIPTION
## 背景

#351 要求把接口层的**占位 `serde_json` roundtrip 测试**替换为真实端到端测试。现状：业务 crate 的「真实 Builder→execute→Transport 路径」端到端覆盖近似为 **0**——`openlark-docs` 全 crate 有 `wiremock` dev-dep 却 **0 处使用**，42 处 `execute()` 全是 `let _ = ...execute()` 丢弃式（Potemkin）；各 API 文件只有 `rejects_empty_*` 校验测试。

## 本 PR 范围（#351 认可的「策略 + 1 个 pilot crate」首步）

动手前与 issue 作者确认两点：
1. **范围** = 策略文档 + 1 个 pilot crate（**非** application 全量；issue 正文「可先做策略 + 1 pilot crate」明确允许）。
2. **目标模式** = 真实 wiremock 端到端（auth 既定模式），**不是** issue 标题字面的 `test_runtime`——后者对应 docs 那套无价值的丢弃式。

Pilot 选 `openlark-security`：39 个 API 文件、小而全（覆盖所有 HTTP 形状）、且已有 `wiremock` dev-dep。

## 改动

- **`docs/API_E2E_TEST_STRATEGY.md`（新增）**：占位测试问题分析、wiremock 食谱、三个踩坑点（`enable_token_cache(false)` 绕过 App token 获取；`{code:0,data}` 信封；跨 crate `TestServer` 限制）、各 crate 规模与优先级表、分批计划。
- **`openlark-security` 全部 39 个 API 文件**：每个新增一个 `Builder→execute→Transport→mock→assert` 端到端测试，覆盖 GET+路径参数 / POST+body / PUT·PATCH / DELETE / LIST+query / 强类型响应（`ListUsersResponse`、`FaceData`）各形状；断言响应 `data` 解析，并反查 `received_requests()` 的 path / query / body。
- **`src/lib.rs`**：移除 2 个占位 roundtrip 测试（`{"test":"value"}`，测的是 serde_json 自身而非任何 security 模型）——正是 #351 要替换的反模式。

仅测试代码改动，**0 行生产代码**，无 `Cargo.toml` 变更（`wiremock` dev-dep 早就在）。

## 食谱（已验证模板）

```rust
let server = MockServer::start().await;
Mock::given(method("GET"))
    .and(path("/open-apis/acs/v1/devices/dev_001"))
    .respond_with(ResponseTemplate::new(200).set_body_json(json!({
        "code": 0, "msg": "success",
        "data": { "device_id": "dev_001" }
    })))
    .mount(&server).await;

let config = Config::builder()
    .app_id("ci_app_id").app_secret("ci_app_secret")
    .base_url(server.uri())
    .enable_token_cache(false)   // ← 关键：绕过 token 获取，直达 mock
    .build();

let data = GetDeviceRequest::new(config, "dev_001").execute().await.expect("...");
assert_eq!(data["device_id"], "dev_001");
let received = server.received_requests().await.unwrap_or_default();
assert_eq!(received.len(), 1);
assert_eq!(received[0].url.path(), "/open-apis/acs/v1/devices/dev_001");
```

## 验证

- `cargo test -p openlark-security --all-features` → **77 passed**（含 39 个新增 e2e）
- `cargo clippy -p openlark-security --all-targets --all-features -- -Dwarnings` → clean
- `cargo clippy -p openlark-security --all-targets --no-default-features -- -Dwarnings` → clean
- `cargo fmt -p openlark-security --check` → clean
- **Mutation teeth-check**：把 `device/get.rs` 的路径改成错的 → 对应 e2e 测试 **FAILED**（请求打不到 mock → 空响应 → `expect` panic），证明测试有真牙、非 Potemkin；已还原。
- 预 PR 工作流（completeness 审计 + adversarial teeth-check，2 agent）：39/39 文件覆盖、0 占位残留、6 个采样测试均能捕获 method / path / body / 解析 四类 bug → **clean**。

## 验收映射（#351）

- [x] 测试策略文档（crate 清单 + 优先级 + 食谱）
- [x] pilot crate（`openlark-security` 39 文件）全量替换为端到端（含移除 `lib.rs` 占位）
- [x] `cargo test` 通过
- [ ] 后续 crate 按 `docs/API_E2E_TEST_STRATEGY.md` §4 分批建子 issue（issue 保持开启）

Refs #351

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and documentation changes with no runtime SDK behavior modified; lockfile is a minor transitive dependency bump.
> 
> **Overview**
> Adds **`docs/API_E2E_TEST_STRATEGY.md`** to document replacing placeholder API tests with **wiremock** end-to-end coverage (mock server, `base_url` injection, `enable_token_cache(false)`, `{code:0,data}` envelopes), plus a crate-by-crate rollout plan for #351.
> 
> **`openlark-security`** is the pilot: each of the 39 API request modules gains a **`test_*_returns_data_on_success`** that runs **Builder → `execute` → Transport** against wiremock, asserts parsed **`data`**, and checks **`received_requests()`** for path, query, and body where relevant (GET/POST/PUT/PATCH/DELETE/list, including typed responses like `FaceData` / `ListUsersResponse`). Existing **`rejects_empty_*`** validation tests stay.
> 
> Removes two generic **`serde_json` roundtrip** tests from **`openlark-security/src/lib.rs`**. **`Cargo.lock`** only bumps **`crossbeam-epoch`** (transitive); no production or `Cargo.toml` changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbc90e8e6b888c933ee1ff8646d8c678495c6483. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->