### PR TITLE
test(helpdesk): 全 55 API 文件加 wiremock e2e + 清占位（#351 第 5 批，P2 收口）

### DIFF
--- a/.github/msrv/Cargo.lock
+++ b/.github/msrv/Cargo.lock
@@ -1762,6 +1762,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1730,6 +1730,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/openlark-helpdesk/Cargo.toml
+++ b/crates/openlark-helpdesk/Cargo.toml
@@ -21,6 +21,8 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
+wiremock = { workspace = true }
+serde_json = { workspace = true }
 
 [features]
 default = ["v1", "async"]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/agent_email.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/agent_email.rs
@@ -104,4 +104,48 @@ mod tests {
         let request = GetAgentEmailRequest::new(Arc::new(config));
         assert_eq!(request.config.app_id(), "test_app_id");
     }
+
+    /// 端到端：GET .../agent_emails → 强类型 GetAgentEmailResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_agent_email_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/helpdesk/v1/agent_emails"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "code": 0,
+                    "msg": "success",
+                    "data": { "data": { "agent_emails": [ { "email": "support@example.com", "is_main": true } ] } }
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetAgentEmailRequest::new(config)
+            .execute()
+            .await
+            .expect("获取客服邮箱应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/agent_emails"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/mod.rs
@@ -41,23 +41,3 @@ impl Agent {
 
 pub use agent_email::GetAgentEmailRequest;
 pub use patch::{PatchAgentRequest, PatchAgentRequestBuilder};
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/patch.rs
@@ -200,4 +200,49 @@ mod tests {
 
         assert!(builder.status.is_none());
     }
+
+    /// 端到端：PATCH .../agents/{agent_id} → 强类型 PatchAgentResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_agent_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/helpdesk/v1/agents/ag_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "agent_id": "ag_001", "status": "online" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let body = PatchAgentBody {
+            status: Some("online".to_string()),
+        };
+        let resp = PatchAgentRequest::new(config, "ag_001".to_string())
+            .execute(body)
+            .await
+            .expect("更新客服信息应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/agents/ag_001"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/schedules/delete.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/schedules/delete.rs
@@ -128,4 +128,46 @@ mod tests {
 
         assert_eq!(builder.agent_id, "agent_123");
     }
+
+    /// 端到端：DELETE .../agents/{agent_id}/schedules → 强类型 DeleteAgentScheduleResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_delete_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/helpdesk/v1/agents/ag_001/schedules"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "success": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = DeleteAgentScheduleRequest::new(config, "ag_001".to_string())
+            .execute()
+            .await
+            .expect("删除客服工作日程应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/agents/ag_001/schedules"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/schedules/get.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/schedules/get.rs
@@ -226,4 +226,54 @@ mod tests {
         assert_eq!(builder.agent_id, "agent_123");
         assert!(builder.page_size.is_none());
     }
+
+    /// 端到端：GET .../agents/{agent_id}/schedules → 强类型 GetAgentScheduleResponse 解析（外层 data 信封 + items）。
+    #[tokio::test]
+    async fn test_get_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/helpdesk/v1/agents/ag_001/schedules"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "code": 0,
+                    "msg": "success",
+                    "data": {
+                        "page_token": "next_page",
+                        "has_more": false,
+                        "items": [
+                            { "agent_id": "ag_001", "work_date": "2026-07-07", "start_time": "09:00:00", "end_time": "18:00:00", "day_of_week": 1 }
+                        ]
+                    }
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetAgentScheduleRequest::new(config, "ag_001".to_string())
+            .execute()
+            .await
+            .expect("获取指定客服工作日程应成功");
+        assert!(resp.items.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/agents/ag_001/schedules"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/schedules/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/schedules/mod.rs
@@ -40,23 +40,3 @@ impl AgentSchedules {
         patch::PatchAgentScheduleRequest::new(self.config, self.agent_id)
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/schedules/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/schedules/patch.rs
@@ -263,4 +263,54 @@ mod tests {
         assert_eq!(builder.agent_id, "agent_123");
         assert!(builder.work_date.is_none());
     }
+
+    /// 端到端：PATCH .../agents/{agent_id}/schedules → 强类型 PatchAgentScheduleResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/helpdesk/v1/agents/ag_001/schedules"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "code": 0,
+                    "msg": "success",
+                    "data": { "data": { "agent_id": "ag_001", "work_date": "2026-07-07", "start_time": "09:00:00", "end_time": "18:00:00", "day_of_week": 1 } }
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let body = PatchAgentScheduleBody {
+            work_date: Some("2026-07-07".to_string()),
+            start_time: Some("09:00:00".to_string()),
+            end_time: Some("18:00:00".to_string()),
+            day_of_week: Some(1),
+        };
+        let resp = PatchAgentScheduleRequest::new(config, "ag_001".to_string())
+            .execute(body)
+            .await
+            .expect("更新客服工作日程应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/agents/ag_001/schedules"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/create.rs
@@ -272,4 +272,53 @@ mod tests {
 
         assert!(builder.agent_id.is_none());
     }
+
+    /// 端到端：POST .../agent_schedules → 强类型 CreateAgentScheduleResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_create_agent_schedule_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/helpdesk/v1/agent_schedules"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "agent_id": "ag_001", "work_date": "2024-01-15" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let body = CreateAgentScheduleBody {
+            agent_id: "ag_001".to_string(),
+            work_date: "2024-01-15".to_string(),
+            start_time: "09:00:00".to_string(),
+            end_time: "18:00:00".to_string(),
+            day_of_week: Some(1),
+        };
+        let resp = CreateAgentScheduleRequest::new(config)
+            .execute(body)
+            .await
+            .expect("创建客服工作日程应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/agent_schedules"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/delete.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/delete.rs
@@ -128,4 +128,46 @@ mod tests {
 
         assert_eq!(builder.agent_id, "agent_123");
     }
+
+    /// 端到端：DELETE .../agents/{agent_id}/schedules → 强类型 DeleteAgentScheduleResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_delete_agent_schedule_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/helpdesk/v1/agents/ag_001/schedules"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "success": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = DeleteAgentScheduleRequest::new(config, "ag_001".to_string())
+            .execute()
+            .await
+            .expect("删除客服工作日程应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/agents/ag_001/schedules"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/get.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/get.rs
@@ -226,4 +226,51 @@ mod tests {
         assert_eq!(builder.agent_id, "agent_123");
         assert!(builder.page_size.is_none());
     }
+
+    /// 端到端：GET .../agents/{agent_id}/schedules → 强类型 GetAgentScheduleResponse 解析（单层 data 信封，items 直挂）。
+    #[tokio::test]
+    async fn test_get_agent_schedule_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/helpdesk/v1/agents/ag_001/schedules"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        { "agent_id": "ag_001", "work_date": "2024-01-15", "start_time": "09:00:00", "end_time": "18:00:00", "day_of_week": 1 }
+                    ],
+                    "has_more": false
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetAgentScheduleRequest::new(config, "ag_001".to_string())
+            .execute()
+            .await
+            .expect("获取指定客服工作日程应成功");
+        assert!(resp.items.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/agents/ag_001/schedules"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/list.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/list.rs
@@ -226,4 +226,51 @@ mod tests {
         let result = query.validate();
         assert!(result.is_err());
     }
+
+    /// 端到端：GET .../agent_schedules → 强类型 ListAgentScheduleResponse 解析（单层 data 信封，items 直挂）。
+    #[tokio::test]
+    async fn test_list_agent_schedule_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/helpdesk/v1/agent_schedules"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        { "agent_id": "ag_001", "work_date": "2024-01-15" }
+                    ],
+                    "has_more": false
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ListAgentScheduleRequest::new(config)
+            .execute()
+            .await
+            .expect("获取客服工作日程列表应成功");
+        assert!(resp.items.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/agent_schedules"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/mod.rs
@@ -58,23 +58,3 @@ pub use delete::{DeleteAgentScheduleRequest, DeleteAgentScheduleRequestBuilder};
 pub use get::{GetAgentScheduleRequest, GetAgentScheduleRequestBuilder};
 pub use list::{ListAgentScheduleRequest, ListAgentScheduleRequestBuilder};
 pub use patch::{PatchAgentScheduleRequest, PatchAgentScheduleRequestBuilder};
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/patch.rs
@@ -263,4 +263,52 @@ mod tests {
         assert_eq!(builder.agent_id, "agent_123");
         assert!(builder.work_date.is_none());
     }
+
+    /// 端到端：PATCH .../agents/{agent_id}/schedules → 强类型 PatchAgentScheduleResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_agent_schedule_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/helpdesk/v1/agents/ag_001/schedules"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "agent_id": "ag_001", "work_date": "2024-01-16" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let body = PatchAgentScheduleBody {
+            work_date: Some("2024-01-16".to_string()),
+            start_time: Some("09:00:00".to_string()),
+            end_time: Some("18:00:00".to_string()),
+            day_of_week: Some(2),
+        };
+        let resp = PatchAgentScheduleRequest::new(config, "ag_001".to_string())
+            .execute(body)
+            .await
+            .expect("更新客服工作日程应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/agents/ag_001/schedules"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/create.rs
@@ -217,4 +217,51 @@ mod tests {
 
         assert!(builder.name.is_none());
     }
+
+    /// 端到端：POST .../agent_skills → 强类型 CreateAgentSkillResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_create_agent_skill_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/helpdesk/v1/agent_skills"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "id": "skl_001", "name": "技术支持" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let body = CreateAgentSkillBody {
+            name: "技术支持".to_string(),
+            description: Some("提供技术支持服务".to_string()),
+            enable: Some(true),
+        };
+        let resp = CreateAgentSkillRequest::new(config)
+            .execute(body)
+            .await
+            .expect("创建客服技能应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/agent_skills"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/delete.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/delete.rs
@@ -137,4 +137,46 @@ mod tests {
 
         assert_eq!(builder.agent_skill_id, "skill_123");
     }
+
+    /// 端到端：DELETE .../agent_skills/{agent_skill_id} → 强类型 DeleteAgentSkillResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_delete_agent_skill_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/helpdesk/v1/agent_skills/skl_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "success": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = DeleteAgentSkillRequest::new(config, "skl_001".to_string())
+            .execute()
+            .await
+            .expect("删除客服技能应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/agent_skills/skl_001"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/get.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/get.rs
@@ -135,4 +135,46 @@ mod tests {
 
         assert_eq!(builder.agent_skill_id, "skill_123");
     }
+
+    /// 端到端：GET .../agent_skills/{agent_skill_id} → 强类型 GetAgentSkillResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_agent_skill_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/helpdesk/v1/agent_skills/skl_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "id": "skl_001", "name": "技术支持", "enable": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetAgentSkillRequest::new(config, "skl_001".to_string())
+            .execute()
+            .await
+            .expect("获取指定客服技能应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/agent_skills/skl_001"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/list.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/list.rs
@@ -124,4 +124,50 @@ mod tests {
 
         // Builder created successfully
     }
+
+    /// 端到端：GET .../agent_skills → 强类型 ListAgentSkillResponse 解析（单层 data 信封，items 直挂）。
+    #[tokio::test]
+    async fn test_list_agent_skill_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/helpdesk/v1/agent_skills"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        { "id": "skl_001", "name": "技术支持", "enable": true }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ListAgentSkillRequest::new(config)
+            .execute()
+            .await
+            .expect("获取客服技能列表应成功");
+        assert!(resp.items.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/agent_skills"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/mod.rs
@@ -58,23 +58,3 @@ pub use delete::{DeleteAgentSkillRequest, DeleteAgentSkillRequestBuilder};
 pub use get::{GetAgentSkillRequest, GetAgentSkillRequestBuilder};
 pub use list::{ListAgentSkillRequest, ListAgentSkillRequestBuilder};
 pub use patch::{PatchAgentSkillRequest, PatchAgentSkillRequestBuilder};
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/patch.rs
@@ -245,4 +245,51 @@ mod tests {
         assert_eq!(builder.agent_skill_id, "skill_123");
         assert!(builder.name.is_none());
     }
+
+    /// 端到端：PATCH .../agent_skills/{agent_skill_id} → 强类型 PatchAgentSkillResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_agent_skill_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/helpdesk/v1/agent_skills/skl_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "id": "skl_001", "name": "更新后技能", "enable": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let body = PatchAgentSkillBody {
+            name: Some("更新后技能".to_string()),
+            enable: Some(true),
+            description: None,
+        };
+        let resp = PatchAgentSkillRequest::new(config, "skl_001".to_string())
+            .execute(body)
+            .await
+            .expect("更新客服技能应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/agent_skills/skl_001"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill_rule/list.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill_rule/list.rs
@@ -122,4 +122,50 @@ mod tests {
             .build();
         let _builder = ListAgentSkillRuleRequestBuilder::new(Arc::new(config));
     }
+
+    /// 端到端：GET .../agent_skill_rules → 强类型 ListAgentSkillRuleResponse 解析（单层 data 信封，items 直挂）。
+    #[tokio::test]
+    async fn test_list_agent_skill_rule_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/helpdesk/v1/agent_skill_rules"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        { "id": "rule_001", "name": "规则一", "skill_id": "skl_001", "priority": 1 }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ListAgentSkillRuleRequest::new(config)
+            .execute()
+            .await
+            .expect("获取客服技能规则列表应成功");
+        assert!(resp.items.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/agent_skill_rules"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill_rule/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill_rule/mod.rs
@@ -26,23 +26,3 @@ impl AgentSkillRule {
 }
 
 pub use list::{ListAgentSkillRuleRequest, ListAgentSkillRuleRequestBuilder};
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/bot/message/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/bot/message/create.rs
@@ -224,4 +224,48 @@ mod tests {
 
         assert!(builder.receive_id.is_none());
     }
+
+    /// 端到端：POST .../message → 强类型 CreateBotMessageResponse 解析（data 内层为 message_id）。
+    #[tokio::test]
+    async fn test_create_bot_message_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/helpdesk/v1/message"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "message_id": "msg_001" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let body = CreateBotMessageBody {
+            receive_id: Some("ou_test_user".to_string()),
+            msg_type: Some("text".to_string()),
+            content: Some(r#"{"text":"hello"}"#.to_string()),
+        };
+        let resp = CreateBotMessageRequest::new(config)
+            .execute(body)
+            .await
+            .expect("机器人发送消息应成功");
+        assert_eq!(resp.message_id.as_deref(), Some("msg_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/helpdesk/v1/message");
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/bot/message/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/bot/message/mod.rs
@@ -26,23 +26,3 @@ impl Message {
         create::CreateBotMessageRequestBuilder::new(self.config.clone())
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/bot/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/bot/mod.rs
@@ -26,23 +26,3 @@ impl Bot {
         message::Message::new(self.config.clone())
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/create.rs
@@ -234,4 +234,49 @@ mod tests {
 
         assert!(builder.name.is_none());
     }
+
+    /// 端到端：POST .../categories → 强类型 CreateCategoryResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_create_category_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/helpdesk/v1/categories"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "id": "cat_new", "name": "技术问题" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let body = CreateCategoryBody {
+            name: "技术问题".to_string(),
+            description: None,
+            parent_id: None,
+            order: None,
+        };
+        let resp = CreateCategoryRequest::new(config)
+            .execute(body)
+            .await
+            .expect("创建分类应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/helpdesk/v1/categories");
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/delete.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/delete.rs
@@ -125,4 +125,46 @@ mod tests {
 
         assert_eq!(builder.id, "category_123");
     }
+
+    /// 端到端：DELETE .../categories/{id} → 强类型 DeleteCategoryResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_delete_category_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/helpdesk/v1/categories/cat_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "success": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = DeleteCategoryRequest::new(config, "cat_001".to_string())
+            .execute()
+            .await
+            .expect("删除分类应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/categories/cat_001"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/get.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/get.rs
@@ -129,4 +129,46 @@ mod tests {
 
         assert_eq!(builder.id, "category_123");
     }
+
+    /// 端到端：GET .../categories/{id} → 强类型 GetCategoryResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_category_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/helpdesk/v1/categories/cat_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "id": "cat_001", "name": "公告分类" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetCategoryRequest::new(config, "cat_001".to_string())
+            .execute()
+            .await
+            .expect("获取分类应成功");
+        assert_eq!(resp.data.unwrap().id.as_deref(), Some("cat_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/categories/cat_001"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/list.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/list.rs
@@ -125,4 +125,44 @@ mod tests {
             .build();
         let _builder = ListCategoryRequestBuilder::new(Arc::new(config));
     }
+
+    /// 端到端：GET .../categories → 强类型 ListCategoryResponse 解析（data 内层为 items 数组）。
+    #[tokio::test]
+    async fn test_list_category_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/helpdesk/v1/categories"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "items": [ { "id": "cat_001", "name": "公告分类" } ] }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ListCategoryRequest::new(config)
+            .execute()
+            .await
+            .expect("获取分类列表应成功");
+        assert!(resp.items.is_some());
+        assert_eq!(resp.items.unwrap().len(), 1);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/helpdesk/v1/categories");
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/mod.rs
@@ -58,23 +58,3 @@ pub use delete::{DeleteCategoryRequest, DeleteCategoryRequestBuilder};
 pub use get::{GetCategoryRequest, GetCategoryRequestBuilder};
 pub use list::{ListCategoryRequest, ListCategoryRequestBuilder};
 pub use patch::{PatchCategoryRequest, PatchCategoryRequestBuilder};
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/patch.rs
@@ -260,4 +260,52 @@ mod tests {
         assert_eq!(builder.id, "category_123");
         assert!(builder.name.is_none());
     }
+
+    /// 端到端：PATCH .../categories/{id} → 强类型 PatchCategoryResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_category_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/helpdesk/v1/categories/cat_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "id": "cat_001", "name": "新名称" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let body = PatchCategoryBody {
+            name: Some("新名称".to_string()),
+            description: None,
+            parent_id: None,
+            order: None,
+        };
+        let resp = PatchCategoryRequest::new(config, "cat_001".to_string())
+            .execute(body)
+            .await
+            .expect("更新分类应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/categories/cat_001"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/event/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/event/mod.rs
@@ -33,23 +33,3 @@ impl Event {
         unsubscribe::EventUnsubscribeRequestBuilder::new(self.config.clone())
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/event/subscribe.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/event/subscribe.rs
@@ -103,4 +103,45 @@ mod tests {
 
         assert!(builder.config.app_id() == "test_app_id");
     }
+
+    /// 端到端：POST .../events/subscribe → 空 body 响应经 extract_response_data 成功返回。
+    #[tokio::test]
+    async fn test_subscribe_event_returns_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/helpdesk/v1/events/subscribe"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {}
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        EventSubscribeRequest::new(config)
+            .execute()
+            .await
+            .expect("订阅服务台事件应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/events/subscribe"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/event/unsubscribe.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/event/unsubscribe.rs
@@ -103,4 +103,45 @@ mod tests {
 
         assert!(builder.config.app_id() == "test_app_id");
     }
+
+    /// 端到端：POST .../events/unsubscribe → 空 body 响应经 extract_response_data 成功返回。
+    #[tokio::test]
+    async fn test_unsubscribe_event_returns_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/helpdesk/v1/events/unsubscribe"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {}
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        EventUnsubscribeRequest::new(config)
+            .execute()
+            .await
+            .expect("取消订阅服务台事件应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/events/unsubscribe"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/create.rs
@@ -228,4 +228,48 @@ mod tests {
 
         assert!(builder.title.is_none());
     }
+
+    /// 端到端：POST .../faqs → 强类型 CreateFaqResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_create_faq_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/helpdesk/v1/faqs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "id": "faq_001", "title": "如何重置密码？" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let body = CreateFaqBody {
+            title: "如何重置密码？".to_string(),
+            content: "请按照以下步骤重置密码...".to_string(),
+            category_id: None,
+        };
+        let resp = CreateFaqRequest::new(config)
+            .execute(body)
+            .await
+            .expect("创建知识库应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/helpdesk/v1/faqs");
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/delete.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/delete.rs
@@ -121,4 +121,46 @@ mod tests {
 
         assert_eq!(builder.id, "faq_123");
     }
+
+    /// 端到端：DELETE .../faqs/{id} → 强类型 DeleteFaqResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_delete_faq_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/helpdesk/v1/faqs/faq_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "success": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = DeleteFaqRequest::new(config, "faq_001".to_string())
+            .execute()
+            .await
+            .expect("删除知识库应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/faqs/faq_001"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/get.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/get.rs
@@ -132,4 +132,46 @@ mod tests {
 
         assert_eq!(builder.id, "faq_123");
     }
+
+    /// 端到端：GET .../faqs/{id} → 强类型 GetFaqResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_faq_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/helpdesk/v1/faqs/faq_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "id": "faq_001", "title": "如何重置密码？" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetFaqRequest::new(config, "faq_001".to_string())
+            .execute()
+            .await
+            .expect("获取指定知识库应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/faqs/faq_001"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/image.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/image.rs
@@ -131,4 +131,49 @@ mod tests {
         assert_eq!(builder.id, "faq_123");
         assert_eq!(builder.image_key, "image_key_456");
     }
+
+    /// 端到端：GET .../faqs/{id}/image/{image_key} → 强类型 GetFaqImageResponse 解析。
+    #[tokio::test]
+    async fn test_get_faq_image_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/helpdesk/v1/faqs/faq_001/image/img_key_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "image_key": "img_key_001", "url": "https://example.com/faq.png" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp =
+            GetFaqImageRequest::new(config, "faq_001".to_string(), "img_key_001".to_string())
+                .execute()
+                .await
+                .expect("获取知识库图片应成功");
+        assert_eq!(resp.image_key.as_deref(), Some("img_key_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/faqs/faq_001/image/img_key_001"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/list.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/list.rs
@@ -128,4 +128,44 @@ mod tests {
             .build();
         let _builder = ListFaqRequestBuilder::new(Arc::new(config));
     }
+
+    /// 端到端：GET .../faqs → 强类型 ListFaqResponse 解析（扁平 data 信封）。
+    #[tokio::test]
+    async fn test_list_faqs_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/helpdesk/v1/faqs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "items": [ { "id": "faq_001", "title": "如何重置密码？" } ] }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ListFaqRequest::new(config)
+            .execute()
+            .await
+            .expect("获取知识库列表应成功");
+        assert!(resp.items.is_some());
+        assert_eq!(resp.items.as_ref().unwrap().len(), 1);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/helpdesk/v1/faqs");
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/mod.rs
@@ -80,23 +80,3 @@ pub use image::{GetFaqImageRequest, GetFaqImageRequestBuilder};
 pub use list::{ListFaqRequest, ListFaqRequestBuilder};
 pub use patch::{PatchFaqRequest, PatchFaqRequestBuilder};
 pub use search::{SearchFaqRequest, SearchFaqRequestBuilder};
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/patch.rs
@@ -248,4 +248,51 @@ mod tests {
         assert_eq!(builder.id, "faq_123");
         assert!(builder.title.is_none());
     }
+
+    /// 端到端：PATCH .../faqs/{id} → 强类型 PatchFaqResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_faq_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/helpdesk/v1/faqs/faq_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "id": "faq_001", "title": "新标题" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let body = PatchFaqBody {
+            title: Some("新标题".to_string()),
+            content: None,
+            category_id: None,
+        };
+        let resp = PatchFaqRequest::new(config, "faq_001".to_string())
+            .execute(body)
+            .await
+            .expect("更新知识库应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/faqs/faq_001"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/search.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/search.rs
@@ -220,4 +220,47 @@ mod tests {
 
         assert!(builder.keyword.is_none());
     }
+
+    /// 端到端：GET .../faqs/search → 强类型 SearchFaqResponse 解析（扁平 data 信封）。
+    #[tokio::test]
+    async fn test_search_faqs_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/helpdesk/v1/faqs/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [ { "id": "faq_001", "title": "如何重置密码？" } ],
+                    "has_more": false
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = SearchFaqRequest::new(config)
+            .keyword("密码")
+            .execute()
+            .await
+            .expect("搜索知识库应成功");
+        assert!(resp.items.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/helpdesk/v1/faqs/search");
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/mod.rs
@@ -93,23 +93,3 @@ impl HelpdeskV1 {
         bot::Bot::new(self.config.clone())
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/cancel_approve.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/cancel_approve.rs
@@ -142,4 +142,48 @@ mod tests {
 
         assert_eq!(builder.notification_id, "notif_123");
     }
+
+    /// 端到端：POST .../notifications/{id}/cancel_approve → 强类型响应解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_cancel_approve_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/helpdesk/v1/notifications/ntf_001/cancel_approve",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "success": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = CancelApproveNotificationRequest::new(config, "ntf_001".to_string())
+            .execute()
+            .await
+            .expect("取消推送通知审核应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/notifications/ntf_001/cancel_approve"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/cancel_send.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/cancel_send.rs
@@ -137,4 +137,48 @@ mod tests {
 
         assert_eq!(builder.notification_id, "notif_123");
     }
+
+    /// 端到端：POST .../notifications/{id}/cancel_send → 强类型响应解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_cancel_send_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/helpdesk/v1/notifications/ntf_001/cancel_send",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "success": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = CancelSendNotificationRequest::new(config, "ntf_001".to_string())
+            .execute()
+            .await
+            .expect("取消推送通知发送应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/notifications/ntf_001/cancel_send"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/create.rs
@@ -201,4 +201,50 @@ mod tests {
 
         assert!(builder.title.is_none());
     }
+
+    /// 端到端：POST .../notifications → 强类型 CreateNotificationResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_create_notification_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/helpdesk/v1/notifications"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "id": "ntf_001", "title": "系统维护通知", "status": "draft" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let body = CreateNotificationBody {
+            title: "系统维护通知".to_string(),
+            content: "系统将于今晚维护".to_string(),
+        };
+        let resp = CreateNotificationRequest::new(config)
+            .execute(body)
+            .await
+            .expect("创建推送通知应成功");
+        assert_eq!(resp.data.unwrap().id.as_deref(), Some("ntf_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/notifications"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/execute_send.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/execute_send.rs
@@ -137,4 +137,48 @@ mod tests {
 
         assert_eq!(builder.notification_id, "notif_123");
     }
+
+    /// 端到端：POST .../notifications/{id}/execute_send → 强类型响应解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_execute_send_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/helpdesk/v1/notifications/ntf_001/execute_send",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "success": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ExecuteSendNotificationRequest::new(config, "ntf_001".to_string())
+            .execute()
+            .await
+            .expect("执行推送通知应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/notifications/ntf_001/execute_send"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/get.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/get.rs
@@ -138,4 +138,46 @@ mod tests {
 
         assert_eq!(builder.notification_id, "notif_123");
     }
+
+    /// 端到端：GET .../notifications/{id} → 强类型 GetNotificationResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_notification_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/helpdesk/v1/notifications/ntf_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "id": "ntf_001", "title": "系统维护通知", "status": "draft" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetNotificationRequest::new(config, "ntf_001".to_string())
+            .execute()
+            .await
+            .expect("获取指定推送通知应成功");
+        assert_eq!(resp.data.unwrap().id.as_deref(), Some("ntf_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/notifications/ntf_001"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/mod.rs
@@ -118,23 +118,3 @@ pub use preview::{PreviewNotificationRequest, PreviewNotificationRequestBuilder}
 pub use submit_approve::{
     SubmitApproveNotificationRequest, SubmitApproveNotificationRequestBuilder,
 };
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/patch.rs
@@ -242,4 +242,50 @@ mod tests {
         assert_eq!(builder.notification_id, "notif_123");
         assert!(builder.title.is_none());
     }
+
+    /// 端到端：PATCH .../notifications/{id} → 强类型 PatchNotificationResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_notification_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/helpdesk/v1/notifications/ntf_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "id": "ntf_001", "title": "新标题", "status": "draft" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let body = PatchNotificationBody {
+            title: Some("新标题".to_string()),
+            content: None,
+        };
+        let resp = PatchNotificationRequest::new(config, "ntf_001".to_string())
+            .execute(body)
+            .await
+            .expect("更新推送通知应成功");
+        assert_eq!(resp.data.unwrap().id.as_deref(), Some("ntf_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/notifications/ntf_001"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/preview.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/preview.rs
@@ -137,4 +137,46 @@ mod tests {
 
         assert_eq!(builder.notification_id, "notif_123");
     }
+
+    /// 端到端：POST .../notifications/{id}/preview → 强类型响应解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_preview_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/helpdesk/v1/notifications/ntf_001/preview"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "content": "预览推送内容" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = PreviewNotificationRequest::new(config, "ntf_001".to_string())
+            .execute()
+            .await
+            .expect("预览推送通知应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/notifications/ntf_001/preview"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/submit_approve.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/submit_approve.rs
@@ -142,4 +142,48 @@ mod tests {
 
         assert_eq!(builder.notification_id, "notif_123");
     }
+
+    /// 端到端：POST .../notifications/{id}/submit_approve → 强类型响应解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_submit_approve_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/helpdesk/v1/notifications/ntf_001/submit_approve",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "success": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = SubmitApproveNotificationRequest::new(config, "ntf_001".to_string())
+            .execute()
+            .await
+            .expect("提交推送通知审核应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/notifications/ntf_001/submit_approve"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/answer_user_query.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/answer_user_query.rs
@@ -110,19 +110,51 @@ impl AnswerUserQueryRequest {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../tickets/{id}/answer_user_query → 强类型 AnswerUserQueryResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_answer_user_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/helpdesk/v1/tickets/tk_001/answer_user_query",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "message_id": "msg_001" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = AnswerUserQueryRequest::new(config, "tk_001")
+            .content("您好，请问需要什么帮助？")
+            .execute()
+            .await
+            .expect("回复用户提问应成功");
+        assert!(resp.data.is_some());
+        assert_eq!(resp.data.unwrap().message_id, "msg_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/tickets/tk_001/answer_user_query"
+        );
     }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/create.rs
@@ -98,4 +98,49 @@ mod tests {
             .description("test".to_string());
         let _ = request;
     }
+
+    /// 端到端：POST .../tickets → 强类型 CreateTicketResponse 解析（扁平响应，单层 data 信封）。
+    #[tokio::test]
+    async fn test_create_ticket_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/helpdesk/v1/tickets"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "ticket_id": "tk_001",
+                    "title": "无法登录",
+                    "created_at": "2024-01-01T00:00:00Z"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = CreateTicketRequest::new(config)
+            .title("无法登录")
+            .execute()
+            .await
+            .expect("创建工单应成功");
+        assert_eq!(resp.ticket_id, "tk_001");
+        assert_eq!(resp.title, "无法登录");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/helpdesk/v1/tickets");
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/customized_fields.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/customized_fields.rs
@@ -78,19 +78,50 @@ impl GetCustomizedFieldsRequest {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../customized_fields → 强类型 GetCustomizedFieldsResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_customized_fields_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/helpdesk/v1/customized_fields"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "fields": [
+                    { "field_id": "f_001", "field_name": "优先级", "field_type": "text" }
+                ] } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetCustomizedFieldsRequest::new(config)
+            .execute()
+            .await
+            .expect("获取自定义字段应成功");
+        assert!(resp.data.is_some());
+        assert_eq!(resp.data.unwrap().fields.len(), 1);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/customized_fields"
+        );
     }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/get.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/get.rs
@@ -55,19 +55,53 @@ impl ApiResponseTrait for GetTicketResponse {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../tickets/{id} → 强类型 GetTicketResponse 解析（扁平响应，单层 data 信封）。
+    #[tokio::test]
+    async fn test_get_ticket_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/helpdesk/v1/tickets/tk_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "ticket_id": "tk_001",
+                    "title": "无法登录",
+                    "status": "open",
+                    "created_at": "2024-01-01T00:00:00Z"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetTicketRequest::new(config, "tk_001".to_string())
+            .execute()
+            .await
+            .expect("获取工单详情应成功");
+        assert_eq!(resp.ticket_id, "tk_001");
+        assert_eq!(resp.status, "open");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/tickets/tk_001"
+        );
     }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/list.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/list.rs
@@ -97,4 +97,50 @@ mod tests {
             .page_token("test".to_string());
         let _ = request;
     }
+
+    /// 端到端：GET .../tickets → 强类型 TicketListResponse 解析（扁平响应，单层 data 信封）。
+    #[tokio::test]
+    async fn test_list_tickets_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/helpdesk/v1/tickets"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "tickets": [
+                        { "ticket_id": "tk_001", "title": "无法登录", "status": "open" }
+                    ],
+                    "page_token": "next_page"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = TicketListRequest::new(config)
+            .execute()
+            .await
+            .expect("获取工单列表应成功");
+        assert_eq!(resp.tickets.len(), 1);
+        assert_eq!(resp.tickets[0].ticket_id, "tk_001");
+        assert_eq!(resp.page_token.as_deref(), Some("next_page"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/helpdesk/v1/tickets");
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/message/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/message/create.rs
@@ -204,4 +204,51 @@ mod tests {
         assert_eq!(builder.ticket_id, "ticket_123");
         assert!(builder.content.is_none());
     }
+
+    /// 端到端：POST .../tickets/{id}/messages → 强类型 CreateTicketMessageResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_create_ticket_message_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/helpdesk/v1/tickets/tk_001/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "id": "msg_001" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let body = CreateTicketMessageBody {
+            content: "您好，请问需要什么帮助？".to_string(),
+            msg_type: Some("text".to_string()),
+        };
+        let resp = CreateTicketMessageRequest::new(config, "tk_001".to_string())
+            .execute(body)
+            .await
+            .expect("发送工单消息应成功");
+        assert!(resp.data.is_some());
+        assert_eq!(resp.data.unwrap().id.as_deref(), Some("msg_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/tickets/tk_001/messages"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/message/list.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/message/list.rs
@@ -133,4 +133,51 @@ mod tests {
 
         assert_eq!(builder.ticket_id, "ticket_123");
     }
+
+    /// 端到端：GET .../tickets/{id}/messages → 强类型 ListTicketMessageResponse 解析（扁平响应，单层 data 信封）。
+    #[tokio::test]
+    async fn test_list_ticket_messages_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/helpdesk/v1/tickets/tk_001/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        { "id": "msg_001", "content": "您好", "msg_type": "text" }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ListTicketMessageRequest::new(config, "tk_001".to_string())
+            .execute()
+            .await
+            .expect("获取工单消息列表应成功");
+        assert!(resp.items.is_some());
+        assert_eq!(resp.items.unwrap().len(), 1);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/tickets/tk_001/messages"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/message/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/message/mod.rs
@@ -31,23 +31,3 @@ impl<'a> TicketMessage<'a> {
 
 pub use create::{CreateTicketMessageRequest, CreateTicketMessageRequestBuilder};
 pub use list::{ListTicketMessageRequest, ListTicketMessageRequestBuilder};
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/mod.rs
@@ -106,23 +106,3 @@ pub use models::{
 pub use start_service::StartServiceRequest;
 pub use ticket_image::GetTicketImageRequest;
 pub use update::UpdateTicketRequest;
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/start_service.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/start_service.rs
@@ -120,19 +120,50 @@ impl StartServiceRequest {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../start_service → 强类型 StartServiceResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_start_service_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/helpdesk/v1/start_service"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "ticket_id": "tk_001" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = StartServiceRequest::new(config)
+            .user_id("ou_001")
+            .service_id("svc_001")
+            .execute()
+            .await
+            .expect("创建服务台对话应成功");
+        assert!(resp.data.is_some());
+        assert_eq!(resp.data.unwrap().ticket_id, "tk_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/start_service"
+        );
     }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/ticket_image.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/ticket_image.rs
@@ -79,19 +79,53 @@ impl GetTicketImageRequest {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../ticket_images（带 ticket_id/image_key 查询参数）→ 强类型 GetTicketImageResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_ticket_image_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/helpdesk/v1/ticket_images"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "image_url": "https://example.com/img_001.png" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetTicketImageRequest::new(config, "tk_001", "img_key_001")
+            .execute()
+            .await
+            .expect("获取工单内图像应成功");
+        assert!(resp.data.is_some());
+        assert_eq!(
+            resp.data.unwrap().image_url,
+            "https://example.com/img_001.png"
+        );
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/ticket_images"
+        );
+        // 验证查询参数正确传递
+        assert_eq!(received[0].url.query_pairs().count(), 2);
     }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/update.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/update.rs
@@ -116,19 +116,52 @@ impl ApiResponseTrait for UpdateTicketResponse {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PUT .../tickets/{id} → 强类型 UpdateTicketResponse 解析（扁平响应，单层 data 信封）。
+    #[tokio::test]
+    async fn test_update_ticket_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/helpdesk/v1/tickets/tk_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "ticket_id": "tk_001",
+                    "updated_at": "2024-01-02T00:00:00Z"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = UpdateTicketRequest::new(config, "tk_001".to_string())
+            .title("更新后的标题")
+            .execute()
+            .await
+            .expect("更新工单应成功");
+        assert_eq!(resp.ticket_id, "tk_001");
+        assert_eq!(resp.updated_at, "2024-01-02T00:00:00Z");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/tickets/tk_001"
+        );
     }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/create.rs
@@ -215,4 +215,51 @@ mod tests {
 
         assert!(builder.name.is_none());
     }
+
+    /// 端到端：POST .../ticket_customized_fields → 强类型 CreateTicketCustomizedFieldResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_create_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/helpdesk/v1/ticket_customized_fields"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "id": "tcf_001", "name": "工单编号" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let body = CreateTicketCustomizedFieldBody {
+            name: "工单编号".to_string(),
+            field_type: "text".to_string(),
+            required: Some(true),
+        };
+        let resp = CreateTicketCustomizedFieldRequest::new(config)
+            .execute(body)
+            .await
+            .expect("创建工单自定义字段应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/ticket_customized_fields"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/delete.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/delete.rs
@@ -131,4 +131,48 @@ mod tests {
 
         assert_eq!(builder.id, "field_123");
     }
+
+    /// 端到端：DELETE .../ticket_customized_fields/{id} → 强类型 DeleteTicketCustomizedFieldResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_delete_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/helpdesk/v1/ticket_customized_fields/tcf_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "success": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = DeleteTicketCustomizedFieldRequest::new(config, "tcf_001".to_string())
+            .execute()
+            .await
+            .expect("删除工单自定义字段应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/ticket_customized_fields/tcf_001"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/get.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/get.rs
@@ -130,4 +130,48 @@ mod tests {
 
         assert_eq!(builder.id, "field_123");
     }
+
+    /// 端到端：GET .../ticket_customized_fields/{id} → 强类型 GetTicketCustomizedFieldResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/helpdesk/v1/ticket_customized_fields/tcf_001"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "code": 0,
+                    "msg": "success",
+                    "data": { "data": { "id": "tcf_001", "name": "工单编号", "field_type": "text", "required": true } }
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetTicketCustomizedFieldRequest::new(config, "tcf_001".to_string())
+            .execute()
+            .await
+            .expect("获取指定工单自定义字段应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/ticket_customized_fields/tcf_001"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/list.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/list.rs
@@ -124,4 +124,48 @@ mod tests {
             .build();
         let _builder = ListTicketCustomizedFieldRequestBuilder::new(Arc::new(config));
     }
+
+    /// 端到端：GET .../ticket_customized_fields → 强类型 ListTicketCustomizedFieldResponse 解析（外层 data 信封 + items）。
+    #[tokio::test]
+    async fn test_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/helpdesk/v1/ticket_customized_fields"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "code": 0,
+                    "msg": "success",
+                    "data": { "items": [ { "id": "tcf_001", "name": "工单编号", "field_type": "text", "required": true } ] }
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ListTicketCustomizedFieldRequest::new(config)
+            .execute()
+            .await
+            .expect("获取工单自定义字段列表应成功");
+        assert!(resp.items.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/ticket_customized_fields"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/mod.rs
@@ -58,24 +58,3 @@ pub use delete::{DeleteTicketCustomizedFieldRequest, DeleteTicketCustomizedField
 pub use get::{GetTicketCustomizedFieldRequest, GetTicketCustomizedFieldRequestBuilder};
 pub use list::{ListTicketCustomizedFieldRequest, ListTicketCustomizedFieldRequestBuilder};
 pub use patch::{PatchTicketCustomizedFieldRequest, PatchTicketCustomizedFieldRequestBuilder};
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/patch.rs
@@ -225,4 +225,52 @@ mod tests {
         assert_eq!(builder.id, "field_123");
         assert!(builder.name.is_none());
     }
+
+    /// 端到端：PATCH .../ticket_customized_fields/{id} → 强类型 PatchTicketCustomizedFieldResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/helpdesk/v1/ticket_customized_fields/tcf_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "id": "tcf_001", "name": "工单编号-改" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let body = PatchTicketCustomizedFieldBody {
+            name: Some("工单编号-改".to_string()),
+            required: Some(true),
+        };
+        let resp = PatchTicketCustomizedFieldRequest::new(config, "tcf_001".to_string())
+            .execute(body)
+            .await
+            .expect("更新工单自定义字段应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/helpdesk/v1/ticket_customized_fields/tcf_001"
+        );
+    }
 }

--- a/crates/openlark-helpdesk/src/service.rs
+++ b/crates/openlark-helpdesk/src/service.rs
@@ -26,23 +26,3 @@ impl HelpdeskService {
         crate::helpdesk::helpdesk::v1::HelpdeskV1::new(self._config.clone())
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}


### PR DESCRIPTION
## 背景

继 security(#374)/cardkit(#375)/user(#376)/analytics(#379) 之后，#351 第 5 批：`openlark-helpdesk`（57 API 文件，**P2 最后一个**）。本批最大，用 **6-agent workflow** 按子域并行转换。

## 改动

- **~55 个 leaf API 文件**新增 wiremock 端到端（6-agent workflow 按子域并行：category+event+bot / faq / notification / ticket / ticket_customized_field+agent / agent_schedule+agent_skill）。保留各文件既有真实测试（builder/validation），仅替换/追加 e2e。
- **16 个 `mod.rs`/`service.rs` 聚合文件**的占位 dummy mod tests 全清。
- `Cargo.toml` 补 `wiremock` + `serde_json` dev-dep；`Cargo.lock` + `.github/msrv/Cargo.lock` 同步 wiremock 依赖边（规避 #376 的 msrv `--locked` 失败）。

## 技术要点

- helpdesk 用 `HelpdeskApiV1` enum 的 `to_url()` 构造路径 + `extract_response_data` 提取响应。
- **信封按 Response struct 形状适配**（agent 自主判断）：`{data: Option<TypedData>}` 的用双层 `{"code":0,"data":{"data":{...}}}`；扁平 struct（如 `{items, page_token}`、`{ticket_id, title}`、`{message_id}`）用单层 `{"code":0,"data":{<flat fields>}}`。token 默认 Tenant → 全用 `enable_token_cache(false)`。
- workflow 模式：agent 仅编辑文件不跑 cargo（避免 target/ 竞争），orchestrator 统一验证。

## ⚠️ e2e 化 catalog 交叉核对发现 2 处待清理（#380，本 PR 不改）

- **`faq/faq_image.rs`**：与 `image.rs` **字节相同**的重复孤儿模块（两者都实现 `GetFaqImageRequest`，但只有 `image.rs` 接进 `Faq::image()` + re-export；`faq_image` 从未被引用 = 死代码）。建议删 `faq_image.rs` + mod.rs 的 `pub mod faq_image;`。
- **`notification/list.rs`**：`GET /notifications` **不在 `api_list_export.csv`**（目录里 notification 只有 8 个端点，无 list）。疑似幻影（或目录导出缺口），需对照飞书文档核实。

两者维持原样，留 #380 处理（同 user `get` #377 的处理方式）。

## 验证

- `cargo test -p openlark-helpdesk --all-features` → 全绿（153+21）
- `cargo clippy` `--all-features` 与 `--no-default-features` 均 `-Dwarnings` clean
- `cargo fmt --check` → clean
- `cargo doc -D warnings` → clean
- completeness grep：helpdesk 全 crate **0** 处 `{"test":"value"}` 占位残留

P2 全部收口（analytics + helpdesk）。

Refs #351