### PR TITLE
test(application): 36 真实端点 wiremock e2e + 修 27 个丢弃响应 bug (#351 P3)

### DIFF
--- a/.github/msrv/Cargo.lock
+++ b/.github/msrv/Cargo.lock
@@ -1588,6 +1588,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **application 36 真实端点占位测试 → wiremock e2e + 修 27 个丢弃响应 bug**（#351 第 6 批，P3
+  application）：`v6/application`（23）/ `v5`（2）/ `v6` 非 app（2）的 `execute_with_options` 用
+  `let _resp = Transport::request(...).await?; Ok(XxxResponse { data: None })` 丢弃响应（永远返回空
+  data），修成 `resp.data.ok_or_else(|| validation_error(...))`。36 个经 catalog 核对为真实端点的
+  API 文件：占位 `serde_json` roundtrip 测试 → wiremock 端到端（Builder → execute → Transport →
+  mock → 断言 data + path）。`v1/` + `v6` 非 application 子域 ~60 残破 stub（双 `application/` path
+  + create/delete 用 GET）归 #382（v0.18 清理）。**非 breaking**：丢弃响应修复使行为变正确（旧返回
+  空 data，无可依赖）；e2e 测试纯新增。
+
 - **ADR 0001 导航壳重设计执行完成**（10 crate / 12 PR：#353-#366）：bot/meeting/mail/helpdesk/analytics/
   user/platform-facade/docs/cardkit/application/workflow 全部按 5 项判定落地（细节见各 PR 及
   `docs/adr/0001-navigation-shell-redesign.md` 执行记录）。platform inception 折叠按 ADR 硬约束 line 105

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,6 +1556,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/openlark-application/Cargo.toml
+++ b/crates/openlark-application/Cargo.toml
@@ -21,6 +21,8 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
+wiremock = { workspace = true }
+serde_json = { workspace = true }
 
 [features]
 default = ["v1", "async"]

--- a/crates/openlark-application/src/application/application/v5/application/favourite.rs
+++ b/crates/openlark-application/src/application/application/v5/application/favourite.rs
@@ -49,9 +49,9 @@ impl GetFavouriteAppsRequest {
         let req: ApiRequest<GetFavouriteAppsResponse> =
             ApiRequest::get("/open-apis/application/v5/applications/favourite");
 
-        let _resp: openlark_core::api::Response<GetFavouriteAppsResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(GetFavouriteAppsResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data
+            .ok_or_else(|| openlark_core::error::validation_error("获取收藏应用", "响应数据为空"))
     }
 }
 
@@ -60,18 +60,45 @@ impl GetFavouriteAppsRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../applications/favourite → 强类型 GetFavouriteAppsResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_favourite_apps_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/application/v5/applications/favourite"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "app_count": 3 } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetFavouriteAppsRequest::new(config)
+            .execute()
+            .await
+            .expect("获取收藏应用应成功");
+        assert_eq!(resp.data.unwrap()["app_count"], 3);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v5/applications/favourite"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v5/application/recommend.rs
+++ b/crates/openlark-application/src/application/application/v5/application/recommend.rs
@@ -49,9 +49,9 @@ impl GetRecommendedAppsRequest {
         let req: ApiRequest<GetRecommendedAppsResponse> =
             ApiRequest::get("/open-apis/application/v5/applications/recommend");
 
-        let _resp: openlark_core::api::Response<GetRecommendedAppsResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(GetRecommendedAppsResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data
+            .ok_or_else(|| openlark_core::error::validation_error("获取推荐应用", "响应数据为空"))
     }
 }
 
@@ -60,18 +60,45 @@ impl GetRecommendedAppsRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../applications/recommend → 强类型 GetRecommendedAppsResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_recommended_apps_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/application/v5/applications/recommend"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "app_count": 5 } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetRecommendedAppsRequest::new(config)
+            .execute()
+            .await
+            .expect("获取推荐应用应成功");
+        assert_eq!(resp.data.unwrap()["app_count"], 5);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v5/applications/recommend"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/app_badge/set.rs
+++ b/crates/openlark-application/src/application/application/v6/app_badge/set.rs
@@ -84,18 +84,47 @@ impl SetAppBadgeRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../app_badge/set → 强类型 SetAppBadgeResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_set_app_badge_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/application/v6/app_badge/set"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "app_id": "cli_test_app", "badge": 5 } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = SetAppBadgeRequest::new(config)
+            .app_id("cli_test_app")
+            .badge(5)
+            .execute()
+            .await
+            .expect("更新应用红点应成功");
+        assert_eq!(resp.data.unwrap()["app_id"], "cli_test_app");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/app_badge/set"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/app_recommend_rule/list.rs
+++ b/crates/openlark-application/src/application/application/v6/app_recommend_rule/list.rs
@@ -49,9 +49,10 @@ impl ListAppRecommendRuleRequest {
         let req: ApiRequest<ListAppRecommendRuleResponse> =
             ApiRequest::get("/open-apis/application/v6/app_recommend_rules");
 
-        let _resp: openlark_core::api::Response<ListAppRecommendRuleResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(ListAppRecommendRuleResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data.ok_or_else(|| {
+            openlark_core::error::validation_error("获取推荐规则列表", "响应数据为空")
+        })
     }
 }
 
@@ -60,18 +61,45 @@ impl ListAppRecommendRuleRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../app_recommend_rules → 强类型 ListAppRecommendRuleResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_list_app_recommend_rule_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/application/v6/app_recommend_rules"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "rule_id": "rule_001", "rule_name": "默认推荐规则" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ListAppRecommendRuleRequest::new(config)
+            .execute()
+            .await
+            .expect("获取推荐规则列表应成功");
+        assert_eq!(resp.data.unwrap()["rule_id"], "rule_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/app_recommend_rules"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/app_usage/department_overview.rs
+++ b/crates/openlark-application/src/application/application/v6/application/app_usage/department_overview.rs
@@ -56,9 +56,10 @@ impl GetApplicationUsageDepartmentOverviewRequest {
         let req: ApiRequest<GetApplicationUsageDepartmentOverviewResponse> =
             ApiRequest::post(&path);
 
-        let _resp: openlark_core::api::Response<GetApplicationUsageDepartmentOverviewResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(GetApplicationUsageDepartmentOverviewResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data.ok_or_else(|| {
+            openlark_core::error::validation_error("获取多部门应用使用概览", "响应数据为空")
+        })
     }
 }
 
@@ -67,18 +68,49 @@ impl GetApplicationUsageDepartmentOverviewRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../applications/{app_id}/app_usage/department_overview → 强类型响应解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_application_usage_department_overview_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/application/v6/applications/cli_test_app/app_usage/department_overview",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "department_id": "od_test", "active_users": 42 } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetApplicationUsageDepartmentOverviewRequest::new(config, "cli_test_app")
+            .execute()
+            .await
+            .expect("获取多部门应用使用概览应成功");
+        let data = resp.data.expect("响应数据不应为空");
+        assert_eq!(data["department_id"], "od_test");
+        assert_eq!(data["active_users"], 42);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications/cli_test_app/app_usage/department_overview"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/app_usage/message_push_overview.rs
+++ b/crates/openlark-application/src/application/application/v6/application/app_usage/message_push_overview.rs
@@ -55,9 +55,10 @@ impl GetMessagePushOverviewRequest {
         );
         let req: ApiRequest<GetMessagePushOverviewResponse> = ApiRequest::post(&path);
 
-        let _resp: openlark_core::api::Response<GetMessagePushOverviewResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(GetMessagePushOverviewResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data.ok_or_else(|| {
+            openlark_core::error::validation_error("获取消息推送概览", "响应数据为空")
+        })
     }
 }
 
@@ -66,18 +67,49 @@ impl GetMessagePushOverviewRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../applications/{app_id}/app_usage/message_push_overview → 强类型响应解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_message_push_overview_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/application/v6/applications/cli_test_app/app_usage/message_push_overview",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "push_count": 128, "read_count": 96 } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetMessagePushOverviewRequest::new(config, "cli_test_app")
+            .execute()
+            .await
+            .expect("获取消息推送概览应成功");
+        let data = resp.data.expect("响应数据不应为空");
+        assert_eq!(data["push_count"], 128);
+        assert_eq!(data["read_count"], 96);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications/cli_test_app/app_usage/message_push_overview"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/app_usage/overview.rs
+++ b/crates/openlark-application/src/application/application/v6/application/app_usage/overview.rs
@@ -55,9 +55,10 @@ impl GetApplicationUsageOverviewRequest {
         );
         let req: ApiRequest<GetApplicationUsageOverviewResponse> = ApiRequest::post(&path);
 
-        let _resp: openlark_core::api::Response<GetApplicationUsageOverviewResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(GetApplicationUsageOverviewResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data.ok_or_else(|| {
+            openlark_core::error::validation_error("获取应用使用概览", "响应数据为空")
+        })
     }
 }
 
