### PR TITLE
test(docs): 清除 38 个 Potemkin 丢弃式 + 15 wiremock e2e（#351 P3 PR A）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **docs 清除 38 个 Potemkin 丢弃式测试 + 15 wiremock e2e**（#351 第 11 批，P3 docs PR A）：
+  baike（entity extract/match 2）+ ccm/drive（export_task/file version/import_task/media/permission/member 13）
+  共 15 文件，每文件含 `let _ = request.execute().await` + `assert!(result.is_ok())` 的 Potemkin 丢弃式——调 execute
+  但丢弃返回值，只断言"线程没 panic"（Config 指向真实飞书无凭证，execute 实际返 Err 被丢弃 → 假绿）。
+  删除这些假绿测试，保留真实 builder/validation 测试，加 wiremock e2e（Config 非 Arc + enum + extract_response_data）。
+  这是 #351 issue 标题「→ test_runtime 端到端」点名的核心反模式（test_runtime 是 Potemkin 封装）。
+  e2e 暴露 latent bug（按代码实际行为处理）：`batch_get_tmp_download_url` execute 手拼重复 query
+  （core HashMap 不支持重复 key），url `?` 被 Transport encode 成 `%3F`。docs 的 ~107 roundtrip 占位留后续 PR。
+  **非 breaking**：纯测试替换。
+
 - **workflow 清除 8 个占位 serde_json roundtrip 测试**（#351 第 10 批，P3 workflow）：
   7 个 `v2/*/models.rs`（纯聚合 struct，0 execute）删除整个 `mod tests` 块；`service.rs` 删除 2 个
   roundtrip 占位保留 4 个真实 builder/action 测试。workflow crate 特殊现状：endpoint 普遍已有

--- a/crates/openlark-docs/src/baike/baike/v1/entity/extract.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/entity/extract.rs
@@ -94,7 +94,6 @@ impl ExtractEntityRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openlark_core::testing::prelude::test_runtime;
 
     /// 测试构建器模式
     #[test]
@@ -102,36 +101,6 @@ mod tests {
         let config = Config::default();
         let request = ExtractEntityRequest::new(config, "测试文本");
         assert_eq!(request.req.text, "测试文本");
-    }
-
-    /// 测试 text 长度验证
-    #[test]
-    fn test_text_length_validation() {
-        let config = Config::default();
-
-        // 最大长度 128
-        let text_128 = "a".repeat(128);
-        let request1 = ExtractEntityRequest::new(config.clone(), text_128);
-        assert_eq!(request1.req.text.chars().count(), 128);
-
-        // 超过 128
-        let text_129 = "a".repeat(129);
-        let request2 = ExtractEntityRequest::new(config.clone(), text_129);
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request2.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-
-        // 测试边界情况
-        let text_127 = "a".repeat(127);
-        let request3 = ExtractEntityRequest::new(config, text_127);
-        assert_eq!(request3.req.text.chars().count(), 127);
     }
 
     /// 测试空文本
@@ -198,5 +167,53 @@ mod tests {
         };
 
         assert!(word.aliases.is_none());
+    }
+
+    /// 端到端：POST .../baike/v1/entities/extract → 强类型 ExtractEntityResponse（单层 data 信封）。
+    #[tokio::test]
+    async fn test_extract_entity_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/baike/v1/entities/extract"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "entity_word": [
+                        { "name": "词条1", "aliases": ["别名1"] },
+                        { "name": "词条2" }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = ExtractEntityRequest::new(config, "提取这段文本的词条")
+            .execute()
+            .await
+            .expect("提取词条应成功");
+        assert_eq!(resp.entity_word.len(), 2);
+        assert_eq!(resp.entity_word[0].name, "词条1");
+        assert_eq!(resp.entity_word[0].aliases.as_ref().unwrap().len(), 1);
+        assert_eq!(resp.entity_word[1].aliases, None);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/baike/v1/entities/extract"
+        );
     }
 }

--- a/crates/openlark-docs/src/baike/baike/v1/entity/match.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/entity/match.rs
@@ -95,7 +95,6 @@ impl MatchEntityRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openlark_core::testing::prelude::test_runtime;
 
     /// 测试构建器模式
     #[test]
@@ -105,52 +104,6 @@ mod tests {
         assert_eq!(request.req.word, "搜索词");
     }
 
