### PR TITLE
test(mail): 34 真实端点 wiremock e2e + 修 7 个丢弃响应 bug (#351 P3)

### DIFF
--- a/.github/msrv/Cargo.lock
+++ b/.github/msrv/Cargo.lock
@@ -1795,6 +1795,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **mail 34 真实端点占位测试 → wiremock e2e + 修 7 个丢弃响应 bug**（#351 第 7 批，P3 mail）：
+  mailgroup 的 `patch` / `alias-delete` / `member-delete` / `manager-batch_create` / `manager-batch_delete` /
+  `permission_member-delete` / `permission_member-batch_delete`（7 个）execute 用
+  `let _resp = ...; Ok(XxxResponse { data: None })` 丢弃响应，修成 `extract_response_data(response, ...)`。
+  34 个 API 文件（user_mailbox / mailgroup / public_mailbox / user 全子域）占位 `serde_json` roundtrip →
+  wiremock 端到端。mail crate 健康（catalog 107 端点 vs 代码 116 文件，幻影少；无衍生清理 issue）。
+  **非 breaking**：丢弃响应修复使行为变正确；e2e 测试纯新增。
+
 - **application 36 真实端点占位测试 → wiremock e2e + 修 27 个丢弃响应 bug**（#351 第 6 批，P3
   application）：`v6/application`（23）/ `v5`（2）/ `v6` 非 app（2）的 `execute_with_options` 用
   `let _resp = Transport::request(...).await?; Ok(XxxResponse { data: None })` 丢弃响应（永远返回空

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1763,6 +1763,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/openlark-mail/Cargo.toml
+++ b/crates/openlark-mail/Cargo.toml
@@ -21,6 +21,8 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
+wiremock = { workspace = true }
+serde_json = { workspace = true }
 
 [features]
 default = ["v1", "async"]

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/alias/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/alias/delete.rs
@@ -1,12 +1,9 @@
 //! 删除邮件组别名
 //! docPath: <https://open.feishu.cn/document/server-docs/mail-v1/mail-group/mailgroup/delete>
 
+use crate::common::api_utils::extract_response_data;
 use openlark_core::{
-    SDKResult,
-    api::{ApiRequest, Response},
-    config::Config,
-    http::Transport,
-    req_option::RequestOption,
+    SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -62,28 +59,57 @@ impl DeleteMailGroupAliasRequest {
         );
         let req: ApiRequest<DeleteMailGroupAliasResponse> = ApiRequest::delete(&path);
 
-        let _resp: Response<DeleteMailGroupAliasResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(DeleteMailGroupAliasResponse { data: None })
+        let response = Transport::request(req, &self.config, Some(option)).await?;
+        extract_response_data(response, "删除邮件组别名")
     }
 }
 
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：DELETE .../mailgroups/{}/aliases/{} → DeleteMailGroupAliasResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_delete_mail_group_alias_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/mail/v1/mailgroups/group_001/aliases/alias_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = DeleteMailGroupAliasRequest::new(config, "group_001", "alias_001")
+            .execute()
+            .await
+            .expect("删除邮件组别名应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/mailgroups/group_001/aliases/alias_001"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/delete.rs
@@ -58,19 +58,47 @@ impl ApiResponseTrait for DeleteMailGroupResponse {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：DELETE .../mailgroups/{} → DeleteMailGroupResponse 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_delete_mail_group_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/mail/v1/mailgroups/group_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "success": true }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = DeleteMailGroupRequest::new(config, "group_001".to_string())
+            .execute()
+            .await
+            .expect("删除邮件组应成功");
+        assert!(resp.success);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/mailgroups/group_001"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/batch_create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/batch_create.rs
@@ -1,6 +1,6 @@
 //! 批量创建邮件组管理员
 
-use crate::common::api_utils::serialize_params;
+use crate::common::api_utils::{extract_response_data, serialize_params};
 use openlark_core::{
     SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
@@ -80,9 +80,8 @@ impl BatchCreateMailGroupManagerRequest {
         let req: ApiRequest<BatchCreateMailGroupManagerResponse> =
             ApiRequest::post(&path).body(serialize_params(&self.body, "批量创建邮件组管理员")?);
 
-        let _resp: openlark_core::api::Response<BatchCreateMailGroupManagerResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(BatchCreateMailGroupManagerResponse { data: None })
+        let response = Transport::request(req, &self.config, Some(option)).await?;
+        extract_response_data(response, "批量创建邮件组管理员")
     }
 }
 
@@ -91,18 +90,48 @@ impl BatchCreateMailGroupManagerRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../mailgroups/{}/managers/batch_create → BatchCreateMailGroupManagerResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_batch_create_mail_group_manager_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/mail/v1/mailgroups/group_001/managers/batch_create",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = BatchCreateMailGroupManagerRequest::new(config, "group_001")
+            .manager_ids(vec!["m1".to_string()])
+            .execute()
+            .await
+            .expect("批量创建邮件组管理员应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/mailgroups/group_001/managers/batch_create"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/batch_delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/batch_delete.rs
@@ -1,6 +1,6 @@
 //! 批量删除邮件组管理员
 
-use crate::common::api_utils::serialize_params;
+use crate::common::api_utils::{extract_response_data, serialize_params};
 use openlark_core::{
     SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
@@ -80,9 +80,8 @@ impl BatchDeleteMailGroupManagerRequest {
         let req: ApiRequest<BatchDeleteMailGroupManagerResponse> =
             ApiRequest::post(&path).body(serialize_params(&self.body, "批量删除邮件组管理员")?);
 
-        let _resp: openlark_core::api::Response<BatchDeleteMailGroupManagerResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(BatchDeleteMailGroupManagerResponse { data: None })
+        let response = Transport::request(req, &self.config, Some(option)).await?;
+        extract_response_data(response, "批量删除邮件组管理员")
     }
 }
 
@@ -91,18 +90,48 @@ impl BatchDeleteMailGroupManagerRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../mailgroups/{}/managers/batch_delete → BatchDeleteMailGroupManagerResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_batch_delete_mail_group_manager_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/mail/v1/mailgroups/group_001/managers/batch_delete",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = BatchDeleteMailGroupManagerRequest::new(config, "group_001")
+            .manager_ids(vec!["m1".to_string()])
+            .execute()
+            .await
+            .expect("批量删除邮件组管理员应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/mailgroups/group_001/managers/batch_delete"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/batch_create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/batch_create.rs
@@ -109,19 +109,61 @@ impl BatchCreateMailGroupMemberRequest {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../mailgroups/{}/members/batch_create → BatchCreateMailGroupMemberResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_batch_create_mail_group_member_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/mail/v1/mailgroups/group_001/members/batch_create",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "data": {
+                        "results": [
+                            { "member_id": "m1", "status": "success" }
+                        ]
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = BatchCreateMailGroupMemberRequest::new(config, "group_001")
+            .members(vec![MailGroupMemberItem {
+                member_id: "m1".to_string(),
+                member_type: None,
+            }])
+            .execute()
+            .await
+            .expect("批量创建邮件组成员应成功");
+        let data = resp.data.expect("响应 data 应非空");
+        assert_eq!(data.results.len(), 1);
+        assert_eq!(data.results[0].member_id, "m1");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/mailgroups/group_001/members/batch_create"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/batch_delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/batch_delete.rs
@@ -67,18 +67,47 @@ impl BatchDeleteMailGroupMemberRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：DELETE .../mailgroups/{}/members/batch_delete → BatchDeleteMailGroupMemberResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_batch_delete_mail_group_member_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/mail/v1/mailgroups/group_001/members/batch_delete",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = BatchDeleteMailGroupMemberRequest::new(config, "group_001")
+            .execute()
+            .await
+            .expect("批量删除邮件组成员应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/mailgroups/group_001/members/batch_delete"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/delete.rs
@@ -1,9 +1,9 @@
 //! 删除邮件组成员
 //! docPath: <https://open.feishu.cn/document/server-docs/mail-v1/mail-group/mailgroup/delete>
 
+use crate::common::api_utils::extract_response_data;
 use openlark_core::{
-    SDKResult, api::ApiRequest, api::Response, config::Config, http::Transport,
-    req_option::RequestOption,
+    SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -53,9 +53,8 @@ impl DeleteMailGroupMemberRequest {
         );
         let req: ApiRequest<DeleteMailGroupMemberResponse> = ApiRequest::delete(&path);
 
-        let _resp: Response<DeleteMailGroupMemberResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(DeleteMailGroupMemberResponse { data: None })
+        let response = Transport::request(req, &self.config, Some(option)).await?;
+        extract_response_data(response, "删除邮件组成员")
     }
 }
 
@@ -68,19 +67,49 @@ impl openlark_core::api::ApiResponseTrait for DeleteMailGroupMemberResponse {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：DELETE .../mailgroups/{}/members/{} → DeleteMailGroupMemberResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_delete_mail_group_member_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/mail/v1/mailgroups/group_001/members/member_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = DeleteMailGroupMemberRequest::new(config, "group_001", "member_001")
+            .execute()
+            .await
+            .expect("删除邮件组成员应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/mailgroups/group_001/members/member_001"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/get.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/get.rs
@@ -74,18 +74,47 @@ impl GetMailGroupMemberRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../mailgroups/{}/members/{} → GetMailGroupMemberResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_mail_group_member_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/mail/v1/mailgroups/group_001/members/member_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetMailGroupMemberRequest::new(config, "group_001", "member_001")
+            .execute()
+            .await
+            .expect("查询指定邮件组成员应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/mailgroups/group_001/members/member_001"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/patch.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/patch.rs
@@ -1,13 +1,9 @@
 //! 修改邮件组部分信息
 //! docPath: <https://open.feishu.cn/document/server-docs/mail-v1/mail-group/mailgroup/patch>
 
-use crate::common::api_utils::serialize_params;
+use crate::common::api_utils::{extract_response_data, serialize_params};
 use openlark_core::{
-    SDKResult,
-    api::{ApiRequest, Response},
-    config::Config,
-    http::Transport,
-    req_option::RequestOption,
+    SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -74,9 +70,8 @@ impl PatchMailGroupRequest {
         let req: ApiRequest<PatchMailGroupResponse> =
             ApiRequest::patch(&path).body(serialize_params(&self.body, "请求")?);
 
-        let _resp: Response<PatchMailGroupResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(PatchMailGroupResponse { data: None })
+        let response = Transport::request(req, &self.config, Some(option)).await?;
+        extract_response_data(response, "修改邮件组部分信息")
     }
 }
 
@@ -89,19 +84,47 @@ impl openlark_core::api::ApiResponseTrait for PatchMailGroupResponse {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PATCH .../mailgroups/{} → PatchMailGroupResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_mail_group_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/mail/v1/mailgroups/group_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = PatchMailGroupRequest::new(config, "group_001")
+            .execute()
+            .await
+            .expect("修改邮件组部分信息应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/mailgroups/group_001"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/batch_create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/batch_create.rs
@@ -109,19 +109,61 @@ impl BatchCreateMailGroupPermissionMemberRequest {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../mailgroups/{}/permission_members/batch_create → BatchCreateMailGroupPermissionMemberResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_batch_create_mail_group_permission_member_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/mail/v1/mailgroups/group_001/permission_members/batch_create",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "data": {
+                        "results": [
+                            { "member_id": "m1", "status": "success" }
+                        ]
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = BatchCreateMailGroupPermissionMemberRequest::new(config, "group_001")
+            .members(vec![PermissionMemberItem {
+                member_id: "m1".to_string(),
+                member_type: None,
+            }])
+            .execute()
+            .await
+            .expect("批量创建邮件组权限成员应成功");
+        let data = resp.data.expect("响应 data 应非空");
+        assert_eq!(data.results.len(), 1);
+        assert_eq!(data.results[0].member_id, "m1");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/mailgroups/group_001/permission_members/batch_create"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/batch_delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/batch_delete.rs
@@ -1,6 +1,6 @@
 //! 批量删除邮件组权限成员
 
-use crate::common::api_utils::serialize_params;
+use crate::common::api_utils::{extract_response_data, serialize_params};
 use openlark_core::{
     SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
@@ -80,28 +80,58 @@ impl BatchDeleteMailGroupPermissionMemberRequest {
         let req: ApiRequest<BatchDeleteMailGroupPermissionMemberResponse> =
             ApiRequest::delete(&path).body(serialize_params(&self.body, "批量删除邮件组权限成员")?);
 
-        let _resp: openlark_core::api::Response<BatchDeleteMailGroupPermissionMemberResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(BatchDeleteMailGroupPermissionMemberResponse { data: None })
+        let response = Transport::request(req, &self.config, Some(option)).await?;
+        extract_response_data(response, "批量删除邮件组权限成员")
     }
 }
 
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：DELETE .../mailgroups/{}/permission_members/batch_delete → BatchDeleteMailGroupPermissionMemberResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_batch_delete_mail_group_permission_member_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/mail/v1/mailgroups/group_001/permission_members/batch_delete",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = BatchDeleteMailGroupPermissionMemberRequest::new(config, "group_001")
+            .permission_member_ids(vec!["pm1".to_string()])
+            .execute()
+            .await
+            .expect("批量删除邮件组权限成员应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/mailgroups/group_001/permission_members/batch_delete"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/delete.rs
@@ -1,9 +1,9 @@
 //! 删除邮件组权限成员
 //! docPath: <https://open.feishu.cn/document/server-docs/mail-v1/mail-group/mailgroup/delete>
 
+use crate::common::api_utils::extract_response_data;
 use openlark_core::{
-    SDKResult, api::ApiRequest, api::Response, config::Config, http::Transport,
-    req_option::RequestOption,
+    SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -53,9 +53,8 @@ impl DeleteMailGroupPermissionMemberRequest {
         );
         let req: ApiRequest<DeleteMailGroupPermissionMemberResponse> = ApiRequest::delete(&path);
 
-        let _resp: Response<DeleteMailGroupPermissionMemberResponse> =
-            Transport::request(req, &self.config, Some(option)).await?;
-        Ok(DeleteMailGroupPermissionMemberResponse { data: None })
+        let response = Transport::request(req, &self.config, Some(option)).await?;
+        extract_response_data(response, "删除邮件组权限成员")
     }
 }
 
@@ -68,19 +67,49 @@ impl openlark_core::api::ApiResponseTrait for DeleteMailGroupPermissionMemberRes
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：DELETE .../mailgroups/{}/permission_members/{} → DeleteMailGroupPermissionMemberResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_delete_mail_group_permission_member_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/mail/v1/mailgroups/group_001/permission_members/pm_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = DeleteMailGroupPermissionMemberRequest::new(config, "group_001", "pm_001")
+            .execute()
+            .await
+            .expect("删除邮件组权限成员应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/mailgroups/group_001/permission_members/pm_001"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/get.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/get.rs
@@ -83,19 +83,58 @@ impl GetMailGroupPermissionMemberRequest {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../mailgroups/{}/permission_members/{} → GetMailGroupPermissionMemberResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_mail_group_permission_member_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/mail/v1/mailgroups/group_001/permission_members/pm_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "data": {
+                        "permission_member_id": "pm_001",
+                        "member_id": "m1",
+                        "member_type": "USER"
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetMailGroupPermissionMemberRequest::new(config, "group_001", "pm_001")
+            .execute()
+            .await
+            .expect("获取邮件组权限成员应成功");
+        let data = resp.data.expect("响应 data 应非空");
+        assert_eq!(data.permission_member_id, "pm_001");
+        assert_eq!(data.member_id, "m1");
+        assert_eq!(data.member_type, "USER");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/mailgroups/group_001/permission_members/pm_001"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/update.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/update.rs
@@ -75,19 +75,48 @@ impl ApiResponseTrait for UpdateMailGroupResponse {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PUT .../mailgroups/{} → UpdateMailGroupResponse 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_update_mail_group_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/mail/v1/mailgroups/group_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "mail_group_id": "group_001", "updated_at": "1700000000" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = UpdateMailGroupRequest::new(config, "group_001".to_string())
+            .execute()
+            .await
+            .expect("更新邮件组应成功");
+        assert_eq!(resp.mail_group_id, "group_001");
+        assert_eq!(resp.updated_at, "1700000000");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/mailgroups/group_001"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/batch_create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/batch_create.rs
@@ -67,18 +67,47 @@ impl BatchCreatePublicMailboxMemberRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../public_mailboxes/{id}/members/batch_create → BatchCreatePublicMailboxMemberResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_batch_create_public_mailbox_member_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/mail/v1/public_mailboxes/mb_001/members/batch_create",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "success": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = BatchCreatePublicMailboxMemberRequest::new(config, "mb_001")
+            .execute()
+            .await
+            .expect("批量添加公共邮箱成员应成功");
+        assert_eq!(resp.data.unwrap()["success"].as_bool(), Some(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/public_mailboxes/mb_001/members/batch_create"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/batch_delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/batch_delete.rs
@@ -67,18 +67,47 @@ impl BatchDeletePublicMailboxMemberRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：DELETE .../public_mailboxes/{id}/members/batch_delete → BatchDeletePublicMailboxMemberResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_batch_delete_public_mailbox_member_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/mail/v1/public_mailboxes/mb_001/members/batch_delete",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "success": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = BatchDeletePublicMailboxMemberRequest::new(config, "mb_001")
+            .execute()
+            .await
+            .expect("批量删除公共邮箱成员应成功");
+        assert_eq!(resp.data.unwrap()["success"].as_bool(), Some(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/public_mailboxes/mb_001/members/batch_delete"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/clear.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/clear.rs
@@ -67,18 +67,47 @@ impl ClearPublicMailboxMemberRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../public_mailboxes/{id}/members/clear → ClearPublicMailboxMemberResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_clear_public_mailbox_member_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/mail/v1/public_mailboxes/mb_001/members/clear",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "success": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ClearPublicMailboxMemberRequest::new(config, "mb_001")
+            .execute()
+            .await
+            .expect("清空公共邮箱成员应成功");
+        assert_eq!(resp.data.unwrap()["success"].as_bool(), Some(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/public_mailboxes/mb_001/members/clear"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/remove_to_recycle_bin.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/remove_to_recycle_bin.rs
@@ -68,18 +68,47 @@ impl RemovePublicMailboxToRecycleBinRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：DELETE .../public_mailboxes/{id}/remove_to_recycle_bin → RemovePublicMailboxToRecycleBinResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_remove_public_mailbox_to_recycle_bin_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/mail/v1/public_mailboxes/mb_001/remove_to_recycle_bin",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "success": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = RemovePublicMailboxToRecycleBinRequest::new(config, "mb_001")
+            .execute()
+            .await
+            .expect("将公共邮箱移至回收站应成功");
+        assert_eq!(resp.data.unwrap()["success"].as_bool(), Some(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/public_mailboxes/mb_001/remove_to_recycle_bin"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/user/query.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user/query.rs
@@ -61,18 +61,45 @@ impl QueryMailUserRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../mail/v1/users/query → QueryMailUserResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_query_mail_user_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/mail/v1/users/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "email": "user@example.com" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = QueryMailUserRequest::new(config)
+            .execute()
+            .await
+            .expect("查询邮箱地址状态应成功");
+        assert_eq!(
+            resp.data.unwrap()["email"].as_str(),
+            Some("user@example.com")
+        );
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/mail/v1/users/query");
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/alias/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/alias/delete.rs
@@ -72,19 +72,49 @@ impl DeleteMailboxAliasRequest {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：DELETE .../user_mailboxes/{id}/aliases/{alias_id} → DeleteMailboxAliasResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_delete_mailbox_alias_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/mail/v1/user_mailboxes/mb_001/aliases/alias_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "deleted": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = DeleteMailboxAliasRequest::new(config, "mb_001", "alias_001")
+            .execute()
+            .await
+            .expect("删除用户邮箱别名应成功");
+        assert_eq!(resp.data.unwrap()["deleted"], true);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/user_mailboxes/mb_001/aliases/alias_001"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/delete.rs
@@ -65,18 +65,45 @@ impl DeleteUserMailboxRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：DELETE .../user_mailboxes/{id} → 强类型 DeleteUserMailboxResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_delete_user_mailbox_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/mail/v1/user_mailboxes/mb_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = DeleteUserMailboxRequest::new(config, "mb_001")
+            .execute()
+            .await
+            .expect("删除用户邮箱应成功");
+        assert!(resp.data.is_some());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/user_mailboxes/mb_001"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/event/subscribe.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/event/subscribe.rs
@@ -64,19 +64,49 @@ impl SubscribeMailboxEventRequest {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../user_mailboxes/{id}/event/subscribe → SubscribeMailboxEventResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_subscribe_mailbox_event_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/mail/v1/user_mailboxes/mb_001/event/subscribe",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "subscribed": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = SubscribeMailboxEventRequest::new(config, "mb_001")
+            .execute()
+            .await
+            .expect("订阅邮箱事件应成功");
+        assert_eq!(resp.data.unwrap()["subscribed"], true);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/user_mailboxes/mb_001/event/subscribe"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/event/subscription.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/event/subscription.rs
@@ -66,18 +66,47 @@ impl GetMailboxEventSubscriptionRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../user_mailboxes/{id}/event/subscription → GetMailboxEventSubscriptionResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_mailbox_event_subscription_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/mail/v1/user_mailboxes/mb_001/event/subscription",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "subscribed": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetMailboxEventSubscriptionRequest::new(config, "mb_001")
+            .execute()
+            .await
+            .expect("获取订阅状态应成功");
+        assert_eq!(resp.data.unwrap()["subscribed"], true);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/user_mailboxes/mb_001/event/subscription"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/event/unsubscribe.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/event/unsubscribe.rs
@@ -64,19 +64,49 @@ impl UnsubscribeMailboxEventRequest {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../user_mailboxes/{id}/event/unsubscribe → UnsubscribeMailboxEventResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_unsubscribe_mailbox_event_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/mail/v1/user_mailboxes/mb_001/event/unsubscribe",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "subscribed": false } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = UnsubscribeMailboxEventRequest::new(config, "mb_001")
+            .execute()
+            .await
+            .expect("取消订阅应成功");
+        assert_eq!(resp.data.unwrap()["subscribed"], false);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/user_mailboxes/mb_001/event/unsubscribe"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/folder/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/folder/delete.rs
@@ -71,19 +71,49 @@ impl DeleteMailboxFolderRequest {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：DELETE .../user_mailboxes/{id}/folders/{folder_id} → DeleteMailboxFolderResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_delete_mailbox_folder_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/mail/v1/user_mailboxes/mb_001/folders/folder_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "deleted": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = DeleteMailboxFolderRequest::new(config, "mb_001", "folder_001")
+            .execute()
+            .await
+            .expect("删除邮箱文件夹应成功");
+        assert_eq!(resp.data.unwrap()["deleted"], true);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/user_mailboxes/mb_001/folders/folder_001"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/folder/patch.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/folder/patch.rs
@@ -70,19 +70,49 @@ impl PatchMailboxFolderRequest {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PATCH .../user_mailboxes/{id}/folders/{folder_id} → PatchMailboxFolderResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_mailbox_folder_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/mail/v1/user_mailboxes/mb_001/folders/folder_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "updated": true } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = PatchMailboxFolderRequest::new(config, "mb_001", "folder_001")
+            .execute()
+            .await
+            .expect("修改邮箱文件夹应成功");
+        assert_eq!(resp.data.unwrap()["updated"], true);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/user_mailboxes/mb_001/folders/folder_001"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/mail_contact/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/mail_contact/delete.rs
@@ -71,19 +71,49 @@ impl DeleteMailContactRequest {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：DELETE .../user_mailboxes/{umb}/mail_contacts/{mc} → 强类型 DeleteMailContactResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_delete_mail_contact_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/mail/v1/user_mailboxes/umb_001/mail_contacts/mc_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "mail_contact_id": "mc_001" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = DeleteMailContactRequest::new(config, "umb_001", "mc_001")
+            .execute()
+            .await
+            .expect("删除邮箱联系人应成功");
+        assert_eq!(resp.data.unwrap()["mail_contact_id"], "mc_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/user_mailboxes/umb_001/mail_contacts/mc_001"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/mail_contact/patch.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/mail_contact/patch.rs
@@ -70,19 +70,49 @@ impl PatchMailContactRequest {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PATCH .../user_mailboxes/{umb}/mail_contacts/{mc} → 强类型 PatchMailContactResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_mail_contact_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/mail/v1/user_mailboxes/umb_001/mail_contacts/mc_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "mail_contact_id": "mc_001" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = PatchMailContactRequest::new(config, "umb_001", "mc_001")
+            .execute()
+            .await
+            .expect("修改邮箱联系人应成功");
+        assert_eq!(resp.data.unwrap()["mail_contact_id"], "mc_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/user_mailboxes/umb_001/mail_contacts/mc_001"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/attachment/download_url.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/attachment/download_url.rs
@@ -87,18 +87,50 @@ impl GetAttachmentDownloadUrlRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../user_mailboxes/{umb}/messages/{msg}/attachments/download_url → 强类型 GetAttachmentDownloadUrlResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_download_url_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/mail/v1/user_mailboxes/umb_001/messages/msg_001/attachments/download_url",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "download_url": "https://example.com/file.zip", "expire_time": "2026-07-08T00:00:00Z" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetAttachmentDownloadUrlRequest::new(config, "umb_001", "msg_001", "att_001")
+            .execute()
+            .await
+            .expect("获取附件下载链接应成功");
+        let data = resp.data.expect("响应 data 应非空");
+        assert_eq!(data.download_url, "https://example.com/file.zip");
+        assert_eq!(data.expire_time, "2026-07-08T00:00:00Z");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/user_mailboxes/umb_001/messages/msg_001/attachments/download_url"
+        );
+        assert_eq!(received[0].url.query(), Some("attachment_id=att_001"));
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/get.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/get.rs
@@ -82,19 +82,52 @@ impl GetMailboxMessageRequest {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../user_mailboxes/{umb}/messages/{msg} → 强类型 GetMailboxMessageResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_mailbox_message_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/mail/v1/user_mailboxes/umb_001/messages/msg_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "message_id": "msg_001", "subject": "测试主题", "body": "测试正文" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetMailboxMessageRequest::new(config, "umb_001", "msg_001")
+            .execute()
+            .await
+            .expect("获取邮件详情应成功");
+        let data = resp.data.expect("响应 data 应非空");
+        assert_eq!(data.message_id, "msg_001");
+        assert_eq!(data.subject, "测试主题");
+        assert_eq!(data.body, "测试正文");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/user_mailboxes/umb_001/messages/msg_001"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/get_by_card.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/get_by_card.rs
@@ -65,19 +65,49 @@ impl GetMailboxMessageByCardRequest {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../user_mailboxes/{umb}/messages/get_by_card → 强类型 GetMailboxMessageByCardResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_by_card_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/mail/v1/user_mailboxes/umb_001/messages/get_by_card",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "message_id": "msg_001" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = GetMailboxMessageByCardRequest::new(config, "umb_001")
+            .execute()
+            .await
+            .expect("获取邮件卡片的邮件列表应成功");
+        assert_eq!(resp.data.unwrap()["message_id"], "msg_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/user_mailboxes/umb_001/messages/get_by_card"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/send.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/send.rs
@@ -64,19 +64,49 @@ impl SendMailboxMessageRequest {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../user_mailboxes/{umb}/messages/send → 强类型 SendMailboxMessageResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_send_mailbox_message_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/mail/v1/user_mailboxes/umb_001/messages/send",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "message_id": "msg_001" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = SendMailboxMessageRequest::new(config, "umb_001")
+            .execute()
+            .await
+            .expect("发送邮件应成功");
+        assert_eq!(resp.data.unwrap()["message_id"], "msg_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/user_mailboxes/umb_001/messages/send"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/delete.rs
@@ -71,19 +71,49 @@ impl DeleteMailboxRuleRequest {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：DELETE .../user_mailboxes/{umb}/rules/{rule} → 强类型 DeleteMailboxRuleResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_delete_mailbox_rule_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/mail/v1/user_mailboxes/umb_001/rules/r_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "rule_id": "r_001" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = DeleteMailboxRuleRequest::new(config, "umb_001", "r_001")
+            .execute()
+            .await
+            .expect("删除收信规则应成功");
+        assert_eq!(resp.data.unwrap()["rule_id"], "r_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/user_mailboxes/umb_001/rules/r_001"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/reorder.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/reorder.rs
@@ -65,19 +65,49 @@ impl ReorderMailboxRuleRequest {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../user_mailboxes/{umb}/rules/reorder → 强类型 ReorderMailboxRuleResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_reorder_mailbox_rule_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/mail/v1/user_mailboxes/umb_001/rules/reorder",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "rule_id": "r_001" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = ReorderMailboxRuleRequest::new(config, "umb_001")
+            .execute()
+            .await
+            .expect("对收信规则进行排序应成功");
+        assert_eq!(resp.data.unwrap()["rule_id"], "r_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/user_mailboxes/umb_001/rules/reorder"
+        );
     }
 }

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/update.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/update.rs
@@ -72,18 +72,47 @@ impl UpdateMailboxRuleRequest {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PUT .../user_mailboxes/{umb}/rules/{rule} → 强类型 UpdateMailboxRuleResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_update_mailbox_rule_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path(
+                "/open-apis/mail/v1/user_mailboxes/umb_001/rules/r_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "rule_id": "r_001" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = UpdateMailboxRuleRequest::new(config, "umb_001", "r_001")
+            .execute()
+            .await
+            .expect("更新收信规则应成功");
+        assert_eq!(resp.data.unwrap()["rule_id"], "r_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/mail/v1/user_mailboxes/umb_001/rules/r_001"
+        );
     }
 }


### PR DESCRIPTION
## 背景

#351 第 7 批，P3 mail。`openlark-mail`（116 API 文件）catalog 核对：**crate 健康**（catalog 107 端点 vs 代码 116 文件，幻影少；无衍生清理 issue）。两种 execute 模式：
- **path 字符串**（user_mailbox / public_mailbox / user）：`resp.data.ok_or_else(validation_error)` + `Response { data: Option<Value> }`（双层 data 信封）
- **enum + extract_response_data**（mailgroup）：`MailApiV1::Xxx.to_url()` + 强类型/`Option<Value>` Response

## 改动

### 1. 修 7 个 mailgroup 丢弃响应 bug
`let _resp = ...; Ok(XxxResponse { data: None })` → `extract_response_data(response, "操作名")`：
- `mailgroup/patch.rs`、`alias/delete.rs`、`member/delete.rs`
- `manager/batch_create.rs`、`manager/batch_delete.rs`
- `permission_member/delete.rs`、`permission_member/batch_delete.rs`

### 2. 34 真实端点 wiremock e2e
占位 `test_serialization_roundtrip` + `test_deserialization_from_json`（测 serde_json 本身）→ `test_<op>_<resource>_returns_data_on_success`：
- MockServer + Mock(method + path) + Config(enable_token_cache(false))
- 信封按 Response struct：`{data: Option<Value>}` → 双层；强类型 struct → 单层
- 断言返回字段 + received_requests 反查 path
- 涵盖 user_mailbox（alias/event/folder/mail_contact/message/rule）+ mailgroup + public_mailbox + user 全子域

## 本地验证

- `cargo test --all-features`：**179 pass / 0 fail**（152 unit + 26 contract + 1 doctest）
- `cargo fmt --check` ✅
- `cargo clippy --all-features + --no-default-features -- -Dwarnings` ✅
- `cargo doc -D warnings` ✅
- `cargo deny check advisories` ✅
- `cargo machete` ✅
- msrv pinned lockfile 同步 ✅

## 关联

- 父 issue：#351
- 同批先例：#374 security / #375 cardkit / #376 user / #379 analytics / #381 helpdesk / #383 application

Refs #351