### PR TITLE
fix(analytics): 修 7 个残缺 stub + 全 20 加 wiremock e2e（#351 第 4 批）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+- **openlark-analytics 修 7 个 search/v2 + report 残缺 stub（#351 第 4 批）**：
+  `data_source` delete/patch、`data_source.item` create/delete、`schema` delete/patch、`report.rule.view`
+  remove 共 7 个 stub 原本残缺——`new(config)` 不收 id 且 URL 为字面 `{}`（无插值），对真实飞书必然 404、
+  不可用。补 id 参数 + `format!` 路径插值，并加 wiremock 端到端覆盖（同 #374/#375/#376 食谱）。**breaking**：
+  7 个 `XxxRequest::new(config)` → `new(config, id)`（`DeleteDataSourceItemRequest` 加 2 个 id）。**迁移**：
+  调用方补传对应 id。全仓零外部消费者（workspace `cargo check --all-targets` 验证无跨 crate 引用；这些
+  stub 此前不可用、无人调用）。
+
 - **openlark-platform 修 `PlatformService::new` 误导签名（#350 P9 platform 子项）**：
   签名 `SDKResult<Self>` 但函数体永远 `Ok(...)`（接口撒谎——调用方据 `Result` 写的错误分支永不达）→ 改为 `Self`
  （非 `Result`，同 user #360 `UserService::new` 修正方向）。**breaking**：`PlatformService::new` 返回类型

--- a/crates/openlark-analytics/src/common/mod.rs
+++ b/crates/openlark-analytics/src/common/mod.rs
@@ -28,24 +28,4 @@ pub struct SearchStats {
     pub page_count: u32,
 }
 
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}
-
 pub mod constants;

--- a/crates/openlark-analytics/src/report/report/v1/rule/query.rs
+++ b/crates/openlark-analytics/src/report/report/v1/rule/query.rs
@@ -59,19 +59,42 @@ impl QueryReportRuleRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET /open-apis/report/v1/rules/query → 响应解析。
+    #[tokio::test]
+    async fn test_query_report_rule_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/report/v1/rules/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = QueryReportRuleRequest::new(config)
+            .execute()
+            .await
+            .expect("查询规则应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/report/v1/rules/query");
     }
 }

--- a/crates/openlark-analytics/src/report/report/v1/rule/view/remove.rs
+++ b/crates/openlark-analytics/src/report/report/v1/rule/view/remove.rs
@@ -1,4 +1,5 @@
 //! 移除规则看板