-    /// 测试 word 为空时的验证
-    #[test]
-    fn test_empty_word_validation() {
-        let config = Config::default();
-        let request = MatchEntityRequest::new(config, "");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
-    /// 测试 word 长度边界值
-    #[test]
-    fn test_word_length_boundaries() {
-        let config = Config::default();
-
-        // 最小长度 1
-        let request1 = MatchEntityRequest::new(config.clone(), "a");
-        assert_eq!(request1.req.word, "a");
-
-        // 最大长度 100
-        let word_100 = "a".repeat(100);
-        let request2 = MatchEntityRequest::new(config.clone(), word_100);
-        assert_eq!(request2.req.word.chars().count(), 100);
-
-        // 超过 100
-        let word_101 = "a".repeat(101);
-        let request3 = MatchEntityRequest::new(config, word_101);
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request3.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
     /// 测试 Unicode 字符计数
     #[test]
     fn test_unicode_character_count() {
@@ -158,5 +111,48 @@ mod tests {
         let word = "🎉🎊🎈"; // 3 个 Unicode 码点
         let request = MatchEntityRequest::new(config, word);
         assert_eq!(request.req.word.chars().count(), 3);
+    }
+
+    /// 端到端：POST .../baike/v1/entities/match → 强类型 MatchEntityResp（单层 data 信封）。
+    #[tokio::test]
+    async fn test_match_entity_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/baike/v1/entities/match"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "results": [
+                        { "entity_id": "en001", "type": 0 }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = MatchEntityRequest::new(config, "飞书")
+            .execute()
+            .await
+            .expect("精准搜索词条应成功");
+        assert_eq!(resp.results.len(), 1);
+        assert_eq!(resp.results[0].entity_id, Some("en001".to_string()));
+        assert_eq!(resp.results[0].type_, Some(0));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/baike/v1/entities/match");
     }
 }

--- a/crates/openlark-docs/src/ccm/drive/v1/export_task/create.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/export_task/create.rs
@@ -141,7 +141,6 @@ impl ApiResponseTrait for CreateExportTaskResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openlark_core::testing::prelude::test_runtime;
 
     /// 测试构建器模式
     #[test]
@@ -163,56 +162,6 @@ mod tests {
             CreateExportTaskResponse::data_format(),
             ResponseFormat::Data
         );
-    }
-
-    /// 测试 token 长度验证
-    #[test]
-    fn test_token_length_validation() {
-        let config = Config::default();
-
-        // 空字符串
-        let request1 = CreateExportTaskRequest::new(config.clone(), "", "token", "docx");
-
-        let result1 = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request1.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result1.is_ok());
-
-        // 超过 27 字节
-        let long_token = "a".repeat(28);
-        let request2 = CreateExportTaskRequest::new(config, long_token, "token", "docx");
-
-        let result2 = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request2.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result2.is_ok());
-    }
-
-    /// 测试 file_extension 枚举值
-    #[test]
-    fn test_file_extension_validation() {
-        let config = Config::default();
-        let request = CreateExportTaskRequest::new(config, "invalid", "token", "docx");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
     }
 
     /// 测试支持的 file_extension 类型
@@ -261,23 +210,6 @@ mod tests {
         }
     }
 
-    /// 测试 CSV 导出需要 sub_id
-    #[test]
-    fn test_csv_requires_sub_id() {
-        let config = Config::default();
-        let request = CreateExportTaskRequest::new(config, "csv", "token", "sheet");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
     /// 测试 sub_id 可选参数
     #[test]
     fn test_sub_id_optional() {
@@ -291,5 +223,43 @@ mod tests {
         let request2 =
             CreateExportTaskRequest::new(config, "csv", "token", "sheet").sub_id("sheet_id");
         assert_eq!(request2.sub_id, Some("sheet_id".to_string()));
+    }
+
+    /// 端到端：POST .../drive/v1/export_tasks → 强类型 CreateExportTaskResponse（单层 data 信封）。
+    #[tokio::test]
+    async fn test_create_export_task_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/drive/v1/export_tasks"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "ticket": "ticket_001" }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp =
+            CreateExportTaskRequest::new(config, "pdf", "boxcnBj8N4yKVRhiMtDBTsXfQqb", "docx")
+                .execute()
+                .await
+                .expect("创建导出任务应成功");
+        assert_eq!(resp.ticket, "ticket_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/drive/v1/export_tasks");
     }
 }

--- a/crates/openlark-docs/src/ccm/drive/v1/export_task/download.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/export_task/download.rs
@@ -76,7 +76,6 @@ impl DownloadExportRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openlark_core::testing::prelude::test_runtime;
 
     /// 测试构建器模式
     #[test]
@@ -84,23 +83,6 @@ mod tests {
         let config = Config::default();
         let request = DownloadExportRequest::new(config, "file_token");
         assert_eq!(request.file_token, "file_token");
-    }
-
-    /// 测试 file_token 为空时的验证
-    #[test]
-    fn test_empty_file_token_validation() {
-        let config = Config::default();
-        let request = DownloadExportRequest::new(config, "");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
     }
 
     /// 测试 file_token 边界值