@@ -66,18 +67,49 @@ impl GetApplicationUsageOverviewRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../applications/{app_id}/app_usage/overview → 强类型 GetApplicationUsageOverviewResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_application_usage_overview_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/application/v6/applications/cli_test_app/app_usage/overview",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "active_users": 256, "total_users": 1024 } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetApplicationUsageOverviewRequest::new(config, "cli_test_app")
+            .execute()
+            .await
+            .expect("获取应用使用概览应成功");
+        let data = resp.data.expect("响应数据不应为空");
+        assert_eq!(data["active_users"], 256);
+        assert_eq!(data["total_users"], 1024);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications/cli_test_app/app_usage/overview"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/app_version/contacts_range_suggest.rs
+++ b/crates/openlark-application/src/application/application/v6/application/app_version/contacts_range_suggest.rs
@@ -61,9 +61,13 @@ impl GetAppVersionContactsRangeSuggestRequest {
         );
         let req: ApiRequest<GetAppVersionContactsRangeSuggestResponse> = ApiRequest::get(&path);
 
-        let _resp: openlark_core::api::Response<GetAppVersionContactsRangeSuggestResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(GetAppVersionContactsRangeSuggestResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data.ok_or_else(|| {
+            openlark_core::error::validation_error(
+                "获取应用版本中开发者申请的通讯录权限范围",
+                "响应数据为空",
+            )
+        })
     }
 }
 
@@ -72,18 +76,47 @@ impl GetAppVersionContactsRangeSuggestRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../{app_id}/app_versions/{version_id}/contacts_range_suggest → 强类型响应解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_app_version_contacts_range_suggest_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/application/v6/applications/cli_test_app/app_versions/ver_1/contacts_range_suggest"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "app_id": "cli_test_app", "version_id": "ver_1" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetAppVersionContactsRangeSuggestRequest::new(config, "cli_test_app", "ver_1")
+            .execute()
+            .await
+            .expect("获取应用版本中开发者申请的通讯录权限范围应成功");
+        let data = resp.data.unwrap();
+        assert_eq!(data["app_id"], "cli_test_app");
+        assert_eq!(data["version_id"], "ver_1");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications/cli_test_app/app_versions/ver_1/contacts_range_suggest"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/app_version/get.rs
+++ b/crates/openlark-application/src/application/application/v6/application/app_version/get.rs
@@ -62,9 +62,10 @@ impl GetApplicationVersionRequest {
         );
         let req: ApiRequest<GetApplicationVersionResponse> = ApiRequest::get(&path);
 
