### PR TITLE
test(user): 占位 roundtrip → wiremock 端到端（#351 第 3 批）；发现 get 幻影 API

### DIFF
--- a/.github/msrv/Cargo.lock
+++ b/.github/msrv/Cargo.lock
@@ -1888,6 +1888,7 @@ dependencies = [
  "serde_repr",
  "tempfile",
  "thiserror",
+ "tokio",
  "tokio-test",
  "url",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1856,6 +1856,7 @@ dependencies = [
  "serde_repr",
  "tempfile",
  "thiserror",
+ "tokio",
  "tokio-test",
  "url",
  "uuid",

--- a/crates/openlark-user/Cargo.toml
+++ b/crates/openlark-user/Cargo.toml
@@ -41,6 +41,7 @@ log = { workspace = true }
 
 
 [dev-dependencies]
+tokio = { workspace = true }
 tokio-test = "0.4"
 wiremock = { workspace = true }
 rstest = { workspace = true }

--- a/crates/openlark-user/src/common/mod.rs
+++ b/crates/openlark-user/src/common/mod.rs
@@ -23,23 +23,3 @@ pub struct UserPreference {
     /// 偏好类别
     pub category: Option<String>,
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/batch_close.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/batch_close.rs
@@ -90,19 +90,50 @@ impl BatchCloseSystemStatusRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../system_statuses/{status_id}/batch_close + body{user_ids} → 响应解析。
+    #[tokio::test]
+    async fn test_batch_close_system_status_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/personal_settings/v1/system_statuses/ss_001/batch_close",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "system_status_id": "ss_001" } }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = BatchCloseSystemStatusRequest::new(config, "ss_001")
+            .user_ids(vec!["u_001".into(), "u_002".into()])
+            .execute()
+            .await
+            .expect("批量关闭系统状态应成功");
+        assert_eq!(resp.data.unwrap()["system_status_id"], "ss_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/personal_settings/v1/system_statuses/ss_001/batch_close"
+        );
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["user_ids"].as_array().unwrap().len(), 2);
     }
 }

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/batch_open.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/batch_open.rs
@@ -67,19 +67,47 @@ impl SystemStatusBatchOpenRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../system_statuses/{status_id}/batch_open → 响应解析。
+    #[tokio::test]
+    async fn test_batch_open_system_status_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/personal_settings/v1/system_statuses/ss_001/batch_open",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "system_status_id": "ss_001" } }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = SystemStatusBatchOpenRequest::new(config, "ss_001")
+            .execute()
+            .await
+            .expect("批量开启系统状态应成功");
+        assert_eq!(resp.data.unwrap()["system_status_id"], "ss_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/personal_settings/v1/system_statuses/ss_001/batch_open"
+        );
     }
 }

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/create.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/create.rs
@@ -60,19 +60,45 @@ impl SystemStatusCreateRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../system_statuses（无 body）→ 响应解析。
+    #[tokio::test]
+    async fn test_create_system_status_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/personal_settings/v1/system_statuses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "system_status_id": "ss_new" } }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = SystemStatusCreateRequest::new(config)
+            .execute()
+            .await
+            .expect("创建系统状态应成功");
+        assert_eq!(resp.data.unwrap()["system_status_id"], "ss_new");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/personal_settings/v1/system_statuses"
+        );
     }
 }

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/delete.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/delete.rs
@@ -75,19 +75,48 @@ impl SystemStatusDeleteRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：DELETE .../system_statuses/{status_id} → 响应解析。
+    #[tokio::test]
+    async fn test_delete_system_status_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/personal_settings/v1/system_statuses/ss_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "system_status_id": "ss_001" } }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = SystemStatusDeleteRequest::new(config)
+            .status_id("ss_001")
+            .execute()
+            .await
+            .expect("删除系统状态应成功");
+        assert_eq!(resp.data.unwrap()["system_status_id"], "ss_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/personal_settings/v1/system_statuses/ss_001"
+        );
     }
 }

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/list.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/list.rs
@@ -60,19 +60,46 @@ impl SystemStatusListRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../system_statuses → 响应解析（data:{data:{...}} 双层信封）。
+    #[tokio::test]
+    async fn test_list_system_status_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/personal_settings/v1/system_statuses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "items": [{ "system_status_id": "ss_001" }] } }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = SystemStatusListRequest::new(config)
+            .execute()
+            .await
+            .expect("获取系统状态列表应成功");
+        let data = resp.data.expect("响应 data 不应为空");
+        assert_eq!(data["items"].as_array().unwrap().len(), 1);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/personal_settings/v1/system_statuses"
+        );
     }
 }

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/patch.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/patch.rs
@@ -75,19 +75,48 @@ impl SystemStatusPatchRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PATCH .../system_statuses/{status_id} → 响应解析。
+    #[tokio::test]
+    async fn test_patch_system_status_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/personal_settings/v1/system_statuses/ss_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "system_status_id": "ss_001" } }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = SystemStatusPatchRequest::new(config)
+            .status_id("ss_001")
+            .execute()
+            .await
+            .expect("更新系统状态应成功");
+        assert_eq!(resp.data.unwrap()["system_status_id"], "ss_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/personal_settings/v1/system_statuses/ss_001"
+        );
     }
 }


