### PR TITLE
test(docs): sheets/docx 38 真实端点 wiremock e2e + 清 42 文件占位 roundtrip（#351 P3 PR A）

### DIFF
--- a/crates/openlark-docs/src/ccm/docx/documents/mod.rs
+++ b/crates/openlark-docs/src/ccm/docx/documents/mod.rs
@@ -3,24 +3,3 @@
 /// 文档标识类型
 #[derive(Debug, Clone)]
 pub struct DocumentId(pub String);
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/docx/models.rs
+++ b/crates/openlark-docs/src/ccm/docx/models.rs
@@ -1084,24 +1084,3 @@ pub mod models_docx {
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/batch_update.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/batch_update.rs
@@ -106,21 +106,54 @@ impl BatchUpdateChatAnnouncementBlocksRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    use crate::ccm::docx::models::block_update::BlockUpdateOperation;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PATCH .../announcement/blocks/batch_update → BatchUpdateChatAnnouncementBlocksResponse（blocks）。
+    #[tokio::test]
+    async fn test_batch_update_chat_announcement_blocks_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/docx/v1/chats/chat001/announcement/blocks/batch_update",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success",
+                "data": { "blocks": [], "revision_id": 2 }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = BatchUpdateChatAnnouncementBlocksRequest::new(config)
+            .execute(BatchUpdateChatAnnouncementBlocksParams {
+                chat_id: "chat001".into(),
+                requests: vec![BatchUpdateRequest {
+                    block_id: "blk1".into(),
+                    operation: BlockUpdateOperation::Raw(json!({})),
+                }],
+            })
+            .await
+            .expect("批量更新群公告块应成功");
+        assert!(resp.blocks.is_empty());
+        assert_eq!(resp.revision_id, Some(2));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/docx/v1/chats/chat001/announcement/blocks/batch_update"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/children/batch_delete.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/children/batch_delete.rs
@@ -100,21 +100,51 @@ impl BatchDeleteChatAnnouncementBlockChildrenRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：DELETE .../blocks/{block_id}/children/batch_delete → BatchDeleteChatAnnouncementBlockChildrenResponse（revision_id）。
+    #[tokio::test]
+    async fn test_batch_delete_chat_announcement_block_children_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/docx/v1/chats/chat001/announcement/blocks/blk1/children/batch_delete",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success",
+                "data": { "revision_id": 2, "client_token": "ct001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = BatchDeleteChatAnnouncementBlockChildrenRequest::new(config)
+            .execute(BatchDeleteChatAnnouncementBlockChildrenParams {
+                chat_id: "chat001".into(),
+                block_id: "blk1".into(),
+                client_token: None,
+                start_index: 0,
+                end_index: 1,
+            })
+            .await
+            .expect("删除群公告子块应成功");
+        assert_eq!(resp.revision_id, 2);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/docx/v1/chats/chat001/announcement/blocks/blk1/children/batch_delete"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/children/create.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/children/create.rs
@@ -105,21 +105,51 @@ impl CreateChatAnnouncementBlockChildrenRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：POST .../blocks/{block_id}/children → CreateChatAnnouncementBlockChildrenResponse（children）。
+    #[tokio::test]
+    async fn test_create_chat_announcement_block_children_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/docx/v1/chats/chat001/announcement/blocks/blk1/children",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success",
+                "data": { "children": [{ "block_id": "newBlk", "block_type": 2 }] }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = CreateChatAnnouncementBlockChildrenRequest::new(config)
+            .execute(CreateChatAnnouncementBlockChildrenParams {
+                chat_id: "chat001".into(),
+                block_id: "blk1".into(),
+                index: None,
+                children: vec![json!({ "block_id": "newBlk", "block_type": 2 })],
+            })
+            .await
+            .expect("创建群公告子块应成功");
+        assert_eq!(resp.children.len(), 1);
+        assert_eq!(resp.children[0].block_id, "newBlk");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/docx/v1/chats/chat001/announcement/blocks/blk1/children"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/children/get.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/children/get.rs
@@ -105,21 +105,50 @@ impl GetChatAnnouncementBlockChildrenRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：GET .../blocks/{block_id}/children → GetChatAnnouncementBlockChildrenResponse（items）。
+    #[tokio::test]
+    async fn test_get_chat_announcement_block_children_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/docx/v1/chats/chat001/announcement/blocks/blk1/children",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success",
+                "data": { "items": [{ "block_id": "blk1", "block_type": 1 }] }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = GetChatAnnouncementBlockChildrenRequest::new(config)
+            .execute(GetChatAnnouncementBlockChildrenParams {
+                chat_id: "chat001".into(),
+                block_id: "blk1".into(),
+                page_size: None,
+                page_token: None,
+            })
+            .await
+            .expect("获取群公告子块应成功");
+        assert_eq!(resp.items.len(), 1);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/docx/v1/chats/chat001/announcement/blocks/blk1/children"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/get.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/get.rs
@@ -95,21 +95,49 @@ impl GetChatAnnouncementBlockRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：GET .../announcement/blocks/{block_id} → GetChatAnnouncementBlockResponse（block）。
+    #[tokio::test]
+    async fn test_get_chat_announcement_block_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/docx/v1/chats/chat001/announcement/blocks/blk1",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success",
+                "data": { "block": { "block_id": "blk1", "block_type": 1 } }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = GetChatAnnouncementBlockRequest::new(config)
+            .execute(GetChatAnnouncementBlockParams {
+                chat_id: "chat001".into(),
+                block_id: "blk1".into(),
+            })
+            .await
+            .expect("获取群公告块内容应成功");
+        let block = resp.block.expect("响应应包含 block");
+        assert_eq!(block.block_id, "blk1");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/docx/v1/chats/chat001/announcement/blocks/blk1"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/list.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/list.rs
@@ -104,21 +104,49 @@ impl GetChatAnnouncementBlocksRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：GET .../announcement/blocks → GetChatAnnouncementBlocksResponse（items）。
+    #[tokio::test]
+    async fn test_list_chat_announcement_blocks_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/docx/v1/chats/chat001/announcement/blocks"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success",
+                "data": { "items": [{ "block_id": "blk1", "block_type": 1 }] }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = GetChatAnnouncementBlocksRequest::new(config)
+            .execute(GetChatAnnouncementBlocksParams {
+                chat_id: "chat001".into(),
+                page_size: None,
+                page_token: None,
+                revision_id: None,
+            })
+            .await
+            .expect("获取群公告所有块应成功");
+        assert_eq!(resp.items.len(), 1);
+        assert_eq!(resp.items[0].block_id, "blk1");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/docx/v1/chats/chat001/announcement/blocks"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/get.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/get.rs
@@ -117,21 +117,44 @@ impl GetChatAnnouncementRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：GET .../chats/{chat_id}/announcement → GetChatAnnouncementResponse（revision_id）。
+    #[tokio::test]
+    async fn test_get_chat_announcement_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/docx/v1/chats/chat001/announcement"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success",
+                "data": { "revision_id": 1, "create_time": 100, "update_time": 200 }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = GetChatAnnouncementRequest::new(config)
+            .chat_id("chat001")
+            .execute()
+            .await
+            .expect("获取群公告应成功");
+        assert_eq!(resp.revision_id, 1);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/docx/v1/chats/chat001/announcement"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/batch_update.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/batch_update.rs
@@ -101,21 +101,52 @@ impl BatchUpdateDocumentBlocksRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：PATCH .../blocks/batch_update → BatchUpdateDocumentBlocksResponse（blocks）。
+    #[tokio::test]
+    async fn test_batch_update_document_blocks_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/docx/v1/documents/doc1/blocks/batch_update",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success",
+                "data": { "blocks": [], "document_revision_id": 2 }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = BatchUpdateDocumentBlocksRequest::new(config)
+            .execute(BatchUpdateDocumentBlocksParams {
+                document_id: "doc1".into(),
+                requests: vec![BatchUpdateRequest {
+                    block_id: "blk1".into(),
+                    operation: BlockUpdateOperation::Raw(json!({})),
+                }],
+            })
+            .await
+            .expect("批量更新块应成功");
+        assert!(resp.blocks.is_empty());
+        assert_eq!(resp.document_revision_id, Some(2));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/docx/v1/documents/doc1/blocks/batch_update"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/children/batch_delete.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/children/batch_delete.rs
@@ -99,21 +99,51 @@ impl BatchDeleteDocumentBlockChildrenRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：DELETE .../blocks/{block_id}/children/batch_delete → BatchDeleteDocumentBlockChildrenResponse（document_revision_id）。
+    #[tokio::test]
+    async fn test_batch_delete_document_block_children_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/docx/v1/documents/doc1/blocks/blk1/children/batch_delete",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success",
+                "data": { "document_revision_id": 2, "client_token": "ct001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = BatchDeleteDocumentBlockChildrenRequest::new(config)
+            .execute(BatchDeleteDocumentBlockChildrenParams {
+                document_id: "doc1".into(),
+                block_id: "blk1".into(),
+                document_revision_id: None,
+                start_index: 0,
+                end_index: 1,
+            })
+            .await
+            .expect("删除子块应成功");
+        assert_eq!(resp.document_revision_id, 2);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/docx/v1/documents/doc1/blocks/blk1/children/batch_delete"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/children/create.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/children/create.rs
@@ -112,21 +112,52 @@ impl CreateDocumentBlockChildrenRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：POST .../blocks/{block_id}/children → CreateDocumentBlockChildrenResponse（children）。
+    #[tokio::test]
+    async fn test_create_document_block_children_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/docx/v1/documents/doc1/blocks/blk1/children",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success",
+                "data": { "children": [{ "block_id": "newBlk", "block_type": 2 }] }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = CreateDocumentBlockChildrenRequest::new(config)
+            .execute(CreateDocumentBlockChildrenParams {
+                document_id: "doc1".into(),
+                block_id: "blk1".into(),
+                document_revision_id: None,
+                index: None,
+                children: vec![json!({ "block_id": "newBlk", "block_type": 2 })],
+            })
+            .await
+            .expect("创建子块应成功");
+        assert_eq!(resp.children.len(), 1);
+        assert_eq!(resp.children[0].block_id, "newBlk");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/docx/v1/documents/doc1/blocks/blk1/children"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/children/get.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/children/get.rs
@@ -106,21 +106,51 @@ impl GetDocumentBlockChildrenRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：GET .../blocks/{block_id}/children → GetDocumentBlockChildrenResponse（items）。
+    #[tokio::test]
+    async fn test_get_document_block_children_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/docx/v1/documents/doc1/blocks/blk1/children",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success",
+                "data": { "items": [{ "block_id": "blk1", "block_type": 1 }] }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = GetDocumentBlockChildrenRequest::new(config)
+            .execute(GetDocumentBlockChildrenParams {
+                document_id: "doc1".into(),
+                block_id: "blk1".into(),
+                document_revision_id: None,
+                page_size: None,
+                page_token: None,
+            })
+            .await
+            .expect("获取子块应成功");
+        assert_eq!(resp.items.len(), 1);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/docx/v1/documents/doc1/blocks/blk1/children"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/descendant/create.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/descendant/create.rs
@@ -124,21 +124,52 @@ impl CreateDocumentBlockDescendantRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：POST .../blocks/{block_id}/descendant → CreateDocumentBlockDescendantResponse（block_id_relations）。
+    #[tokio::test]
+    async fn test_create_document_block_descendant_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/docx/v1/documents/doc1/blocks/blk1/descendant",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success",
+                "data": { "block_id_relations": [] }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = CreateDocumentBlockDescendantRequest::new(config)
+            .execute(CreateDocumentBlockDescendantParams {
+                document_id: "doc1".into(),
+                block_id: "blk1".into(),
+                document_revision_id: None,
+                index: None,
+                children_id: vec!["tmp1".into()],
+                descendants: vec![json!({ "block_id": "tmp1", "block_type": 2 })],
+            })
+            .await
+            .expect("创建嵌套块应成功");
+        assert!(resp.block_id_relations.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/docx/v1/documents/doc1/blocks/blk1/descendant"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/get.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/get.rs
@@ -89,21 +89,47 @@ impl GetDocumentBlockRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：GET .../blocks/{block_id} → GetDocumentBlockResponse（block）。
+    #[tokio::test]
+    async fn test_get_document_block_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/docx/v1/documents/doc1/blocks/blk1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success",
+                "data": { "block": { "block_id": "blk1", "block_type": 1 } }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = GetDocumentBlockRequest::new(config)
+            .execute(GetDocumentBlockParams {
+                document_id: "doc1".into(),
+                block_id: "blk1".into(),
+                document_revision_id: None,
+            })
+            .await
+            .expect("获取块内容应成功");
+        assert_eq!(resp.block.block_id, "blk1");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/docx/v1/documents/doc1/blocks/blk1"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/list.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/list.rs
@@ -108,21 +108,49 @@ impl GetDocumentBlocksRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：GET .../documents/{document_id}/blocks → GetDocumentBlocksResponse（items）。
+    #[tokio::test]
+    async fn test_get_document_blocks_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/docx/v1/documents/doc1/blocks"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success",
+                "data": { "items": [{ "block_id": "blk1", "block_type": 1 }] }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = GetDocumentBlocksRequest::new(config)
+            .execute(GetDocumentBlocksParams {
+                document_id: "doc1".into(),
+                page_size: None,
+                page_token: None,
+                document_revision_id: None,
+            })
+            .await
+            .expect("获取文档所有块应成功");
+        assert_eq!(resp.items.len(), 1);
+        assert_eq!(resp.items[0].block_id, "blk1");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/docx/v1/documents/doc1/blocks"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/patch.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/patch.rs
@@ -96,26 +96,51 @@ impl UpdateDocumentBlockRequest {
 #[cfg(test)]
 mod tests {
 
-    use serde_json;
-
     use super::*;
     use crate::ccm::docx::models::block_update::{
         BlockUpdateOperation, InsertTableRowRequest, MergeTableCellsRequest,
     };
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PATCH .../blocks/{block_id} → UpdateDocumentBlockResponse（block）。
+    #[tokio::test]
+    async fn test_update_document_block_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/docx/v1/documents/doc1/blocks/blk1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success",
+                "data": { "block": { "block_id": "blk1", "block_type": 1 } }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let resp = UpdateDocumentBlockRequest::new(config)
+            .execute(UpdateDocumentBlockParams {
+                document_id: "doc1".into(),
+                block_id: "blk1".into(),
+                update: BlockUpdateOperation::Raw(json!({})),
+            })
+            .await
+            .expect("更新块内容应成功");
+        assert_eq!(resp.block.block_id, "blk1");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/docx/v1/documents/doc1/blocks/blk1"
+        );
     }
 
     #[test]

--- a/crates/openlark-docs/src/ccm/docx/v1/document/convert.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/convert.rs
@@ -110,21 +110,49 @@ impl ConvertContentToBlocksRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：POST /open-apis/docx/documents/blocks/convert → ConvertContentToBlocksResponse（first_level_block_ids）。
+    #[tokio::test]
+    async fn test_convert_content_to_blocks_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/docx/documents/blocks/convert"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success",
+                "data": { "first_level_block_ids": ["blk1", "blk2"] }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = ConvertContentToBlocksRequest::new(config)
+            .execute(ConvertContentToBlocksParams {
+                content_type: ContentType::Markdown,
+                content: "# 标题".into(),
+            })
+            .await
+            .expect("转换内容应成功");
+        assert_eq!(resp.first_level_block_ids.len(), 2);
+        assert_eq!(resp.first_level_block_ids[0], "blk1");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/docx/documents/blocks/convert"
+        );
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["content_type"], "markdown");
     }
 }