-        let _resp: openlark_core::api::Response<GetApplicationVersionResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(GetApplicationVersionResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data.ok_or_else(|| {
+            openlark_core::error::validation_error("获取应用版本信息", "响应数据为空")
+        })
     }
 }
 
@@ -73,18 +74,49 @@ impl GetApplicationVersionRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../applications/{app_id}/app_versions/{version_id} → 强类型 GetApplicationVersionResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_application_version_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/application/v6/applications/cli_test_app/app_versions/ver_1",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "app_id": "cli_test_app", "version_id": "ver_1" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetApplicationVersionRequest::new(config, "cli_test_app", "ver_1")
+            .execute()
+            .await
+            .expect("获取应用版本信息应成功");
+        let data = resp.data.unwrap();
+        assert_eq!(data["app_id"], "cli_test_app");
+        assert_eq!(data["version_id"], "ver_1");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications/cli_test_app/app_versions/ver_1"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/app_version/list.rs
+++ b/crates/openlark-application/src/application/application/v6/application/app_version/list.rs
@@ -56,9 +56,10 @@ impl ListApplicationVersionsRequest {
         );
         let req: ApiRequest<ListApplicationVersionsResponse> = ApiRequest::get(&path);
 
-        let _resp: openlark_core::api::Response<ListApplicationVersionsResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(ListApplicationVersionsResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data.ok_or_else(|| {
+            openlark_core::error::validation_error("获取应用版本列表", "响应数据为空")
+        })
     }
 }
 
@@ -67,18 +68,47 @@ impl ListApplicationVersionsRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../applications/{app_id}/app_versions → 强类型 ListApplicationVersionsResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_list_application_versions_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/application/v6/applications/cli_test_app/app_versions",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "items": [] } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ListApplicationVersionsRequest::new(config, "cli_test_app")
+            .execute()
+            .await
+            .expect("获取应用版本列表应成功");
+        assert!(resp.data.unwrap()["items"].is_array());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications/cli_test_app/app_versions"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/app_version/patch.rs
+++ b/crates/openlark-application/src/application/application/v6/application/app_version/patch.rs
@@ -62,9 +62,10 @@ impl PatchApplicationAppVersionRequest {
         );
         let req: ApiRequest<PatchApplicationAppVersionResponse> = ApiRequest::patch(&path);
 
-        let _resp: openlark_core::api::Response<PatchApplicationAppVersionResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(PatchApplicationAppVersionResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data.ok_or_else(|| {
+            openlark_core::error::validation_error("更新应用审核状态", "响应数据为空")
+        })
     }
 }
 
@@ -73,18 +74,49 @@ impl PatchApplicationAppVersionRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PATCH .../applications/{app_id}/app_versions/{version_id} → 强类型 PatchApplicationAppVersionResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_application_app_version_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/application/v6/applications/cli_test_app/app_versions/ver_1",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "app_id": "cli_test_app", "version_id": "ver_1" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = PatchApplicationAppVersionRequest::new(config, "cli_test_app", "ver_1")
+            .execute()
+            .await
+            .expect("更新应用审核状态应成功");
+        let data = resp.data.unwrap();
+        assert_eq!(data["app_id"], "cli_test_app");
+        assert_eq!(data["version_id"], "ver_1");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications/cli_test_app/app_versions/ver_1"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/collaborators/get.rs
+++ b/crates/openlark-application/src/application/application/v6/application/collaborators/get.rs
@@ -56,9 +56,10 @@ impl GetApplicationCollaboratorsRequest {
         );
         let req: ApiRequest<GetApplicationCollaboratorsResponse> = ApiRequest::get(&path);
 
-        let _resp: openlark_core::api::Response<GetApplicationCollaboratorsResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(GetApplicationCollaboratorsResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data.ok_or_else(|| {
+            openlark_core::error::validation_error("获取应用协作者列表", "响应数据为空")
+        })
     }
 }
 
@@ -67,18 +68,49 @@ impl GetApplicationCollaboratorsRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../applications/{app_id}/collaborators → 强类型 GetApplicationCollaboratorsResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_application_collaborators_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/application/v6/applications/cli_test_app/collaborators",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "app_id": "cli_test_app", "collaborators": [] } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetApplicationCollaboratorsRequest::new(config, "cli_test_app")
+            .execute()
+            .await
+            .expect("获取应用协作者列表应成功");
+        let data = resp.data.unwrap();
+        assert_eq!(data["app_id"], "cli_test_app");
+        assert!(data["collaborators"].is_array());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications/cli_test_app/collaborators"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/collaborators/list.rs
+++ b/crates/openlark-application/src/application/application/v6/application/collaborators/list.rs
@@ -56,9 +56,10 @@ impl ListApplicationCollaboratorsRequest {
         );
         let req: ApiRequest<ListApplicationCollaboratorsResponse> = ApiRequest::get(&path);
 
-        let _resp: openlark_core::api::Response<ListApplicationCollaboratorsResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(ListApplicationCollaboratorsResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data.ok_or_else(|| {
+            openlark_core::error::validation_error("获取应用协作者列表", "响应数据为空")
+        })
     }
 }
 