+//! docPath: <https://open.feishu.cn/document/server-docs/report-v1/rule-view/remove>
 
 use openlark_core::{
     SDKResult,
@@ -6,6 +7,7 @@ use openlark_core::{
     config::Config,
     http::Transport,
     req_option::RequestOption,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -14,6 +16,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub struct RemoveReportRuleViewRequest {
     config: Arc<Config>,
+    rule_id: String,
 }
 
 /// 移除规则看板响应。
@@ -31,8 +34,11 @@ impl ApiResponseTrait for RemoveReportRuleViewResponse {
 
 impl RemoveReportRuleViewRequest {
     /// 创建新的请求构建器。
-    pub fn new(config: Arc<Config>) -> Self {
-        Self { config }
+    pub fn new(config: Arc<Config>, rule_id: impl Into<String>) -> Self {
+        Self {
+            config,
+            rule_id: rule_id.into(),
+        }
     }
 
     /// 执行移除规则看板请求。
@@ -45,7 +51,8 @@ impl RemoveReportRuleViewRequest {
         self,
         option: RequestOption,
     ) -> SDKResult<RemoveReportRuleViewResponse> {
-        let path = "/open-apis/report/v1/rules/{}/views/remove".to_string();
+        validate_required!(self.rule_id, "rule_id 不能为空");
+        let path = format!("/open-apis/report/v1/rules/{}/views/remove", self.rule_id);
         let req: ApiRequest<RemoveReportRuleViewResponse> = ApiRequest::post(&path);
 
         let resp = Transport::request(req, &self.config, Some(option)).await?;
@@ -58,19 +65,45 @@ impl RemoveReportRuleViewRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../rules/{rule_id}/views/remove（修复后路径插值）→ 响应解析。
+    #[tokio::test]
+    async fn test_remove_report_rule_view_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/report/v1/rules/rule_001/views/remove"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = RemoveReportRuleViewRequest::new(config, "rule_001")
+            .execute()
+            .await
+            .expect("移除规则看板应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/report/v1/rules/rule_001/views/remove"
+        );
     }
 }

--- a/crates/openlark-analytics/src/report/report/v1/task/query.rs
+++ b/crates/openlark-analytics/src/report/report/v1/task/query.rs
@@ -59,19 +59,42 @@ impl QueryReportTaskRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/report/v1/tasks/query → 响应解析。
+    #[tokio::test]
+    async fn test_query_report_task_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/report/v1/tasks/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = QueryReportTaskRequest::new(config)
+            .execute()
+            .await
+            .expect("查询任务应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/report/v1/tasks/query");
     }
 }

--- a/crates/openlark-analytics/src/search/search/mod.rs
+++ b/crates/openlark-analytics/src/search/search/mod.rs
@@ -1,23 +1,3 @@
 //! Search API 模块
 
 pub mod v2;
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-analytics/src/search/search/v2.rs
+++ b/crates/openlark-analytics/src/search/search/v2.rs
@@ -10,23 +10,3 @@ pub mod message;
 pub mod query;
 pub mod schema;
 pub mod user;
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-analytics/src/search/search/v2/app/create.rs
+++ b/crates/openlark-analytics/src/search/search/v2/app/create.rs
@@ -56,19 +56,42 @@ impl SearchAppRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/search/v2/app → 响应解析。
+    #[tokio::test]
+    async fn test_create_search_app_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/search/v2/app"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = SearchAppRequest::new(config)
+            .execute()
+            .await
+            .expect("创建搜索应用应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/search/v2/app");
     }
 }

--- a/crates/openlark-analytics/src/search/search/v2/data_source/create.rs
+++ b/crates/openlark-analytics/src/search/search/v2/data_source/create.rs
@@ -59,19 +59,42 @@ impl CreateDataSourceRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/search/v2/data_sources → 响应解析。
+    #[tokio::test]
+    async fn test_create_data_source_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/search/v2/data_sources"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = CreateDataSourceRequest::new(config)
+            .execute()
+            .await
+            .expect("创建数据源应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/search/v2/data_sources");
     }
 }