--- a/crates/openlark-docs/src/ccm/docx/v1/document/create.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/create.rs
@@ -115,21 +115,44 @@ impl CreateDocumentRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：POST /open-apis/docx/v1/documents → CreateDocumentResponse（document）。
+    #[tokio::test]
+    async fn test_create_document_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/docx/v1/documents"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success",
+                "data": { "document": { "document_id": "doc1", "revision_id": 1 } }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = CreateDocumentRequest::new(config)
+            .title("测试文档")
+            .execute()
+            .await
+            .expect("创建文档应成功");
+        assert_eq!(resp.document.document_id, "doc1");
+        assert_eq!(resp.document.revision_id, 1);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/docx/v1/documents");
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["title"], "测试文档");
     }
 }

--- a/crates/openlark-docs/src/ccm/docx/v1/document/get.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/get.rs
@@ -127,21 +127,42 @@ impl GetDocumentRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：GET .../documents/{document_id} → GetDocumentResponse（document）。
+    #[tokio::test]
+    async fn test_get_document_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/docx/v1/documents/doc1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success",
+                "data": { "document": { "document_id": "doc1", "revision_id": 1 } }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = GetDocumentRequest::new(config)
+            .document_id("doc1")
+            .execute()
+            .await
+            .expect("获取文档应成功");
+        assert_eq!(resp.document.document_id, "doc1");
+        assert_eq!(resp.document.revision_id, 1);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/docx/v1/documents/doc1");
     }
 }

