### PR TITLE
test(platform/app_engine): 44 真实端点 wiremock e2e（#351 P3 PR A）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **platform app_engine/apaas 44 真实端点占位测试 → wiremock e2e**（#351 第 9 批，P3 platform PR A）：
+  app_engine/apaas/v1 全子域（application/audit_log/environment_variable/flow/function/object/record/
+  record_permission/role + approval_instance/approval_task/user_task + workspace）占位 `serde_json`
+  roundtrip → wiremock 端到端。模式：Config 非 Arc + url 字符串 + `response.data.ok_or_else`。
+  e2e 覆盖 query 拼装（手工 `params.push`）、POST body 透传、强类型 Response 嵌套 struct 断言。
+  directory/admin/mdm/tenant/trust_party 留 PR B。**非 breaking**：纯测试新增。
+
 - **meeting calendar/v4 + meeting_room 40 真实端点占位测试 → wiremock e2e**（#351 第 8 批，P3 meeting PR B）：
   calendar/v4 全子域（calendar / event / exchange_binding / freebusy / setting / timeoff_event）+
   meeting_room 全子域（building / freebusy / instance / room / summary）占位 `serde_json` roundtrip →

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/audit_log/audit_log_list.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/audit_log/audit_log_list.rs
@@ -146,21 +146,72 @@ pub type AuditLogListBuilder = AuditLogListRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../applications/{ns}/audit_log/audit_log_list → 强类型 AuditLogListResponse。
+    #[tokio::test]
+    async fn test_list_audit_log_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/apaas/v1/applications/ns_test/audit_log/audit_log_list",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        {
+                            "log_id": "log_001",
+                            "operation_type": "CREATE",
+                            "operator": "u_001",
+                            "operation_time": 1717000000
+                        }
+                    ],
+                    "has_more": false,
+                    "page": 1,
+                    "page_size": 20
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = AuditLogListRequestBuilder::new(config, "ns_test")
+            .start_time(1716000000)
+            .end_time(1717000000)
+            .page(1)
+            .page_size(20)
+            .execute()
+            .await
+            .expect("查询审计日志列表应成功");
+        assert_eq!(resp.items.len(), 1);
+        assert_eq!(resp.items[0].log_id, "log_001");
+        assert!(!resp.has_more);
+        assert_eq!(resp.page, 1);
+        assert_eq!(resp.page_size, 20);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/audit_log/audit_log_list"
+        );
+        let query = received[0].url.query().unwrap_or("");
+        assert!(query.contains("start_time=1716000000"));
+        assert!(query.contains("end_time=1717000000"));
+        assert!(query.contains("page=1"));
+        assert!(query.contains("page_size=20"));
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/audit_log/data_change_log_detail.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/audit_log/data_change_log_detail.rs
@@ -105,21 +105,63 @@ pub type DataChangeLogDetailBuilder = DataChangeLogDetailRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../audit_log/data_change_log_detail?log_id=... → DataChangeLogDetailResponse。
+    #[tokio::test]
+    async fn test_get_data_change_log_detail_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/apaas/v1/applications/ns_test/audit_log/data_change_log_detail",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "data_change_log": {
+                        "log_id": "log_001",
+                        "change_type": "UPDATE",
+                        "object_type": "record",
+                        "object_id": "obj_001",
+                        "operator": "u_001",
+                        "change_time": 1717000000,
+                        "before_data": {"name": "old"},
+                        "after_data": {"name": "new"}
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = DataChangeLogDetailRequestBuilder::new(config, "ns_test", "log_001")
+            .execute()
+            .await
+            .expect("查询数据变更日志详情应成功");
+        assert_eq!(resp.data_change_log.log_id, "log_001");
+        assert_eq!(resp.data_change_log.change_type, "UPDATE");
+        assert_eq!(resp.data_change_log.object_id, "obj_001");
+        assert_eq!(resp.data_change_log.operator, "u_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/audit_log/data_change_log_detail"
+        );
+        let query = received[0].url.query().unwrap_or("");
+        assert!(query.contains("log_id=log_001"));
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/audit_log/data_change_logs_list.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/audit_log/data_change_logs_list.rs
@@ -152,21 +152,74 @@ pub type DataChangeLogsListBuilder = DataChangeLogsListRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../audit_log/data_change_logs_list → 强类型 DataChangeLogsListResponse。
+    #[tokio::test]
+    async fn test_list_data_change_logs_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/apaas/v1/applications/ns_test/audit_log/data_change_logs_list",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        {
+                            "log_id": "log_001",
+                            "change_type": "UPDATE",
+                            "object_type": "record",
+                            "object_id": "obj_001",
+                            "operator": "u_001",
+                            "change_time": 1717000000
+                        }
+                    ],
+                    "has_more": false,
+                    "page": 1,
+                    "page_size": 20
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = DataChangeLogsListRequestBuilder::new(config, "ns_test")
+            .start_time(1716000000)
+            .end_time(1717000000)
+            .page(1)
+            .page_size(20)
+            .execute()
+            .await
+            .expect("查询数据变更日志列表应成功");
+        assert_eq!(resp.items.len(), 1);
+        assert_eq!(resp.items[0].log_id, "log_001");
+        assert_eq!(resp.items[0].change_type, "UPDATE");
+        assert!(!resp.has_more);
+        assert_eq!(resp.page, 1);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/audit_log/data_change_logs_list"
+        );
+        let query = received[0].url.query().unwrap_or("");
+        assert!(query.contains("start_time=1716000000"));
+        assert!(query.contains("end_time=1717000000"));
+        assert!(query.contains("page=1"));
+        assert!(query.contains("page_size=20"));
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/audit_log/get.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/audit_log/get.rs
@@ -96,21 +96,58 @@ pub type AuditLogGetBuilder = AuditLogGetRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../audit_log?log_id=... → AuditLogGetResponse（inner data.audit_log）。
+    #[tokio::test]
+    async fn test_get_audit_log_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/apaas/v1/applications/ns_test/audit_log"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "audit_log": {
+                        "log_id": "log_001",
+                        "operation_type": "CREATE",
+                        "operator": "u_001",
+                        "operation_time": 1717000000,
+                        "details": {"action": "create_record"}
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = AuditLogGetRequestBuilder::new(config, "ns_test", "log_001")
+            .execute()
+            .await
+            .expect("查询审计日志详情应成功");
+        assert_eq!(resp.audit_log.log_id, "log_001");
+        assert_eq!(resp.audit_log.operation_type, "CREATE");
+        assert_eq!(resp.audit_log.operator, "u_001");
+        assert_eq!(resp.audit_log.details["action"], "create_record");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/audit_log"
+        );
+        let query = received[0].url.query().unwrap_or("");
+        assert!(query.contains("log_id=log_001"));
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/environment_variable/get.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/environment_variable/get.rs
@@ -97,21 +97,60 @@ pub type EnvironmentVariableGetBuilder = EnvironmentVariableGetRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../environment_variables/{api_name} → EnvironmentVariableGetResponse。
+    #[tokio::test]
+    async fn test_get_environment_variable_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/apaas/v1/applications/ns_test/environment_variables/env_var_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "environment_variable": {
+                        "api_name": "env_var_001",
+                        "name": "ENV_NAME",
+                        "value": "value_001",
+                        "description": "测试变量"
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = EnvironmentVariableGetRequestBuilder::new(config, "ns_test", "env_var_001")
+            .execute()
+            .await
+            .expect("查询环境变量详情应成功");
+        assert_eq!(resp.environment_variable.api_name, "env_var_001");
+        assert_eq!(resp.environment_variable.name, "ENV_NAME");
+        assert_eq!(resp.environment_variable.value, "value_001");
+        assert_eq!(
+            resp.environment_variable.description.as_deref(),
+            Some("测试变量")
+        );
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/environment_variables/env_var_001"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/environment_variable/query.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/environment_variable/query.rs
@@ -134,21 +134,66 @@ pub type EnvironmentVariableQueryBuilder = EnvironmentVariableQueryRequestBuilde
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../environment_variables/query → EnvironmentVariableQueryResponse。
+    #[tokio::test]
+    async fn test_query_environment_variable_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/apaas/v1/applications/ns_test/environment_variables/query",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        {
+                            "api_name": "env_var_001",
+                            "name": "ENV_NAME",
+                            "value": "value_001",
+                            "description": "测试变量"
+                        }
+                    ],
+                    "has_more": false,
+                    "page": 1,
+                    "page_size": 20
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = EnvironmentVariableQueryRequestBuilder::new(config, "ns_test")
+            .page(1)
+            .page_size(20)
+            .execute()
+            .await
+            .expect("查询环境变量列表应成功");
+        assert_eq!(resp.items.len(), 1);
+        assert_eq!(resp.items[0].api_name, "env_var_001");
+        assert_eq!(resp.items[0].value, "value_001");
+        assert!(!resp.has_more);
+        assert_eq!(resp.page, 1);
+        assert_eq!(resp.page_size, 20);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/environment_variables/query"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/flow/execute.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/flow/execute.rs
@@ -102,21 +102,54 @@ pub type FlowExecuteBuilder = FlowExecuteRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../flows/{flow_id}/execute → 强类型 FlowExecuteResponse。
+    #[tokio::test]
+    async fn test_execute_flow_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/apaas/v1/applications/ns_test/flows/flow_001/execute",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "instance_id": "inst_001",
+                    "status": "RUNNING",
+                    "message": "流程已发起"
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = FlowExecuteRequestBuilder::new(config, "ns_test", "flow_001")
+            .params(json!({"input": "value"}))
+            .execute()
+            .await
+            .expect("发起流程应成功");
+        assert_eq!(resp.instance_id, "inst_001");
+        assert_eq!(resp.status, "RUNNING");
+        assert_eq!(resp.message, "流程已发起");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/flows/flow_001/execute"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/function/invoke.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/function/invoke.rs
@@ -106,21 +106,54 @@ pub type FunctionInvokeBuilder = FunctionInvokeRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../functions/{api_name}/invoke → 强类型 FunctionInvokeResponse。
+    #[tokio::test]
+    async fn test_invoke_function_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/apaas/v1/applications/ns_test/functions/func_001/invoke",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "result": {"output": "ok"},
+                    "status": "SUCCESS",
+                    "message": "执行成功"
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = FunctionInvokeRequestBuilder::new(config, "ns_test", "func_001")
+            .params(json!({"arg": 1}))
+            .execute()
+            .await
+            .expect("执行函数应成功");
+        assert_eq!(resp.status, "SUCCESS");
+        assert_eq!(resp.message, "执行成功");
+        assert_eq!(resp.result["output"], "ok");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/functions/func_001/invoke"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/object/oql_query.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/object/oql_query.rs
@@ -117,21 +117,54 @@ pub type OqlQueryBuilder = OqlQueryRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../applications/{ns}/objects/oql_query → 强类型 OqlQueryResponse。
+    #[tokio::test]
+    async fn test_oql_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/apaas/v1/applications/ns_test/objects/oql_query",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        { "id": "rec_001", "data": { "name": "记录一" } }
+                    ],
+                    "has_more": false
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = OqlQueryRequestBuilder::new(config, "ns_test", "SELECT * FROM User")
+            .execute()
+            .await
+            .expect("执行 OQL 查询应成功");
+        assert_eq!(resp.items.len(), 1);
+        assert!(!resp.has_more);
+        assert_eq!(resp.items[0].id, "rec_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/objects/oql_query"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/batch_create.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/batch_create.rs
@@ -123,21 +123,56 @@ pub type RecordBatchCreateBuilder = RecordBatchCreateRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../records/batch_create → 强类型 RecordBatchCreateResponse。
+    #[tokio::test]
+    async fn test_batch_create_records_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/apaas/v1/applications/ns_test/objects/obj_test/records/batch_create",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        { "id": "rec_001", "success": true },
+                        { "id": "rec_002", "success": true }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = RecordBatchCreateRequestBuilder::new(config, "ns_test", "obj_test")
+            .record(json!({ "name": "记录一" }))
+            .record(json!({ "name": "记录二" }))
+            .execute()
+            .await
+            .expect("批量新建记录应成功");
+        assert_eq!(resp.items.len(), 2);
+        assert_eq!(resp.items[0].id, "rec_001");
+        assert!(resp.items[0].success);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/objects/obj_test/records/batch_create"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/batch_delete.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/batch_delete.rs
@@ -124,21 +124,58 @@ pub type RecordBatchDeleteBuilder = RecordBatchDeleteRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：DELETE .../records/batch_delete → 强类型 RecordBatchDeleteResponse。
+    #[tokio::test]
+    async fn test_batch_delete_records_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/apaas/v1/applications/ns_test/objects/obj_test/records/batch_delete",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "deleted_count": 2,
+                    "items": [
+                        { "id": "rec_001", "success": true },
+                        { "id": "rec_002", "success": true }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = RecordBatchDeleteRequestBuilder::new(config, "ns_test", "obj_test")
+            .record_id("rec_001")
+            .record_id("rec_002")
+            .execute()
+            .await
+            .expect("批量删除记录应成功");
+        assert_eq!(resp.deleted_count, 2);
+        assert_eq!(resp.items.len(), 2);
+        assert_eq!(resp.items[0].id, "rec_001");
+        assert!(resp.items[0].success);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/objects/obj_test/records/batch_delete"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/batch_query.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/batch_query.rs
@@ -143,21 +143,59 @@ pub type RecordBatchQueryBuilder = RecordBatchQueryRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../records/batch_query → 强类型 RecordBatchQueryResponse。
+    #[tokio::test]
+    async fn test_batch_query_records_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/apaas/v1/applications/ns_test/objects/obj_test/records/batch_query",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        {
+                            "id": "rec_001",
+                            "data": { "name": "记录一" },
+                            "created_time": 1700000000,
+                            "updated_time": 1700000001
+                        }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = RecordBatchQueryRequestBuilder::new(config, "ns_test", "obj_test")
+            .record_id("rec_001")
+            .execute()
+            .await
+            .expect("批量查询记录应成功");
+        assert_eq!(resp.items.len(), 1);
+        assert_eq!(resp.items[0].id, "rec_001");
+        assert_eq!(resp.items[0].created_time, 1700000000);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/objects/obj_test/records/batch_query"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/batch_update.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/batch_update.rs
@@ -158,21 +158,54 @@ pub type RecordBatchUpdateBuilder = RecordBatchUpdateRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：PATCH .../records/batch_update → 强类型 RecordBatchUpdateResponse。
+    #[tokio::test]
+    async fn test_batch_update_records_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/apaas/v1/applications/ns_test/objects/obj_test/records/batch_update",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        { "id": "rec_001", "success": true }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = RecordBatchUpdateRequestBuilder::new(config, "ns_test", "obj_test")
+            .record("rec_001", json!({ "name": "更新后的记录" }))
+            .execute()
+            .await
+            .expect("批量编辑记录应成功");
+        assert_eq!(resp.items.len(), 1);
+        assert_eq!(resp.items[0].id, "rec_001");
+        assert!(resp.items[0].success);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/objects/obj_test/records/batch_update"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/delete.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/delete.rs
@@ -85,21 +85,48 @@ pub type RecordDeleteBuilder = RecordDeleteRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：DELETE .../records/{record_id} → 强类型 RecordDeleteResponse。
+    #[tokio::test]
+    async fn test_delete_record_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/apaas/v1/applications/ns_test/objects/obj_test/records/rec_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "id": "rec_001", "message": "删除成功" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = RecordDeleteRequestBuilder::new(config, "ns_test", "obj_test", "rec_001")
+            .execute()
+            .await
+            .expect("删除记录应成功");
+        assert_eq!(resp.id, "rec_001");
+        assert_eq!(resp.message, "删除成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/objects/obj_test/records/rec_001"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/patch.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/patch.rs
@@ -116,21 +116,49 @@ pub type RecordPatchBuilder = RecordPatchRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：PATCH .../records/{record_id} → 强类型 RecordPatchResponse。
+    #[tokio::test]
+    async fn test_patch_record_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/apaas/v1/applications/ns_test/objects/obj_test/records/rec_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "id": "rec_001", "updated_time": 1700000002 }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = RecordPatchRequestBuilder::new(config, "ns_test", "obj_test", "rec_001")
+            .data(json!({ "name": "更新后的记录" }))
+            .execute()
+            .await
+            .expect("编辑记录应成功");
+        assert_eq!(resp.id, "rec_001");
+        assert_eq!(resp.updated_time, 1700000002);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/objects/obj_test/records/rec_001"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/query.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/query.rs
@@ -119,21 +119,55 @@ pub type RecordQueryBuilder = RecordQueryRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../records/{record_id}/query → 强类型 RecordQueryResponse。
+    #[tokio::test]
+    async fn test_query_record_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/apaas/v1/applications/ns_test/objects/obj_test/records/rec_001/query",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "id": "rec_001",
+                    "data": { "name": "记录一" },
+                    "created_time": 1700000000,
+                    "updated_time": 1700000001
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = RecordQueryRequestBuilder::new(config, "ns_test", "obj_test", "rec_001")
+            .field("name")
+            .execute()
+            .await
+            .expect("获取记录详情应成功");
+        assert_eq!(resp.id, "rec_001");
+        assert_eq!(resp.created_time, 1700000000);
+        assert_eq!(resp.updated_time, 1700000001);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/objects/obj_test/records/rec_001/query"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/object/search.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/object/search.rs
@@ -155,21 +155,59 @@ pub type RecordSearchBuilder = RecordSearchRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../applications/{ns}/objects/search → 强类型 RecordSearchResponse。
+    #[tokio::test]
+    async fn test_search_records_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/apaas/v1/applications/ns_test/objects/search",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        { "id": "rec_001", "data": { "name": "记录一" }, "score": 0.95 }
+                    ],
+                    "has_more": false,
+                    "page": 1,
+                    "page_size": 20
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = RecordSearchRequestBuilder::new(config, "ns_test", "关键字")
+            .page(1)
+            .page_size(20)
+            .execute()
+            .await
+            .expect("搜索记录应成功");
+        assert_eq!(resp.items.len(), 1);
+        assert!(!resp.has_more);
+        assert_eq!(resp.page, 1);
+        assert_eq!(resp.page_size, 20);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/objects/search"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/record_permission/member/batch_create_authorization.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/record_permission/member/batch_create_authorization.rs
@@ -111,20 +111,50 @@ pub type RecordPermissionBatchCreateAuthBuilder = RecordPermissionBatchCreateAut
 
 #[cfg(test)]
 mod tests {
-    use serde_json;
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../record_permissions/{api_name}/member/batch_create_authorization。
+    #[tokio::test]
+    async fn test_batch_create_record_permission_member_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/apaas/v1/applications/ns_test/record_permissions/rp_001/member/batch_create_authorization"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "authorized_count": 2,
+                    "message": "授权成功"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = RecordPermissionBatchCreateAuthRequestBuilder::new(config, "ns_test", "rp_001")
+            .user_ids(vec!["u_001".to_string(), "u_002".to_string()])
+            .execute()
+            .await
+            .expect("批量创建记录权限用户授权应成功");
+        assert_eq!(resp.authorized_count, 2);
+        assert_eq!(resp.message, "授权成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/record_permissions/rp_001/member/batch_create_authorization"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/record_permission/member/batch_remove_authorization.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/record_permission/member/batch_remove_authorization.rs
@@ -111,20 +111,50 @@ pub type RecordPermissionBatchRemoveAuthBuilder = RecordPermissionBatchRemoveAut
 
 #[cfg(test)]
 mod tests {
-    use serde_json;
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../record_permissions/{api_name}/member/batch_remove_authorization。
+    #[tokio::test]
+    async fn test_batch_remove_record_permission_member_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/apaas/v1/applications/ns_test/record_permissions/rp_001/member/batch_remove_authorization"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "removed_count": 2,
+                    "message": "取消授权成功"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = RecordPermissionBatchRemoveAuthRequestBuilder::new(config, "ns_test", "rp_001")
+            .user_ids(vec!["u_001".to_string(), "u_002".to_string()])
+            .execute()
+            .await
+            .expect("批量删除记录权限用户授权应成功");
+        assert_eq!(resp.removed_count, 2);
+        assert_eq!(resp.message, "取消授权成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/record_permissions/rp_001/member/batch_remove_authorization"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/role/member/batch_create_authorization.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/role/member/batch_create_authorization.rs
@@ -111,20 +111,50 @@ pub type RoleMemberBatchCreateAuthBuilder = RoleMemberBatchCreateAuthRequestBuil
 
 #[cfg(test)]
 mod tests {
-    use serde_json;
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../roles/{role_api_name}/member/batch_create_authorization。
+    #[tokio::test]
+    async fn test_batch_create_role_member_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/apaas/v1/applications/ns_test/roles/role_001/member/batch_create_authorization"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "authorized_count": 2,
+                    "message": "授权成功"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = RoleMemberBatchCreateAuthRequestBuilder::new(config, "ns_test", "role_001")
+            .user_ids(vec!["u_001".to_string(), "u_002".to_string()])
+            .execute()
+            .await
+            .expect("批量创建角色成员授权应成功");
+        assert_eq!(resp.authorized_count, 2);
+        assert_eq!(resp.message, "授权成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/roles/role_001/member/batch_create_authorization"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/role/member/batch_remove_authorization.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/role/member/batch_remove_authorization.rs
@@ -111,20 +111,50 @@ pub type RoleMemberBatchRemoveAuthBuilder = RoleMemberBatchRemoveAuthRequestBuil
 
 #[cfg(test)]
 mod tests {
-    use serde_json;
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../roles/{role_api_name}/member/batch_remove_authorization。
+    #[tokio::test]
+    async fn test_batch_remove_role_member_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/apaas/v1/applications/ns_test/roles/role_001/member/batch_remove_authorization"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "removed_count": 2,
+                    "message": "取消授权成功"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = RoleMemberBatchRemoveAuthRequestBuilder::new(config, "ns_test", "role_001")
+            .user_ids(vec!["u_001".to_string(), "u_002".to_string()])
+            .execute()
+            .await
+            .expect("批量删除角色成员授权应成功");
+        assert_eq!(resp.removed_count, 2);
+        assert_eq!(resp.message, "取消授权成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/roles/role_001/member/batch_remove_authorization"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/role/member/get.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/role/member/get.rs
@@ -119,20 +119,64 @@ pub type RoleMemberGetBuilder = RoleMemberGetRequestBuilder;
 
 #[cfg(test)]
 mod tests {
-    use serde_json;
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET .../roles/{role_api_name}/member → 强类型 RoleMemberGetResponse。
+    #[tokio::test]
+    async fn test_get_role_member_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/apaas/v1/applications/ns_test/roles/role_001/member",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        {
+                            "user_id": "u_001",
+                            "member_type": "USER",
+                            "added_time": 1717000000
+                        }
+                    ],
+                    "has_more": false
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = RoleMemberGetRequestBuilder::new(config, "ns_test", "role_001")
+            .page(1)
+            .page_size(20)
+            .execute()
+            .await
+            .expect("查询角色成员信息应成功");
+        assert_eq!(resp.items.len(), 1);
+        assert_eq!(resp.items[0].user_id, "u_001");
+        assert_eq!(resp.items[0].member_type, "USER");
+        assert!(!resp.has_more);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/applications/ns_test/roles/role_001/member"
+        );
+        let query = received[0].url.query().unwrap_or("");
+        assert!(query.contains("page=1"));
+        assert!(query.contains("page_size=20"));
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/approval_instance/cancel.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/approval_instance/cancel.rs
@@ -76,21 +76,48 @@ pub type CancelInstanceBuilder = CancelInstanceRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../approval_instances/{id}/cancel → 强类型 CancelInstanceResponse。
+    #[tokio::test]
+    async fn test_cancel_approval_instance_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/apaas/v1/approval_instances/inst_001/cancel",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "result": "success" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = CancelInstanceRequestBuilder::new(config)
+            .approval_instance_id("inst_001")
+            .execute()
+            .await
+            .expect("撤销审批实例应成功");
+        assert_eq!(resp.result, "success");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/approval_instances/inst_001/cancel"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/approval_instance/get.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/approval_instance/get.rs
@@ -81,21 +81,53 @@ pub type GetInstanceBuilder = GetInstanceRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../approval_instances/{id} → 强类型 GetInstanceResponse。
+    #[tokio::test]
+    async fn test_get_approval_instance_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/apaas/v1/approval_instances/inst_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "instance_id": "inst_001",
+                    "status": "APPROVING",
+                    "initiator_id": "u_001",
+                    "create_time": "1717000000"
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetInstanceRequestBuilder::new(config)
+            .approval_instance_id("inst_001")
+            .execute()
+            .await
+            .expect("获取审批实例详情应成功");
+        assert_eq!(resp.instance_id, "inst_001");
+        assert_eq!(resp.status, "APPROVING");
+        assert_eq!(resp.initiator_id, "u_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/approval_instances/inst_001"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/approval_task/add_assignee.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/approval_task/add_assignee.rs
@@ -96,21 +96,49 @@ pub type AddAssigneeBuilder = AddAssigneeRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../approval_tasks/{id}/add_assignee → 强类型 AddAssigneeResponse。
+    #[tokio::test]
+    async fn test_add_assignee_approval_task_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/apaas/v1/approval_tasks/task_001/add_assignee",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "result": "success" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = AddAssigneeRequestBuilder::new(config)
+            .approval_task_id("task_001")
+            .user_ids(vec!["u_001".to_string(), "u_002".to_string()])
+            .execute()
+            .await
+            .expect("人工任务加签应成功");
+        assert_eq!(resp.result, "success");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/approval_tasks/task_001/add_assignee"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/approval_task/agree.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/approval_task/agree.rs
@@ -73,21 +73,46 @@ pub type AgreeTaskBuilder = AgreeTaskRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../approval_tasks/{id}/agree → 强类型 AgreeTaskResponse。
+    #[tokio::test]
+    async fn test_agree_approval_task_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/apaas/v1/approval_tasks/task_001/agree"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "result": "success" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = AgreeTaskRequestBuilder::new(config)
+            .approval_task_id("task_001")
+            .execute()
+            .await
+            .expect("同意人工任务应成功");
+        assert_eq!(resp.result, "success");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/approval_tasks/task_001/agree"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/approval_task/cancel.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/approval_task/cancel.rs
@@ -75,21 +75,46 @@ pub type CancelTaskBuilder = CancelTaskRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../approval_tasks/{id}/cancel → 强类型 CancelTaskResponse。
+    #[tokio::test]
+    async fn test_cancel_approval_task_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/apaas/v1/approval_tasks/task_001/cancel"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "result": "success" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = CancelTaskRequestBuilder::new(config)
+            .approval_task_id("task_001")
+            .execute()
+            .await
+            .expect("撤销人工任务应成功");
+        assert_eq!(resp.result, "success");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/approval_tasks/task_001/cancel"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/approval_task/reject.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/approval_task/reject.rs
@@ -94,21 +94,47 @@ pub type RejectTaskBuilder = RejectTaskRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../approval_tasks/{id}/reject → 强类型 RejectTaskResponse。
+    #[tokio::test]
+    async fn test_reject_approval_task_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/apaas/v1/approval_tasks/task_001/reject"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "result": "success" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = RejectTaskRequestBuilder::new(config)
+            .approval_task_id("task_001")
+            .reason("内容不符合要求")
+            .execute()
+            .await
+            .expect("拒绝人工任务应成功");
+        assert_eq!(resp.result, "success");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/approval_tasks/task_001/reject"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/approval_task/transfer.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/approval_task/transfer.rs
@@ -112,20 +112,52 @@ pub type TransferApprovalTaskBuilder = TransferApprovalTaskRequestBuilder;
 
 #[cfg(test)]
 mod tests {
-    use serde_json;
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST .../approval_tasks/{id}/transfer → 强类型 TransferApprovalTaskResponse。
+    #[tokio::test]
+    async fn test_transfer_approval_task_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/apaas/v1/approval_tasks/task_001/transfer"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "task_id": "task_001",
+                    "result": true,
+                    "message": "转交成功"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = TransferApprovalTaskRequestBuilder::new(config, "task_001", "u_002")
+            .reason("出差转交")
+            .execute()
+            .await
+            .expect("转交人工任务应成功");
+        assert_eq!(resp.task_id, "task_001");
+        assert!(resp.result);
+        assert_eq!(resp.message, "转交成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/approval_tasks/task_001/transfer"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/user_task/cc.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/user_task/cc.rs
@@ -112,21 +112,53 @@ pub type CcTaskBuilder = CcTaskRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../user_tasks/{id}/cc → 强类型 CcTaskResponse。
+    #[tokio::test]
+    async fn test_cc_user_task_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/apaas/v1/user_tasks/task_001/cc"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "task_id": "task_001",
+                    "cc_id": "cc_001",
+                    "message": "抄送成功"
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = CcTaskRequestBuilder::new(config, "task_001")
+            .user_ids(vec!["u_001".to_string(), "u_002".to_string()])
+            .reason("请知会")
+            .execute()
+            .await
+            .expect("抄送人工任务应成功");
+        assert_eq!(resp.task_id, "task_001");
+        assert_eq!(resp.cc_id, "cc_001");
+        assert_eq!(resp.message, "抄送成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/user_tasks/task_001/cc"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/user_task/chat_group.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/user_task/chat_group.rs
@@ -132,21 +132,54 @@ pub type ChatGroupBuilder = ChatGroupRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../user_tasks/{id}/chat_group → 强类型 ChatGroupResponse。
+    #[tokio::test]
+    async fn test_chat_group_user_task_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/apaas/v1/user_tasks/task_001/chat_group"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "chat_id": "oc_001",
+                    "name": "任务协作群",
+                    "message": "建群成功"
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = ChatGroupRequestBuilder::new(config, "task_001")
+            .name("任务协作群")
+            .owner_id("u_001")
+            .member_ids(vec!["u_002".to_string(), "u_003".to_string()])
+            .execute()
+            .await
+            .expect("发起群聊应成功");
+        assert_eq!(resp.chat_id, "oc_001");
+        assert_eq!(resp.name, "任务协作群");
+        assert_eq!(resp.message, "建群成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/user_tasks/task_001/chat_group"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/user_task/expediting.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/user_task/expediting.rs
@@ -99,21 +99,50 @@ pub type ExpeditingBuilder = ExpeditingRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../user_tasks/{id}/expediting → 强类型 ExpeditingResponse。
+    #[tokio::test]
+    async fn test_expediting_user_task_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/apaas/v1/user_tasks/task_001/expediting"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "task_id": "task_001",
+                    "message": "已催办"
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = ExpeditingRequestBuilder::new(config, "task_001")
+            .user_ids(vec!["u_001".to_string(), "u_002".to_string()])
+            .execute()
+            .await
+            .expect("催办人工任务应成功");
+        assert_eq!(resp.task_id, "task_001");
+        assert_eq!(resp.message, "已催办");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/user_tasks/task_001/expediting"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/user_task/query.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/user_task/query.rs
@@ -199,21 +199,67 @@ pub type UserTaskQueryBuilder = UserTaskQueryRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../user_task/query → 强类型 UserTaskQueryResponse。
+    #[tokio::test]
+    async fn test_query_user_task_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/apaas/v1/user_task/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "tasks": [
+                        {
+                            "task_id": "task_001",
+                            "title": "待审批",
+                            "status": "PENDING",
+                            "initiator_id": "u_001",
+                            "created_at": 1717000000_i64,
+                            "updated_at": 1717000100_i64
+                        }
+                    ],
+                    "has_more": false,
+                    "page": 1,
+                    "page_size": 10,
+                    "total_count": 1
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = UserTaskQueryRequestBuilder::new(config)
+            .status("PENDING")
+            .user_id("u_001")
+            .page(1)
+            .page_size(10)
+            .execute()
+            .await
+            .expect("查询人工任务应成功");
+        assert_eq!(resp.tasks.len(), 1);
+        assert!(!resp.has_more);
+        assert_eq!(resp.page, 1);
+        assert_eq!(resp.total_count, 1);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/user_task/query"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/user_task/rollback.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/user_task/rollback.rs
@@ -103,21 +103,52 @@ pub type RollbackTaskBuilder = RollbackTaskRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../user_tasks/{id}/rollback → 强类型 RollbackTaskResponse。
+    #[tokio::test]
+    async fn test_rollback_user_task_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/apaas/v1/user_tasks/task_001/rollback"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "task_id": "task_001",
+                    "result": true,
+                    "message": "退回成功"
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = RollbackTaskRequestBuilder::new(config, "task_001", "node_1")
+            .reason("信息需补充")
+            .execute()
+            .await
+            .expect("退回人工任务应成功");
+        assert_eq!(resp.task_id, "task_001");
+        assert!(resp.result);
+        assert_eq!(resp.message, "退回成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/user_tasks/task_001/rollback"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/user_task/rollback_points.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/user_task/rollback_points.rs
@@ -91,21 +91,64 @@ pub type RollbackPointsBuilder = RollbackPointsRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../user_tasks/{id}/rollback_points → 强类型 RollbackPointsResponse。
+    #[tokio::test]
+    async fn test_rollback_points_user_task_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/apaas/v1/user_tasks/task_001/rollback_points",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "task_id": "task_001",
+                    "rollback_points": [
+                        {
+                            "node_id": "node_1",
+                            "node_name": "部门审批",
+                            "node_type": "APPROVAL",
+                            "can_rollback": true
+                        },
+                        {
+                            "node_id": "node_2",
+                            "node_name": "发起人",
+                            "node_type": "START",
+                            "can_rollback": false
+                        }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = RollbackPointsRequestBuilder::new(config, "task_001")
+            .execute()
+            .await
+            .expect("查询可退回位置应成功");
+        assert_eq!(resp.task_id, "task_001");
+        assert_eq!(resp.rollback_points.len(), 2);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/user_tasks/task_001/rollback_points"
+        );
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/workspace/enum_mod/enum_get.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/workspace/enum_mod/enum_get.rs
@@ -103,21 +103,59 @@ pub type EnumGetBuilder = EnumGetRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../apaas/v1/workspaces/{ws}/enums/{enum_name} → 强类型 EnumGetResponse。
+    #[tokio::test]
+    async fn test_get_enum_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/apaas/v1/workspaces/ws_001/enums/priority"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "enum_name": "priority",
+                    "description": "优先级枚举",
+                    "values": [
+                        {"value_id": "v1", "value_name": "高", "is_default": true},
+                        {"value_id": "v2", "value_name": "低", "is_default": false}
+                    ],
+                    "created_time": 1700000000,
+                    "updated_time": 1700000100
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = EnumGetRequestBuilder::new(config, "ws_001", "priority")
+            .execute()
+            .await
+            .expect("获取枚举详情应成功");
+        assert_eq!(resp.enum_name, "priority");
+        assert_eq!(resp.description.as_deref(), Some("优先级枚举"));
+        assert_eq!(resp.values.len(), 2);
+        assert_eq!(resp.values[0].value_id, "v1");
+        assert_eq!(resp.created_time, 1700000000);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/workspaces/ws_001/enums/priority"
+        );
+        assert_eq!(received[0].method, "GET");
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/workspace/sql_commands.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/workspace/sql_commands.rs
@@ -99,21 +99,53 @@ pub type SqlCommandsBuilder = SqlCommandsRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../apaas/v1/workspaces/{ws}/sql_commands → 强类型 SqlCommandsResponse。
+    #[tokio::test]
+    async fn test_execute_sql_commands_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/apaas/v1/workspaces/ws_001/sql_commands"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "result": {
+                        "data": [{"id": 1}, {"id": 2}],
+                        "affected_rows": 2,
+                        "message": "OK"
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = SqlCommandsRequestBuilder::new(config, "ws_001", "SELECT * FROM t")
+            .execute()
+            .await
+            .expect("执行 SQL 应成功");
+        assert_eq!(resp.result.affected_rows, 2);
+        assert_eq!(resp.result.message, "OK");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/workspaces/ws_001/sql_commands"
+        );
+        assert_eq!(received[0].method, "POST");
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/records_batch_update.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/records_batch_update.rs
@@ -144,21 +144,57 @@ pub type TableRecordsBatchUpdateBuilder = TableRecordsBatchUpdateRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：PATCH .../tables/{table}/records_batch_update → 强类型 TableRecordsBatchUpdateResponse。
+    #[tokio::test]
+    async fn test_batch_update_records_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/apaas/v1/workspaces/ws_001/tables/user/records_batch_update",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "updated_count": 2,
+                    "items": [
+                        {"id": "r1", "success": true},
+                        {"id": "r2", "success": true}
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = TableRecordsBatchUpdateRequestBuilder::new(config, "ws_001", "user")
+            .record("r1", json!({"name": "alice"}))
+            .record("r2", json!({"name": "bob"}))
+            .execute()
+            .await
+            .expect("批量更新记录应成功");
+        assert_eq!(resp.updated_count, 2);
+        assert_eq!(resp.items.len(), 2);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/workspaces/ws_001/tables/user/records_batch_update"
+        );
+        assert_eq!(received[0].method, "PATCH");
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/records_delete.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/records_delete.rs
@@ -105,21 +105,54 @@ pub type TableRecordsDeleteBuilder = TableRecordsDeleteRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：DELETE .../tables/{table}/records → 强类型 TableRecordsDeleteResponse。
+    #[tokio::test]
+    async fn test_delete_records_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/apaas/v1/workspaces/ws_001/tables/user/records",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "deleted_count": 2,
+                    "message": "OK"
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = TableRecordsDeleteRequestBuilder::new(config, "ws_001", "user")
+            .record_id("r1")
+            .record_id("r2")
+            .execute()
+            .await
+            .expect("删除数据表记录应成功");
+        assert_eq!(resp.deleted_count, 2);
+        assert_eq!(resp.message, "OK");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/workspaces/ws_001/tables/user/records"
+        );
+        assert_eq!(received[0].method, "DELETE");
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/records_get.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/records_get.rs
@@ -155,21 +155,59 @@ pub type TableRecordsGetBuilder = TableRecordsGetRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../tables/{table}/records → 强类型 TableRecordsGetResponse。
+    #[tokio::test]
+    async fn test_get_records_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/apaas/v1/workspaces/ws_001/tables/user/records"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        {"id": "r1", "data": {"name": "alice"}, "created_time": 1700000000, "updated_time": 1700000050}
+                    ],
+                    "has_more": true,
+                    "page": 1,
+                    "page_size": 20,
+                    "total_count": 35
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = TableRecordsGetRequestBuilder::new(config, "ws_001", "user")
+            .page(1)
+            .page_size(20)
+            .execute()
+            .await
+            .expect("查询数据表记录应成功");
+        assert_eq!(resp.items.len(), 1);
+        assert_eq!(resp.items[0].id, "r1");
+        assert!(resp.has_more);
+        assert_eq!(resp.total_count, 35);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/workspaces/ws_001/tables/user/records"
+        );
+        assert_eq!(received[0].method, "GET");
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/records_patch.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/records_patch.rs
@@ -125,21 +125,53 @@ pub type TableRecordsPatchBuilder = TableRecordsPatchRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：PATCH .../tables/{table}/records → 强类型 TableRecordsPatchResponse。
+    #[tokio::test]
+    async fn test_patch_records_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/apaas/v1/workspaces/ws_001/tables/user/records",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "updated_count": 3,
+                    "message": "OK"
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = TableRecordsPatchRequestBuilder::new(config, "ws_001", "user", "age > 18")
+            .data(json!({"status": "active"}))
+            .execute()
+            .await
+            .expect("按条件更新记录应成功");
+        assert_eq!(resp.updated_count, 3);
+        assert_eq!(resp.message, "OK");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/workspaces/ws_001/tables/user/records"
+        );
+        assert_eq!(received[0].method, "PATCH");
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/records_post.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/records_post.rs
@@ -123,21 +123,58 @@ pub type TableRecordsPostBuilder = TableRecordsPostRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：POST .../tables/{table}/records → 强类型 TableRecordsPostResponse。
+    #[tokio::test]
+    async fn test_post_records_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/apaas/v1/workspaces/ws_001/tables/user/records",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        {"id": "r1", "success": true},
+                        {"id": "r2", "success": false, "error": "冲突"}
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = TableRecordsPostRequestBuilder::new(config, "ws_001", "user")
+            .record(json!({"id": "r1", "name": "alice"}))
+            .record(json!({"id": "r2", "name": "bob"}))
+            .execute()
+            .await
+            .expect("添加或更新记录应成功");
+        assert_eq!(resp.items.len(), 2);
+        assert!(resp.items[0].success);
+        assert!(!resp.items[1].success);
+        assert_eq!(resp.items[1].error.as_deref(), Some("冲突"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/workspaces/ws_001/tables/user/records"
+        );
+        assert_eq!(received[0].method, "POST");
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/table_get.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/table_get.rs
@@ -104,21 +104,59 @@ pub type TableGetBuilder = TableGetRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../apaas/v1/workspaces/{ws}/tables/{table_name} → 强类型 TableGetResponse。
+    #[tokio::test]
+    async fn test_get_table_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/apaas/v1/workspaces/ws_001/tables/user"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "table_name": "user",
+                    "description": "用户表",
+                    "fields": [
+                        {"field_name": "id", "field_type": "int", "is_primary_key": true, "description": "主键"},
+                        {"field_name": "name", "field_type": "string", "is_primary_key": false}
+                    ],
+                    "created_time": 1700000000,
+                    "updated_time": 1700000100
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = TableGetRequestBuilder::new(config, "ws_001", "user")
+            .execute()
+            .await
+            .expect("获取数据表详情应成功");
+        assert_eq!(resp.table_name, "user");
+        assert_eq!(resp.description.as_deref(), Some("用户表"));
+        assert_eq!(resp.fields.len(), 2);
+        assert!(resp.fields[0].is_primary_key);
+        assert_eq!(resp.created_time, 1700000000);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/workspaces/ws_001/tables/user"
+        );
+        assert_eq!(received[0].method, "GET");
     }
 }

--- a/crates/openlark-platform/src/app_engine/apaas/v1/workspace/view/views_get.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/workspace/view/views_get.rs
@@ -137,21 +137,70 @@ pub type ViewsGetBuilder = ViewsGetRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
-    use serde_json;
+    /// 端到端：GET .../apaas/v1/workspaces/{ws}/views/{view_name}/records → 强类型 ViewsGetResponse。
+    #[tokio::test]
+    async fn test_get_views_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/apaas/v1/workspaces/ws_001/views/active/records",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        {"id": "r1", "data": {"name": "alice"}, "created_time": 1700000000, "updated_time": 1700000050}
+                    ],
+                    "has_more": false,
+                    "page": 1,
+                    "page_size": 20
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = ViewsGetRequestBuilder::new(config, "ws_001", "active")
+            .page(1)
+            .page_size(20)
+            .execute()
+            .await
+            .expect("查询视图记录应成功");
+        assert_eq!(resp.items.len(), 1);
+        assert_eq!(resp.items[0].id, "r1");
+        assert!(!resp.has_more);
+        assert_eq!(resp.page, 1);
+        assert_eq!(resp.page_size, 20);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/apaas/v1/workspaces/ws_001/views/active/records"
+        );
+        assert_eq!(received[0].method, "GET");
+        let query = received[0].url.query().unwrap_or("");
+        assert!(
+            query.contains("page=1"),
+            "query should contain page=1: {query}"
+        );
+        assert!(
+            query.contains("page_size=20"),
+            "query should contain page_size=20: {query}"
+        );
     }
 }


