### PR TITLE
test(cardkit): 占位 roundtrip 测试 → wiremock 端到端（#351 第 2 批）

### DIFF
--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/batch_update.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/batch_update.rs
@@ -139,21 +139,46 @@ impl BatchUpdateCardRequestBuilder {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：POST .../cards/{card_id}/batch_update + body 序列化 → BatchUpdateCardResponse。
+    #[tokio::test]
+    async fn test_batch_update_card_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/cardkit/v1/cards/card_001/batch_update"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "card_id": "card_001", "app_id": "app_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let body = BatchUpdateCardBody {
+            card_id: "card_001".into(),
+            operations: vec![json!({ "op": "replace", "path": "/title" })],
+        };
+        let resp = BatchUpdateCardRequest::new(config)
+            .execute(body)
+            .await
+            .expect("局部更新卡片实体应成功");
+        assert_eq!(resp.card_id.as_deref(), Some("card_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["operations"][0]["op"], "replace");
     }
 }

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/create.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/create.rs
@@ -202,21 +202,50 @@ pub async fn create_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：POST /open-apis/cardkit/v1/cards + body 序列化 → 强类型 CreateCardResponse。
+    #[tokio::test]
+    async fn test_create_card_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/cardkit/v1/cards"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "card_id": "card_001", "app_id": "app_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let body = CreateCardBody {
+            card_content: json!({ "schema": "2.0" }),
+            card_type: None,
+            template_id: None,
+            temp: None,
+            temp_expire_time: None,
+        };
+        let resp = CreateCardRequest::new(config)
+            .execute(body)
+            .await
+            .expect("创建卡片实体应成功");
+        assert_eq!(resp.card_id.as_deref(), Some("card_001"));
+        assert_eq!(resp.app_id.as_deref(), Some("app_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["card_content"]["schema"], "2.0");
     }
 }

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/content.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/content.rs
@@ -139,21 +139,49 @@ impl UpdateCardElementContentRequestBuilder {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：PUT .../cards/{card_id}/elements/{element_id}/content + body 序列化 → UpdateCardElementContentResponse。
+    #[tokio::test]
+    async fn test_update_card_element_content_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path(
+                "/open-apis/cardkit/v1/cards/card_001/elements/elem_001/content",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "card_id": "card_001", "element_id": "elem_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let body = UpdateCardElementContentBody {
+            card_id: "card_001".into(),
+            element_id: "elem_001".into(),
+            content: json!({ "tag": "markdown", "content": "hello" }),
+        };
+        let resp = UpdateCardElementContentRequest::new(config)
+            .execute(body)
+            .await
+            .expect("流式更新文本应成功");
+        assert_eq!(resp.element_id.as_deref(), Some("elem_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["content"]["tag"], "markdown");
     }
 }

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/create.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/create.rs
@@ -144,21 +144,46 @@ pub async fn create_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：POST .../cards/{card_id}/elements + body 序列化 → CreateCardElementResponse。
+    #[tokio::test]
+    async fn test_create_card_element_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/cardkit/v1/cards/card_001/elements"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "card_id": "card_001", "element_id": "elem_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let body = CreateCardElementBody {
+            card_id: "card_001".into(),
+            element: json!({ "tag": "div" }),
+        };
+        let resp = CreateCardElementRequest::new(config)
+            .execute(body)
+            .await
+            .expect("新增组件应成功");
+        assert_eq!(resp.element_id.as_deref(), Some("elem_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["element"]["tag"], "div");
     }
 }

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/delete.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/delete.rs
@@ -121,21 +121,51 @@ impl DeleteCardElementRequestBuilder {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：DELETE .../cards/{card_id}/elements/{element_id}（无 body）→ DeleteCardElementResponse。
+    #[tokio::test]
+    async fn test_delete_card_element_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/cardkit/v1/cards/card_001/elements/elem_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "card_id": "card_001", "element_id": "elem_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let body = DeleteCardElementBody {
+            card_id: "card_001".into(),
+            element_id: "elem_001".into(),
+        };
+        let resp = DeleteCardElementRequest::new(config)
+            .execute(body)
+            .await
+            .expect("删除组件应成功");
+        assert_eq!(resp.card_id.as_deref(), Some("card_001"));
+        assert_eq!(resp.element_id.as_deref(), Some("elem_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/cardkit/v1/cards/card_001/elements/elem_001"
+        );
     }
 }

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/mod.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/mod.rs
@@ -34,24 +34,3 @@ pub use patch::{PatchCardElementBody, PatchCardElementRequest, PatchCardElementR
 pub use update::{
     UpdateCardElementBody, UpdateCardElementRequest, UpdateCardElementRequestBuilder,
 };
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/models.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/models.rs
@@ -87,24 +87,3 @@ impl ApiResponseTrait for DeleteCardElementResponse {
         ResponseFormat::Data
     }
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/patch.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/patch.rs
@@ -135,21 +135,49 @@ impl PatchCardElementRequestBuilder {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：PATCH .../cards/{card_id}/elements/{element_id} + body 序列化 → PatchCardElementResponse。
+    #[tokio::test]
+    async fn test_patch_card_element_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/cardkit/v1/cards/card_001/elements/elem_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "card_id": "card_001", "element_id": "elem_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let body = PatchCardElementBody {
+            card_id: "card_001".into(),
+            element_id: "elem_001".into(),
+            patch: json!({ "tag": "column_set" }),
+        };
+        let resp = PatchCardElementRequest::new(config)
+            .execute(body)
+            .await
+            .expect("更新组件属性应成功");
+        assert_eq!(resp.element_id.as_deref(), Some("elem_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["patch"]["tag"], "column_set");
     }
 }

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/update.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/update.rs
@@ -138,21 +138,49 @@ impl UpdateCardElementRequestBuilder {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：PUT .../cards/{card_id}/elements/{element_id} + body 序列化 → UpdateCardElementResponse。
+    #[tokio::test]
+    async fn test_update_card_element_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path(
+                "/open-apis/cardkit/v1/cards/card_001/elements/elem_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "card_id": "card_001", "element_id": "elem_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let body = UpdateCardElementBody {
+            card_id: "card_001".into(),
+            element_id: "elem_001".into(),
+            patch: json!({ "tag": "div" }),
+        };
+        let resp = UpdateCardElementRequest::new(config)
+            .execute(body)
+            .await
+            .expect("更新组件属性应成功");
+        assert_eq!(resp.card_id.as_deref(), Some("card_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["patch"]["tag"], "div");
     }
 }

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/id_convert.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/id_convert.rs
@@ -163,21 +163,48 @@ pub async fn convert_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：POST /open-apis/cardkit/v1/cards/id_convert + body 序列化 → ConvertCardIdResponse。
+    #[tokio::test]
+    async fn test_convert_card_id_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/cardkit/v1/cards/id_convert"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "card_id": "open_card_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let body = ConvertCardIdBody {
+            source_id_type: "card_id".into(),
+            target_id_type: "open_id".into(),
+            card_ids: vec!["card_001".into()],
+        };
+        let resp = ConvertCardIdRequest::new(config)
+            .execute(body)
+            .await
+            .expect("转换 ID 应成功");
+        assert_eq!(resp.card_id.as_deref(), Some("open_card_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["source_id_type"], "card_id");
+        assert_eq!(sent["card_ids"][0], "card_001");
     }
 }

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/mod.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/mod.rs
@@ -13,22 +13,3 @@ pub mod settings;
 pub mod update;
 
 pub mod element;
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/models.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/models.rs
@@ -16,24 +16,3 @@ impl ApiResponseTrait for ConvertCardIdResponse {
         ResponseFormat::Data
     }
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/settings.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/settings.rs
@@ -136,21 +136,46 @@ impl UpdateCardSettingsRequestBuilder {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：PATCH .../cards/{card_id}/settings + body 序列化 → UpdateCardSettingsResponse。
+    #[tokio::test]
+    async fn test_update_card_settings_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/cardkit/v1/cards/card_001/settings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "card_id": "card_001", "app_id": "app_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let body = UpdateCardSettingsBody {
+            card_id: "card_001".into(),
+            settings: json!({ "sharing": { "permission": "anyone_can_edit" } }),
+        };
+        let resp = UpdateCardSettingsRequest::new(config)
+            .execute(body)
+            .await
+            .expect("更新卡片实体配置应成功");
+        assert_eq!(resp.app_id.as_deref(), Some("app_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["settings"]["sharing"]["permission"], "anyone_can_edit");
     }
 }

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/update.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/update.rs
@@ -169,21 +169,48 @@ impl UpdateCardRequestBuilder {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：PUT .../cards/{card_id} + body 序列化 → UpdateCardResponse。
+    #[tokio::test]
+    async fn test_update_card_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/cardkit/v1/cards/card_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "card_id": "card_001", "app_id": "app_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let body = UpdateCardBody {
+            card_id: "card_001".into(),
+            card_content: json!({ "schema": "2.0" }),
+            card_type: None,
+            update_mask: None,
+        };
+        let resp = UpdateCardRequest::new(config)
+            .execute(body)
+            .await
+            .expect("全量更新卡片实体应成功");
+        assert_eq!(resp.card_id.as_deref(), Some("card_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["card_content"]["schema"], "2.0");
     }
 }

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/mod.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/mod.rs
@@ -1,24 +1,3 @@
 //! cardkit v1
 
 pub mod card;
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-cardkit/src/common/chain.rs
+++ b/crates/openlark-cardkit/src/common/chain.rs
@@ -227,24 +227,3 @@ impl CardElementResource {
         .await
     }
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}


### PR DESCRIPTION
## 背景

继 security pilot（PR #374）之后，按 `docs/API_E2E_TEST_STRATEGY.md` §4 优先级表推进 #351 的第 2 批：`openlark-cardkit`（10 个 API 文件，P1）。

## 改动

- **`openlark-cardkit` 全部 10 个 API 文件**：每个新增一个 `Builder→execute→Transport→mock→assert` 端到端测试，强类型 body/response，覆盖 POST/PUT/PATCH/DELETE 及路径参数（`.../cards/{card_id}`、`.../cards/{card_id}/elements/{element_id}`）各形状；断言强类型响应字段，并反查 `received_requests()` 的 path/body。
- **移除全 crate 的占位 serde roundtrip 测试**（`{"test":"value"}`，测的是 serde_json 自身而非任何 cardkit 模型）——共 6 个聚合文件的 `mod tests`：`v1/mod.rs`、`card/mod.rs`、`element/mod.rs`、`card/models.rs`、`element/models.rs`、`common/chain.rs`（10 个 API 文件的内联占位在加 e2e 时已一并替换）。

仅测试代码改动，**0 行生产代码**，无 `Cargo.toml` 变更（`wiremock` dev-dep 早就在）。

## 模式（同 #374）

```rust
let server = MockServer::start().await;
Mock::given(method("POST")).and(path("/open-apis/cardkit/v1/cards"))
    .respond_with(ResponseTemplate::new(200).set_body_json(json!({
        "code": 0, "msg": "success",
        "data": { "card_id": "card_001", "app_id": "app_001" }
    })))
    .mount(&server).await;

let config = Config::builder()
    .app_id("ci_app_id").app_secret("ci_app_secret")
    .base_url(server.uri())
    .enable_token_cache(false)   // ← 绕过 token 获取，直达 mock
    .build();

let body = CreateCardBody { card_content: json!({"schema":"2.0"}), card_type: None, template_id: None, temp: None, temp_expire_time: None };
let resp = CreateCardRequest::new(config).execute(body).await.expect("...");
assert_eq!(resp.card_id.as_deref(), Some("card_001"));
let received = server.received_requests().await.unwrap_or_default();
assert_eq!(received.len(), 1);
let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
assert_eq!(sent["card_content"]["schema"], "2.0");
```

cardkit 比 security 多一层：请求未显式设 `AccessTokenType`，默认走 **Tenant**，故同样需要 `enable_token_cache(false)` 绕过 `NoOpTokenProvider`。teeth 机制与 #374 同构（错路径→请求打不到 mock→`expect` panic）。

## 验证

- `cargo test -p openlark-cardkit --all-features` → 全绿
- `cargo clippy -p openlark-cardkit --all-targets --all-features -- -Dwarnings` → clean
- `cargo clippy -p openlark-cardkit --all-targets --no-default-features -- -Dwarnings` → clean
- `cargo fmt -p openlark-cardkit --check` → clean
- completeness grep：cardkit 全 crate **0** 处 `{"test":"value"}` 占位残留

Refs #351

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime behavior or dependency updates; risk is limited to CI/test maintenance.
> 
> **Overview**
> **Replaces** generic `serde_json` roundtrip placeholders across `openlark-cardkit` with **wiremock-backed async E2E tests** on all **10** cardkit v1 API modules (create/update/batch_update/settings/id_convert and card element CRUD/content/patch/update).
> 
> Each new test runs `Request::execute` against a mock server (`base_url` + `enable_token_cache(false)`), checks **typed response fields**, and inspects **`received_requests()`** for HTTP method/path and serialized body (DELETE asserts path only).
> 
> **Removes** duplicate placeholder `mod tests` blocks from six barrel/model/chain files (`v1/mod.rs`, `card/mod.rs`, `element/mod.rs`, both `models.rs`, `common/chain.rs`) so the crate no longer carries `{"test":"value"}` noise. **No production or `Cargo.toml` changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 270585ce718740939ef419e092c73e37b7dd8326. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->