@@ -130,5 +112,44 @@ mod tests {
         let config = Config::default();
         let request = DownloadExportRequest::new(config, "file_token").max_size(2048);
         assert_eq!(request.max_size, 2048);
+    }
+
+    /// 端到端：GET .../export_tasks/file/{file_token}/download → Response<Vec<u8>> 二进制载荷。
+    #[tokio::test]
+    async fn test_download_export_returns_data_on_success() {
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let body = b"PK\x03\x04 fake export file bytes";
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/drive/v1/export_tasks/file/ftk001/download",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.to_vec()))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = DownloadExportRequest::new(config, "ftk001")
+            .execute()
+            .await
+            .expect("下载导出文件应成功");
+        let bytes = resp.data.expect("响应 data 应非空");
+        assert_eq!(bytes, body.to_vec());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/drive/v1/export_tasks/file/ftk001/download"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/drive/v1/export_task/get.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/export_task/get.rs
@@ -103,7 +103,6 @@ impl ApiResponseTrait for GetExportTaskResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openlark_core::testing::prelude::test_runtime;
 
     /// 测试构建器模式
     #[test]
@@ -120,56 +119,6 @@ mod tests {
         assert_eq!(GetExportTaskResponse::data_format(), ResponseFormat::Data);
     }
 
-    /// 测试 ticket 为空时的验证
-    #[test]
-    fn test_empty_ticket_validation() {
-        let config = Config::default();
-        let request = GetExportTaskRequest::new(config, "", "token");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
-    /// 测试 token 长度验证
-    #[test]
-    fn test_token_length_validation() {
-        let config = Config::default();
-
-        // 空字符串
-        let request1 = GetExportTaskRequest::new(config.clone(), "ticket", "");
-
-        let result1 = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request1.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result1.is_ok());
-
-        // 超过 27 字节
-        let long_token = "a".repeat(28);
-        let request2 = GetExportTaskRequest::new(config, "ticket", long_token);
-
-        let result2 = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request2.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result2.is_ok());
-    }
-
     /// 测试 token 边界值
     #[test]
     fn test_token_boundaries() {
@@ -183,5 +132,65 @@ mod tests {
         let token27 = "a".repeat(27);
         let request2 = GetExportTaskRequest::new(config, "ticket", token27);
         assert_eq!(request2.token.len(), 27);
+    }
+
+    /// 端到端：GET .../export_tasks/{ticket}?token=... → 强类型 GetExportTaskResponse（单层 data 信封）。
+    #[tokio::test]
+    async fn test_get_export_task_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/drive/v1/export_tasks/ticket_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "result": {
+                        "file_extension": "pdf",
+                        "type": "docx",
+                        "file_name": "导出文件.pdf",
+                        "file_token": "ftk001",
+                        "file_size": 1024,
+                        "job_error_msg": "",
+                        "job_status": 0
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetExportTaskRequest::new(config, "ticket_001", "boxcnBj8N4yKVRhiMtDBTsXfQqb")
+            .execute()
+            .await
+            .expect("查询导出任务应成功");
+        let result = resp.result.expect("result 应非空");
+        assert_eq!(result.file_extension, "pdf");
+        assert_eq!(result.r#type, "docx");
+        assert_eq!(result.file_token.as_deref(), Some("ftk001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/drive/v1/export_tasks/ticket_001"
+        );
+        assert!(
+            received[0]
+                .url
+                .query()
+                .unwrap_or("")
+                .contains("token=boxcnBj8N4yKVRhiMtDBTsXfQqb")
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/drive/v1/file/version/create.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/file/version/create.rs
@@ -110,7 +110,6 @@ pub type CreateFileVersionResponse = FileVersionInfo;
 mod tests {
     use super::*;
     use openlark_core::api::ApiResponseTrait;
-    use openlark_core::testing::prelude::test_runtime;
 
     /// 测试构建器模式
     #[test]
@@ -133,75 +132,6 @@ mod tests {
             <FileVersionInfo as ApiResponseTrait>::data_format(),
             openlark_core::api::ResponseFormat::Data
         );
-    }
-
-    /// 测试 file_token 为空时的验证
-    #[test]
-    fn test_empty_file_token_validation() {
-        let config = Config::default();
-        let request = CreateFileVersionRequest::new(config, "", "name", "docx");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
-    /// 测试 name 为空时的验证
-    #[test]
-    fn test_empty_name_validation() {
-        let config = Config::default();
-        let request = CreateFileVersionRequest::new(config, "token", "", "docx");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
-    /// 测试 name 超长时的验证
-    #[test]
-    fn test_name_length_validation() {
-        let config = Config::default();
-        let long_name = "a".repeat(1025);
-        let request = CreateFileVersionRequest::new(config, "token", long_name, "docx");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
-    /// 测试 obj_type 枚举值验证
-    #[test]
-    fn test_obj_type_validation() {
-        let config = Config::default();
-        let request = CreateFileVersionRequest::new(config, "token", "name", "invalid");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
     }
 
     /// 测试支持的 obj_type 类型
@@ -228,5 +158,53 @@ mod tests {
         let name = "🎉🎊🎈"; // 3 个码点
         let request = CreateFileVersionRequest::new(config, "token", name, "docx");
         assert_eq!(request.name.chars().count(), 3);
+    }
+
+    /// 端到端：POST .../files/{file_token}/versions → 强类型 FileVersionInfo（单层 data 信封）。
+    #[tokio::test]
+    async fn test_create_file_version_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/drive/v1/files/ftk001/versions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "name": "项目文档 第 1 版",
+                    "version": "fnJfyX",
+                    "parent_token": "ftk001",
+                    "status": "active",
+                    "obj_type": "docx"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = CreateFileVersionRequest::new(config, "ftk001", "项目文档 第 1 版", "docx")
+            .execute()
+            .await
+            .expect("创建文档版本应成功");
+        assert_eq!(resp.name.as_deref(), Some("项目文档 第 1 版"));
+        assert_eq!(resp.version.as_deref(), Some("fnJfyX"));
+        assert_eq!(resp.parent_token.as_deref(), Some("ftk001"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/drive/v1/files/ftk001/versions"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/drive/v1/file/version/get.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/file/version/get.rs
@@ -90,7 +90,6 @@ pub type GetFileVersionResponse = FileVersionInfo;
 mod tests {
     use super::*;
     use openlark_core::api::ApiResponseTrait;
-    use openlark_core::testing::prelude::test_runtime;
 
     /// 测试构建器模式
     #[test]
@@ -112,57 +111,6 @@ mod tests {
             <FileVersionInfo as ApiResponseTrait>::data_format(),
             openlark_core::api::ResponseFormat::Data
         );
-    }
-
-    /// 测试 file_token 为空时的验证
-    #[test]
-    fn test_empty_file_token_validation() {
-        let config = Config::default();
-        let request = GetFileVersionRequest::new(config, "", "version_id", "docx");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
-    /// 测试 version_id 为空时的验证
-    #[test]
-    fn test_empty_version_id_validation() {
-        let config = Config::default();
-        let request = GetFileVersionRequest::new(config, "token", "", "docx");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
-    /// 测试 obj_type 枚举值验证
-    #[test]
-    fn test_obj_type_validation() {
-        let config = Config::default();
-        let request = GetFileVersionRequest::new(config, "token", "version", "invalid");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
     }
 
     /// 测试支持的 obj_type 类型
@@ -191,5 +139,59 @@ mod tests {
         let request2 =
             GetFileVersionRequest::new(config, "token", "version", "docx").user_id_type("user_id");
         assert_eq!(request2.user_id_type, Some("user_id".to_string()));
+    }
+
+    /// 端到端：GET .../files/{file_token}/versions/{version_id}?obj_type=docx → 强类型 FileVersionInfo（单层 data 信封）。
+    #[tokio::test]
+    async fn test_get_file_version_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/drive/v1/files/ftk001/versions/fnJfyX"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "name": "项目文档 第 1 版",
+                    "version": "fnJfyX",
+                    "parent_token": "ftk001",
+                    "status": "active",
+                    "obj_type": "docx"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetFileVersionRequest::new(config, "ftk001", "fnJfyX", "docx")
+            .execute()
+            .await
+            .expect("获取文档版本应成功");
+        assert_eq!(resp.version.as_deref(), Some("fnJfyX"));
+        assert_eq!(resp.name.as_deref(), Some("项目文档 第 1 版"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/drive/v1/files/ftk001/versions/fnJfyX"
+        );
+        assert!(
+            received[0]
+                .url
+                .query()
+                .unwrap_or("")
+                .contains("obj_type=docx")
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/drive/v1/file/version/list.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/file/version/list.rs
@@ -107,7 +107,6 @@ pub type ListFileVersionsResponse = ListFileVersionsData;
 mod tests {
     use super::*;
     use openlark_core::api::ApiResponseTrait;
-    use openlark_core::testing::prelude::test_runtime;
 
     /// 测试构建器模式
     #[test]
@@ -133,84 +132,6 @@ mod tests {
         );
     }
 
-    /// 测试 file_token 为空时的验证
-    #[test]
-    fn test_empty_file_token_validation() {
-        let config = Config::default();
-        let request = ListFileVersionsRequest::new(config, "", 20, "docx");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
-    /// 测试 page_size 边界值
-    #[test]
-    fn test_page_size_boundaries() {
-        let config = Config::default();
-
-        // 测试最小值
-        let request1 = ListFileVersionsRequest::new(config.clone(), "token", 1, "docx");
-        assert_eq!(request1.page_size, 1);
-
-        // 测试最大值
-        let request2 = ListFileVersionsRequest::new(config.clone(), "token", 100, "docx");
-        assert_eq!(request2.page_size, 100);
-
-        // 测试超出范围
-        let request3 = ListFileVersionsRequest::new(config, "token", 101, "docx");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request3.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
-    /// 测试 page_size 为 0 时的验证
-    #[test]
-    fn test_zero_page_size_validation() {
-        let config = Config::default();
-        let request = ListFileVersionsRequest::new(config, "token", 0, "docx");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
-    /// 测试 obj_type 枚举值验证
-    #[test]
-    fn test_obj_type_validation() {
-        let config = Config::default();
-        let request = ListFileVersionsRequest::new(config, "token", 20, "invalid");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
     /// 测试支持的 obj_type 类型
     #[test]
     fn test_supported_obj_types() {
@@ -231,5 +152,69 @@ mod tests {
             ListFileVersionsRequest::new(config, "token", 20, "docx").page_token("next_page_token");
 
         assert_eq!(request.page_token, Some("next_page_token".to_string()));
+    }
+
+    /// 端到端：GET .../files/{file_token}/versions?page_size&obj_type → 强类型 ListFileVersionsData（单层 data 信封）。
+    #[tokio::test]
+    async fn test_list_file_versions_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/drive/v1/files/ftk001/versions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        { "name": "项目文档 第 1 版", "version": "fnJfyX", "obj_type": "docx" },
+                        { "name": "项目文档 第 2 版", "version": "fnJfyY", "obj_type": "docx" }
+                    ],
+                    "page_token": "next_page_token",
+                    "has_more": true
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = ListFileVersionsRequest::new(config, "ftk001", 20, "docx")
+            .execute()
+            .await
+            .expect("获取文档版本列表应成功");
+        assert_eq!(resp.items.len(), 2);
+        assert_eq!(resp.items[0].version.as_deref(), Some("fnJfyX"));
+        assert!(resp.has_more);
+        assert_eq!(resp.page_token.as_deref(), Some("next_page_token"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/drive/v1/files/ftk001/versions"
+        );
+        assert!(
+            received[0]
+                .url
+                .query()
+                .unwrap_or("")
+                .contains("page_size=20")
+        );
+        assert!(
+            received[0]
+                .url
+                .query()
+                .unwrap_or("")
+                .contains("obj_type=docx")
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/drive/v1/import_task/create.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/import_task/create.rs
@@ -143,7 +143,6 @@ impl ApiResponseTrait for CreateImportTaskResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openlark_core::testing::prelude::test_runtime;
 
     /// 测试构建器模式
     #[test]
@@ -182,77 +181,6 @@ mod tests {
         );
     }
 
-    /// 测试 file_extension 为空时的验证
-    #[test]
-    fn test_empty_file_extension_validation() {
-        let config = Config::default();
-        let point = Point::new("mount_key");
-        let request = CreateImportTaskRequest::new(config, "", "file_token", "sheet", point);
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
-    /// 测试 file_token 长度验证
-    #[test]
-    fn test_file_token_length_validation() {
-        let config = Config::default();
-        let point = Point::new("mount_key");
-
-        // 空字符串
-        let request1 =
-            CreateImportTaskRequest::new(config.clone(), "pdf", "", "sheet", point.clone());
-
-        let result1 = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request1.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result1.is_ok());
-
-        // 超过 27 字节
-        let long_token = "a".repeat(28);
-        let request2 = CreateImportTaskRequest::new(config, "pdf", long_token, "sheet", point);
-
-        let result2 = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request2.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result2.is_ok());
-    }
-
-    /// 测试 type 枚举值验证
-    #[test]
-    fn test_type_validation() {
-        let config = Config::default();
-        let point = Point::new("mount_key");
-        let request = CreateImportTaskRequest::new(config, "pdf", "file_token", "invalid", point);
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
     /// 测试支持的 type 类型
     #[test]
     fn test_supported_types() {
@@ -289,5 +217,50 @@ mod tests {
         let request2 = CreateImportTaskRequest::new(config, "pdf", "file_token", "sheet", point)
             .file_name("custom_name");
         assert_eq!(request2.file_name, Some("custom_name".to_string()));
+    }
+
+    /// 端到端：POST /open-apis/drive/v1/import_tasks → CreateImportTaskResponse（ticket）。
+    #[tokio::test]
+    async fn test_create_import_task_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/drive/v1/import_tasks"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "ticket": "import_ticket_001"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = CreateImportTaskRequest::new(
+            config,
+            "pdf",
+            "fileTokenAbc",
+            "docx",
+            Point::new("AbqrfuRTjlJEIJduwDwcnIabcef"),
+        )
+        .execute()
+        .await
+        .expect("创建导入任务应成功");
+        assert_eq!(resp.ticket, "import_ticket_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/drive/v1/import_tasks");
     }
 }

--- a/crates/openlark-docs/src/ccm/drive/v1/import_task/get.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/import_task/get.rs
@@ -95,7 +95,6 @@ impl ApiResponseTrait for GetImportTaskResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openlark_core::testing::prelude::test_runtime;
 
     /// 测试构建器模式
     #[test]
@@ -111,23 +110,6 @@ mod tests {
         assert_eq!(GetImportTaskResponse::data_format(), ResponseFormat::Data);
     }
 
-    /// 测试 ticket 为空时的验证
-    #[test]
-    fn test_empty_ticket_validation() {
-        let config = Config::default();
-        let request = GetImportTaskRequest::new(config, "");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
     /// 测试 ticket 边界值
     #[test]
     fn test_ticket_boundaries() {
@@ -141,5 +123,56 @@ mod tests {
         let long_ticket = "a".repeat(100);
         let request2 = GetImportTaskRequest::new(config, long_ticket);
         assert_eq!(request2.ticket.len(), 100);
+    }
+
+    /// 端到端：GET /open-apis/drive/v1/import_tasks/{ticket} → GetImportTaskResponse（result）。
+    #[tokio::test]
+    async fn test_get_import_task_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/drive/v1/import_tasks/import_ticket_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "result": {
+                        "ticket": "import_ticket_001",
+                        "type": "docx",
+                        "job_status": 0,
+                        "token": "doccnXxXxXxXxXxXxXxXxXxXxXxXxXxX",
+                        "url": "https://example.feishu.cn/docx/doccnXxXxXxXxXxXxXxXxXxXxXxXxXxX"
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = GetImportTaskRequest::new(config, "import_ticket_001")
+            .execute()
+            .await
+            .expect("查询导入任务应成功");
+        let result = resp.result.expect("响应应包含 result");
+        assert_eq!(result.ticket.as_deref(), Some("import_ticket_001"));
+        assert_eq!(result.r#type, "docx");
+        assert_eq!(result.job_status, Some(0));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/drive/v1/import_tasks/import_ticket_001"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/drive/v1/media/batch_get_tmp_download_url.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/media/batch_get_tmp_download_url.rs
@@ -121,7 +121,6 @@ impl ApiResponseTrait for BatchGetTmpDownloadUrlResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openlark_core::testing::prelude::test_runtime;
 
     /// 测试构建器模式
     #[test]
@@ -158,68 +157,6 @@ mod tests {
         );
     }
 
-    /// 测试空 file_tokens 验证
-    #[test]
-    fn test_empty_file_tokens_validation() {
-        let config = Config::default();
-        let request = BatchGetTmpDownloadUrlRequest::new(config, vec![]);
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
-    /// 测试 file_tokens 数量限制
-    #[test]
-    fn test_file_tokens_count_validation() {
-        let config = Config::default();
-
-        // 最大 5 个 token
-        let tokens_5: Vec<String> = ["a"; 5].iter().map(|s| s.to_string()).collect();
-        let request1 = BatchGetTmpDownloadUrlRequest::new(config.clone(), tokens_5);
-        assert_eq!(request1.file_tokens.len(), 5);
-
-        // 超过 5 个
-        let tokens_6: Vec<String> = ["a"; 6].iter().map(|s| s.to_string()).collect();
-        let request2 = BatchGetTmpDownloadUrlRequest::new(config, tokens_6);
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request2.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
-    /// 测试空 token 验证
-    #[test]
-    fn test_empty_token_in_list_validation() {
-        let config = Config::default();
-        let request = BatchGetTmpDownloadUrlRequest::new(
-            config,
-            vec!["valid_token".to_string(), "".to_string()],
-        );
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
     /// 测试单 token
     #[test]
     fn test_single_token() {
@@ -242,5 +179,82 @@ mod tests {
         let request2 = BatchGetTmpDownloadUrlRequest::new(config, vec!["token".to_string()])
             .extra("extra_param");
         assert_eq!(request2.extra, Some("extra_param".to_string()));
+    }
+
+    /// 端到端：GET /open-apis/drive/v1/medias/batch_get_tmp_download_url → BatchGetTmpDownloadUrlResponse。
+    #[tokio::test]
+    async fn test_batch_get_tmp_download_url_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::method;
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        // execute 手拼 file_tokens 重复 query（url.push_str 非 .query()）与 Transport 不兼容，
+        // path 含 query 不匹配；pre-existing bug，mock 放宽只匹配 method，path 走 received 断言。
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "tmp_download_urls": [
+                        {
+                            "file_token": "media_token_001",
+                            "tmp_download_url": "https://download.example.com/001"
+                        },
+                        {
+                            "file_token": "media_token_002",
+                            "tmp_download_url": "https://download.example.com/002"
+                        }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = BatchGetTmpDownloadUrlRequest::new(
+            config,
+            vec!["media_token_001".to_string(), "media_token_002".to_string()],
+        )
+        .execute()
+        .await
+        .expect("获取临时下载链接应成功");
+        assert_eq!(resp.tmp_download_urls.len(), 2);
+        assert_eq!(resp.tmp_download_urls[0].file_token, "media_token_001");
+        assert_eq!(
+            resp.tmp_download_urls[1].tmp_download_url,
+            "https://download.example.com/002"
+        );
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        // execute 手拼 file_tokens 重复 query（core HashMap 不支持重复 key，见 execute 注释），
+        // url 的 `?` 被 Transport encode 成 `%3F`，path 含 `%3Ffile_tokens=...`。
+        // pre-existing bug（与 product_assign_info 同类），此处只验证请求到达正确端点 + 响应解析。
+        assert!(
+            received[0]
+                .url
+                .path()
+                .contains("batch_get_tmp_download_url")
+        );
+        assert!(
+            received[0]
+                .url
+                .path()
+                .contains("file_tokens=media_token_001")
+        );
+        assert!(
+            received[0]
+                .url
+                .path()
+                .contains("file_tokens=media_token_002")
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/drive/v1/media/download.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/media/download.rs
@@ -109,7 +109,6 @@ impl DownloadMediaRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openlark_core::testing::prelude::test_runtime;
 
     /// 测试构建器模式
     #[test]
@@ -122,55 +121,6 @@ mod tests {
         assert_eq!(request.file_token, "media_token");
         assert_eq!(request.extra, Some("extra".to_string()));
         assert_eq!(request.range, Some("bytes=0-100".to_string()));
-    }
-
-    /// 测试 file_token 为空时的验证
-    #[test]
-    fn test_empty_file_token_validation() {
-        let config = Config::default();
-        let request = DownloadMediaRequest::new(config, "");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
-    /// 测试 range 格式验证
-    #[test]
-    fn test_range_format_validation() {
-        let config = Config::default();
-
-        // 缺少 bytes= 前缀
-        let request1 = DownloadMediaRequest::new(config.clone(), "token").range("0-100");
-
-        let result1 = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request1.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result1.is_ok());
-
-        // 缺少连字符
-        let request2 = DownloadMediaRequest::new(config.clone(), "token").range("bytes=0100");
-
-        let result2 = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request2.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result2.is_ok());
     }
 
     /// 测试有效的 range 格式
@@ -222,5 +172,42 @@ mod tests {
         let config = Config::default();
         let request = DownloadMediaRequest::new(config, "media_token").max_size(512);
         assert_eq!(request.max_size, 512);
+    }
+
+    /// 端到端：GET /open-apis/drive/v1/medias/{file_token}/download → 二进制 Response<Vec<u8>>。
+    #[tokio::test]
+    async fn test_download_media_returns_data_on_success() {
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let body = b"hello download binary payload".to_vec();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/drive/v1/medias/media_token_001/download"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = DownloadMediaRequest::new(config, "media_token_001")
+            .execute()
+            .await
+            .expect("下载素材应成功");
+        let data = resp.data.expect("响应应包含二进制数据");
+        assert_eq!(data, body);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/drive/v1/medias/media_token_001/download"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/drive/v1/permission/member/auth.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/permission/member/auth.rs
@@ -106,7 +106,6 @@ impl ApiResponseTrait for AuthPermissionMemberResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openlark_core::testing::prelude::test_runtime;
 
     /// 测试构建器模式
     #[test]
@@ -126,40 +125,6 @@ mod tests {
             AuthPermissionMemberResponse::data_format(),
             ResponseFormat::Data
         );
-    }
-
-    /// 测试 token 为空时的验证
-    #[test]
-    fn test_empty_token_validation() {
-        let config = Config::default();
-        let request = AuthPermissionMemberRequest::new(config, "", "docx", "view");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
-    /// 测试 action 枚举值验证
-    #[test]
-    fn test_action_validation() {
-        let config = Config::default();
-        let request = AuthPermissionMemberRequest::new(config, "token", "docx", "invalid");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
     }
 
     /// 测试支持的 action 类型
@@ -195,5 +160,58 @@ mod tests {
 
         let response2 = AuthPermissionMemberResponse { auth_result: false };
         assert!(!response2.auth_result);
+    }
+
+    /// 端到端：GET /open-apis/drive/v1/permissions/{token}/members/auth → AuthPermissionMemberResponse。
+    #[tokio::test]
+    async fn test_auth_permission_member_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/drive/v1/permissions/file_token_001/members/auth",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "auth_result": true
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = AuthPermissionMemberRequest::new(config, "file_token_001", "docx", "view")
+            .execute()
+            .await
+            .expect("权限判断应成功");
+        assert!(resp.auth_result);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/drive/v1/permissions/file_token_001/members/auth"
+        );
+        let query = received[0].url.query().unwrap_or("");
+        assert!(
+            query.contains("type=docx"),
+            "query 应携带 type=docx，实际：{query}"
+        );
+        assert!(
+            query.contains("action=view"),
+            "query 应携带 action=view，实际：{query}"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/drive/v1/permission/member/list.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/permission/member/list.rs
@@ -133,7 +133,6 @@ impl ApiResponseTrait for ListPermissionMembersResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openlark_core::testing::prelude::test_runtime;
 
     /// 测试构建器模式
     #[test]
@@ -178,58 +177,6 @@ mod tests {
         );
     }
 
-    /// 测试 token 为空时的验证
-    #[test]
-    fn test_empty_token_validation() {
-        let config = Config::default();
-        let request = ListPermissionMembersRequest::new(config, "", "docx");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
-    /// 测试 file_type 枚举值验证
-    #[test]
-    fn test_file_type_validation() {
-        let config = Config::default();
-        let request = ListPermissionMembersRequest::new(config, "token", "invalid");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
-    /// 测试 perm_type 枚举值验证
-    #[test]
-    fn test_perm_type_validation() {
-        let config = Config::default();
-        let request =
-            ListPermissionMembersRequest::new(config, "token", "docx").perm_type("invalid");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
     /// 测试支持的 file_type 类型
     #[test]
     fn test_supported_file_types() {
@@ -260,5 +207,69 @@ mod tests {
 
         assert_eq!(request2.fields, Some("*".to_string()));
         assert_eq!(request2.perm_type, Some("container".to_string()));
+    }
+
+    /// 端到端：GET /open-apis/drive/v1/permissions/{token}/members → ListPermissionMembersResponse。
+    #[tokio::test]
+    async fn test_list_permission_members_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/drive/v1/permissions/file_token_001/members",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        {
+                            "member_type": "openid",
+                            "member_id": "ou_member_001",
+                            "perm": "view",
+                            "name": "张三"
+                        },
+                        {
+                            "member_type": "email",
+                            "member_id": "user@example.com",
+                            "perm": "edit"
+                        }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = ListPermissionMembersRequest::new(config, "file_token_001", "docx")
+            .execute()
+            .await
+            .expect("获取协作者列表应成功");
+        assert_eq!(resp.items.len(), 2);
+        assert_eq!(resp.items[0].member_id, "ou_member_001");
+        assert_eq!(resp.items[0].perm, "view");
+        assert_eq!(resp.items[1].member_type, "email");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/drive/v1/permissions/file_token_001/members"
+        );
+        let query = received[0].url.query().unwrap_or("");
+        assert!(
+            query.contains("type=docx"),
+            "query 应携带 type=docx，实际：{query}"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/drive/v1/permission/member/transfer_owner.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/permission/member/transfer_owner.rs
@@ -190,7 +190,6 @@ impl ApiResponseTrait for TransferOwnerResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openlark_core::testing::prelude::test_runtime;
 
     /// 测试构建器模式
     #[test]
@@ -212,74 +211,6 @@ mod tests {
     #[test]
     fn test_response_trait() {
         assert_eq!(TransferOwnerResponse::data_format(), ResponseFormat::Data);
-    }
-
-    /// 测试 token 为空时的验证
-    #[test]
-    fn test_empty_token_validation() {
-        let config = Config::default();
-        let request = TransferOwnerRequest::new(config, "", "docx", "openid", "ou_xxx");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
-    /// 测试 file_type 枚举值验证
-    #[test]
-    fn test_file_type_validation() {
-        let config = Config::default();
-        let request = TransferOwnerRequest::new(config, "token", "invalid", "openid", "ou_xxx");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
-    /// 测试 member_type 枚举值验证
-    #[test]
-    fn test_member_type_validation() {
-        let config = Config::default();
-        let request = TransferOwnerRequest::new(config, "token", "docx", "invalid", "ou_xxx");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
-    }
-
-    /// 测试 member_id 为空时的验证
-    #[test]
-    fn test_empty_member_id_validation() {
-        let config = Config::default();
-        let request = TransferOwnerRequest::new(config, "token", "docx", "openid", "");
-
-        let result = std::thread::spawn(move || {
-            let rt = test_runtime();
-            rt.block_on(async move {
-                let _ = request.execute().await;
-            })
-        })
-        .join();
-
-        assert!(result.is_ok());
     }
 
     /// 测试支持的 file_type 类型
@@ -329,5 +260,51 @@ mod tests {
         assert!(request.remove_old_owner.is_none());
         assert!(request.stay_put.is_none());
         assert!(request.old_owner_perm.is_none());
+    }
+
+    /// 端到端：POST /open-apis/drive/v1/permissions/{token}/members/transfer_owner → TransferOwnerResponse。
+    #[tokio::test]
+    async fn test_transfer_owner_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/drive/v1/permissions/file_token_001/members/transfer_owner",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {}
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        TransferOwnerRequest::new(config, "file_token_001", "docx", "openid", "ou_new_owner")
+            .execute()
+            .await
+            .expect("转移所有者应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/drive/v1/permissions/file_token_001/members/transfer_owner"
+        );
+        let query = received[0].url.query().unwrap_or("");
+        assert!(
+            query.contains("type=docx"),
+            "query 应携带 type=docx，实际：{query}"
+        );
     }
 }


### PR DESCRIPTION
## 背景

#351 第 11 批，P3 docs PR A。docs 是 #351 issue 标题「占位测试 → test_runtime 端到端」**最核心的反模式战场**——`test_runtime` 本身只是 Tokio Runtime 封装，**不是 mock**；docs 的 Potemkin 用法是 \`let _ = request.execute().await\` 调 execute 但丢弃返回值，只 \`assert!(result.is_ok())\` 测"线程没 panic"（Config 指向真实飞书无凭证，execute 实际返 Err 被丢弃 → 假绿）。

## 改动

### 清除 38 个 Potemkin 丢弃式（15 文件）
- **baike**（2）：entity/extract, entity/match
- **ccm/drive**（13）：export_task(create/download/get) + file/version(create/get/list) + import_task(create/get) + media(batch_get_tmp_download_url/download) + permission/member(auth/list/transfer_owner)

每文件：删 Potemkin fn（保留真实 builder/validation 测试）+ 加 1 个 `test_*_returns_data_on_success` wiremock e2e。

### e2e 暴露 latent bug（按代码实际行为处理，不修）
**`batch_get_tmp_download_url`** execute 手拼重复 query（`file_tokens=t1&file_tokens=t2`，因 core HashMap 不支持重复 key），url 的 `?` 被 Transport encode 成 `%3F`，path 含 `%3Ffile_tokens=...`。与 platform `product_assign_info` 同类 bug（core query HashMap 限制）。测试放宽 mock 匹配 + path 断言用 `contains`，bug 留后续。

### 特殊处理
- `media/download.rs` + `export_task/download.rs`：返回 `Vec<u8>` 二进制（`ResponseFormat::Binary`），mock 用 `set_body_bytes`
- `permission/member/transfer_owner.rs`：空 Response struct，mock body `"data": {}`

## 本地验证

- `cargo test --all-features`：**1091 pass / 0 fail**
- Potemkin 丢弃式残留：**0**
- `cargo fmt --check` ✅ / `cargo clippy --all-features + --no-default-features` ✅
- `cargo doc -D` ✅ / `cargo deny` ✅

## 后续

docs 还有 ~107 roundtrip 占位（ccm 79 + base 31 + 零散）留后续 PR。本 PR 聚焦 #351 核心 Potemkin 反模式。

## 关联

父 issue #351；同批先例 #374-#389。

Refs #351