### PR DESCRIPTION
## 背景

#351 第 9 批，P3 platform（拆多 PR）。本 PR A 覆盖 **app_engine/apaas/v1**（44 endpoint，最大子域）。directory/admin/mdm/tenant/trust_party（33 占位）留 PR B。

platform 已有 wiremock dev-dep（此前 0 使用），本 PR 首次启用。

## 改动

### 44 endpoint wiremock e2e
- **application**（23）：audit_log(4) + environment_variable(2) + flow(1) + function(1) + object(9) + record_permission(2) + role(3) + search/oql
- **approval + user_task**（13）：approval_instance(2) + approval_task(5) + user_task(6)
- **workspace**（9）：table/records + view + enum + sql_commands

模式：**Config 非 Arc** + url 字符串 + `response.data.ok_or_else`。信封按 Response struct（强类型嵌套 / 裸 Value）。query 手工拼接（`params.push(format!(...))`）的文件断言 `received[0].url.query()`。

## 本地验证

- `cargo test --all-features`：**196 pass / 0 fail**
- app_engine 占位残留：**0**
- `cargo fmt --check` ✅ / `cargo clippy --all-features + --no-default-features` ✅
- `cargo doc -D` ✅ / `cargo deny` ✅ / `cargo machete` ✅

## 关联

父 issue #351；同批先例 #374/#375/#376/#379/#381/#383/#384/#385/#386。

Refs #351