### PR TITLE
test(meeting): calendar/v4 + meeting_room 40 真实端点 wiremock e2e（#351 P3 PR B）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **meeting calendar/v4 + meeting_room 40 真实端点占位测试 → wiremock e2e**（#351 第 8 批，P3 meeting PR B）：
+  calendar/v4 全子域（calendar / event / exchange_binding / freebusy / setting / timeoff_event）+
+  meeting_room 全子域（building / freebusy / instance / room / summary）占位 `serde_json` roundtrip →
+  wiremock 端到端。calendar 用 `CalendarApiV4` enum + `to_url()`；meeting_room 用常量 path。
+  4 个聚合文件（calendar responses.rs/responses_new.rs、common/chain.rs、meeting_room responses.rs）
+  纯 struct 占位测试删除。至此 **meeting crate 占位测试 0 残留**（PR A+B 合计 90 endpoint e2e）。
+  e2e 暴露 latent bug（按代码实际行为 mock，不修）：calendar `primary.rs` enum 注 GET 但 execute POST、
+  meeting_room 多处 path 单复数不一致 + update 用 POST 非 PATCH。**非 breaking**：纯测试新增。
+
 - **meeting vc/v1 视频会议 50 真实端点占位测试 → wiremock e2e**（#351 第 8 批，P3 meeting PR A）：
   vc/v1 全子域（export/meeting/participant/report/reserve/reserve_config/room/room_level/
   room_config/scope_config/resource_reservation_list）占位 `serde_json` roundtrip → wiremock 端到端。

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/acl/delete.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/acl/delete.rs
@@ -63,21 +63,49 @@ impl DeleteCalendarAclRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：DELETE .../calendars/{calendar_id}/acls/{acl_id} → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_delete_calendar_acl_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/calendar/v4/calendars/cal_001/acls/acl_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "deleted": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = DeleteCalendarAclRequest::new(config)
+            .calendar_id("cal_001")
+            .acl_id("acl_001")
+            .execute()
+            .await
+            .expect("删除访问控制应成功");
+        assert_eq!(resp["deleted"], json!(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/cal_001/acls/acl_001"
+        );
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/acl/subscription.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/acl/subscription.rs
@@ -62,21 +62,48 @@ impl SubscriptionCalendarAclRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../calendars/{calendar_id}/acls/subscription → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_subscription_calendar_acl_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/calendar/v4/calendars/cal_001/acls/subscription",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "subscription_id": "sub_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = SubscriptionCalendarAclRequest::new(config)
+            .calendar_id("cal_001")
+            .execute(json!({ "subscription_id": "sub_001" }))
+            .await
+            .expect("订阅日历访问控制变更事件应成功");
+        assert_eq!(resp["subscription_id"], json!("sub_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/cal_001/acls/subscription"
+        );
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/acl/unsubscription.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/acl/unsubscription.rs
@@ -61,21 +61,48 @@ impl UnsubscriptionCalendarAclRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../calendars/{calendar_id}/acls/unsubscription → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_unsubscription_calendar_acl_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/calendar/v4/calendars/cal_001/acls/unsubscription",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "unsubscribed": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = UnsubscriptionCalendarAclRequest::new(config)
+            .calendar_id("cal_001")
+            .execute(json!({ "subscription_id": "sub_001" }))
+            .await
+            .expect("取消订阅日历访问控制变更事件应成功");
+        assert_eq!(resp["unsubscribed"], json!(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/cal_001/acls/unsubscription"
+        );
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/delete.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/delete.rs
@@ -70,21 +70,46 @@ impl DeleteCalendarRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：DELETE .../calendars/{calendar_id} → DeleteCalendarResponse（空 data 信封）。
+    #[tokio::test]
+    async fn test_delete_calendar_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/calendar/v4/calendars/cal_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let _resp = DeleteCalendarRequest::new(config)
+            .calendar_id("cal_001")
+            .execute()
+            .await
+            .expect("删除共享日历应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/cal_001"
+        );
+        assert_eq!(received[0].method, "DELETE");
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/attendee/batch_delete.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/attendee/batch_delete.rs
@@ -72,21 +72,49 @@ impl BatchDeleteCalendarEventAttendeeRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../events/{event_id}/attendees/batch_delete → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_batch_delete_calendar_event_attendee_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/calendar/v4/calendars/cal_001/events/evt_001/attendees/batch_delete",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "deleted": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = BatchDeleteCalendarEventAttendeeRequest::new(config)
+            .calendar_id("cal_001")
+            .event_id("evt_001")
+            .execute(json!({ "need_notification": false }))
+            .await
+            .expect("删除日程参与人应成功");
+        assert_eq!(resp["deleted"], json!(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/cal_001/events/evt_001/attendees/batch_delete"
+        );
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/delete.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/delete.rs
@@ -63,21 +63,49 @@ impl DeleteCalendarEventRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：DELETE .../events/{event_id} → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_delete_calendar_event_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/calendar/v4/calendars/cal_001/events/evt_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "deleted": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = DeleteCalendarEventRequest::new(config)
+            .calendar_id("cal_001")
+            .event_id("evt_001")
+            .execute()
+            .await
+            .expect("删除日程应成功");
+        assert_eq!(resp["deleted"], json!(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/cal_001/events/evt_001"
+        );
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/get.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/get.rs
@@ -72,21 +72,52 @@ impl GetCalendarEventRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../events/{event_id} → 裸 Value 解析（单层 data 信封，带 user_id_type 查询参数）。
+    #[tokio::test]
+    async fn test_get_calendar_event_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/calendar/v4/calendars/cal_001/events/evt_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "event_id": "evt_001", "summary": "周会" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetCalendarEventRequest::new(config)
+            .calendar_id("cal_001")
+            .event_id("evt_001")
+            .query_param("user_id_type", "open_id")
+            .execute()
+            .await
+            .expect("获取日程应成功");
+        assert_eq!(resp["event_id"], json!("evt_001"));
+        assert_eq!(resp["summary"], json!("周会"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/cal_001/events/evt_001"
+        );
+        assert_eq!(received[0].url.query(), Some("user_id_type=open_id"));
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/instance_view.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/instance_view.rs
@@ -65,21 +65,50 @@ impl InstanceViewCalendarEventRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../events/instance_view → 裸 Value 解析（单层 data 信封，带 start_time 查询参数）。
+    #[tokio::test]
+    async fn test_instance_view_calendar_event_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/calendar/v4/calendars/cal_001/events/instance_view",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "events": [{ "event_id": "evt_001" }] }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = InstanceViewCalendarEventRequest::new(config)
+            .calendar_id("cal_001")
+            .query_param("start_time", "1700000000")
+            .execute()
+            .await
+            .expect("查询日程视图应成功");
+        assert_eq!(resp["events"][0]["event_id"], json!("evt_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/cal_001/events/instance_view"
+        );
+        assert_eq!(received[0].url.query(), Some("start_time=1700000000"));
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/instances.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/instances.rs
@@ -74,21 +74,51 @@ impl InstancesCalendarEventRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../events/{event_id}/instances → 裸 Value 解析（单层 data 信封，带 page_size 查询参数）。
+    #[tokio::test]
+    async fn test_instances_calendar_event_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/calendar/v4/calendars/cal_001/events/evt_001/instances",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "items": [{ "event_id": "evt_001" }] }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = InstancesCalendarEventRequest::new(config)
+            .calendar_id("cal_001")
+            .event_id("evt_001")
+            .query_param("page_size", "20")
+            .execute()
+            .await
+            .expect("获取重复日程实例应成功");
+        assert_eq!(resp["items"][0]["event_id"], json!("evt_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/cal_001/events/evt_001/instances"
+        );
+        assert_eq!(received[0].url.query(), Some("page_size=20"));
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/meeting_chat/delete.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/meeting_chat/delete.rs
@@ -63,21 +63,49 @@ impl DeleteMeetingChatRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：DELETE .../events/{event_id}/meeting_chat → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_delete_meeting_chat_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/calendar/v4/calendars/cal_001/events/evt_001/meeting_chat",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "unbound": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = DeleteMeetingChatRequest::new(config)
+            .calendar_id("cal_001")
+            .event_id("evt_001")
+            .execute()
+            .await
+            .expect("解绑会议群应成功");
+        assert_eq!(resp["unbound"], json!(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/cal_001/events/evt_001/meeting_chat"
+        );
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/patch.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/patch.rs
@@ -72,21 +72,49 @@ impl PatchCalendarEventRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：PATCH .../events/{event_id} → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_patch_calendar_event_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/calendar/v4/calendars/cal_001/events/evt_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "event_id": "evt_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = PatchCalendarEventRequest::new(config)
+            .calendar_id("cal_001")
+            .event_id("evt_001")
+            .execute(json!({ "summary": "更新后的主题" }))
+            .await
+            .expect("更新日程应成功");
+        assert_eq!(resp["event_id"], json!("evt_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/cal_001/events/evt_001"
+        );
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/reply.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/reply.rs
@@ -72,21 +72,49 @@ impl ReplyCalendarEventRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../events/{event_id}/reply → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_reply_calendar_event_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/calendar/v4/calendars/cal_001/events/evt_001/reply",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "replied": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = ReplyCalendarEventRequest::new(config)
+            .calendar_id("cal_001")
+            .event_id("evt_001")
+            .execute(json!({ "rsvp_status": "accept" }))
+            .await
+            .expect("回复日程应成功");
+        assert_eq!(resp["replied"], json!(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/cal_001/events/evt_001/reply"
+        );
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/search.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/search.rs
@@ -61,21 +61,48 @@ impl SearchCalendarEventRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../events/search → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_search_calendar_event_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/calendar/v4/calendars/cal_001/events/search",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "items": [{ "event_id": "evt_001" }] }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = SearchCalendarEventRequest::new(config)
+            .calendar_id("cal_001")
+            .execute(json!({ "query": "周会" }))
+            .await
+            .expect("搜索日程应成功");
+        assert_eq!(resp["items"][0]["event_id"], json!("evt_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/cal_001/events/search"
+        );
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/subscription.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/subscription.rs
@@ -65,21 +65,48 @@ impl SubscriptionCalendarEventRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../events/subscription → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_subscription_calendar_event_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/calendar/v4/calendars/cal_001/events/subscription",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "subscription_id": "sub_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = SubscriptionCalendarEventRequest::new(config)
+            .calendar_id("cal_001")
+            .execute(json!({ "subscription_type": 1 }))
+            .await
+            .expect("订阅日程变更事件应成功");
+        assert_eq!(resp["subscription_id"], json!("sub_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/cal_001/events/subscription"
+        );
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/unsubscription.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/event/unsubscription.rs
@@ -65,21 +65,48 @@ impl UnsubscriptionCalendarEventRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../events/unsubscription → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_unsubscription_calendar_event_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/calendar/v4/calendars/cal_001/events/unsubscription",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "unsubscribed": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = UnsubscriptionCalendarEventRequest::new(config)
+            .calendar_id("cal_001")
+            .execute(json!({ "subscription_id": "sub_001" }))
+            .await
+            .expect("取消订阅日程变更事件应成功");
+        assert_eq!(resp["unsubscribed"], json!(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/cal_001/events/unsubscription"
+        );
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/mget.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/mget.rs
@@ -49,21 +49,51 @@ impl MgetCalendarRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../calendars/mget → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_mget_calendar_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/calendar/v4/calendars/mget"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "calendars": [
+                        { "calendar_id": "cal_001" },
+                        { "calendar_id": "cal_002" }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = MgetCalendarRequest::new(config)
+            .execute(json!({ "calendar_ids": ["cal_001", "cal_002"] }))
+            .await
+            .expect("批量查询日历信息应成功");
+        assert_eq!(resp["calendars"][0]["calendar_id"], json!("cal_001"));
+        assert_eq!(resp["calendars"][1]["calendar_id"], json!("cal_002"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/mget"
+        );
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/patch.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/patch.rs
@@ -105,21 +105,60 @@ impl PatchCalendarRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：PATCH .../calendars/{calendar_id} → PatchCalendarResponse（强类型无 inner data，单层 resp.calendar）。
+    #[tokio::test]
+    async fn test_patch_calendar_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/calendar/v4/calendars/cal_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "calendar": {
+                        "calendar_id": "cal_001",
+                        "summary": "更新后的日历",
+                        "description": "新描述",
+                        "color": "-1",
+                        "permissions": { "is_readable": true, "is_writable": true },
+                        "primary": false,
+                        "calendar_type": "primary"
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = PatchCalendarRequest::new(config)
+            .calendar_id("cal_001")
+            .execute(json!({ "summary": "更新后的日历" }))
+            .await
+            .expect("更新日历信息应成功");
+        assert_eq!(resp.calendar.calendar_id, "cal_001");
+        assert_eq!(resp.calendar.summary, "更新后的日历");
+        assert_eq!(resp.calendar.description.as_deref(), Some("新描述"));
+        assert_eq!(resp.calendar.primary, Some(false));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/cal_001"
+        );
+        assert_eq!(received[0].method, "PATCH");
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/primary.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/primary.rs
@@ -39,21 +39,45 @@ impl PrimaryCalendarRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../calendars/primary → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_primary_calendar_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/calendar/v4/calendars/primary"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "primary_calendar_id": "cal_primary_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = PrimaryCalendarRequest::new(config)
+            .execute()
+            .await
+            .expect("查询主日历信息应成功");
+        assert_eq!(resp["primary_calendar_id"], json!("cal_primary_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/primary"
+        );
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/primarys.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/primarys.rs
@@ -39,21 +39,49 @@ impl PrimarysCalendarRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../calendars/primarys → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_primarys_calendar_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/calendar/v4/calendars/primarys"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "primary_calendar_list": [
+                        { "user_id": "u_001", "calendar_id": "cal_001" }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = PrimarysCalendarRequest::new(config)
+            .execute()
+            .await
+            .expect("批量获取主日历信息应成功");
+        assert_eq!(resp["primary_calendar_list"][0]["user_id"], json!("u_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/primarys"
+        );
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/search.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/search.rs
@@ -49,21 +49,49 @@ impl SearchCalendarRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../calendars/search → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_search_calendar_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/calendar/v4/calendars/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "calendars": [
+                        { "calendar_id": "cal_001", "summary": "团队日历" }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = SearchCalendarRequest::new(config)
+            .execute(json!({ "query": "团队", "page_size": 20 }))
+            .await
+            .expect("搜索日历应成功");
+        assert_eq!(resp["calendars"][0]["calendar_id"], json!("cal_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/search"
+        );
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/subscribe.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/subscribe.rs
@@ -54,21 +54,46 @@ impl SubscribeCalendarRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../calendars/{calendar_id}/subscribe → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_subscribe_calendar_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/calendar/v4/calendars/cal_001/subscribe"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "subscribed": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = SubscribeCalendarRequest::new(config)
+            .calendar_id("cal_001")
+            .execute()
+            .await
+            .expect("订阅日历应成功");
+        assert_eq!(resp["subscribed"], json!(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/cal_001/subscribe"
+        );
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/subscription.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/subscription.rs
@@ -49,21 +49,45 @@ impl SubscriptionCalendarRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../calendars/subscription → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_subscription_calendar_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/calendar/v4/calendars/subscription"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "subscription_id": "sub_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = SubscriptionCalendarRequest::new(config)
+            .execute(json!({ "subscription_id": "sub_001" }))
+            .await
+            .expect("订阅日历变更事件应成功");
+        assert_eq!(resp["subscription_id"], json!("sub_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/subscription"
+        );
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/unsubscribe.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/unsubscribe.rs
@@ -54,21 +54,46 @@ impl UnsubscribeCalendarRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../calendars/{calendar_id}/unsubscribe → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_unsubscribe_calendar_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/calendar/v4/calendars/cal_001/unsubscribe"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "unsubscribed": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = UnsubscribeCalendarRequest::new(config)
+            .calendar_id("cal_001")
+            .execute()
+            .await
+            .expect("取消订阅日历应成功");
+        assert_eq!(resp["unsubscribed"], json!(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/cal_001/unsubscribe"
+        );
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/calendar/unsubscription.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/calendar/unsubscription.rs
@@ -47,21 +47,45 @@ impl UnsubscriptionCalendarRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../calendars/unsubscription → 裸 Value 解析（单层 data 信封）。
+    #[tokio::test]
+    async fn test_unsubscription_calendar_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/calendar/v4/calendars/unsubscription"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "unsubscribed": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = UnsubscriptionCalendarRequest::new(config)
+            .execute(json!({ "subscription_id": "sub_001" }))
+            .await
+            .expect("取消订阅日历变更事件应成功");
+        assert_eq!(resp["unsubscribed"], json!(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/calendars/unsubscription"
+        );
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/exchange_binding/delete.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/exchange_binding/delete.rs
@@ -57,19 +57,47 @@ impl DeleteExchangeBindingRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：DELETE .../calendar/v4/exchange_bindings/{id} → DeleteExchangeBindingResponse（data.deleted）。
+    #[tokio::test]
+    async fn test_delete_exchange_binding_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/calendar/v4/exchange_bindings/binding_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "deleted": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = DeleteExchangeBindingRequest::new(config)
+            .exchange_binding_id("binding_001")
+            .execute()
+            .await
+            .expect("解除 Exchange 绑定应成功");
+        assert_eq!(resp.deleted, Some(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/exchange_bindings/binding_001"
+        );
+        assert_eq!(received[0].method, "DELETE");
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/exchange_binding/get.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/exchange_binding/get.rs
@@ -56,19 +56,54 @@ impl GetExchangeBindingRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../calendar/v4/exchange_bindings/{id} → GetExchangeBindingResponse（data.exchange_binding_id）。
+    #[tokio::test]
+    async fn test_get_exchange_binding_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/calendar/v4/exchange_bindings/binding_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "exchange_binding_id": "binding_001",
+                    "user_id": "user_001",
+                    "exchange_account": "user@example.com",
+                    "status": 1
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetExchangeBindingRequest::new(config)
+            .exchange_binding_id("binding_001")
+            .execute()
+            .await
+            .expect("查询 Exchange 绑定应成功");
+        assert_eq!(resp.exchange_binding_id, "binding_001");
+        assert_eq!(resp.user_id.as_deref(), Some("user_001"));
+        assert_eq!(resp.status, Some(1));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/exchange_bindings/binding_001"
+        );
+        assert_eq!(received[0].method, "GET");
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/freebusy/batch.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/freebusy/batch.rs
@@ -49,19 +49,65 @@ impl BatchFreebusyRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../calendar/v4/freebusy/batch → BatchFreebusyResponse（data.freebusy_list）。
+    #[tokio::test]
+    async fn test_batch_freebusy_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/calendar/v4/freebusy/batch"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "freebusy_list": [
+                        {
+                            "user_id": "user_001",
+                            "freebusy_list": [
+                                { "start_time": 1000, "end_time": 2000, "status": 1 }
+                            ]
+                        }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body = BatchFreebusyRequestBody {
+            user_ids: vec!["user_001".to_string()],
+            start_time: 1000,
+            end_time: 2000,
+            calendar_ids: None,
+            time_zone: None,
+        };
+
+        let resp = BatchFreebusyRequest::new(config)
+            .execute(body)
+            .await
+            .expect("批量查询忙闲应成功");
+        assert_eq!(resp.freebusy_list.len(), 1);
+        assert_eq!(resp.freebusy_list[0].user_id, "user_001");
+        assert_eq!(resp.freebusy_list[0].freebusy_list[0].status, 1);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/freebusy/batch"
+        );
+        assert_eq!(received[0].method, "POST");
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/responses.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/responses.rs
@@ -148,24 +148,3 @@ pub struct ExchangeBindingInfo {
     /// 绑定状态
     pub status: String,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-meeting/src/calendar/calendar/v4/responses_new.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/responses_new.rs
@@ -809,24 +809,3 @@ impl ApiResponseTrait for PatchMeetingMinuteResponse {
         ResponseFormat::Data
     }
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-meeting/src/calendar/calendar/v4/setting/generate_caldav_conf.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/setting/generate_caldav_conf.rs
@@ -40,21 +40,49 @@ impl GenerateCaldavConfRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../calendar/v4/settings/generate_caldav_conf → 裸 Value 解析（data.caldav_url）。
+    #[tokio::test]
+    async fn test_generate_caldav_conf_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/calendar/v4/settings/generate_caldav_conf"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "caldav_url": "https://caldav.example.com/dav",
+                    "username": "user_001"
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GenerateCaldavConfRequest::new(config)
+            .execute()
+            .await
+            .expect("生成 CalDAV 配置应成功");
+        assert_eq!(resp["caldav_url"], json!("https://caldav.example.com/dav"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/settings/generate_caldav_conf"
+        );
+        assert_eq!(received[0].method, "POST");
     }
 }

--- a/crates/openlark-meeting/src/calendar/calendar/v4/timeoff_event/delete.rs
+++ b/crates/openlark-meeting/src/calendar/calendar/v4/timeoff_event/delete.rs
@@ -54,21 +54,47 @@ impl DeleteTimeoffEventRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：DELETE .../calendar/v4/timeoff_events/{id} → 裸 Value 解析（单层 resp["deleted"]）。
+    #[tokio::test]
+    async fn test_delete_timeoff_event_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/calendar/v4/timeoff_events/event_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "deleted": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = DeleteTimeoffEventRequest::new(config)
+            .timeoff_event_id("event_001")
+            .execute()
+            .await
+            .expect("删除请假日程应成功");
+        assert_eq!(resp["deleted"], json!(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/calendar/v4/timeoff_events/event_001"
+        );
+        assert_eq!(received[0].method, "DELETE");
     }
 }

--- a/crates/openlark-meeting/src/common/chain.rs
+++ b/crates/openlark-meeting/src/common/chain.rs
@@ -120,12 +120,3 @@ impl VcNoteResourceClient {
         crate::vc::vc::v1::note::unsubscription::UnsubscribeNoteRequest::new(self.config.clone())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_serialization_roundtrip() {
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-}

--- a/crates/openlark-meeting/src/meeting_room/building/batch_get.rs
+++ b/crates/openlark-meeting/src/meeting_room/building/batch_get.rs
@@ -53,21 +53,51 @@ impl BatchGetBuildingRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../meeting_room/building/batch_get → 裸 Value（单层 resp["field"]）。
+    #[tokio::test]
+    async fn test_batch_get_building_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/meeting_room/building/batch_get"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "buildings": [
+                        { "building_id": "bldg_001", "name": "1号楼" }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = BatchGetBuildingRequest::new(config)
+            .query_param("page_size", "10")
+            .execute()
+            .await
+            .expect("查询建筑物详情应成功");
+        assert_eq!(resp["buildings"][0]["building_id"], json!("bldg_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/meeting_room/building/batch_get"
+        );
+        assert_eq!(received[0].url.query(), Some("page_size=10"));
     }
 }

--- a/crates/openlark-meeting/src/meeting_room/building/batch_get_id.rs
+++ b/crates/openlark-meeting/src/meeting_room/building/batch_get_id.rs
@@ -51,21 +51,47 @@ impl BatchGetBuildingIdRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../meeting_room/building/batch_get_id → 裸 Value（单层 resp["field"]）。
+    #[tokio::test]
+    async fn test_batch_get_id_building_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/meeting_room/building/batch_get_id"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "building_ids": ["bldg_001", "bldg_002"] }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = BatchGetBuildingIdRequest::new(config)
+            .query_param("page_size", "20")
+            .execute()
+            .await
+            .expect("查询建筑物ID应成功");
+        assert_eq!(resp["building_ids"][0], json!("bldg_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/meeting_room/building/batch_get_id"
+        );
+        assert_eq!(received[0].url.query(), Some("page_size=20"));
     }
 }

--- a/crates/openlark-meeting/src/meeting_room/building/delete.rs
+++ b/crates/openlark-meeting/src/meeting_room/building/delete.rs
@@ -56,21 +56,47 @@ impl DeleteBuildingRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：DELETE .../meeting_room/buildings/{building_id} → 裸 Value（单层 resp["field"]）。
+    #[tokio::test]
+    async fn test_delete_building_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/meeting_room/buildings/bldg_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "success": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = DeleteBuildingRequest::new(config)
+            .building_id("bldg_001")
+            .execute()
+            .await
+            .expect("删除建筑物应成功");
+        assert_eq!(resp["success"], json!(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/meeting_room/buildings/bldg_001"
+        );
+        assert_eq!(received[0].method, "DELETE");
     }
 }

--- a/crates/openlark-meeting/src/meeting_room/building/update.rs
+++ b/crates/openlark-meeting/src/meeting_room/building/update.rs
@@ -62,21 +62,47 @@ impl UpdateBuildingRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../meeting_room/buildings/{building_id} → 裸 Value（单层 resp["field"]）。
+    #[tokio::test]
+    async fn test_update_building_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/meeting_room/buildings/bldg_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "building_id": "bldg_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = UpdateBuildingRequest::new(config)
+            .building_id("bldg_001")
+            .execute(json!({ "name": "更新1号楼" }))
+            .await
+            .expect("更新建筑物应成功");
+        assert_eq!(resp["building_id"], json!("bldg_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/meeting_room/buildings/bldg_001"
+        );
+        assert_eq!(received[0].method, "POST");
     }
 }

--- a/crates/openlark-meeting/src/meeting_room/freebusy/batch_get.rs
+++ b/crates/openlark-meeting/src/meeting_room/freebusy/batch_get.rs
@@ -53,21 +53,51 @@ impl BatchGetFreebusyRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../meeting_room/freebusy/batch_get → 裸 Value（单层 resp["field"]）。
+    #[tokio::test]
+    async fn test_batch_get_freebusy_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/meeting_room/freebusy/batch_get"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "freebusy_list": [
+                        { "room_id": "room_001", "status": "busy" }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = BatchGetFreebusyRequest::new(config)
+            .query_param("time_scope", "day")
+            .execute()
+            .await
+            .expect("查询会议室忙闲应成功");
+        assert_eq!(resp["freebusy_list"][0]["room_id"], json!("room_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/meeting_room/freebusy/batch_get"
+        );
+        assert_eq!(received[0].url.query(), Some("time_scope=day"));
     }
 }

--- a/crates/openlark-meeting/src/meeting_room/instance/reply.rs
+++ b/crates/openlark-meeting/src/meeting_room/instance/reply.rs
@@ -47,21 +47,46 @@ impl ReplyInstanceRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../meeting_room/instance/reply → 裸 Value（单层 resp["field"]）。
+    #[tokio::test]
+    async fn test_reply_instance_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/meeting_room/instance/reply"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "instance_id": "inst_001", "status": "replied" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = ReplyInstanceRequest::new(config)
+            .execute(json!({ "instance_id": "inst_001", "reply": "accept" }))
+            .await
+            .expect("回复会议室日程实例应成功");
+        assert_eq!(resp["instance_id"], json!("inst_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/meeting_room/instance/reply"
+        );
+        assert_eq!(received[0].method, "POST");
     }
 }

--- a/crates/openlark-meeting/src/meeting_room/responses.rs
+++ b/crates/openlark-meeting/src/meeting_room/responses.rs
@@ -267,21 +267,4 @@ pub struct SummaryData {
 }
 
 #[cfg(test)]
-mod tests {
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}
+mod tests {}

--- a/crates/openlark-meeting/src/meeting_room/room/batch_get.rs
+++ b/crates/openlark-meeting/src/meeting_room/room/batch_get.rs
@@ -52,21 +52,51 @@ impl BatchGetRoomRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../meeting_room/room/batch_get → 裸 Value（单层 resp["field"]）。
+    #[tokio::test]
+    async fn test_batch_get_room_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/meeting_room/room/batch_get"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "rooms": [
+                        { "room_id": "room_001", "name": "大会议室" }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = BatchGetRoomRequest::new(config)
+            .query_param("page_size", "10")
+            .execute()
+            .await
+            .expect("查询会议室详情应成功");
+        assert_eq!(resp["rooms"][0]["room_id"], json!("room_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/meeting_room/room/batch_get"
+        );
+        assert_eq!(received[0].url.query(), Some("page_size=10"));
     }
 }

--- a/crates/openlark-meeting/src/meeting_room/room/batch_get_id.rs
+++ b/crates/openlark-meeting/src/meeting_room/room/batch_get_id.rs
@@ -51,21 +51,47 @@ impl BatchGetRoomIdRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../meeting_room/room/batch_get_id → 裸 Value（单层 resp["field"]）。
+    #[tokio::test]
+    async fn test_batch_get_id_room_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/meeting_room/room/batch_get_id"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "room_ids": ["room_001", "room_002"] }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = BatchGetRoomIdRequest::new(config)
+            .query_param("page_size", "20")
+            .execute()
+            .await
+            .expect("查询会议室ID应成功");
+        assert_eq!(resp["room_ids"][0], json!("room_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/meeting_room/room/batch_get_id"
+        );
+        assert_eq!(received[0].url.query(), Some("page_size=20"));
     }
 }

--- a/crates/openlark-meeting/src/meeting_room/room/delete.rs
+++ b/crates/openlark-meeting/src/meeting_room/room/delete.rs
@@ -56,21 +56,47 @@ impl DeleteRoomRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：DELETE .../meeting_room/rooms/{room_id} → 裸 Value（单层 resp["field"]）。
+    #[tokio::test]
+    async fn test_delete_room_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/meeting_room/rooms/room_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "success": true }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = DeleteRoomRequest::new(config)
+            .room_id("room_001")
+            .execute()
+            .await
+            .expect("删除会议室应成功");
+        assert_eq!(resp["success"], json!(true));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/meeting_room/rooms/room_001"
+        );
+        assert_eq!(received[0].method, "DELETE");
     }
 }

--- a/crates/openlark-meeting/src/meeting_room/room/update.rs
+++ b/crates/openlark-meeting/src/meeting_room/room/update.rs
@@ -62,21 +62,47 @@ impl UpdateRoomRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../meeting_room/room/update → 裸 Value（单层 resp["field"]）。
+    #[tokio::test]
+    async fn test_update_room_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/meeting_room/room/update"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "room_id": "room_001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = UpdateRoomRequest::new(config)
+            .room_id("room_001")
+            .execute(json!({ "name": "更新大会议室" }))
+            .await
+            .expect("更新会议室应成功");
+        assert_eq!(resp["room_id"], json!("room_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/meeting_room/room/update"
+        );
+        assert_eq!(received[0].method, "POST");
     }
 }

--- a/crates/openlark-meeting/src/meeting_room/summary/batch_get.rs
+++ b/crates/openlark-meeting/src/meeting_room/summary/batch_get.rs
@@ -47,21 +47,50 @@ impl BatchGetSummaryRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../meeting_room/rooms/batch_get_summary → 裸 Value（单层 resp["field"]）。
+    #[tokio::test]
+    async fn test_batch_get_summary_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/meeting_room/rooms/batch_get_summary"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "summaries": [
+                        { "room_id": "room_001", "topic": "周会" }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = BatchGetSummaryRequest::new(config)
+            .execute(json!({ "room_ids": ["room_001"] }))
+            .await
+            .expect("查询会议室日程主题和会议详情应成功");
+        assert_eq!(resp["summaries"][0]["room_id"], json!("room_001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/meeting_room/rooms/batch_get_summary"
+        );
+        assert_eq!(received[0].method, "POST");
     }
 }


### PR DESCRIPTION
## 背景

#351 第 8 批，P3 meeting PR B（接 #385 PR A 的 vc/v1）。本 PR 覆盖 calendar/v4 + meeting_room，至此 **meeting crate 占位测试 0 残留**（PR A+B 合计 90 endpoint e2e）。

## 改动

### 40 endpoint wiremock e2e
- **calendar/v4**（30 endpoint）：calendar(13) + event(11) + exchange_binding(2) + freebusy(1) + setting(1) + timeoff_event(1) + meeting_room(11)
- `CalendarApiV4` enum + `to_url()`；meeting_room 常量 path；都 Config 非 Arc + extract_response_data
- 信封按 Response struct（裸 Value/强类型单层、嵌套 struct 按字段）
- query/body 断言（若有）

### 聚合文件占位清理（4 个）
纯 struct 定义文件（0 execute）的 serde_json 占位测试删除：`calendar/responses.rs`、`calendar/responses_new.rs`、`common/chain.rs`、`meeting_room/responses.rs`。

### e2e 暴露 latent bug（不修，按代码实际行为 mock）
- **calendar `primary.rs`**：enum 注释 GET 但 execute 用 POST
- **meeting_room**：多处 path 单复数不一致（`building/` vs `buildings/{id}`）+ `update` 用 POST 非 PATCH（enum 名 `BuildingPatch`/`RoomUpdate` 但 method 不一致）

留后续 issue（涉及 execute/enum 行为变更）。

## 本地验证

- `cargo test --all-features`：**167 pass / 0 fail**
- 占位残留：**0**（全 crate 清除）
- `cargo fmt --check` ✅
- `cargo clippy --all-features + --no-default-features --features "vc calendar meeting-room" -- -Dwarnings` ✅
- `cargo doc -D warnings` ✅ / `cargo deny check advisories` ✅

## 关联

父 issue #351；PR A: #385（vc/v1）。同批先例 #374/#375/#376/#379/#381/#383/#384。

Refs #351