@@ -67,18 +68,49 @@ impl ListApplicationCollaboratorsRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../applications/{app_id}/collaborators → 强类型 ListApplicationCollaboratorsResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_list_application_collaborators_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/application/v6/applications/cli_test_app/collaborators",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "app_id": "cli_test_app", "collaborators": [] } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ListApplicationCollaboratorsRequest::new(config, "cli_test_app")
+            .execute()
+            .await
+            .expect("获取应用协作者列表应成功");
+        let data = resp.data.unwrap();
+        assert_eq!(data["app_id"], "cli_test_app");
+        assert!(data["collaborators"].is_array());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications/cli_test_app/collaborators"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/collaborators/update.rs
+++ b/crates/openlark-application/src/application/application/v6/application/collaborators/update.rs
@@ -55,9 +55,9 @@ impl UpdateApplicationCollaboratorsRequest {
         );
         let req: ApiRequest<UpdateApplicationCollaboratorsResponse> = ApiRequest::put(&path);
 
-        let _resp: openlark_core::api::Response<UpdateApplicationCollaboratorsResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(UpdateApplicationCollaboratorsResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data
+            .ok_or_else(|| openlark_core::error::validation_error("更新应用协作者", "响应数据为空"))
     }
 }
 
@@ -66,18 +66,47 @@ impl UpdateApplicationCollaboratorsRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PUT .../applications/{app_id}/collaborators → 强类型 UpdateApplicationCollaboratorsResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_update_application_collaborators_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path(
+                "/open-apis/application/v6/applications/cli_test_app/collaborators",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "app_id": "cli_test_app" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = UpdateApplicationCollaboratorsRequest::new(config, "cli_test_app")
+            .execute()
+            .await
+            .expect("更新应用协作者应成功");
+        assert_eq!(resp.data.unwrap()["app_id"], "cli_test_app");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications/cli_test_app/collaborators"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/contacts_range/patch.rs
+++ b/crates/openlark-application/src/application/application/v6/application/contacts_range/patch.rs
@@ -56,9 +56,10 @@ impl PatchApplicationContactsRangeRequest {
         );
         let req: ApiRequest<PatchApplicationContactsRangeResponse> = ApiRequest::patch(&path);
 
-        let _resp: openlark_core::api::Response<PatchApplicationContactsRangeResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(PatchApplicationContactsRangeResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data.ok_or_else(|| {
+            openlark_core::error::validation_error("更新应用通讯录权限范围配置", "响应数据为空")
+        })
     }
 }
 
@@ -67,18 +68,48 @@ impl PatchApplicationContactsRangeRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PATCH .../applications/{app_id}/contacts_range → 强类型
+    /// PatchApplicationContactsRangeResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_contacts_range_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/application/v6/applications/cli_test_app/contacts_range",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "updated": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = PatchApplicationContactsRangeRequest::new(config, "cli_test_app")
+            .execute()
+            .await
+            .expect("更新应用通讯录权限范围配置应成功");
+        assert_eq!(resp.data.unwrap()["updated"], true);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications/cli_test_app/contacts_range"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/contacts_range_configuration.rs
+++ b/crates/openlark-application/src/application/application/v6/application/contacts_range_configuration.rs
@@ -57,9 +57,10 @@ impl GetApplicationContactsRangeConfigurationRequest {
         let req: ApiRequest<GetApplicationContactsRangeConfigurationResponse> =
             ApiRequest::get(&path);
 
-        let _resp: openlark_core::api::Response<GetApplicationContactsRangeConfigurationResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(GetApplicationContactsRangeConfigurationResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data.ok_or_else(|| {
+            openlark_core::error::validation_error("获取应用通讯录权限范围配置", "响应数据为空")
+        })
     }
 }
 
@@ -68,18 +69,48 @@ impl GetApplicationContactsRangeConfigurationRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../applications/{app_id}/contacts_range_configuration → 强类型
+    /// GetApplicationContactsRangeConfigurationResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_contacts_range_configuration_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/application/v6/applications/cli_test_app/contacts_range_configuration",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "scope": "all" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetApplicationContactsRangeConfigurationRequest::new(config, "cli_test_app")
+            .execute()
+            .await
+            .expect("获取应用通讯录权限范围配置应成功");
+        assert_eq!(resp.data.unwrap()["scope"], "all");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications/cli_test_app/contacts_range_configuration"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/feedback/list.rs
+++ b/crates/openlark-application/src/application/application/v6/application/feedback/list.rs
@@ -56,9 +56,10 @@ impl ListApplicationFeedbackRequest {
         );
         let req: ApiRequest<ListApplicationFeedbackResponse> = ApiRequest::get(&path);
 
-        let _resp: openlark_core::api::Response<ListApplicationFeedbackResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(ListApplicationFeedbackResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data.ok_or_else(|| {
+            openlark_core::error::validation_error("获取应用反馈列表", "响应数据为空")
+        })
     }
 }
 
@@ -67,18 +68,48 @@ impl ListApplicationFeedbackRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../applications/{app_id}/feedbacks → 强类型
+    /// ListApplicationFeedbackResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_list_feedback_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/application/v6/applications/cli_test_app/feedbacks",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "total": 3 } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ListApplicationFeedbackRequest::new(config, "cli_test_app")
+            .execute()
+            .await
+            .expect("获取应用反馈列表应成功");
+        assert_eq!(resp.data.unwrap()["total"], 3);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications/cli_test_app/feedbacks"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/feedback/patch.rs
+++ b/crates/openlark-application/src/application/application/v6/application/feedback/patch.rs
@@ -62,9 +62,9 @@ impl PatchApplicationFeedbackRequest {
         );
         let req: ApiRequest<PatchApplicationFeedbackResponse> = ApiRequest::patch(&path);
 
-        let _resp: openlark_core::api::Response<PatchApplicationFeedbackResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(PatchApplicationFeedbackResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data
+            .ok_or_else(|| openlark_core::error::validation_error("更新应用反馈", "响应数据为空"))
     }
 }
 
