### PR TITLE
test(meeting/vc): 50 真实端点 wiremock e2e（#351 P3 PR A）

### DIFF
--- a/.github/msrv/Cargo.lock
+++ b/.github/msrv/Cargo.lock
@@ -1811,6 +1811,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **meeting vc/v1 视频会议 50 真实端点占位测试 → wiremock e2e**（#351 第 8 批，P3 meeting PR A）：
+  vc/v1 全子域（export/meeting/participant/report/reserve/reserve_config/room/room_level/
+  room_config/scope_config/resource_reservation_list）占位 `serde_json` roundtrip → wiremock 端到端。
+  vc 统一模式：`VcApiV1` enum + `to_url()` + `extract_response_data` + Config 非 Arc + query 断言。
+  信封按 Response struct（裸 Value/强类型单层、`GetDailyReportResponse` 内含 `data` 双层）。
+  e2e 暴露 2 个 latent bug（本次按代码实际行为 mock，不修）：`export/download` 硬编码 path 缺 task_id 参数
+  （飞书真实 `:task_id/download`）、`get_active_meeting` path 与 enum 不一致（`get_active_meeting` vs `active_meeting`）。
+  calendar/v4 + meeting_room 留 PR B。**非 breaking**：纯测试新增 + execute 未动。
+
 - **mail 34 真实端点占位测试 → wiremock e2e + 修 7 个丢弃响应 bug**（#351 第 7 批，P3 mail）：
   mailgroup 的 `patch` / `alias-delete` / `member-delete` / `manager-batch_create` / `manager-batch_delete` /
   `permission_member-delete` / `permission_member-batch_delete`（7 个）execute 用

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,6 +1779,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/openlark-meeting/Cargo.toml
+++ b/crates/openlark-meeting/Cargo.toml
@@ -51,6 +51,8 @@ chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
+wiremock = { workspace = true }
+serde_json = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["anyhow", "async-trait", "chrono", "thiserror", "uuid"]