--- a/crates/openlark-analytics/src/search/search/v2/data_source/delete.rs
+++ b/crates/openlark-analytics/src/search/search/v2/data_source/delete.rs
@@ -7,6 +7,7 @@ use openlark_core::{
     config::Config,
     http::Transport,
     req_option::RequestOption,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -15,6 +16,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub struct DeleteDataSourceRequest {
     config: Arc<Config>,
+    data_source_id: String,
 }
 
 /// 删除数据源响应。
@@ -32,8 +34,11 @@ impl ApiResponseTrait for DeleteDataSourceResponse {
 
 impl DeleteDataSourceRequest {
     /// 创建新的请求构建器。
-    pub fn new(config: Arc<Config>) -> Self {
-        Self { config }
+    pub fn new(config: Arc<Config>, data_source_id: impl Into<String>) -> Self {
+        Self {
+            config,
+            data_source_id: data_source_id.into(),
+        }
     }
 
     /// 执行删除数据源请求。
@@ -46,7 +51,8 @@ impl DeleteDataSourceRequest {
         self,
         option: RequestOption,
     ) -> SDKResult<DeleteDataSourceResponse> {
-        let path = "/open-apis/search/v2/data_sources/{}".to_string();
+        validate_required!(self.data_source_id, "data_source_id 不能为空");
+        let path = format!("/open-apis/search/v2/data_sources/{}", self.data_source_id);
         let req: ApiRequest<DeleteDataSourceResponse> = ApiRequest::delete(&path);
 
         let resp = Transport::request(req, &self.config, Some(option)).await?;
@@ -59,19 +65,45 @@ impl DeleteDataSourceRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：DELETE .../data_sources/{data_source_id}（修复后路径插值）→ 响应解析。
+    #[tokio::test]
+    async fn test_delete_data_source_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/search/v2/data_sources/ds_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = DeleteDataSourceRequest::new(config, "ds_001")
+            .execute()
+            .await
+            .expect("删除数据源应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/search/v2/data_sources/ds_001"
+        );
     }
 }

--- a/crates/openlark-analytics/src/search/search/v2/data_source/get.rs
+++ b/crates/openlark-analytics/src/search/search/v2/data_source/get.rs
@@ -74,19 +74,51 @@ impl GetDataSourceRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET /open-apis/search/v2/data_sources/{data_source_id} → 响应解析。
+    #[tokio::test]
+    async fn test_get_data_source_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/search/v2/data_sources/ds_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "data": {
+                        "data_source_id": "ds_001",
+                        "name": "n",
+                        "description": "d"
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetDataSourceRequest::new(config, "ds_001")
+            .execute()
+            .await
+            .expect("获取数据源应成功");
+        assert_eq!(resp.data.unwrap().data_source_id, "ds_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/search/v2/data_sources/ds_001"
+        );
     }
 }

--- a/crates/openlark-analytics/src/search/search/v2/data_source/item/create.rs
+++ b/crates/openlark-analytics/src/search/search/v2/data_source/item/create.rs
@@ -1,5 +1,5 @@
 //! 为指定数据项创建索引
-//! docPath: <https://open.feishu.cn/document/server-docs/search-v2/open-search/data_source/create>
+//! docPath: <https://open.feishu.cn/document/server-docs/search-v2/open-search/data_source-item/create>
 
 use openlark_core::{
     SDKResult,
@@ -7,6 +7,7 @@ use openlark_core::{
     config::Config,
     http::Transport,
     req_option::RequestOption,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -15,6 +16,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub struct CreateDataSourceItemRequest {
     config: Arc<Config>,
+    data_source_id: String,
 }
 
 /// 为指定数据项创建索引响应。
@@ -32,8 +34,11 @@ impl ApiResponseTrait for CreateDataSourceItemResponse {
 
 impl CreateDataSourceItemRequest {
     /// 创建新的请求构建器。
-    pub fn new(config: Arc<Config>) -> Self {
-        Self { config }
+    pub fn new(config: Arc<Config>, data_source_id: impl Into<String>) -> Self {
+        Self {
+            config,
+            data_source_id: data_source_id.into(),
+        }
     }
 
     /// 执行为指定数据项创建索引请求。
@@ -46,7 +51,11 @@ impl CreateDataSourceItemRequest {
         self,
         option: RequestOption,
     ) -> SDKResult<CreateDataSourceItemResponse> {
-        let path = "/open-apis/search/v2/data_sources/{}/items".to_string();
+        validate_required!(self.data_source_id, "data_source_id 不能为空");
+        let path = format!(
+            "/open-apis/search/v2/data_sources/{}/items",
+            self.data_source_id
+        );
         let req: ApiRequest<CreateDataSourceItemResponse> = ApiRequest::post(&path);
 
         let resp = Transport::request(req, &self.config, Some(option)).await?;
@@ -60,19 +69,45 @@ impl CreateDataSourceItemRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../data_sources/{data_source_id}/items（修复后路径插值）→ 响应解析。
+    #[tokio::test]
+    async fn test_create_data_source_item_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/search/v2/data_sources/ds_001/items"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = CreateDataSourceItemRequest::new(config, "ds_001")
+            .execute()
+            .await
+            .expect("为指定数据项创建索引应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/search/v2/data_sources/ds_001/items"
+        );
     }
 }

--- a/crates/openlark-analytics/src/search/search/v2/data_source/item/delete.rs
+++ b/crates/openlark-analytics/src/search/search/v2/data_source/item/delete.rs
@@ -1,5 +1,5 @@
 //! 删除数据项
-//! docPath: <https://open.feishu.cn/document/server-docs/search-v2/open-search/data_source/delete>
+//! docPath: <https://open.feishu.cn/document/server-docs/search-v2/open-search/data_source-item/delete>
 
 use openlark_core::{
     SDKResult,
@@ -7,6 +7,7 @@ use openlark_core::{
     config::Config,
     http::Transport,
     req_option::RequestOption,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -15,6 +16,8 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub struct DeleteDataSourceItemRequest {
     config: Arc<Config>,
+    data_source_id: String,
+    item_id: String,
 }
 
 /// 删除数据项响应。
@@ -32,8 +35,16 @@ impl ApiResponseTrait for DeleteDataSourceItemResponse {
 
 impl DeleteDataSourceItemRequest {
     /// 创建新的请求构建器。
-    pub fn new(config: Arc<Config>) -> Self {
-        Self { config }
+    pub fn new(
+        config: Arc<Config>,
+        data_source_id: impl Into<String>,
+        item_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            config,
+            data_source_id: data_source_id.into(),
+            item_id: item_id.into(),
+        }
     }
 
     /// 执行删除数据项请求。
@@ -46,7 +57,12 @@ impl DeleteDataSourceItemRequest {
         self,
         option: RequestOption,
     ) -> SDKResult<DeleteDataSourceItemResponse> {
-        let path = "/open-apis/search/v2/data_sources/{}/items/{}".to_string();
+        validate_required!(self.data_source_id, "data_source_id 不能为空");
+        validate_required!(self.item_id, "item_id 不能为空");
+        let path = format!(
+            "/open-apis/search/v2/data_sources/{}/items/{}",
+            self.data_source_id, self.item_id
+        );
         let req: ApiRequest<DeleteDataSourceItemResponse> = ApiRequest::delete(&path);
 
         let resp = Transport::request(req, &self.config, Some(option)).await?;
@@ -59,19 +75,47 @@ impl DeleteDataSourceItemRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：DELETE .../data_sources/{data_source_id}/items/{item_id}（修复后路径插值）→ 响应解析。
+    #[tokio::test]
+    async fn test_delete_data_source_item_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/search/v2/data_sources/ds_001/items/it_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = DeleteDataSourceItemRequest::new(config, "ds_001", "it_001")
+            .execute()
+            .await
+            .expect("删除数据项应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/search/v2/data_sources/ds_001/items/it_001"
+        );
     }
 }

--- a/crates/openlark-analytics/src/search/search/v2/data_source/item/get.rs
+++ b/crates/openlark-analytics/src/search/search/v2/data_source/item/get.rs
@@ -81,19 +81,52 @@ impl GetDataSourceItemRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET /open-apis/search/v2/data_sources/{data_source_id}/items/{item_id} → 响应解析。
+    #[tokio::test]
+    async fn test_get_data_source_item_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/search/v2/data_sources/ds_001/items/it_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "data": {
+                        "item_id": "it_001",
+                        "data": {}
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetDataSourceItemRequest::new(config, "ds_001", "it_001")
+            .execute()
+            .await
+            .expect("查询指定数据项应成功");
+        assert_eq!(resp.data.unwrap().item_id, "it_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/search/v2/data_sources/ds_001/items/it_001"
+        );
     }
 }

--- a/crates/openlark-analytics/src/search/search/v2/data_source/list.rs
+++ b/crates/openlark-analytics/src/search/search/v2/data_source/list.rs
@@ -59,19 +59,42 @@ impl ListDataSourceRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET /open-apis/search/v2/data_sources → 响应解析。
+    #[tokio::test]
+    async fn test_list_data_sources_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/search/v2/data_sources"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ListDataSourceRequest::new(config)
+            .execute()
+            .await
+            .expect("获取数据源列表应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/search/v2/data_sources");
     }
 }

--- a/crates/openlark-analytics/src/search/search/v2/data_source/patch.rs
+++ b/crates/openlark-analytics/src/search/search/v2/data_source/patch.rs
@@ -7,6 +7,7 @@ use openlark_core::{
     config::Config,
     http::Transport,
     req_option::RequestOption,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -15,6 +16,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub struct PatchDataSourceRequest {
     config: Arc<Config>,
+    data_source_id: String,
 }
 
 /// 修改数据源响应。
@@ -32,8 +34,11 @@ impl ApiResponseTrait for PatchDataSourceResponse {
 
 impl PatchDataSourceRequest {
     /// 创建新的请求构建器。
-    pub fn new(config: Arc<Config>) -> Self {
-        Self { config }
+    pub fn new(config: Arc<Config>, data_source_id: impl Into<String>) -> Self {
+        Self {
+            config,
+            data_source_id: data_source_id.into(),
+        }
     }
 
     /// 执行修改数据源请求。
@@ -46,7 +51,8 @@ impl PatchDataSourceRequest {
         self,
         option: RequestOption,
     ) -> SDKResult<PatchDataSourceResponse> {
-        let path = "/open-apis/search/v2/data_sources/{}".to_string();
+        validate_required!(self.data_source_id, "data_source_id 不能为空");
+        let path = format!("/open-apis/search/v2/data_sources/{}", self.data_source_id);
         let req: ApiRequest<PatchDataSourceResponse> = ApiRequest::patch(&path);
 
         let resp = Transport::request(req, &self.config, Some(option)).await?;
@@ -59,19 +65,45 @@ impl PatchDataSourceRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PATCH .../data_sources/{data_source_id}（修复后路径插值）→ 响应解析。
+    #[tokio::test]
+    async fn test_patch_data_source_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/search/v2/data_sources/ds_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = PatchDataSourceRequest::new(config, "ds_001")
+            .execute()
+            .await
+            .expect("修改数据源应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/search/v2/data_sources/ds_001"
+        );
     }
 }

--- a/crates/openlark-analytics/src/search/search/v2/doc_wiki/search.rs
+++ b/crates/openlark-analytics/src/search/search/v2/doc_wiki/search.rs
@@ -59,19 +59,45 @@ impl SearchDocWikiRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/search/v2/doc_wiki/search → 响应解析。
+    #[tokio::test]
+    async fn test_search_doc_wiki_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/search/v2/doc_wiki/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = SearchDocWikiRequest::new(config)
+            .execute()
+            .await
+            .expect("搜索知识库应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/search/v2/doc_wiki/search"
+        );
     }
 }

--- a/crates/openlark-analytics/src/search/search/v2/message/create.rs
+++ b/crates/openlark-analytics/src/search/search/v2/message/create.rs
@@ -59,19 +59,42 @@ impl SearchMessageRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/search/v2/message → 响应解析。
+    #[tokio::test]
+    async fn test_create_search_message_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/search/v2/message"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = SearchMessageRequest::new(config)
+            .execute()
+            .await
+            .expect("创建搜索消息应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/search/v2/message");
     }
 }

--- a/crates/openlark-analytics/src/search/search/v2/query.rs
+++ b/crates/openlark-analytics/src/search/search/v2/query.rs
@@ -135,21 +135,6 @@ impl SuggestRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-
     #[tokio::test]
     async fn test_query_stub_returns_explicit_error() {
         let config = Arc::new(AnalyticsConfig::default());

--- a/crates/openlark-analytics/src/search/search/v2/schema/create.rs
+++ b/crates/openlark-analytics/src/search/search/v2/schema/create.rs
@@ -59,19 +59,42 @@ impl CreateSchemaRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/search/v2/schemas → 响应解析。
+    #[tokio::test]
+    async fn test_create_schema_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/search/v2/schemas"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = CreateSchemaRequest::new(config)
+            .execute()
+            .await
+            .expect("创建数据范式应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/search/v2/schemas");
     }
 }

--- a/crates/openlark-analytics/src/search/search/v2/schema/delete.rs
+++ b/crates/openlark-analytics/src/search/search/v2/schema/delete.rs
@@ -7,6 +7,7 @@ use openlark_core::{
     config::Config,
     http::Transport,
     req_option::RequestOption,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -15,6 +16,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub struct DeleteSchemaRequest {
     config: Arc<Config>,
+    schema_id: String,
 }
 
 /// 删除数据范式响应。
@@ -32,8 +34,11 @@ impl ApiResponseTrait for DeleteSchemaResponse {
 
 impl DeleteSchemaRequest {
     /// 创建新的请求构建器。
-    pub fn new(config: Arc<Config>) -> Self {
-        Self { config }
+    pub fn new(config: Arc<Config>, schema_id: impl Into<String>) -> Self {
+        Self {
+            config,
+            schema_id: schema_id.into(),
+        }
     }
 
     /// 执行删除数据范式请求。
@@ -46,7 +51,8 @@ impl DeleteSchemaRequest {
         self,
         option: RequestOption,
     ) -> SDKResult<DeleteSchemaResponse> {
-        let path = "/open-apis/search/v2/schemas/{}".to_string();
+        validate_required!(self.schema_id, "schema_id 不能为空");
+        let path = format!("/open-apis/search/v2/schemas/{}", self.schema_id);
         let req: ApiRequest<DeleteSchemaResponse> = ApiRequest::delete(&path);
 
         let resp = Transport::request(req, &self.config, Some(option)).await?;
@@ -59,19 +65,45 @@ impl DeleteSchemaRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：DELETE .../schemas/{schema_id}（修复后路径插值）→ 响应解析。
+    #[tokio::test]
+    async fn test_delete_schema_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/search/v2/schemas/sch_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = DeleteSchemaRequest::new(config, "sch_001")
+            .execute()
+            .await
+            .expect("删除数据范式应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/search/v2/schemas/sch_001"
+        );
     }
 }

--- a/crates/openlark-analytics/src/search/search/v2/schema/get.rs
+++ b/crates/openlark-analytics/src/search/search/v2/schema/get.rs
@@ -80,19 +80,51 @@ impl GetSchemaRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET /open-apis/search/v2/schemas/{schema_id} → 响应解析。
+    #[tokio::test]
+    async fn test_get_schema_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/search/v2/schemas/sch_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "data": {
+                        "schema_id": "sch_001",
+                        "name": "n",
+                        "fields": []
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetSchemaRequest::new(config, "sch_001")
+            .execute()
+            .await
+            .expect("获取数据范式应成功");
+        assert_eq!(resp.data.unwrap().schema_id, "sch_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/search/v2/schemas/sch_001"
+        );
     }
 }

--- a/crates/openlark-analytics/src/search/search/v2/schema/patch.rs
+++ b/crates/openlark-analytics/src/search/search/v2/schema/patch.rs
@@ -7,6 +7,7 @@ use openlark_core::{
     config::Config,
     http::Transport,
     req_option::RequestOption,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -15,6 +16,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub struct PatchSchemaRequest {
     config: Arc<Config>,
+    schema_id: String,
 }
 
 /// 修改数据范式响应。
@@ -32,8 +34,11 @@ impl ApiResponseTrait for PatchSchemaResponse {
 
 impl PatchSchemaRequest {
     /// 创建新的请求构建器。
-    pub fn new(config: Arc<Config>) -> Self {
-        Self { config }
+    pub fn new(config: Arc<Config>, schema_id: impl Into<String>) -> Self {
+        Self {
+            config,
+            schema_id: schema_id.into(),
+        }
     }
 
     /// 执行修改数据范式请求。
@@ -46,7 +51,8 @@ impl PatchSchemaRequest {
         self,
         option: RequestOption,
     ) -> SDKResult<PatchSchemaResponse> {
-        let path = "/open-apis/search/v2/schemas/{}".to_string();
+        validate_required!(self.schema_id, "schema_id 不能为空");
+        let path = format!("/open-apis/search/v2/schemas/{}", self.schema_id);
         let req: ApiRequest<PatchSchemaResponse> = ApiRequest::patch(&path);
 
         let resp = Transport::request(req, &self.config, Some(option)).await?;
@@ -59,19 +65,45 @@ impl PatchSchemaRequest {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PATCH .../schemas/{schema_id}（修复后路径插值）→ 响应解析。
+    #[tokio::test]
+    async fn test_patch_schema_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/search/v2/schemas/sch_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = PatchSchemaRequest::new(config, "sch_001")
+            .execute()
+            .await
+            .expect("修改数据范式应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/search/v2/schemas/sch_001"
+        );
     }
 }

--- a/crates/openlark-analytics/src/search/search/v2/user.rs
+++ b/crates/openlark-analytics/src/search/search/v2/user.rs
@@ -81,21 +81,6 @@ impl SearchUserRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-
     #[tokio::test]
     async fn test_user_search_stub_returns_explicit_error() {
         let config = Arc::new(AnalyticsConfig::default());


### PR DESCRIPTION
## 背景

继 security(#374)/cardkit(#375)/user(#376) 之后，#351 第 4 批：`openlark-analytics`（20 个 API 文件，P2）。e2e 化过程暴露 **7 个残缺 stub**。

## ⚠️ Breaking：7 个残缺 stub 修复

e2e 化核对 `api_list_export.csv` + 已实现兄弟（`get.rs` 用 `format!`）时发现 7 个 stub 实现残缺——**真实飞书 API，但 SDK 实现不可用**：

| 文件 | 问题 | 修复 |
|---|---|---|
| `data_source/delete`、`patch` | `new(config)` 不收 id + URL 字面 `{}` | `new(config, data_source_id)` + `format!` |
| `data_source/item/create` | 同上 | `new(config, data_source_id)` + `format! .../items` |
| `data_source/item/delete` | 同上（2 个字面 `{}`） | `new(config, ds_id, item_id)` + `format!` |
| `schema/delete`、`patch` | 同上 | `new(config, schema_id)` + `format!` |
| `report/rule/view/remove` | 同上 | `new(config, rule_id)` + `format!` |

**breaking**：7 个 `XxxRequest::new(config)` → `new(config, id)`。但这些 stub 此前不可用（URL 字面 `{}` → 飞书 404），**全仓零消费者**（workspace `cargo check --all-targets` 验证无跨 crate 引用）。CHANGELOG `### Breaking Changes` 已记，迁移：调用方补传 id。

## e2e 转换（全 20 API 文件）

- **18 个真实端点**加 wiremock e2e（7 修复 stub + 11 原本正确）：`get`/`item-get`/`schema-get` 强类型响应，`create`/`list`/`query` 等无参 Value 响应（双层 `data` 信封）。模式同 #374/#375/#376（`wiremock` + `base_url` + `enable_token_cache(false)`）。
- **`query.rs` / `user.rs`** 是显式 runtime stub（`execute` 恒返回 `Err(unsupported)`，无 HTTP），保留其真实 stub-error 测试，仅删占位。

## 占位清理

移除全 crate **23 处**占位 `{"test":"value"}` roundtrip：18 个 API 文件内联 + `common/mod.rs`、`search/v2.rs`、`search/search/mod.rs` 3 个聚合文件 + query/user 2 个 stub。

## 备注

- analytics 已有 `tokio` **常规**依赖 → `#[tokio::test]` 直接可用，**无 Cargo.toml/Cargo.lock 变更**（规避 #376 的 msrv-lockfile 同步问题）。
- 一个由 e2e 化直接暴露的 bug 簇（7 个 copy-paste 残缺 stub），印证 #351「URL 是否拼对」覆盖的价值。

## 验证

- `cargo test -p openlark-analytics --all-features` → 全绿（23+10+1）
- `cargo clippy` `--all-features` 与 `--no-default-features` 均 `-Dwarnings` clean
- `cargo fmt --check` → clean
- `cargo doc -D warnings` → clean（intra-doc）
- workspace `cargo check --all-targets --all-features` → 无跨 crate 破坏

Refs #351