@@ -73,18 +73,48 @@ impl PatchApplicationFeedbackRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PATCH .../applications/{app_id}/feedbacks/{feedback_id} → 强类型
+    /// PatchApplicationFeedbackResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_feedback_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/application/v6/applications/cli_test_app/feedbacks/fb_123",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "feedback_id": "fb_123" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = PatchApplicationFeedbackRequest::new(config, "cli_test_app", "fb_123")
+            .execute()
+            .await
+            .expect("更新应用反馈应成功");
+        assert_eq!(resp.data.unwrap()["feedback_id"], "fb_123");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications/cli_test_app/feedbacks/fb_123"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/get.rs
+++ b/crates/openlark-application/src/application/application/v6/application/get.rs
@@ -53,9 +53,9 @@ impl GetApplicationRequest {
         let path = format!("/open-apis/application/v6/applications/{}", self.app_id);
         let req: ApiRequest<GetApplicationResponse> = ApiRequest::get(&path);
 
-        let _resp: openlark_core::api::Response<GetApplicationResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(GetApplicationResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data
+            .ok_or_else(|| openlark_core::error::validation_error("获取应用信息", "响应数据为空"))
     }
 }
 
@@ -64,18 +64,45 @@ impl GetApplicationRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../applications/{app_id} → 强类型 GetApplicationResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_application_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/application/v6/applications/cli_test_app"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "app_id": "cli_test_app", "app_name": "测试应用" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetApplicationRequest::new(config, "cli_test_app")
+            .execute()
+            .await
+            .expect("获取应用信息应成功");
+        assert_eq!(resp.data.unwrap()["app_id"], "cli_test_app");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications/cli_test_app"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/list.rs
+++ b/crates/openlark-application/src/application/application/v6/application/list.rs
@@ -49,9 +49,10 @@ impl ListApplicationsRequest {
         let path = "/open-apis/application/v6/applications";
         let req: ApiRequest<ListApplicationsResponse> = ApiRequest::get(path);
 
-        let _resp: openlark_core::api::Response<ListApplicationsResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(ListApplicationsResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data.ok_or_else(|| {
+            openlark_core::error::validation_error("获取企业安装的应用", "响应数据为空")
+        })
     }
 }
 
@@ -60,18 +61,45 @@ impl ListApplicationsRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET /open-apis/application/v6/applications → 强类型 ListApplicationsResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_list_applications_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/application/v6/applications"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "items": [] } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ListApplicationsRequest::new(config)
+            .execute()
+            .await
+            .expect("获取企业安装的应用应成功");
+        assert!(resp.data.unwrap()["items"].is_array());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/management/update.rs
+++ b/crates/openlark-application/src/application/application/v6/application/management/update.rs
@@ -55,9 +55,9 @@ impl UpdateApplicationManagementRequest {
         );
         let req: ApiRequest<UpdateApplicationManagementResponse> = ApiRequest::put(&path);
 
-        let _resp: openlark_core::api::Response<UpdateApplicationManagementResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(UpdateApplicationManagementResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data
+            .ok_or_else(|| openlark_core::error::validation_error("启停用应用", "响应数据为空"))
     }
 }
 
@@ -66,18 +66,48 @@ impl UpdateApplicationManagementRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PUT .../applications/{app_id}/management → 强类型
+    /// UpdateApplicationManagementResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_update_management_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path(
+                "/open-apis/application/v6/applications/cli_test_app/management",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "status": "enabled" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = UpdateApplicationManagementRequest::new(config, "cli_test_app")
+            .execute()
+            .await
+            .expect("启停用应用应成功");
+        assert_eq!(resp.data.unwrap()["status"], "enabled");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications/cli_test_app/management"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/owner/update.rs
+++ b/crates/openlark-application/src/application/application/v6/application/owner/update.rs
@@ -55,9 +55,9 @@ impl UpdateAppOwnerRequest {
         );
         let req: ApiRequest<UpdateAppOwnerResponse> = ApiRequest::put(&path);
 
-        let _resp: openlark_core::api::Response<UpdateAppOwnerResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(UpdateAppOwnerResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data
+            .ok_or_else(|| openlark_core::error::validation_error("转移应用所有者", "响应数据为空"))
     }
 }
 
@@ -66,18 +66,48 @@ impl UpdateAppOwnerRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PUT .../applications/{app_id}/owner → 强类型
+    /// UpdateAppOwnerResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_update_owner_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path(
+                "/open-apis/application/v6/applications/cli_test_app/owner",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "new_owner": "ou_test_owner" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = UpdateAppOwnerRequest::new(config, "cli_test_app")
+            .execute()
+            .await
+            .expect("转移应用所有者应成功");
+        assert_eq!(resp.data.unwrap()["new_owner"], "ou_test_owner");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications/cli_test_app/owner"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/patch.rs
+++ b/crates/openlark-application/src/application/application/v6/application/patch.rs
@@ -53,9 +53,10 @@ impl PatchApplicationRequest {
         let path = format!("/open-apis/application/v6/applications/{}", self.app_id);
         let req: ApiRequest<PatchApplicationResponse> = ApiRequest::patch(&path);
 
-        let _resp: openlark_core::api::Response<PatchApplicationResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(PatchApplicationResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data.ok_or_else(|| {
+            openlark_core::error::validation_error("更新应用分组信息", "响应数据为空")
+        })
     }
 }
 
