### PR TITLE
test(workflow): 清除 8 个占位 serde_json roundtrip 测试（#351 P3）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **workflow 清除 8 个占位 serde_json roundtrip 测试**（#351 第 10 批，P3 workflow）：
+  7 个 `v2/*/models.rs`（纯聚合 struct，0 execute）删除整个 `mod tests` 块；`service.rs` 删除 2 个
+  roundtrip 占位保留 4 个真实 builder/action 测试。workflow crate 特殊现状：endpoint 普遍已有
+  `test_*_url`（`to_url()` 断言）+ builder 测试（334 测试，部分覆盖 URL 拼装与 builder），**非 roundtrip 占位**，
+  故本批只清 roundtrip；endpoint 的完整 wiremock e2e（execute → Transport → 响应解析）作为后续议题。
+  **非 breaking**：纯测试删除。
+
 - **platform directory/admin/mdm/tenant/trust_party 32 真实端点占位测试 → wiremock e2e**（#351 第 9 批，P3 platform PR B）：
   directory/v1（department/employee/collaboration_rule 15）+ admin/v1/badge·password（6）+ mdm（3）+ tenant/v2（2）+
   trust_party/v1（4）占位 → wiremock 端到端。admin/v1 audit·users 是显式 stub（PlatformConfig + business_error

--- a/crates/openlark-workflow/src/service.rs
+++ b/crates/openlark-workflow/src/service.rs
@@ -550,21 +550,6 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-
-    #[test]
     fn test_task_list_query_builder() {
         let query = WorkflowTaskListQuery::for_tasklist("tasklist_123")
             .section_guid("section_456")

--- a/crates/openlark-workflow/src/v2/attachment/models.rs
+++ b/crates/openlark-workflow/src/v2/attachment/models.rs
@@ -27,23 +27,3 @@ pub struct DeleteAttachmentResponse {
     /// 附件 GUID
     pub attachment_guid: String,
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-workflow/src/v2/comment/models.rs
+++ b/crates/openlark-workflow/src/v2/comment/models.rs
@@ -105,23 +105,3 @@ pub struct ListCommentsResponse {
     #[serde(default)]
     pub items: Vec<CommentItem>,
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-workflow/src/v2/custom_field/models.rs
+++ b/crates/openlark-workflow/src/v2/custom_field/models.rs
@@ -147,23 +147,3 @@ pub struct ListCustomFieldsResponse {
     #[serde(default)]
     pub items: Vec<CustomFieldItem>,
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-workflow/src/v2/section/models.rs
+++ b/crates/openlark-workflow/src/v2/section/models.rs
@@ -131,23 +131,3 @@ pub struct ListSectionsResponse {
     #[serde(default)]
     pub items: Vec<SectionItem>,
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-workflow/src/v2/task/models.rs
+++ b/crates/openlark-workflow/src/v2/task/models.rs
@@ -318,23 +318,3 @@ pub struct ListTasksResponse {
     #[serde(default)]
     pub items: Vec<TaskItem>,
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-workflow/src/v2/tasklist/activity_subscription/models.rs
+++ b/crates/openlark-workflow/src/v2/tasklist/activity_subscription/models.rs
@@ -149,23 +149,3 @@ pub struct ListActivitySubscriptionsResponse {
     #[serde(default)]
     pub items: Vec<ActivitySubscription>,
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-workflow/src/v2/tasklist/models.rs
+++ b/crates/openlark-workflow/src/v2/tasklist/models.rs
@@ -179,23 +179,3 @@ pub struct ListTasklistsResponse {
     #[serde(default)]
     pub items: Vec<TasklistItem>,
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}


### PR DESCRIPTION
## 背景

#351 第 10 批，P3 workflow。workflow crate 现状特殊：**endpoint 普遍已有 `test_*_url`（`to_url()` 断言）+ builder 测试**（334 测试，部分覆盖 URL 拼装与 builder 构造），**非 roundtrip 占位**。占位 roundtrip 只集中在 8 个聚合文件。

## 改动

### 清除 8 个 roundtrip 占位
- **7 个 `v2/*/models.rs`**（custom_field/section/comment/attachment/tasklist/task/tasklist.activity_subscription）：纯聚合 struct（0 execute），删整个 `mod tests` 块
- **`service.rs`**：删 `test_serialization_roundtrip` + `test_deserialization_from_json`，保留 4 个真实 builder/action 测试

## workflow e2e 覆盖说明

workflow 的 endpoint 测试现状是 `test_*_url`（enum `to_url()` 断言）+ builder 单元测试——这比 roundtrip 占位有意义（验证 URL 拼装），但**不调 execute**，非完整 wiremock e2e。171 文件的 e2e 升级（execute → Transport → 响应解析）作为后续议题，不在本批 roundtrip 清除范围。

## 本地验证

- `cargo test --all-features`：**340 pass / 0 fail**
- workflow 占位残留：**0**
- `cargo fmt --check` ✅ / `cargo clippy --all-features + --no-default-features` ✅

## 关联

父 issue #351；同批先例 #374-#388。

Refs #351