### PR DESCRIPTION
## 背景

继 security（#374）、cardkit（#375）之后，按 `docs/API_E2E_TEST_STRATEGY.md` §4 推进 #351 第 3 批：`openlark-user`（personal_settings/system_status）。

## 改动

- **6 个真实 API 文件**新增 wiremock 端到端测试：`list` / `create` / `patch` / `delete` / `batch_open` / `batch_close`（覆盖 GET/POST/PATCH/DELETE + 路径参数 `.../system_statuses/{status_id}`）。
- **移除 7 处占位 roundtrip 测试**（`{"test":"value"}`）：6 个 API 文件内联 mod + `common/mod.rs`。
- 为 `#[tokio::test]` 补 `tokio` dev-dep（user crate 之前只有 `tokio-test`）；`Cargo.lock` 仅 +1 行依赖边。

模式同 #374/#375：`wiremock` + `base_url` + `enable_token_cache(false)`。user crate 的差异：用 `Arc<Config>`；响应是 `{data: Option<Value>}` + `ResponseFormat::Data`，故 mock 需双层 `data` 信封 `{"code":0,"data":{"data":{...}}}`。

## ⚠️ 重大发现：`get.rs` 是幻影 API（本 PR 未改）

核对 `api_list_export.csv`，飞书 `personal_settings/v1/system_status` **只有 6 个 API（无 get）**——目录里"获取系统状态"对应的是 `list`。而 `get.rs`：
- 实现一个**不存在的接口**；
- URL 畸形：`/open-apis/personal-settings/personal-settings/v1/system-status/get`（双段 + 连字符，与其它 6 个文件的 `/open-apis/personal_settings/v1/system_statuses` 矛盾）；
- 无 `docPath`；`new(config)` 不收 id。

但它被 `personal_settings/mod.rs` 的 `pub fn get(&self) -> SystemStatusGetRequest` **暴露为公共方法**——调用即打假 URL。删除属 **breaking public API 变更**（移除 `get()`），应在单独 issue 处理（建议下个 minor 版本）。本 PR **不动 `get.rs`**，其占位测试保留待删除时一并清理。

> 建议后续：开一个 issue 专门移除 `SystemStatusGetRequest` / `service.get()`（phantom API）。

## 验证

- `cargo test -p openlark-user --all-features` → 全绿（6 个新 e2e）
- `cargo clippy -p openlark-user --all-targets --all-features -- -Dwarnings` → clean
- `cargo clippy -p openlark-user --all-targets --no-default-features -- -Dwarnings` → clean
- `cargo fmt -p openlark-user --check` → clean
- completeness grep：仅 `get.rs` 残留占位（已标记为幻影 API，待单独移除）

Refs #351

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and dev-dependency changes; runtime SDK behavior is unchanged.
> 
> **Overview**
> Replaces **placeholder JSON roundtrip tests** in `openlark-user` with **wiremock end-to-end tests** for the six real `personal_settings/v1/system_status` clients: `list`, `create`, `patch`, `delete`, `batch_open`, and `batch_close`.
> 
> Each new `#[tokio::test]` drives `Transport` against a mock server (`base_url` + `enable_token_cache(false)`), stubs the correct HTTP method/path, uses the **double `data` envelope** in mocks (`{"code":0,"data":{"data":{...}}}`) to match `ResponseFormat::Data`, and asserts parsed fields plus outbound URL (and `user_ids` body for `batch_close`). The same placeholders are **removed** from `common/mod.rs`.
> 
> Adds **`tokio`** under `[dev-dependencies]` (and lockfile) so async tests compile; **no production code** changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e01f117d2d9be3c22fb4ffcfefcf7de442cf9551. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->