@@ -64,18 +65,45 @@ impl PatchApplicationRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PATCH .../applications/{app_id} → 强类型 PatchApplicationResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_application_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/application/v6/applications/cli_test_app"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "app_id": "cli_test_app" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = PatchApplicationRequest::new(config, "cli_test_app")
+            .execute()
+            .await
+            .expect("更新应用分组信息应成功");
+        assert_eq!(resp.data.unwrap()["app_id"], "cli_test_app");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications/cli_test_app"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/underauditlist.rs
+++ b/crates/openlark-application/src/application/application/v6/application/underauditlist.rs
@@ -49,9 +49,10 @@ impl GetApplicationUnderauditlistRequest {
         let path = "/open-apis/application/v6/applications/underauditlist";
         let req: ApiRequest<GetApplicationUnderauditlistResponse> = ApiRequest::get(path);
 
-        let _resp: openlark_core::api::Response<GetApplicationUnderauditlistResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(GetApplicationUnderauditlistResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data.ok_or_else(|| {
+            openlark_core::error::validation_error("查看待审核的应用列表", "响应数据为空")
+        })
     }
 }
 
@@ -60,18 +61,47 @@ impl GetApplicationUnderauditlistRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../applications/underauditlist → 强类型 GetApplicationUnderauditlistResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_application_underauditlist_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/application/v6/applications/underauditlist",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "items": [] } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetApplicationUnderauditlistRequest::new(config)
+            .execute()
+            .await
+            .expect("查看待审核的应用列表应成功");
+        assert!(resp.data.unwrap()["items"].is_array());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications/underauditlist"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/visibility/check_white_black_list.rs
+++ b/crates/openlark-application/src/application/application/v6/application/visibility/check_white_black_list.rs
@@ -56,9 +56,13 @@ impl CheckApplicationVisibilityWhiteBlackListRequest {
         let req: ApiRequest<CheckApplicationVisibilityWhiteBlackListResponse> =
             ApiRequest::post(&path);
 
-        let _resp: openlark_core::api::Response<CheckApplicationVisibilityWhiteBlackListResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(CheckApplicationVisibilityWhiteBlackListResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data.ok_or_else(|| {
+            openlark_core::error::validation_error(
+                "查询用户或部门是否在应用的可用或禁用名单",
+                "响应数据为空",
+            )
+        })
     }
 }
 
@@ -67,18 +71,49 @@ impl CheckApplicationVisibilityWhiteBlackListRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../applications/{app_id}/visibility/check_white_black_list → 强类型响应解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_check_application_visibility_white_black_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/application/v6/applications/cli_test_app/visibility/check_white_black_list",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "in_white_list": true, "in_black_list": false } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = CheckApplicationVisibilityWhiteBlackListRequest::new(config, "cli_test_app")
+            .execute()
+            .await
+            .expect("查询用户或部门是否在应用的可用或禁用名单应成功");
+        let data = resp.data.expect("响应数据不应为空");
+        assert_eq!(data["in_white_list"], true);
+        assert_eq!(data["in_black_list"], false);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications/cli_test_app/visibility/check_white_black_list"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/application/visibility/patch.rs
+++ b/crates/openlark-application/src/application/application/v6/application/visibility/patch.rs
@@ -56,9 +56,10 @@ impl PatchApplicationVisibilityRequest {
         );
         let req: ApiRequest<PatchApplicationVisibilityResponse> = ApiRequest::patch(&path);
 
-        let _resp: openlark_core::api::Response<PatchApplicationVisibilityResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(PatchApplicationVisibilityResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data.ok_or_else(|| {
+            openlark_core::error::validation_error("更新应用可用范围", "响应数据为空")
+        })
     }
 }
 
@@ -67,18 +68,47 @@ impl PatchApplicationVisibilityRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PATCH .../applications/{app_id}/visibility → 强类型 PatchApplicationVisibilityResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_application_visibility_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/application/v6/applications/cli_test_app/visibility",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "app_id": "cli_test_app", "result": "ok" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = PatchApplicationVisibilityRequest::new(config, "cli_test_app")
+            .execute()
+            .await
+            .expect("更新应用可用范围应成功");
+        assert_eq!(resp.data.unwrap()["result"], "ok");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/applications/cli_test_app/visibility"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/scope/apply.rs
+++ b/crates/openlark-application/src/application/application/v6/scope/apply.rs
@@ -72,18 +72,45 @@ impl ApplyScopeRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../scopes/apply → 强类型 ApplyScopeResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_apply_scope_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/application/v6/scopes/apply"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "apply_id": "apply_001", "status": "pending" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ApplyScopeRequest::new(config)
+            .execute()
+            .await
+            .expect("向管理员申请授权应成功");
+        assert_eq!(resp.data.unwrap()["apply_id"], "apply_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v6/scopes/apply"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v6/scope/list.rs
+++ b/crates/openlark-application/src/application/application/v6/scope/list.rs
@@ -49,9 +49,10 @@ impl ListApplicationScopeRequest {
         let path = "/open-apis/application/v6/scopes";
         let req: ApiRequest<ListApplicationScopeResponse> = ApiRequest::get(path);
 
-        let _resp: openlark_core::api::Response<ListApplicationScopeResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(ListApplicationScopeResponse { data: None })
+        let resp = Transport::request(req, &self.config, Some(option)).await?;
+        resp.data.ok_or_else(|| {
+            openlark_core::error::validation_error("查询租户授权状态", "响应数据为空")
+        })
     }
 }
 
@@ -60,18 +61,42 @@ impl ListApplicationScopeRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../scopes → 强类型 ListApplicationScopeResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_list_application_scope_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/application/v6/scopes"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "scope_id": "scope_001", "scope_name": "通讯录读取" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ListApplicationScopeRequest::new(config)
+            .execute()
+            .await
+            .expect("查询租户授权状态应成功");
+        assert_eq!(resp.data.unwrap()["scope_id"], "scope_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/application/v6/scopes");
     }
 }

