### PR TITLE
chore(user): deprecate 幻影 API SystemStatusResource::get()（#377 铺路）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   配合 v0.18 deprecated 清理节奏，下个 breaking 窗口删除。**非 breaking**：仅 deprecation
   warning，旧调用仍可编译。
 
+- **user `SystemStatusResource::get()` 标 `#[deprecated]`**（#377）：`personal_settings/v1/
+  system_status::get` 是幻影 API——飞书该目录无 `get` 接口（"获取系统状态"对应 `list`），URL
+  畸形且被暴露为 `service.get()` 公共方法（调用即打不存在的端点）。标记 deprecated，note 指明
+  替代（`SystemStatusResource::list` / `SystemStatusListRequest`）。配合 v0.18 deprecated 清理
+  节奏，下个 breaking 窗口连同 `get.rs` / `SystemStatusGetRequest` 一并删除。**非 breaking**：
+  仅 deprecation warning，旧调用仍可编译。
+
 ### Breaking Changes
 
 - **openlark-platform 修 `PlatformService::new` 误导签名（#350 P9 platform 子项）**：

--- a/crates/openlark-user/src/personal_settings/mod.rs
+++ b/crates/openlark-user/src/personal_settings/mod.rs
@@ -38,6 +38,13 @@ impl SystemStatusResource {
     }
 
     /// 获取系统状态详情。
+    ///
+    /// ⚠️ **幻影 API**：飞书 `personal_settings/v1/system_status` 无 `get` 接口（目录里
+    /// "获取系统状态"对应的是 [`list`](SystemStatusResource::list)），此方法请求的是一个不
+    /// 存在的端点。将在 v0.18.0 移除（#377）；请改用 [`list`](SystemStatusResource::list)。
+    #[deprecated(
+        note = "幻影 API：飞书无 system_status get 接口，将在 v0.18.0 移除；请改用 list（SystemStatusListRequest）（#377）"
+    )]
     pub fn get(&self) -> SystemStatusGetRequest {
         SystemStatusGetRequest::new(self.config.clone())
     }

--- a/crates/openlark-user/tests/user_contract_models.rs
+++ b/crates/openlark-user/tests/user_contract_models.rs
@@ -192,6 +192,7 @@ fn user_service_config_roundtrip() {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[allow(deprecated)] // get() 是幻影 API（#377），v0.18 移除前仍验证其可达
 fn system_status_service_access_contract() {
     use openlark_core::config::Config;
     use openlark_user::UserService;


### PR DESCRIPTION
## 背景

#377（由 #351 第 3 批 user crate e2e 化、PR #376 发现）：`personal_settings::system_status::get` 是**幻影 API**——飞书该目录无 `get` 接口（"获取系统状态"对应 `list`），URL 畸形，却被 `SystemStatusResource::get()` 暴露为公共方法（调用即打不存在的端点）。

删除属 breaking public API，安排在 v0.18。本 PR 按 `docs/DEPRECATED_API_SUPPORT_POLICY.md`（≥1 发布周期 + note 指明替代）**先标 `#[deprecated]` 铺路**。

## 改动

- `SystemStatusResource::get()` 标 `#[deprecated]`，note：无飞书接口 / 改用 `list`（`SystemStatusListRequest`）/ v0.18.0 移除（#377）。doc-comment 同步说明。
- `tests/user_contract_models.rs::system_status_service_access_contract` 加 `#[allow(deprecated)]`——v0.18 真正删除 `get()` 前，contract 测试仍验证其可达。
- `CHANGELOG.md` `[Unreleased]/Changed` 增条目（照 analytics Search #308 deprecation 先例）。

**非 breaking**：仅 deprecation warning，旧调用仍可编译。

## 验证

- `cargo test -p openlark-user --all-features` → 全绿
- `cargo clippy -p openlark-user --all-targets --all-features -- -Dwarnings` → clean
- `cargo clippy -p openlark-user --all-targets --no-default-features -- -Dwarnings` → clean
- `cargo fmt -p openlark-user --check` → clean
- `cargo doc -p openlark-user --no-deps --all-features`（`-D warnings`）→ clean（intra-doc link 解析正常）

## 后续

v0.18 breaking 窗口：删除 `get.rs` + `pub mod get` + `SystemStatusGetRequest/Response` + `SystemStatusResource::get()` + contract 测试对应行 + CHANGELOG Breaking Changes 条目（追踪于 #377）。

Refs #377