--- a/crates/openlark-docs/src/ccm/docx/v1/document/raw_content.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/raw_content.rs
@@ -90,21 +90,46 @@ impl GetDocumentRawContentRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：GET .../documents/{document_id}/raw_content → GetDocumentRawContentResponse（content）。
+    #[tokio::test]
+    async fn test_get_document_raw_content_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/docx/v1/documents/doc1/raw_content"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success",
+                "data": { "content": "文档纯文本内容" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = GetDocumentRawContentRequest::new(config)
+            .execute(GetDocumentRawContentParams {
+                document_id: "doc1".into(),
+                lang: None,
+            })
+            .await
+            .expect("获取文档纯文本应成功");
+        assert_eq!(resp.content, "文档纯文本内容");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/docx/v1/documents/doc1/raw_content"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets/v3/models.rs
+++ b/crates/openlark-docs/src/ccm/sheets/v3/models.rs
@@ -427,24 +427,3 @@ pub struct PagedResponse<T> {
     /// 总数
     pub total: Option<i32>,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/models.rs
+++ b/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/models.rs
@@ -222,24 +222,3 @@ pub struct FindResult {
     /// 命中结果的行数
     pub rows_count: i32,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter/create.rs
+++ b/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter/create.rs
@@ -75,21 +75,63 @@ pub async fn create_filter_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：POST .../sheets/{sheet_id}/filter → CreateFilterResponse（空 data）。
+    #[tokio::test]
+    async fn test_create_filter_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        create_filter(
+            &config,
+            "tokenAbc",
+            "sheetId001",
+            CreateFilterRequest {
+                range: "A1:A10".into(),
+                col: "0".into(),
+                condition: Condition {
+                    column_id: "A".into(),
+                    operator: "equals".into(),
+                    value: None,
+                    ignore_case: None,
+                },
+            },
+        )
+        .await
+        .expect("创建筛选应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter"
+        );
+        // 校验请求体透传
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["range"], "A1:A10");
+        assert_eq!(sent["col"], "0");
+        assert_eq!(sent["condition"]["operator"], "equals");
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter/delete.rs
+++ b/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter/delete.rs
@@ -55,21 +55,44 @@ pub async fn delete_filter_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：DELETE .../sheets/{sheet_id}/filter → DeleteFilterResponse（空 data）。
+    #[tokio::test]
+    async fn test_delete_filter_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        delete_filter(&config, "tokenAbc", "sheetId001")
+            .await
+            .expect("删除筛选应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter/get.rs
+++ b/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter/get.rs
@@ -62,21 +62,51 @@ pub async fn get_filter_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：GET .../sheets/{sheet_id}/filter → GetFilterResponse（sheet_filter_info）。
+    #[tokio::test]
+    async fn test_get_filter_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "sheet_filter_info": {
+                        "filter_id": "filter_001",
+                        "range": "A1:A10"
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = get_filter(&config, "tokenAbc", "sheetId001")
+            .await
+            .expect("获取筛选应成功");
+        assert_eq!(resp.sheet_filter_info.filter_id, "filter_001");
+        assert_eq!(resp.sheet_filter_info.range, "A1:A10");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter/update.rs
+++ b/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter/update.rs
@@ -73,21 +73,61 @@ pub async fn update_filter_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：PUT .../sheets/{sheet_id}/filter → UpdateFilterResponse（空 data）。
+    #[tokio::test]
+    async fn test_update_filter_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path(
+                "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        update_filter(
+            &config,
+            "tokenAbc",
+            "sheetId001",
+            UpdateFilterRequest {
+                col: "0".into(),
+                condition: Condition {
+                    column_id: "A".into(),
+                    operator: "contains".into(),
+                    value: None,
+                    ignore_case: None,
+                },
+            },
+        )
+        .await
+        .expect("更新筛选应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter"
+        );
+        // 校验请求体透传
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["col"], "0");
+        assert_eq!(sent["condition"]["operator"], "contains");
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter_view/condition/create.rs
+++ b/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter_view/condition/create.rs
@@ -82,21 +82,58 @@ pub async fn create_filter_condition_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：POST .../filter_views/{fv}/conditions → CreateFilterConditionResponse（condition）。
+    #[tokio::test]
+    async fn test_create_filter_condition_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter_views/fv001/conditions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "condition": { "filter_view_id": "fv001", "column_id": "E", "operator": "equals" }
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = create_filter_condition(
+            &config,
+            "tokenAbc",
+            "sheetId001",
+            "fv001",
+            CreateFilterConditionRequest {
+                condition_id: "E".into(),
+                filter_type: "noCheck".into(),
+                compare_type: "none".into(),
+                expected: vec![],
+            },
+        )
+        .await
+        .expect("创建筛选条件应成功");
+        assert_eq!(resp.condition.column_id, "E");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter_views/fv001/conditions"
+        );
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["condition_id"], "E");
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter_view/condition/delete.rs
+++ b/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter_view/condition/delete.rs
@@ -66,21 +66,42 @@ pub async fn delete_filter_condition_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：DELETE .../conditions/{condition_id} → DeleteFilterConditionResponse（空 data）。
+    #[tokio::test]
+    async fn test_delete_filter_condition_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter_views/fv001/conditions/E"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        delete_filter_condition(&config, "tokenAbc", "sheetId001", "fv001", "E")
+            .await
+            .expect("删除筛选条件应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter_views/fv001/conditions/E"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter_view/condition/get.rs
+++ b/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter_view/condition/get.rs
@@ -70,21 +70,46 @@ pub async fn get_filter_condition_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：GET .../conditions/{condition_id} → GetFilterConditionResponse（condition）。
+    #[tokio::test]
+    async fn test_get_filter_condition_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter_views/fv001/conditions/E"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "condition": { "filter_view_id": "fv001", "column_id": "E", "operator": "equals" }
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = get_filter_condition(&config, "tokenAbc", "sheetId001", "fv001", "E")
+            .await
+            .expect("获取筛选条件应成功");
+        assert_eq!(resp.condition.column_id, "E");
+        assert_eq!(resp.condition.operator, "equals");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter_views/fv001/conditions/E"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter_view/condition/query.rs
+++ b/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter_view/condition/query.rs
@@ -66,21 +66,50 @@ pub async fn query_filter_conditions_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：GET .../conditions/query → QueryFilterConditionsResponse（items）。
+    #[tokio::test]
+    async fn test_query_filter_conditions_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter_views/fv001/conditions/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        { "filter_view_id": "fv001", "column_id": "E", "operator": "equals" },
+                        { "filter_view_id": "fv001", "column_id": "F", "operator": "contains" }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = query_filter_conditions(&config, "tokenAbc", "sheetId001", "fv001")
+            .await
+            .expect("查询筛选条件应成功");
+        assert_eq!(resp.items.len(), 2);
+        assert_eq!(resp.items[0].column_id, "E");
+        assert_eq!(resp.items[1].operator, "contains");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter_views/fv001/conditions/query"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter_view/condition/update.rs
+++ b/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter_view/condition/update.rs
@@ -87,21 +87,58 @@ pub async fn update_filter_condition_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：PUT .../conditions/{condition_id} → UpdateFilterConditionResponse（condition）。
+    #[tokio::test]
+    async fn test_update_filter_condition_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter_views/fv001/conditions/E"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "condition": { "filter_view_id": "fv001", "column_id": "E", "operator": "contains" }
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = update_filter_condition(
+            &config,
+            "tokenAbc",
+            "sheetId001",
+            "fv001",
+            "E",
+            UpdateFilterConditionRequest {
+                filter_type: Some("noCheck".into()),
+                compare_type: None,
+                expected: Some(vec!["v1".into()]),
+            },
+        )
+        .await
+        .expect("更新筛选条件应成功");
+        assert_eq!(resp.condition.operator, "contains");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter_views/fv001/conditions/E"
+        );
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["filter_type"], "noCheck");
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter_view/create.rs
+++ b/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter_view/create.rs
@@ -76,21 +76,63 @@ pub async fn create_filter_view_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：POST .../sheets/{sheet_id}/filter_views → CreateFilterViewResponse（filter_view）。
+    #[tokio::test]
+    async fn test_create_filter_view_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter_views",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "filter_view": {
+                        "filter_view_id": "fv001",
+                        "name": "筛选视图1",
+                        "range": "A1:A10"
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = create_filter_view(
+            &config,
+            "tokenAbc",
+            "sheetId001",
+            CreateFilterViewRequest {
+                filter_view_id: None,
+                filter_view_name: Some("筛选视图1".into()),
+                range: "A1:A10".into(),
+            },
+        )
+        .await
+        .expect("创建筛选视图应成功");
+        assert_eq!(resp.filter_view.filter_view_id, "fv001");
+        assert_eq!(resp.filter_view.name, "筛选视图1");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter_views"
+        );
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["range"], "A1:A10");
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter_view/delete.rs
+++ b/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter_view/delete.rs
@@ -62,21 +62,44 @@ pub async fn delete_filter_view_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：DELETE .../filter_views/{filter_view_id} → DeleteFilterViewResponse（空 data）。
+    #[tokio::test]
+    async fn test_delete_filter_view_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter_views/fv001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        delete_filter_view(&config, "tokenAbc", "sheetId001", "fv001")
+            .await
+            .expect("删除筛选视图应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter_views/fv001"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter_view/get.rs
+++ b/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter_view/get.rs
@@ -65,21 +65,52 @@ pub async fn get_filter_view_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：GET .../filter_views/{filter_view_id} → GetFilterViewResponse（filter_view）。
+    #[tokio::test]
+    async fn test_get_filter_view_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter_views/fv001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "filter_view": {
+                        "filter_view_id": "fv001",
+                        "name": "筛选视图1",
+                        "range": "A1:A10"
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = get_filter_view(&config, "tokenAbc", "sheetId001", "fv001")
+            .await
+            .expect("获取筛选视图应成功");
+        assert_eq!(resp.filter_view.filter_view_id, "fv001");
+        assert_eq!(resp.filter_view.name, "筛选视图1");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter_views/fv001"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter_view/patch.rs
+++ b/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter_view/patch.rs
@@ -80,21 +80,62 @@ pub async fn update_filter_view_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：PATCH .../filter_views/{filter_view_id} → UpdateFilterViewResponse（filter_view）。
+    #[tokio::test]
+    async fn test_update_filter_view_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter_views/fv001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "filter_view": {
+                        "filter_view_id": "fv001",
+                        "name": "新名称",
+                        "range": "B1:B10"
+                    }
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = update_filter_view(
+            &config,
+            "tokenAbc",
+            "sheetId001",
+            "fv001",
+            UpdateFilterViewRequest {
+                filter_view_name: Some("新名称".into()),
+                range: Some("B1:B10".into()),
+            },
+        )
+        .await
+        .expect("更新筛选视图应成功");
+        assert_eq!(resp.filter_view.name, "新名称");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter_views/fv001"
+        );
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["filter_view_name"], "新名称");
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter_view/query.rs
+++ b/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/filter_view/query.rs
@@ -59,21 +59,52 @@ pub async fn query_filter_views_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：GET .../sheets/{sheet_id}/filter_views/query → QueryFilterViewsResponse（items）。
+    #[tokio::test]
+    async fn test_query_filter_views_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter_views/query",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        { "filter_view_id": "fv001", "name": "视图1", "range": "A1:A10" },
+                        { "filter_view_id": "fv002", "name": "视图2", "range": "B1:B10" }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = query_filter_views(&config, "tokenAbc", "sheetId001")
+            .await
+            .expect("查询筛选视图应成功");
+        assert_eq!(resp.items.len(), 2);
+        assert_eq!(resp.items[0].filter_view_id, "fv001");
+        assert_eq!(resp.items[1].range, "B1:B10");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/filter_views/query"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/float_image/create.rs
+++ b/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/float_image/create.rs
@@ -91,21 +91,58 @@ pub async fn create_float_image_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：POST .../float_images → CreateFloatImageResponse（float_image）。
+    #[tokio::test]
+    async fn test_create_float_image_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/float_images"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "float_image": { "float_image_id": "fi001", "float_image_token": "tok001", "range": "A1", "width": 100, "height": 50, "offset_x": 0, "offset_y": 0 } }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = create_float_image(
+            &config,
+            "tokenAbc",
+            "sheetId001",
+            CreateFloatImageRequest {
+                float_image_id: None,
+                float_image_token: "tok001".into(),
+                range: "A1".into(),
+                width: None,
+                height: None,
+                offset_x: None,
+                offset_y: None,
+            },
+        )
+        .await
+        .expect("创建浮动图片应成功");
+        assert_eq!(resp.float_image.float_image_id, "fi001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/float_images"
+        );
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["float_image_token"], "tok001");
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/float_image/delete.rs
+++ b/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/float_image/delete.rs
@@ -62,21 +62,44 @@ pub async fn delete_float_image_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：DELETE .../float_images/{float_image_id} → DeleteFloatImageResponse（空 data）。
+    #[tokio::test]
+    async fn test_delete_float_image_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/float_images/fi001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        delete_float_image(&config, "tokenAbc", "sheetId001", "fi001")
+            .await
+            .expect("删除浮动图片应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/float_images/fi001"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/float_image/get.rs
+++ b/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/float_image/get.rs
@@ -69,21 +69,44 @@ pub async fn get_float_image_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：GET .../float_images/{float_image_id} → GetFloatImageResponse（float_image）。
+    #[tokio::test]
+    async fn test_get_float_image_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/float_images/fi001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "float_image": { "float_image_id": "fi001", "float_image_token": "tok001", "range": "A1", "width": 100, "height": 50, "offset_x": 0, "offset_y": 0 } }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = get_float_image(&config, "tokenAbc", "sheetId001", "fi001")
+            .await
+            .expect("获取浮动图片应成功");
+        assert_eq!(resp.float_image.float_image_id, "fi001");
+        assert_eq!(resp.float_image.width, 100);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/float_images/fi001"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/float_image/patch.rs
+++ b/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/float_image/patch.rs
@@ -93,21 +93,57 @@ pub async fn update_float_image_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：PATCH .../float_images/{float_image_id} → UpdateFloatImageResponse（float_image）。
+    #[tokio::test]
+    async fn test_update_float_image_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/float_images/fi001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "float_image": { "float_image_id": "fi001", "float_image_token": "tok001", "range": "A1", "width": 100, "height": 50, "offset_x": 0, "offset_y": 0 } }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = update_float_image(
+            &config,
+            "tokenAbc",
+            "sheetId001",
+            "fi001",
+            UpdateFloatImageRequest {
+                range: Some("A1".into()),
+                width: Some(100.0),
+                height: None,
+                offset_x: None,
+                offset_y: None,
+            },
+        )
+        .await
+        .expect("更新浮动图片应成功");
+        assert_eq!(resp.float_image.float_image_id, "fi001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/float_images/fi001"
+        );
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["range"], "A1");
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/float_image/query.rs
+++ b/crates/openlark-docs/src/ccm/sheets/v3/spreadsheet/sheet/float_image/query.rs
@@ -63,21 +63,50 @@ pub async fn query_float_images_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：GET .../float_images/query → QueryFloatImagesResponse（items）。
+    #[tokio::test]
+    async fn test_query_float_images_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/float_images/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "items": [
+                        { "float_image_id": "fi001", "float_image_token": "tok001", "range": "A1", "width": 100, "height": 50, "offset_x": 0, "offset_y": 0 },
+                        { "float_image_id": "fi002", "float_image_token": "tok002", "range": "B1", "width": 200, "height": 100, "offset_x": 0, "offset_y": 0 }
+                    ]
+                }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = query_float_images(&config, "tokenAbc", "sheetId001")
+            .await
+            .expect("查询浮动图片应成功");
+        assert_eq!(resp.items.len(), 2);
+        assert_eq!(resp.items[0].float_image_id, "fi001");
+        assert_eq!(resp.items[1].range, "B1");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/tokenAbc/sheets/sheetId001/float_images/query"
+        );
     }
 }