--- a/crates/openlark-application/src/application/application/v7/app_avatar/upload/create.rs
+++ b/crates/openlark-application/src/application/application/v7/app_avatar/upload/create.rs
@@ -40,6 +40,7 @@ impl AppAvatarUploadCreateRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
     use super::*;
 
@@ -47,5 +48,47 @@ mod tests {
     fn builder_initializes() {
         let config = Arc::new(Config::default());
         let _request = AppAvatarUploadCreateRequest::new(config);
+    }
+
+    /// 端到端：POST .../app_avatar/upload → 原始 serde_json::Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_create_app_avatar_upload_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/application/v7/app_avatar/upload"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "icon": "avatar_data" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = AppAvatarUploadCreateRequest::new(config)
+            .execute(json!({ "image_type": "icon" }))
+            .await
+            .expect("上传应用图标应成功");
+        assert_eq!(resp["icon"], "avatar_data");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v7/app_avatar/upload"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v7/application/ability/patch.rs
+++ b/crates/openlark-application/src/application/application/v7/application/ability/patch.rs
@@ -56,6 +56,7 @@ impl ApplicationAbilityPatchRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
     use super::*;
 
@@ -63,5 +64,50 @@ mod tests {
     fn builder_initializes() {
         let config = Arc::new(Config::default());
         let _request = ApplicationAbilityPatchRequest::new(config);
+    }
+
+    /// 端到端：PATCH .../applications/{app_id}/ability → 原始 serde_json::Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_application_ability_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/application/v7/applications/cli_test_app/ability",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "app_id": "cli_test_app" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ApplicationAbilityPatchRequest::new(config)
+            .app_id("cli_test_app")
+            .execute(json!({ "abilities": [] }))
+            .await
+            .expect("更新应用能力配置应成功");
+        assert_eq!(resp["app_id"], "cli_test_app");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v7/applications/cli_test_app/ability"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v7/application/base/patch.rs
+++ b/crates/openlark-application/src/application/application/v7/application/base/patch.rs
@@ -56,6 +56,7 @@ impl ApplicationBasePatchRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
     use super::*;
 
@@ -63,5 +64,50 @@ mod tests {
     fn builder_initializes() {
         let config = Arc::new(Config::default());
         let _request = ApplicationBasePatchRequest::new(config);
+    }
+
+    /// 端到端：PATCH .../applications/{app_id}/base → 原始 serde_json::Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_application_base_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/application/v7/applications/cli_test_app/base",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "app_id": "cli_test_app" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ApplicationBasePatchRequest::new(config)
+            .app_id("cli_test_app")
+            .execute(json!({ "app_name": "测试应用" }))
+            .await
+            .expect("更新应用基础信息配置应成功");
+        assert_eq!(resp["app_id"], "cli_test_app");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v7/applications/cli_test_app/base"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v7/application/config/patch.rs
+++ b/crates/openlark-application/src/application/application/v7/application/config/patch.rs
@@ -56,6 +56,7 @@ impl ApplicationConfigPatchRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
     use super::*;
 
@@ -63,5 +64,50 @@ mod tests {
     fn builder_initializes() {
         let config = Arc::new(Config::default());
         let _request = ApplicationConfigPatchRequest::new(config);
+    }
+
+    /// 端到端：PATCH .../applications/{app_id}/config → 原始 serde_json::Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_application_config_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/application/v7/applications/cli_test_app/config",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "app_id": "cli_test_app" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ApplicationConfigPatchRequest::new(config)
+            .app_id("cli_test_app")
+            .execute(json!({ "dev_config": {} }))
+            .await
+            .expect("更新应用开发配置应成功");
+        assert_eq!(resp["app_id"], "cli_test_app");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v7/applications/cli_test_app/config"
+        );
     }
 }

--- a/crates/openlark-application/src/application/application/v7/application/publish/create.rs
+++ b/crates/openlark-application/src/application/application/v7/application/publish/create.rs
@@ -56,6 +56,7 @@ impl ApplicationPublishCreateRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
     use super::*;
 
@@ -63,5 +64,50 @@ mod tests {
     fn builder_initializes() {
         let config = Arc::new(Config::default());
         let _request = ApplicationPublishCreateRequest::new(config);
+    }
+
+    /// 端到端：POST .../applications/{app_id}/publish → 原始 serde_json::Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_create_application_publish_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/application/v7/applications/cli_test_app/publish",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "publish_id": "pub_001" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ApplicationPublishCreateRequest::new(config)
+            .app_id("cli_test_app")
+            .execute(json!({ "version": "1.0.0" }))
+            .await
+            .expect("提交发布自建应用应成功");
+        assert_eq!(resp["publish_id"], "pub_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/application/v7/applications/cli_test_app/publish"
+        );
     }
 }

--- a/crates/openlark-application/src/workplace/workplace/v1/custom_workplace_access_data/search.rs
+++ b/crates/openlark-application/src/workplace/workplace/v1/custom_workplace_access_data/search.rs
@@ -109,19 +109,49 @@ pub type AccessDataSearchCustomBuilder = AccessDataSearchCustomRequestBuilder;
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../custom_workplace_access_data/search → 强类型 AccessDataSearchCustomResponse 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_search_custom_workplace_access_data_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/workplace/v1/custom_workplace_access_data/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "items": [ { "date": "2026-01-01", "visit_count": 10, "visitor_count": 5 } ] }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = AccessDataSearchCustomRequestBuilder::new(config)
+            .start_date("2026-01-01")
+            .end_date("2026-01-02")
+            .execute()
+            .await
+            .expect("定制工作台访问数据查询应成功");
+        assert_eq!(resp.items[0].date, "2026-01-01");
+        assert_eq!(resp.items[0].visit_count, 10);
+        assert_eq!(resp.items[0].visitor_count, 5);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/workplace/v1/custom_workplace_access_data/search"
+        );
     }
 }