--- a/crates/openlark-meeting/src/vc/vc/v1/export/download.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/export/download.rs
@@ -76,22 +76,52 @@ impl DownloadExportRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../exports/download + query 拼装 + 强类型 DownloadExportResponse 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_download_export_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/vc/v1/exports/download"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "url": "https://files.example.com/export_001.zip" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = DownloadExportRequest::new(config)
+            .query_param("task_id", "task_001")
+            .execute()
+            .await
+            .expect("下载导出文件应成功");
+        assert_eq!(resp.url, "https://files.example.com/export_001.zip");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/vc/v1/exports/download");
+        assert!(
+            received[0]
+                .url
+                .query()
+                .unwrap_or("")
+                .contains("task_id=task_001")
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/export/get.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/export/get.rs
@@ -63,22 +63,54 @@ impl GetExportTaskRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../exports/{task_id} + query 拼装 + 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_get_export_task_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/vc/v1/exports/task_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "task_id": "task_001", "status": "done", "file_url": "https://files.example.com/export.zip" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetExportTaskRequest::new(config)
+            .task_id("task_001")
+            .query_param("need_file_url", "true")
+            .execute()
+            .await
+            .expect("查询导出任务结果应成功");
+        assert_eq!(resp["task_id"], "task_001");
+        assert_eq!(resp["status"], "done");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/vc/v1/exports/task_001");
+        assert!(
+            received[0]
+                .url
+                .query()
+                .unwrap_or("")
+                .contains("need_file_url=true")
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/export/meeting_list.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/export/meeting_list.rs
@@ -47,22 +47,47 @@ impl ExportMeetingListRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../exports/meeting_list + body + 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_export_meeting_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/vc/v1/exports/meeting_list"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "task_id": "task_ml_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = ExportMeetingListRequest::new(config)
+            .execute(json!({ "start_time": "1704067200", "end_time": "1706745599" }))
+            .await
+            .expect("导出会议明细应成功");
+        assert_eq!(resp["task_id"], "task_ml_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/exports/meeting_list"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/export/participant_list.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/export/participant_list.rs
@@ -47,22 +47,47 @@ impl ExportParticipantListRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../exports/participant_list + body + 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_export_participant_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/vc/v1/exports/participant_list"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "task_id": "task_pl_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = ExportParticipantListRequest::new(config)
+            .execute(json!({ "meeting_ids": ["meeting_001"] }))
+            .await
+            .expect("导出参会人明细应成功");
+        assert_eq!(resp["task_id"], "task_pl_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/exports/participant_list"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/export/participant_quality_list.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/export/participant_quality_list.rs
@@ -47,22 +47,47 @@ impl ExportParticipantQualityListRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../exports/participant_quality_list + body + 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_export_participant_quality_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/vc/v1/exports/participant_quality_list"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "task_id": "task_pql_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = ExportParticipantQualityListRequest::new(config)
+            .execute(json!({ "start_time": "1704067200", "end_time": "1706745599" }))
+            .await
+            .expect("导出参会人会议质量数据应成功");
+        assert_eq!(resp["task_id"], "task_pql_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/exports/participant_quality_list"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/export/resource_reservation_list.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/export/resource_reservation_list.rs
@@ -47,22 +47,47 @@ impl ExportResourceReservationListRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../exports/resource_reservation_list + body + 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_export_resource_reservation_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/vc/v1/exports/resource_reservation_list"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "task_id": "task_rr_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = ExportResourceReservationListRequest::new(config)
+            .execute(json!({ "start_time": "1704067200", "end_time": "1706745599" }))
+            .await
+            .expect("导出会议室预定数据应成功");
+        assert_eq!(resp["task_id"], "task_rr_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/exports/resource_reservation_list"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/meeting/end.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/meeting/end.rs
@@ -79,21 +79,46 @@ impl EndMeetingRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：PATCH .../meetings/{id}/end → 强类型 EndMeetingResponse 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_end_meeting_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/vc/v1/meetings/mtg_001/end"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "success": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = EndMeetingRequest::new(config)
+            .meeting_id("mtg_001")
+            .execute(json!({}))
+            .await
+            .expect("结束会议应成功");
+        assert!(resp.success);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/meetings/mtg_001/end"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/meeting/get.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/meeting/get.rs
@@ -96,21 +96,51 @@ impl GetMeetingRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../meetings/{id} → 强类型 GetMeetingResponse 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_get_meeting_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/vc/v1/meetings/mtg_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "meeting_id": "mtg_001",
+                    "topic": "周会",
+                    "start_time": "2026-07-08 10:00:00",
+                    "end_time": "2026-07-08 11:00:00"
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetMeetingRequest::new(config)
+            .meeting_id("mtg_001")
+            .query_param("user_id_type", "open_id")
+            .execute()
+            .await
+            .expect("获取会议详情应成功");
+        assert_eq!(resp.meeting_id, "mtg_001");
+        assert_eq!(resp.topic, "周会");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/vc/v1/meetings/mtg_001");
+        assert_eq!(received[0].url.query(), Some("user_id_type=open_id"));
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/meeting/invite.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/meeting/invite.rs
@@ -79,21 +79,46 @@ impl InviteMeetingRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：PATCH .../meetings/{id}/invite → 强类型 InviteMeetingResponse 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_invite_meeting_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/vc/v1/meetings/mtg_001/invite"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "success": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = InviteMeetingRequest::new(config)
+            .meeting_id("mtg_001")
+            .execute(json!({"invitees": ["user_001"]}))
+            .await
+            .expect("邀请参会人应成功");
+        assert!(resp.success);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/meetings/mtg_001/invite"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/meeting/kickout.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/meeting/kickout.rs
@@ -79,21 +79,46 @@ impl KickoutMeetingRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../meetings/{id}/kickout → 强类型 KickoutMeetingResponse 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_kickout_meeting_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/vc/v1/meetings/mtg_001/kickout"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "success": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = KickoutMeetingRequest::new(config)
+            .meeting_id("mtg_001")
+            .execute(json!({"kickout_users": ["user_001"]}))
+            .await
+            .expect("移除参会人应成功");
+        assert!(resp.success);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/meetings/mtg_001/kickout"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/meeting/list_by_no.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/meeting/list_by_no.rs
@@ -52,21 +52,51 @@ impl ListByNoMeetingRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../meetings/list_by_no → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_list_by_no_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/vc/v1/meetings/list_by_no"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "meeting_infos": [
+                        { "meeting_id": "mtg_001", "meeting_no": "123456789" }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = ListByNoMeetingRequest::new(config)
+            .query_param("meeting_no", "123456789")
+            .execute()
+            .await
+            .expect("获取与会议号关联的会议列表应成功");
+        assert_eq!(resp["meeting_infos"][0]["meeting_id"], "mtg_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/meetings/list_by_no"
+        );
+        assert_eq!(received[0].url.query(), Some("meeting_no=123456789"));
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/meeting/recording/get.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/meeting/recording/get.rs
@@ -63,21 +63,53 @@ impl GetRecordingRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../meetings/{id}/recording → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_get_recording_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/vc/v1/meetings/mtg_001/recording"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "recording": {
+                        "recording_id": "rec_001",
+                        "status": "completed"
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetRecordingRequest::new(config)
+            .meeting_id("mtg_001")
+            .query_param("user_id_type", "open_id")
+            .execute()
+            .await
+            .expect("获取录制文件应成功");
+        assert_eq!(resp["recording"]["recording_id"], "rec_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/meetings/mtg_001/recording"
+        );
+        assert_eq!(received[0].url.query(), Some("user_id_type=open_id"));
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/meeting/recording/set_permission.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/meeting/recording/set_permission.rs
@@ -61,21 +61,48 @@ impl SetRecordingPermissionRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：PATCH .../meetings/{id}/recording/set_permission → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_set_recording_permission_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/vc/v1/meetings/mtg_001/recording/set_permission",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "success": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = SetRecordingPermissionRequest::new(config)
+            .meeting_id("mtg_001")
+            .execute(json!({"share_permission": "anyone_with_link"}))
+            .await
+            .expect("授权录制文件应成功");
+        assert_eq!(resp["success"], json!(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/meetings/mtg_001/recording/set_permission"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/meeting/recording/start.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/meeting/recording/start.rs
@@ -61,21 +61,46 @@ impl StartRecordingRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：PATCH .../meetings/{id}/recording/start → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_start_recording_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/vc/v1/meetings/mtg_001/recording/start"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "success": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = StartRecordingRequest::new(config)
+            .meeting_id("mtg_001")
+            .execute(json!({}))
+            .await
+            .expect("开始录制应成功");
+        assert_eq!(resp["success"], json!(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/meetings/mtg_001/recording/start"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/meeting/recording/stop.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/meeting/recording/stop.rs
@@ -61,21 +61,46 @@ impl StopRecordingRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：PATCH .../meetings/{id}/recording/stop → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_stop_recording_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/vc/v1/meetings/mtg_001/recording/stop"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "success": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = StopRecordingRequest::new(config)
+            .meeting_id("mtg_001")
+            .execute(json!({}))
+            .await
+            .expect("停止录制应成功");
+        assert_eq!(resp["success"], json!(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/meetings/mtg_001/recording/stop"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/meeting/set_host.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/meeting/set_host.rs
@@ -79,21 +79,46 @@ impl SetHostMeetingRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：PATCH .../meetings/{id}/set_host → 强类型 SetHostMeetingResponse 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_set_host_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/vc/v1/meetings/mtg_001/set_host"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "success": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = SetHostMeetingRequest::new(config)
+            .meeting_id("mtg_001")
+            .execute(json!({"host_user_id": "user_001"}))
+            .await
+            .expect("设置主持人应成功");
+        assert!(resp.success);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/meetings/mtg_001/set_host"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/meeting_list/get.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/meeting_list/get.rs
@@ -73,22 +73,50 @@ impl GetMeetingListRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../meeting_list + query 拼装 + 强类型 GetMeetingListResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_meeting_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/vc/v1/meeting_list"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "total": 2, "items": [{ "meeting_id": "m_001" }, { "meeting_id": "m_002" }] } }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetMeetingListRequest::new(config)
+            .query_param("start_time", "1704067200")
+            .query_param("end_time", "1706745599")
+            .execute()
+            .await
+            .expect("查询会议明细应成功");
+        assert_eq!(resp.data["total"], 2);
+        assert_eq!(resp.data["items"].as_array().unwrap().len(), 2);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/vc/v1/meeting_list");
+        let query = received[0].url.query().unwrap_or("");
+        assert!(query.contains("start_time=1704067200"));
+        assert!(query.contains("end_time=1706745599"));
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/participant_list/get.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/participant_list/get.rs
@@ -74,22 +74,49 @@ impl GetParticipantListRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../participant_list + query 拼装 + 强类型 GetParticipantListResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_participant_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/vc/v1/participant_list"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "items": [{ "user_id": "u_001" }, { "user_id": "u_002" }] } }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetParticipantListRequest::new(config)
+            .query_param("meeting_id", "m_001")
+            .query_param("page_size", "20")
+            .execute()
+            .await
+            .expect("查询参会人明细应成功");
+        assert_eq!(resp.data["items"].as_array().unwrap().len(), 2);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/vc/v1/participant_list");
+        let query = received[0].url.query().unwrap_or("");
+        assert!(query.contains("meeting_id=m_001"));
+        assert!(query.contains("page_size=20"));
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/participant_quality_list/get.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/participant_quality_list/get.rs
@@ -52,22 +52,53 @@ impl GetParticipantQualityListRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../participant_quality_list + query 拼装 + 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_get_participant_quality_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/vc/v1/participant_quality_list"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "items": [{ "user_id": "u_001", "score": 95 }], "has_more": false }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetParticipantQualityListRequest::new(config)
+            .query_param("meeting_id", "m_001")
+            .query_param("page_size", "20")
+            .execute()
+            .await
+            .expect("查询参会人会议质量数据应成功");
+        assert_eq!(resp["items"].as_array().unwrap().len(), 1);
+        assert_eq!(resp["has_more"], false);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/participant_quality_list"
+        );
+        let query = received[0].url.query().unwrap_or("");
+        assert!(query.contains("meeting_id=m_001"));
+        assert!(query.contains("page_size=20"));
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/report/get_daily.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/report/get_daily.rs
@@ -73,21 +73,50 @@ impl GetDailyReportRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../reports/get_daily → 强类型 GetDailyReportResponse 解析（双层 data 信封）。
+    #[tokio::test]
+    async fn test_get_daily_report_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/vc/v1/reports/get_daily"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "data": { "meeting_count": 12, "participant_count": 36 } }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetDailyReportRequest::new(config)
+            .query_param("start_time", "1719888000")
+            .query_param("end_time", "1719974400")
+            .execute()
+            .await
+            .expect("获取会议报告应成功");
+        assert_eq!(resp.data["meeting_count"], json!(12));
+        assert_eq!(resp.data["participant_count"], json!(36));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/vc/v1/reports/get_daily");
+        assert_eq!(
+            received[0].url.query_pairs().count(),
+            2,
+            "应携带两个查询参数"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/report/get_top_user.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/report/get_top_user.rs
@@ -52,21 +52,57 @@ impl GetTopUserReportRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../reports/get_top_user → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_get_top_user_report_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/vc/v1/reports/get_top_user"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "top_users": [
+                        { "user_id": "user_001", "meeting_count": 42 }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetTopUserReportRequest::new(config)
+            .query_param("start_time", "1719888000")
+            .query_param("end_time", "1719974400")
+            .query_param("limit", "10")
+            .execute()
+            .await
+            .expect("获取 Top 用户列表应成功");
+        assert_eq!(resp["top_users"][0]["user_id"], "user_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/reports/get_top_user"
+        );
+        assert_eq!(
+            received[0].url.query_pairs().count(),
+            3,
+            "应携带三个查询参数"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/reserve/apply.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/reserve/apply.rs
@@ -67,22 +67,45 @@ impl ApplyReserveRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../vc/v1/reserves/apply → 强类型 ApplyReserveResponse 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_apply_reserve_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/vc/v1/reserves/apply"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "meeting_id": "m_001", "reserve_id": "r_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = ApplyReserveRequest::new(config)
+            .execute(json!({ "topic": "测试预约" }))
+            .await
+            .expect("预约会议应成功");
+        assert_eq!(resp.meeting_id, "m_001");
+        assert_eq!(resp.reserve_id, "r_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/vc/v1/reserves/apply");
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/reserve/delete.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/reserve/delete.rs
@@ -76,22 +76,45 @@ impl DeleteReserveRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：DELETE .../vc/v1/reserves/{reserve_id} → 强类型 DeleteReserveResponse 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_delete_reserve_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/vc/v1/reserves/r_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "success": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = DeleteReserveRequest::new(config)
+            .reserve_id("r_001")
+            .execute()
+            .await
+            .expect("删除预约应成功");
+        assert!(resp.success);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/vc/v1/reserves/r_001");
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/reserve/get.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/reserve/get.rs
@@ -97,22 +97,53 @@ impl GetReserveRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../vc/v1/reserves/{reserve_id} → 强类型 GetReserveResponse 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_get_reserve_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/vc/v1/reserves/r_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "reserve_id": "r_001",
+                    "meeting_id": "m_001",
+                    "topic": "周会",
+                    "start_time": "2026-07-08 10:00",
+                    "end_time": "2026-07-08 11:00"
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetReserveRequest::new(config)
+            .reserve_id("r_001")
+            .execute()
+            .await
+            .expect("获取预约应成功");
+        assert_eq!(resp.reserve_id, "r_001");
+        assert_eq!(resp.meeting_id, "m_001");
+        assert_eq!(resp.topic, "周会");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/vc/v1/reserves/r_001");
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/reserve/get_active_meeting.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/reserve/get_active_meeting.rs
@@ -65,22 +65,49 @@ impl GetActiveMeetingRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../vc/v1/reserves/{reserve_id}/get_active_meeting → serde_json::Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_get_active_meeting_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/vc/v1/reserves/r_001/get_active_meeting"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "meeting_id": "m_001", "status": "ongoing" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetActiveMeetingRequest::new(config)
+            .reserve_id("r_001")
+            .execute()
+            .await
+            .expect("获取活跃会议应成功");
+        assert_eq!(resp["meeting_id"], "m_001");
+        assert_eq!(resp["status"], "ongoing");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/reserves/r_001/get_active_meeting"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/reserve/update.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/reserve/update.rs
@@ -79,22 +79,45 @@ impl UpdateReserveRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：PUT .../vc/v1/reserves/{reserve_id} → 强类型 UpdateReserveResponse 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_update_reserve_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/vc/v1/reserves/r_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "success": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = UpdateReserveRequest::new(config)
+            .reserve_id("r_001")
+            .execute(json!({ "topic": "更新后的主题" }))
+            .await
+            .expect("更新预约应成功");
+        assert!(resp.success);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/vc/v1/reserves/r_001");
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/reserve_config/admin/get.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/reserve_config/admin/get.rs
@@ -65,22 +65,48 @@ impl GetReserveConfigAdminRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../vc/v1/reserve_configs/{reserve_config_id}/admin → serde_json::Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_get_reserve_config_admin_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/vc/v1/reserve_configs/rc_001/admin"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "admin_user_ids": ["ou_001", "ou_002"] }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetReserveConfigAdminRequest::new(config)
+            .reserve_config_id("rc_001")
+            .execute()
+            .await
+            .expect("查询会议室预定管理员应成功");
+        assert_eq!(resp["admin_user_ids"][0], "ou_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/reserve_configs/rc_001/admin"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/reserve_config/admin/patch.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/reserve_config/admin/patch.rs
@@ -57,22 +57,48 @@ impl PatchReserveConfigAdminRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：PATCH .../vc/v1/reserve_configs/{reserve_config_id}/admin → serde_json::Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_reserve_config_admin_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/vc/v1/reserve_configs/rc_001/admin"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "admin_user_ids": ["ou_001", "ou_002"] }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = PatchReserveConfigAdminRequest::new(config)
+            .reserve_config_id("rc_001")
+            .execute(json!({ "admin_user_ids": ["ou_001", "ou_002"] }))
+            .await
+            .expect("更新会议室预定管理员应成功");
+        assert_eq!(resp["admin_user_ids"][1], "ou_002");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/reserve_configs/rc_001/admin"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/reserve_config/disable_inform/get.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/reserve_config/disable_inform/get.rs
@@ -65,22 +65,50 @@ impl GetDisableInformRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../vc/v1/reserve_configs/{reserve_config_id}/disable_inform → serde_json::Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_get_disable_inform_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/vc/v1/reserve_configs/rc_001/disable_inform",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "disable_inform": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetDisableInformRequest::new(config)
+            .reserve_config_id("rc_001")
+            .execute()
+            .await
+            .expect("查询禁用状态变更通知应成功");
+        assert_eq!(resp["disable_inform"], true);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/reserve_configs/rc_001/disable_inform"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/reserve_config/disable_inform/patch.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/reserve_config/disable_inform/patch.rs
@@ -58,22 +58,50 @@ impl PatchDisableInformRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：PATCH .../vc/v1/reserve_configs/{reserve_config_id}/disable_inform → serde_json::Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_disable_inform_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/vc/v1/reserve_configs/rc_001/disable_inform",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "disable_inform": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = PatchDisableInformRequest::new(config)
+            .reserve_config_id("rc_001")
+            .execute(json!({ "disable_inform": true }))
+            .await
+            .expect("更新禁用状态变更通知应成功");
+        assert_eq!(resp["disable_inform"], true);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/reserve_configs/rc_001/disable_inform"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/reserve_config/form/get.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/reserve_config/form/get.rs
@@ -65,22 +65,49 @@ impl GetReserveConfigFormRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../vc/v1/reserve_configs/{reserve_config_id}/form → serde_json::Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_get_reserve_config_form_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/vc/v1/reserve_configs/rc_001/form"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "form_id": "f_001", "field_count": 3 }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetReserveConfigFormRequest::new(config)
+            .reserve_config_id("rc_001")
+            .execute()
+            .await
+            .expect("查询会议室预定表单应成功");
+        assert_eq!(resp["form_id"], "f_001");
+        assert_eq!(resp["field_count"], 3);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/reserve_configs/rc_001/form"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/reserve_config/form/patch.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/reserve_config/form/patch.rs
@@ -58,22 +58,49 @@ impl PatchReserveConfigFormRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：PATCH .../vc/v1/reserve_configs/{reserve_config_id}/form → serde_json::Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_reserve_config_form_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/vc/v1/reserve_configs/rc_001/form"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "form_id": "f_001", "field_count": 5 }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = PatchReserveConfigFormRequest::new(config)
+            .reserve_config_id("rc_001")
+            .execute(json!({ "form_id": "f_001", "fields": [] }))
+            .await
+            .expect("更新会议室预定表单应成功");
+        assert_eq!(resp["form_id"], "f_001");
+        assert_eq!(resp["field_count"], 5);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/reserve_configs/rc_001/form"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/reserve_config/patch.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/reserve_config/patch.rs
@@ -58,22 +58,49 @@ impl PatchReserveConfigRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：PATCH .../vc/v1/reserve_configs/{reserve_config_id} → serde_json::Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_reserve_config_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/vc/v1/reserve_configs/rc_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "scope_config_id": "rc_001", "updated": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = PatchReserveConfigRequest::new(config)
+            .reserve_config_id("rc_001")
+            .execute(json!({ "scope_config_id": "rc_001" }))
+            .await
+            .expect("更新会议室预定限制应成功");
+        assert_eq!(resp["scope_config_id"], "rc_001");
+        assert_eq!(resp["updated"], true);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/reserve_configs/rc_001"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/reserve_config/reserve_scope.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/reserve_config/reserve_scope.rs
@@ -52,22 +52,48 @@ impl GetReserveScopeRequest {
 }
 
 #[cfg(test)]
+#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../vc/v1/reserve_configs/reserve_scope → serde_json::Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_get_reserve_scope_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/vc/v1/reserve_configs/reserve_scope"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "scope_config_id": "rc_001", "scope": "all" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetReserveScopeRequest::new(config)
+            .execute()
+            .await
+            .expect("查询会议室预定限制应成功");
+        assert_eq!(resp["scope_config_id"], "rc_001");
+        assert_eq!(resp["scope"], "all");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/reserve_configs/reserve_scope"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/resource_reservation_list/get.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/resource_reservation_list/get.rs
@@ -53,21 +53,49 @@ impl GetResourceReservationListRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../resource_reservation_list → data 信封解析。
+    #[tokio::test]
+    async fn test_get_resource_reservation_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/vc/v1/resource_reservation_list"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "reservations": [
+                        { "reservation_id": "res_001" }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetResourceReservationListRequest::new(config)
+            .execute()
+            .await
+            .expect("查询会议室预定数据应成功");
+        assert_eq!(resp["reservations"][0]["reservation_id"], "res_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/resource_reservation_list"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/responses.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/responses.rs
@@ -143,24 +143,3 @@ impl ApiResponseTrait for DeleteRoomResponse {
         ResponseFormat::Data
     }
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-meeting/src/vc/vc/v1/room/delete.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/room/delete.rs
@@ -73,21 +73,44 @@ impl DeleteRoomRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：DELETE .../vc/v1/rooms/{room_id} → 裸 Value 解析（单层 resp["field"]）。
+    #[tokio::test]
+    async fn test_delete_room_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/vc/v1/rooms/room_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "success": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = DeleteRoomRequest::new(config)
+            .room_id("room_001")
+            .execute()
+            .await
+            .expect("删除会议室应成功");
+        assert_eq!(resp["success"], json!(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/vc/v1/rooms/room_001");
+        assert_eq!(received[0].method, "DELETE");
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/room/get.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/room/get.rs
@@ -104,21 +104,57 @@ impl GetRoomRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../vc/v1/rooms/{room_id} → 强类型 GetRoomResponse（无 inner data，单层 resp.field）。
+    #[tokio::test]
+    async fn test_get_room_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/vc/v1/rooms/room_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "room_id": "room_001",
+                    "name": "大会议室",
+                    "room_level_id": "lvl_1",
+                    "capacity": 12,
+                    "building_id": "bldg_1",
+                    "floor": "3F",
+                    "email": "room_001@example.com",
+                    "status": "available",
+                    "active": true,
+                    "approval_required": false
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetRoomRequest::new(config)
+            .room_id("room_001")
+            .execute()
+            .await
+            .expect("查询会议室应成功");
+        assert_eq!(resp.room_id, "room_001");
+        assert_eq!(resp.name, "大会议室");
+        assert_eq!(resp.capacity, 12);
+        assert!(resp.active);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/vc/v1/rooms/room_001");
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/room/mget.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/room/mget.rs
@@ -75,21 +75,49 @@ impl MgetRoomRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../vc/v1/rooms/mget → 强类型 MgetRoomResponse（无 inner data，单层 resp.rooms）。
+    #[tokio::test]
+    async fn test_mget_room_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/vc/v1/rooms/mget"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "rooms": [
+                        { "room_id": "room_001", "name": "大会议室", "capacity": 12 },
+                        { "room_id": "room_002", "name": "小会议室", "capacity": 6 }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = MgetRoomRequest::new(config)
+            .execute(json!({ "room_ids": ["room_001", "room_002"] }))
+            .await
+            .expect("批量查询会议室应成功");
+        assert_eq!(resp.rooms.len(), 2);
+        assert_eq!(resp.rooms[0].room_id, "room_001");
+        assert_eq!(resp.rooms[1].capacity, 6);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/vc/v1/rooms/mget");
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/room/patch.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/room/patch.rs
@@ -79,21 +79,44 @@ impl PatchRoomRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：PATCH .../vc/v1/rooms/{room_id} → 强类型 PatchRoomResponse（无 inner data，单层 resp.success）。
+    #[tokio::test]
+    async fn test_patch_room_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/vc/v1/rooms/room_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "success": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = PatchRoomRequest::new(config)
+            .room_id("room_001")
+            .execute(json!({ "name": "更新会议室" }))
+            .await
+            .expect("更新会议室应成功");
+        assert!(resp.success);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/vc/v1/rooms/room_001");
+        assert_eq!(received[0].method, "PATCH");
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/room/search.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/room/search.rs
@@ -45,21 +45,46 @@ impl SearchRoomRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../vc/v1/rooms/search → 裸 Value 解析（单层 resp["field"]）。
+    #[tokio::test]
+    async fn test_search_room_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/vc/v1/rooms/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "rooms": [
+                        { "room_id": "room_001", "name": "大会议室" }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = SearchRoomRequest::new(config)
+            .execute(json!({ "query": "大" }))
+            .await
+            .expect("搜索会议室应成功");
+        assert_eq!(resp["rooms"][0]["room_id"], json!("room_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/vc/v1/rooms/search");
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/room_config/query.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/room_config/query.rs
@@ -73,21 +73,51 @@ impl QueryRoomConfigRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../room_configs/query → QueryRoomConfigResponse 解析（data 信封）。
+    #[tokio::test]
+    async fn test_query_room_config_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/vc/v1/room_configs/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "configs": [
+                        { "config_id": "rc_001", "name": "默认配置" }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = QueryRoomConfigRequest::new(config)
+            .execute(json!({ "room_id": "room_001" }))
+            .await
+            .expect("查询会议室配置应成功");
+        assert_eq!(resp.configs.len(), 1);
+        assert_eq!(resp.configs[0].config_id, "rc_001");
+        assert_eq!(resp.configs[0].name, "默认配置");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/room_configs/query"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/room_config/set.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/room_config/set.rs
@@ -47,21 +47,42 @@ impl SetRoomConfigRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../room_configs/set → data 信封解析。
+    #[tokio::test]
+    async fn test_set_room_config_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/vc/v1/room_configs/set"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "updated": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = SetRoomConfigRequest::new(config)
+            .execute(json!({ "room_id": "room_001", "config": {} }))
+            .await
+            .expect("设置会议室配置应成功");
+        assert_eq!(resp["updated"], true);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/vc/v1/room_configs/set");
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/room_config/set_checkboard_access_code.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/room_config/set_checkboard_access_code.rs
@@ -47,21 +47,47 @@ impl SetCheckboardAccessCodeRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../room_configs/set_checkboard_access_code → data 信封解析。
+    #[tokio::test]
+    async fn test_set_checkboard_access_code_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/vc/v1/room_configs/set_checkboard_access_code",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "access_code": "code_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = SetCheckboardAccessCodeRequest::new(config)
+            .execute(json!({ "room_id": "room_001" }))
+            .await
+            .expect("创建签到板部署码应成功");
+        assert_eq!(resp["access_code"], "code_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/room_configs/set_checkboard_access_code"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/room_config/set_room_access_code.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/room_config/set_room_access_code.rs
@@ -49,21 +49,45 @@ impl SetRoomAccessCodeRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../room_configs/set_room_access_code → data 信封解析。
+    #[tokio::test]
+    async fn test_set_room_access_code_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/vc/v1/room_configs/set_room_access_code"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "access_code": "code_002" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = SetRoomAccessCodeRequest::new(config)
+            .execute(json!({ "room_id": "room_001" }))
+            .await
+            .expect("创建会议室部署码应成功");
+        assert_eq!(resp["access_code"], "code_002");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/room_configs/set_room_access_code"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/room_level/del.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/room_level/del.rs
@@ -48,21 +48,42 @@ impl DeleteRoomLevelRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../vc/v1/room_levels/del → 裸 Value 解析（单层 resp["field"]）。
+    #[tokio::test]
+    async fn test_delete_room_level_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/vc/v1/room_levels/del"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "success": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = DeleteRoomLevelRequest::new(config)
+            .execute(json!({ "room_level_id": "lvl_001" }))
+            .await
+            .expect("删除会议室层级应成功");
+        assert_eq!(resp["success"], json!(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/vc/v1/room_levels/del");
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/room_level/get.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/room_level/get.rs
@@ -100,21 +100,55 @@ impl GetRoomLevelRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../vc/v1/room_levels/{room_level_id} → 强类型 GetRoomLevelResponse（单层 resp.field）+ query 断言。
+    #[tokio::test]
+    async fn test_get_room_level_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/vc/v1/room_levels/lvl_001"))
+            .and(query_param("room_level_type", "1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "room_level_id": "lvl_001",
+                    "name": "一楼层级",
+                    "capacity_min": 4,
+                    "capacity_max": 20
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetRoomLevelRequest::new(config)
+            .room_level_id("lvl_001")
+            .query_param("room_level_type", "1")
+            .execute()
+            .await
+            .expect("查询会议室层级应成功");
+        assert_eq!(resp.room_level_id, "lvl_001");
+        assert_eq!(resp.name, "一楼层级");
+        assert_eq!(resp.capacity_max, Some(20));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/room_levels/lvl_001"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/room_level/mget.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/room_level/mget.rs
@@ -46,21 +46,46 @@ impl MgetRoomLevelRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../vc/v1/room_levels/mget → 裸 Value 解析（单层 resp["field"]）。
+    #[tokio::test]
+    async fn test_mget_room_level_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/vc/v1/room_levels/mget"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "room_levels": [
+                        { "room_level_id": "lvl_001", "name": "一楼层级" }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = MgetRoomLevelRequest::new(config)
+            .execute(json!({ "room_level_id_list": ["lvl_001"] }))
+            .await
+            .expect("批量查询会议室层级应成功");
+        assert_eq!(resp["room_levels"][0]["room_level_id"], json!("lvl_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/vc/v1/room_levels/mget");
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/room_level/patch.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/room_level/patch.rs
@@ -61,21 +61,47 @@ impl PatchRoomLevelRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：PATCH .../vc/v1/room_levels/{room_level_id} → 裸 Value 解析（单层 resp["field"]）。
+    #[tokio::test]
+    async fn test_patch_room_level_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/vc/v1/room_levels/lvl_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "success": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = PatchRoomLevelRequest::new(config)
+            .room_level_id("lvl_001")
+            .execute(json!({ "name": "更新层级" }))
+            .await
+            .expect("更新会议室层级应成功");
+        assert_eq!(resp["success"], json!(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/room_levels/lvl_001"
+        );
+        assert_eq!(received[0].method, "PATCH");
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/room_level/search.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/room_level/search.rs
@@ -53,21 +53,51 @@ impl SearchRoomLevelRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../vc/v1/room_levels/search → 裸 Value 解析（单层 resp["field"]）+ query 断言。
+    #[tokio::test]
+    async fn test_search_room_level_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/vc/v1/room_levels/search"))
+            .and(query_param("page_size", "20"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "room_levels": [
+                        { "room_level_id": "lvl_001", "name": "一楼层级" }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = SearchRoomLevelRequest::new(config)
+            .query_param("page_size", "20")
+            .execute()
+            .await
+            .expect("搜索会议室层级应成功");
+        assert_eq!(resp["room_levels"][0]["room_level_id"], json!("lvl_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/vc/v1/room_levels/search"
+        );
     }
 }

--- a/crates/openlark-meeting/src/vc/vc/v1/scope_config/get.rs
+++ b/crates/openlark-meeting/src/vc/vc/v1/scope_config/get.rs
@@ -52,21 +52,42 @@ impl GetScopeConfigRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../scope_config → data 信封解析。
+    #[tokio::test]
+    async fn test_get_scope_config_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/vc/v1/scope_config"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "scope_id": "scope_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetScopeConfigRequest::new(config)
+            .execute()
+            .await
+            .expect("查询会议室配置应成功");
+        assert_eq!(resp["scope_id"], "scope_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/vc/v1/scope_config");
     }
 }


### PR DESCRIPTION
## 背景

#351 第 8 批，P3 meeting（拆 2 PR）。本 PR A 聚焦 **vc/v1 视频会议**（50 endpoint）。calendar/v4 + meeting_room 留 PR B。

vc/v1 统一模式：`VcApiV1` enum + `to_url()` + `extract_response_data` + **Config 非 Arc** + query。Response 两种：裸 `Value`（单层）或强类型 struct。

## 改动

### 50 endpoint wiremock e2e
全子域占位 `test_serialization_roundtrip` + `test_deserialization_from_json`（测 serde_json 本身）→ `test_<op>_<resource>_returns_data_on_success`：
- MockServer + Mock(method + path) + Config(enable_token_cache(false)，**非 Arc**)
- 信封按 Response struct：裸 Value → 单层断言 `resp["field"]`；强类型无 inner data → 单层断言 `resp.field`；`GetDailyReportResponse` 内含 `data` → 双层
- query 断言（若有 query_params）
- received_requests 反查 path + method

子域：export(6) / meeting_list(1) / participant_list(2) / meeting(10) / report(2) / reserve(5) / reserve_config(8) / room(5) / room_level(5) / room_config(4) / scope_config(1) / resource_reservation_list(1)

### 占位清理
`responses.rs`（聚合 struct 文件，0 execute）的纯 serde_json 占位测试删除。

### e2e 暴露 2 个 latent bug（不修，按代码实际行为 mock）
1. **`export/download.rs`**：硬编码 path `/vc/v1/exports/download` 缺 task_id 参数（飞书真实 `:task_id/download`）。enum 有 `ExportDownload(task_id)` variant 但生产代码没用。
2. **`reserve/get_active_meeting.rs`**：path `get_active_meeting` 与 enum `VcApiV1::ReserveGetActiveMeeting`（`active_meeting`）不一致。

留后续 issue 跟进（非本 PR 范围，修涉及 execute/enum 行为变更）。

## 本地验证

- `cargo test --all-features`：**216 pass / 0 fail**（197 unit + 18 contract + 1 doctest）
- `cargo fmt --check` ✅
- `cargo clippy --all-features + --no-default-features --features vc -- -Dwarnings` ✅
- `cargo doc -D warnings` ✅ / `cargo deny check advisories` ✅ / `cargo machete` ✅
- msrv pinned lockfile 同步 ✅

## 关联

父 issue #351；同批先例 #374/#375/#376/#379/#381/#383/#384。calendar + meeting_room 留 PR B。

Refs #351