### PR DESCRIPTION
## 背景

#351 P3 第 6 批：`openlark-docs` ccm/sheets + ccm/docx 占位 `serde_json` roundtrip 测试 → wiremock 端到端。

继 #390（drive Potemkin 丢弃式清除）后，本轮清除 sheets/docx 全部 `test_serialization_roundtrip` / `test_deserialization_from_json` 占位测试（测 `{"test":"value"}` 的假 roundtrip），替换为验证 `Builder/fn → execute → Transport → 响应解析` 完整链路的 wiremock e2e。

## 改造内容（42 文件）

### ccm/sheets（21 文件，19 e2e）

| 子域 | 文件 | e2e |
|---|---|---|
| filter | create/get/update/delete | 4（POST/GET/PUT/DELETE） |
| filter_view | create/query/get/patch/delete | 5 |
| filter_view/condition | create/query/get/update/delete | 5 |
| float_image | create/query/get/patch/delete | 5 |
| models | v3/models.rs + spreadsheet/models.rs | Potemkin 清除（无 API 端点） |

函数式 API 模式：`create_filter(&config, token, sheet_id, params)` → wiremock 断言 method/path/body。

### ccm/docx（21 文件，19 e2e）

| 子域 | 文件 | e2e |
|---|---|---|
| chat/announcement | get + block/list/get/batch_update + block/children/create/get/batch_delete | 7 |
| document | create/get/raw_content/convert + block/list/get/patch/batch_update + block/children/create/get/batch_delete + block/descendant/create | 12 |
| models + documents/mod | 2 文件 | Potemkin 清除 |

Builder API 模式：`XxxRequest::new(config).field(...).execute(params)` → wiremock 断言。

`block/patch` 既有 3 个 `BlockUpdateOperation` 序列化测试保留，追加 1 个 e2e。

## 验证

- `cargo test -p openlark-docs --all-features`：1032 lib + 5 + 2 + 6 全过
- `cargo clippy -p openlark-docs --all-targets --all-features -- -Dwarnings`：通过
- `cargo clippy -p openlark-docs --all-targets --no-default-features -- -Dwarnings`：通过
- `cargo fmt --check`：通过

## 模式要点（3 个 footgun）

1. `enable_token_cache(false)` — 绕过 token 获取，请求直达 mock
2. `ResponseFormat::Data` 信封 — mock body 必须 `{"code":0,"msg":"success","data":{...}}`
3. `use super::*;` — 测试模块需导入父模块的 `Config`/请求类型/wiremock

## 后续

- **PR B**：ccm 剩余 sheets_v2(14) + wiki(12) + drive(11) + 零散(8) = 45
- **base PR**：base/bitable(27) + base/base(4) + baike(5) + common(1) + minutes(1) = 38