--- a/crates/openlark-application/src/workplace/workplace/v1/workplace_access_data/search.rs
+++ b/crates/openlark-application/src/workplace/workplace/v1/workplace_access_data/search.rs
@@ -109,19 +109,49 @@ pub type AccessDataSearchWorkplaceBuilder = AccessDataSearchWorkplaceRequestBuil
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../workplace_access_data/search → 强类型 AccessDataSearchWorkplaceResponse 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_search_workplace_access_data_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/workplace/v1/workplace_access_data/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "items": [ { "date": "2026-01-01", "visit_count": 10, "visitor_count": 5 } ] }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = AccessDataSearchWorkplaceRequestBuilder::new(config)
+            .start_date("2026-01-01")
+            .end_date("2026-01-02")
+            .execute()
+            .await
+            .expect("工作台访问数据查询应成功");
+        assert_eq!(resp.items[0].date, "2026-01-01");
+        assert_eq!(resp.items[0].visit_count, 10);
+        assert_eq!(resp.items[0].visitor_count, 5);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/workplace/v1/workplace_access_data/search"
+        );
     }
 }

--- a/crates/openlark-application/src/workplace/workplace/v1/workplace_block_access_data/search.rs
+++ b/crates/openlark-application/src/workplace/workplace/v1/workplace_block_access_data/search.rs
@@ -115,19 +115,61 @@ pub type AccessDataSearchBlockBuilder = AccessDataSearchBlockRequestBuilder;
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../workplace_block_access_data/search → 强类型 AccessDataSearchBlockResponse 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_search_workplace_block_access_data_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/workplace/v1/workplace_block_access_data/search",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [ {
+                        "date": "2026-01-01",
+                        "block_id": "blk_test",
+                        "block_name": "测试组件",
+                        "visit_count": 10,
+                        "visitor_count": 5
+                    } ]
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = AccessDataSearchBlockRequestBuilder::new(config)
+            .start_date("2026-01-01")
+            .end_date("2026-01-02")
+            .execute()
+            .await
+            .expect("工作台小组件访问数据查询应成功");
+        assert_eq!(resp.items[0].date, "2026-01-01");
+        assert_eq!(resp.items[0].block_id, "blk_test");
+        assert_eq!(resp.items[0].block_name, "测试组件");
+        assert_eq!(resp.items[0].visit_count, 10);
+        assert_eq!(resp.items[0].visitor_count, 5);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/workplace/v1/workplace_block_access_data/search"
+        );
     }
 }


### PR DESCRIPTION
## 背景

#351 第 6 批，进入 **P3 大 crate**。`openlark-application`（153 API 文件）catalog 全量核对发现这个 crate 是**半成品**：

- **~60 残破 stub**（`v1/` + `v6` 非 application 子域）：path 双 `application/`（多一层）+ create/delete 用 GET → 飞书调用必 404。归 **#382**（v0.18 清理）。
- **27 个丢弃响应 bug**：`v6/application`（23）+ `v5`（2）+ `v6` 非 app（2）的 `execute_with_options` 用 `let _resp = ...; Ok(XxxResponse { data: None })`——**execute 永远返回空 data，从未透传真实响应**。
- **36 个真实端点**（catalog 核对）：占位 `serde_json` roundtrip 测试 → wiremock 端到端。

## 改动

### 1. 修 27 个丢弃响应 bug
\`\`\`rust
// 前（永远返回空）
let _resp: Response<T> = Transport::request(...).await?;
Ok(T { data: None })

// 后（透传真实响应）
let resp = Transport::request(...).await?;
resp.data.ok_or_else(|| validation_error("<op>", "响应数据为空"))
\`\`\`

### 2. 36 真实端点 wiremock e2e
每个文件删掉占位的 `test_serialization_roundtrip` + `test_deserialization_from_json`（测 serde_json 本身，不触发 Builder→execute→Transport），换成：
- \`test_<op>_<resource>_returns_data_on_success\`
- MockServer + Mock(method + path) + Config(enable_token_cache(false))
- 断言返回 data + \`received_requests\` 反查 path

信封按 Response struct 形状：
- \`{ data: Option<Value> }\` inner 字段 → 双层 \`"data":{"data":{...}}\`（v6/application、v5）
- 直接返回 \`SDKResult<Value>\` → 单层（v7）
- 直接业务字段 struct → 单层（workplace）

### 3. 衍生 issue #382
~60 残破 stub（v1 全部 + v6 非 application 重复子域）批量清理，留 v0.18 breaking 窗口。

## 本地验证

- \`cargo test -p openlark-application --all-features\`：**176 pass / 0 fail**
- \`cargo fmt --check\` ✅
- \`cargo clippy --all-features --all-targets -- -Dwarnings\` ✅
- \`cargo clippy --no-default-features --all-targets -- -Dwarnings\` ✅
- \`cargo doc --all-features -D warnings\` ✅
- \`cargo deny check advisories\` ✅
- \`cargo machete\` ✅
- msrv pinned lockfile 同步 ✅

## 关联

- 父 issue：#351（P10 占位测试 → e2e）
- 衍生：#382（application ~60 残破 stub 清理，v0.18）
- 同类先例：#374 security / #375 cardkit / #376 user / #379 analytics / #381 helpdesk

Refs #351