### PR TITLE
test(docs): sheets_v2/wiki/drive 20 e2e + 清 45 文件占位 roundtrip（#351 P3 PR B）

### DIFF
--- a/crates/openlark-docs/src/ccm/doc/v2/models.rs
+++ b/crates/openlark-docs/src/ccm/doc/v2/models.rs
@@ -178,23 +178,3 @@ pub struct BatchUpdateOperation {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub new_title: Option<String>,
 }
-
-#[cfg(test)]
-mod tests {
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/docs/v1/models.rs
+++ b/crates/openlark-docs/src/ccm/docs/v1/models.rs
@@ -28,24 +28,3 @@ impl ApiResponseTrait for DocsContent {
         ResponseFormat::Data
     }
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/drive/permission/models.rs
+++ b/crates/openlark-docs/src/ccm/drive/permission/models.rs
@@ -154,24 +154,3 @@ pub struct UserPermission {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_owner: Option<bool>,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/drive/v1/file/comment/models.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/file/comment/models.rs
@@ -149,24 +149,3 @@ pub struct Comment {
 }
 
 impl ApiResponseTrait for Comment {}
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/drive/v1/file/comment/reply/models.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/file/comment/reply/models.rs
@@ -72,24 +72,3 @@ pub struct Person {
     /// 用户 ID。
     pub user_id: String,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/drive/v1/file/subscription/models.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/file/subscription/models.rs
@@ -23,24 +23,3 @@ pub struct Subscription {
 }
 
 impl ApiResponseTrait for Subscription {}
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/drive/v1/file/version/models.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/file/version/models.rs
@@ -51,24 +51,3 @@ pub struct ListFileVersionsData {
 
 impl ApiResponseTrait for FileVersionInfo {}
 impl ApiResponseTrait for ListFileVersionsData {}
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/drive/v1/meta/batch_query.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/meta/batch_query.rs
@@ -219,21 +219,45 @@ pub async fn batch_query(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：POST /open-apis/drive/v1/metas/batch_query → BatchQueryMetaResponse（metas）。
+    #[tokio::test]
+    async fn test_batch_query_meta_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/drive/v1/metas/batch_query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "metas": [] }
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = batch_query(
+            BatchQueryMetaRequest::new(vec![RequestDoc {
+                doc_token: "ftk001".into(),
+                doc_type: "doc".into(),
+            }]),
+            &config,
+            None,
+        )
+        .await
+        .expect("批量查询元数据应成功");
+        assert!(resp.metas.is_empty());
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/drive/v1/metas/batch_query"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/drive/v1/permission/member/models.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/permission/member/models.rs
@@ -64,24 +64,3 @@ pub struct PermissionMemberItem {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_label: Option<bool>,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/drive/v1/permission/public/models.rs
+++ b/crates/openlark-docs/src/ccm/drive/v1/permission/public/models.rs
@@ -18,24 +18,3 @@ pub struct PermissionPublic {
     /// 节点是否已加锁（加锁后不再继承父级页面权限）
     pub lock_switch: Option<bool>,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/drive/v2/permission/public/get.rs
+++ b/crates/openlark-docs/src/ccm/drive/v2/permission/public/get.rs
@@ -88,21 +88,40 @@ pub async fn get_permission_public_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：GET .../permissions/{token}/public?type=doc → GetPermissionPublicResponse。
+    #[tokio::test]
+    async fn test_get_permission_public_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/drive/v2/permissions/token001/public"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp =
+            get_permission_public(GetPermissionPublicRequest::new("token001", "doc"), &config)
+                .await
+                .expect("获取云文档权限应成功");
+        assert!(resp.permission_public.is_none());
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/drive/v2/permissions/token001/public"
+        );
+        assert!(received[0].url.query().unwrap_or("").contains("type=doc"));
     }
 }

--- a/crates/openlark-docs/src/ccm/drive/v2/permission/public/models.rs
+++ b/crates/openlark-docs/src/ccm/drive/v2/permission/public/models.rs
@@ -20,24 +20,3 @@ pub struct PermissionPublic {
     /// 节点是否已加锁（加锁后不再继承父级页面权限）
     pub lock_switch: Option<bool>,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/drive/v2/permission/public/patch.rs
+++ b/crates/openlark-docs/src/ccm/drive/v2/permission/public/patch.rs
@@ -140,21 +140,42 @@ pub async fn update_permission_public_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：PATCH .../permissions/{token}/public?type=doc → UpdatePermissionPublicResponse。
+    #[tokio::test]
+    async fn test_update_permission_public_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/drive/v2/permissions/token001/public"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = update_permission_public(
+            UpdatePermissionPublicRequest::new("token001", "doc"),
+            &config,
+        )
+        .await
+        .expect("更新云文档权限应成功");
+        assert!(resp.permission_public.is_none());
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/drive/v2/permissions/token001/public"
+        );
+        assert!(received[0].url.query().unwrap_or("").contains("type=doc"));
     }
 }

--- a/crates/openlark-docs/src/ccm/explorer/explorer/mod.rs
+++ b/crates/openlark-docs/src/ccm/explorer/explorer/mod.rs
@@ -32,24 +32,3 @@ pub struct ExplorerId;
 // mod requests; // Generated: Module file not found
 // mod responses; // Generated: Module file not found
 // mod response_impls; // Generated: Module file not found
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/explorer/v2/models.rs
+++ b/crates/openlark-docs/src/ccm/explorer/v2/models.rs
@@ -201,24 +201,3 @@ pub struct DeleteResult {
     /// 错误信息
     pub error: Option<String>,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/models/mod.rs
+++ b/crates/openlark-docs/src/ccm/models/mod.rs
@@ -40,23 +40,3 @@ pub struct PagedResponse<T> {
     /// 是否还有更多数据
     pub has_more: bool,
 }
-
-#[cfg(test)]
-mod tests {
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/permission/mod.rs
+++ b/crates/openlark-docs/src/ccm/permission/mod.rs
@@ -34,24 +34,3 @@ pub struct PublicPermission {
     /// 权限类型
     pub permission_type: String,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/permission/v2/models.rs
+++ b/crates/openlark-docs/src/ccm/permission/v2/models.rs
@@ -107,24 +107,3 @@ pub struct UserInfo {
     /// 用户名称
     pub name: String,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/sheets_v2/models.rs
+++ b/crates/openlark-docs/src/ccm/sheets_v2/models.rs
@@ -799,21 +799,6 @@ mod tests {
     use serde_json;
 
     #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-
-    #[test]
     fn test_read_single_range_request_validation() {
         let valid_request = ReadSingleRangeRequest {
             spreadsheet_token: "token123".to_string(),

--- a/crates/openlark-docs/src/ccm/sheets_v2/v2/data_io/mod.rs
+++ b/crates/openlark-docs/src/ccm/sheets_v2/v2/data_io/mod.rs
@@ -388,21 +388,50 @@ pub async fn values_image_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：GET .../values/{range} → ReadSingleRangeResponse。
+    #[tokio::test]
+    async fn test_read_single_range_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/sheets/v2/spreadsheets/token001/values/A1:B2",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = read_single_range(
+            &config,
+            "token001",
+            ReadSingleRangeParams {
+                value_range: "A1:B2".into(),
+                value_render_option: None,
+                date_render_option: None,
+            },
+        )
+        .await
+        .expect("读取单个范围应成功");
+        assert!(resp.data.is_none());
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert!(
+            received[0]
+                .url
+                .path()
+                .starts_with("/open-apis/sheets/v2/spreadsheets/token001/values/")
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets_v2/v2/data_io/models.rs
+++ b/crates/openlark-docs/src/ccm/sheets_v2/v2/data_io/models.rs
@@ -422,24 +422,3 @@ pub struct ImageResult {
     #[serde(rename = "updated_cells")]
     pub updated_cells: i32,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/sheets_v2/v2/filter/mod.rs
+++ b/crates/openlark-docs/src/ccm/sheets_v2/v2/filter/mod.rs
@@ -227,21 +227,49 @@ pub async fn delete_filter_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：POST .../filterViews → CreateFilterResponse。
+    #[tokio::test]
+    async fn test_create_filter_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/sheets/v3/spreadsheets/token001/filterViews",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = create_filter(
+            &config,
+            "token001",
+            CreateFilterParams {
+                range: "Sheet1!A1:C10".into(),
+                filter_spec: FilterSpec {
+                    filter_specs: vec![],
+                },
+            },
+        )
+        .await
+        .expect("创建筛选应成功");
+        assert!(resp.data.is_none());
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/token001/filterViews"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets_v2/v2/filter/models.rs
+++ b/crates/openlark-docs/src/ccm/sheets_v2/v2/filter/models.rs
@@ -130,24 +130,3 @@ pub struct DeleteFilterResult {
     #[serde(rename = "filter_id")]
     pub filter_id: String,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/sheets_v2/v2/float_image/mod.rs
+++ b/crates/openlark-docs/src/ccm/sheets_v2/v2/float_image/mod.rs
@@ -248,21 +248,55 @@ pub async fn delete_float_image_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：POST .../sheets/{sheet_id}/float_images → CreateFloatImageResponse。
+    #[tokio::test]
+    async fn test_create_float_image_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/sheets/v3/spreadsheets/token001/sheets/sid001/float_images",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = create_float_image(
+            &config,
+            "token001",
+            CreateFloatImageParams {
+                image_token: "img001".into(),
+                sheet_id: "sid001".into(),
+                float_image: FloatImagePosition {
+                    offset_x: 0,
+                    offset_y: 0,
+                    width: 100,
+                    height: 50,
+                    scale: 1.0,
+                    z_index: 0,
+                },
+            },
+        )
+        .await
+        .expect("创建浮图应成功");
+        assert!(resp.data.is_none());
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/token001/sheets/sid001/float_images"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets_v2/v2/float_image/models.rs
+++ b/crates/openlark-docs/src/ccm/sheets_v2/v2/float_image/models.rs
@@ -135,24 +135,3 @@ pub struct DeleteFloatImageResponse {
     /// 浮图删除结果
     pub data: Option<FloatImageResult>,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/sheets_v2/v2/mod.rs
+++ b/crates/openlark-docs/src/ccm/sheets_v2/v2/mod.rs
@@ -86,24 +86,3 @@ pub use sheet::SheetApi;
 /// 重新导出相关类型。
 pub use sheet_operations::SheetOperationsApi;
 // pub use self::spreadsheet::SpreadsheetApi; // Generated: Module use not found
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/sheets_v2/v2/sheet/mod.rs
+++ b/crates/openlark-docs/src/ccm/sheets_v2/v2/sheet/mod.rs
@@ -230,21 +230,47 @@ pub async fn delete_sheet_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：POST .../sheets_batch_update → AddSheetResponse。
+    #[tokio::test]
+    async fn test_add_sheet_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/sheets/v2/spreadsheets/token001/sheets_batch_update",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = add_sheet(
+            &config,
+            "token001",
+            AddSheetParams {
+                title: "新工作表".into(),
+                index: None,
+            },
+        )
+        .await
+        .expect("添加工作表应成功");
+        assert!(resp.data.is_none());
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v2/spreadsheets/token001/sheets_batch_update"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets_v2/v2/sheet/models.rs
+++ b/crates/openlark-docs/src/ccm/sheets_v2/v2/sheet/models.rs
@@ -140,24 +140,3 @@ pub struct DeleteSheetResult {
     #[serde(rename = "sheet_id")]
     pub sheet_id: String,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/sheets_v2/v2/sheet_operations/mod.rs
+++ b/crates/openlark-docs/src/ccm/sheets_v2/v2/sheet_operations/mod.rs
@@ -366,21 +366,47 @@ pub async fn unmerge_cells_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：POST .../dimensionRange/delete → DeleteRangeResponse。
+    #[tokio::test]
+    async fn test_delete_range_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/sheets/v3/spreadsheets/token001/dimensionRange/delete",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = delete_range(
+            &config,
+            "token001",
+            DeleteRangeParams {
+                range: "Sheet1!A1:A5".into(),
+                dimension: "ROWS".into(),
+            },
+        )
+        .await
+        .expect("删除范围应成功");
+        assert!(resp.data.is_none());
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/token001/dimensionRange/delete"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets_v2/v2/sheet_operations/models.rs
+++ b/crates/openlark-docs/src/ccm/sheets_v2/v2/sheet_operations/models.rs
@@ -230,24 +230,3 @@ pub struct UnmergeCellsResult {
     #[serde(rename = "unmerge_range")]
     pub unmerge_range: String,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/sheets_v2/v2/spreadsheet/mod.rs
+++ b/crates/openlark-docs/src/ccm/sheets_v2/v2/spreadsheet/mod.rs
@@ -178,21 +178,44 @@ pub async fn update_spreadsheet_with_options(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：GET /open-apis/sheets/v3/spreadsheets/{token} → GetSpreadsheetResponse。
+    #[tokio::test]
+    async fn test_get_spreadsheet_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/sheets/v3/spreadsheets/token001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = get_spreadsheet(
+            &config,
+            "token001",
+            GetSpreadsheetParams {
+                include_sheet: None,
+            },
+        )
+        .await
+        .expect("获取表格应成功");
+        assert!(resp.data.is_none());
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/sheets/v3/spreadsheets/token001"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/sheets_v2/v2/spreadsheet/models.rs
+++ b/crates/openlark-docs/src/ccm/sheets_v2/v2/spreadsheet/models.rs
@@ -130,24 +130,3 @@ pub struct UpdateSpreadsheetResult {
     #[serde(rename = "update_time")]
     pub update_time: i64,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/wiki/v1/node/search.rs
+++ b/crates/openlark-docs/src/ccm/wiki/v1/node/search.rs
@@ -142,21 +142,37 @@ impl SearchWikiRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：POST /open-apis/wiki/v1/nodes/search → SearchWikiResponse（items）。
+    #[tokio::test]
+    async fn test_search_wiki_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/wiki/v1/nodes/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "items": [], "has_more": false }
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = SearchWikiRequest::new(config)
+            .query("测试")
+            .execute()
+            .await
+            .expect("搜索Wiki应成功");
+        assert!(resp.items.is_empty());
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/wiki/v1/nodes/search");
     }
 }

--- a/crates/openlark-docs/src/ccm/wiki/v2/models.rs
+++ b/crates/openlark-docs/src/ccm/wiki/v2/models.rs
@@ -97,24 +97,3 @@ pub struct WikiSearchResult {
     /// wiki 对应图标的 url
     pub icon: Option<String>,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/ccm/wiki/v2/space/get_node.rs
+++ b/crates/openlark-docs/src/ccm/wiki/v2/space/get_node.rs
@@ -89,21 +89,39 @@ impl GetWikiSpaceNodeRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：GET /open-apis/wiki/v2/spaces/get_node → GetWikiSpaceNodeResponse。
+    #[tokio::test]
+    async fn test_get_wiki_space_node_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/wiki/v2/spaces/get_node"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = GetWikiSpaceNodeRequest::new(config)
+            .execute(GetWikiSpaceNodeParams {
+                token: "nt001".into(),
+                obj_type: None,
+            })
+            .await
+            .expect("获取知识空间节点应成功");
+        assert!(resp.node.is_none());
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/wiki/v2/spaces/get_node");
     }
 }

--- a/crates/openlark-docs/src/ccm/wiki/v2/space/member/create.rs
+++ b/crates/openlark-docs/src/ccm/wiki/v2/space/member/create.rs
@@ -111,21 +111,44 @@ impl CreateWikiSpaceMemberRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：POST .../spaces/{space_id}/members → CreateWikiSpaceMemberResponse。
+    #[tokio::test]
+    async fn test_create_wiki_space_member_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/wiki/v2/spaces/sp001/members"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = CreateWikiSpaceMemberRequest::new(config)
+            .space_id("sp001")
+            .execute(CreateWikiSpaceMemberParams {
+                member_type: "openid".into(),
+                member_id: "ou001".into(),
+                member_role: "member".into(),
+            })
+            .await
+            .expect("添加知识空间成员应成功");
+        assert!(resp.member.is_none());
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/wiki/v2/spaces/sp001/members"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/wiki/v2/space/member/delete.rs
+++ b/crates/openlark-docs/src/ccm/wiki/v2/space/member/delete.rs
@@ -110,21 +110,45 @@ impl DeleteWikiSpaceMemberRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：DELETE .../spaces/{space_id}/members/{member_id} → DeleteWikiSpaceMemberResponse。
+    #[tokio::test]
+    async fn test_delete_wiki_space_member_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/wiki/v2/spaces/sp001/members/mb001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = DeleteWikiSpaceMemberRequest::new(config)
+            .space_id("sp001")
+            .member_id("mb001")
+            .execute(DeleteWikiSpaceMemberParams {
+                member_role: "member".into(),
+                member_type: "openid".into(),
+                member_kind: "user".into(),
+            })
+            .await
+            .expect("删除知识空间成员应成功");
+        assert!(resp.member.is_none());
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/wiki/v2/spaces/sp001/members/mb001"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/wiki/v2/space/member/list.rs
+++ b/crates/openlark-docs/src/ccm/wiki/v2/space/member/list.rs
@@ -108,21 +108,40 @@ impl ListWikiSpaceMembersRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：GET .../spaces/{space_id}/members → ListWikiSpaceMembersResponse。
+    #[tokio::test]
+    async fn test_list_wiki_space_members_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/wiki/v2/spaces/sp001/members"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "members": [] }
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = ListWikiSpaceMembersRequest::new(config)
+            .space_id("sp001")
+            .execute(None)
+            .await
+            .expect("获取知识空间成员列表应成功");
+        assert!(resp.members.is_empty());
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/wiki/v2/spaces/sp001/members"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/wiki/v2/space/node/copy.rs
+++ b/crates/openlark-docs/src/ccm/wiki/v2/space/node/copy.rs
@@ -108,21 +108,45 @@ impl CopyWikiSpaceNodeRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：POST .../nodes/{node_token}/copy → CopyWikiSpaceNodeResponse。
+    #[tokio::test]
+    async fn test_copy_wiki_space_node_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/wiki/v2/spaces/sp001/nodes/nt001/copy"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = CopyWikiSpaceNodeRequest::new(config)
+            .space_id("sp001")
+            .node_token("nt001")
+            .execute(CopyWikiSpaceNodeParams {
+                target_parent_token: "pt001".into(),
+                target_space_id: "sp002".into(),
+                title: None,
+            })
+            .await
+            .expect("复制知识空间节点应成功");
+        assert!(resp.node.is_none());
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/wiki/v2/spaces/sp001/nodes/nt001/copy"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/wiki/v2/space/node/move.rs
+++ b/crates/openlark-docs/src/ccm/wiki/v2/space/node/move.rs
@@ -108,21 +108,44 @@ impl MoveWikiSpaceNodeRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：POST .../nodes/{node_token}/move → MoveWikiSpaceNodeResponse。
+    #[tokio::test]
+    async fn test_move_wiki_space_node_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/wiki/v2/spaces/sp001/nodes/nt001/move"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = MoveWikiSpaceNodeRequest::new(config)
+            .space_id("sp001")
+            .node_token("nt001")
+            .execute(MoveWikiSpaceNodeParams {
+                target_parent_token: "pt001".into(),
+                target_space_id: "sp002".into(),
+            })
+            .await
+            .expect("移动知识空间节点应成功");
+        assert!(resp.node.is_none());
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/wiki/v2/spaces/sp001/nodes/nt001/move"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/wiki/v2/space/node/move_docs_to_wiki.rs
+++ b/crates/openlark-docs/src/ccm/wiki/v2/space/node/move_docs_to_wiki.rs
@@ -145,21 +145,45 @@ impl MoveDocsToWikiRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：POST .../nodes/move_docs_to_wiki → MoveDocsToWikiResponse。
+    #[tokio::test]
+    async fn test_move_docs_to_wiki_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/wiki/v2/spaces/sp001/nodes/move_docs_to_wiki",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "wiki_token": "wt001" }
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = MoveDocsToWikiRequest::new(config)
+            .space_id("sp001")
+            .obj_token("obj001")
+            .obj_type("docx")
+            .parent_wiki_token("pwt001")
+            .execute()
+            .await
+            .expect("移动云文档至知识空间应成功");
+        assert_eq!(resp.wiki_token.as_deref(), Some("wt001"));
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/wiki/v2/spaces/sp001/nodes/move_docs_to_wiki"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/wiki/v2/space/node/update_title.rs
+++ b/crates/openlark-docs/src/ccm/wiki/v2/space/node/update_title.rs
@@ -99,21 +99,44 @@ impl UpdateWikiSpaceNodeTitleRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：POST .../nodes/{node_token}/update_title → UpdateWikiSpaceNodeTitleResponse（空 data）。
+    #[tokio::test]
+    async fn test_update_wiki_space_node_title_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/wiki/v2/spaces/sp001/nodes/nt001/update_title",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        UpdateWikiSpaceNodeTitleRequest::new(config)
+            .space_id("sp001")
+            .node_token("nt001")
+            .execute(UpdateWikiSpaceNodeTitleParams {
+                title: "新标题".into(),
+            })
+            .await
+            .expect("更新节点标题应成功");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/wiki/v2/spaces/sp001/nodes/nt001/update_title"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/wiki/v2/space/setting/update.rs
+++ b/crates/openlark-docs/src/ccm/wiki/v2/space/setting/update.rs
@@ -85,21 +85,47 @@ impl UpdateWikiSpaceSettingRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    use crate::ccm::wiki::v2::models::WikiSpaceSetting;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：PUT .../spaces/{space_id}/setting → UpdateWikiSpaceSettingResponse。
+    #[tokio::test]
+    async fn test_update_wiki_space_setting_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/wiki/v2/spaces/sp001/setting"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success",
+                "data": { "setting": { "create_setting": "admin", "security_setting": "allow", "comment_setting": "allow" } }
+            })))
+            .mount(&server).await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = UpdateWikiSpaceSettingRequest::new(config)
+            .space_id("sp001")
+            .execute(WikiSpaceSetting {
+                create_setting: "admin".into(),
+                security_setting: "allow".into(),
+                comment_setting: "allow".into(),
+            })
+            .await
+            .expect("更新知识空间设置应成功");
+        let setting = resp.setting.expect("响应应包含 setting");
+        assert_eq!(setting.create_setting, "admin");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/wiki/v2/spaces/sp001/setting"
+        );
     }
 }

--- a/crates/openlark-docs/src/ccm/wiki/v2/task/get.rs
+++ b/crates/openlark-docs/src/ccm/wiki/v2/task/get.rs
@@ -94,21 +94,37 @@ impl GetWikiTaskRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：GET /open-apis/wiki/v2/tasks/{task_id} → GetWikiTaskResponse。
+    #[tokio::test]
+    async fn test_get_wiki_task_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/wiki/v2/tasks/tk001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = GetWikiTaskRequest::new(config)
+            .task_id("tk001")
+            .execute()
+            .await
+            .expect("获取任务结果应成功");
+        assert!(resp.task.is_none());
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/wiki/v2/tasks/tk001");
     }
 }


### PR DESCRIPTION
## 背景

#351 P3 第 7 批：`openlark-docs` ccm 剩余子域（sheets_v2 + wiki + drive + 零散）占位 roundtrip → wiremock e2e。

继 PR A（#391，sheets + docx 38 e2e）后，本轮清除 ccm 剩余全部 `test_serialization_roundtrip` 占位测试。

## 改造内容（44 文件）

### ccm/sheets_v2（14 文件，6 e2e + 8 model 清除）

sheets_v2 的 API 定义在 `mod.rs` 中（每个 mod.rs 含 3-7 个函数式 API，共 29 个）。每个 mod.rs 加 1 个代表性 e2e（覆盖该模块的 URL/method/响应解析模式）：

| mod.rs | 代表 e2e | HTTP | URL |
|---|---|---|---|
| spreadsheet | get_spreadsheet | GET | /sheets/v3/spreadsheets/{token} |
| data_io | read_single_range | GET | /sheets/v2/spreadsheets/{token}/values/{range} |
| sheet_operations | delete_range | POST | .../dimensionRange/delete |
| float_image | create_float_image | POST | .../sheets/{sid}/float_images |
| filter | create_filter | POST | .../filterViews |
| sheet | add_sheet | POST | .../sheets_batch_update |

8 个 models.rs 清除 Potemkin。

### ccm/wiki（12 文件，11 e2e + 1 model 清除）

11 个 API 文件 e2e（Builder 模式）：search / get_node / task / member×3 / node×4 / setting。

### ccm/drive（11 文件，3 e2e + 8 model 清除）

3 个 API e2e：meta/batch_query（POST）、permission/public get（GET）+ patch（PATCH）。
8 个 models.rs 清除 Potemkin。

### ccm 零散（8 文件）

explorer / permission / doc / docs / export_tasks / models 的 models.rs 和 mod.rs 清除 Potemkin。

## 验证

- `cargo test -p openlark-docs --all-features --lib`：1010 全过
- `cargo clippy --all-targets --all-features -- -Dwarnings`：通过
- `cargo clippy --all-targets --no-default-features -- -Dwarnings`：通过
- `cargo fmt --check`：通过

## 说明

sheets_v2 每个 mod.rs 含多个 API 但仅加 1 个代表性 e2e——这些 API 共享相同的函数式模式（`fn(config, token, params) → Response`），代表性 e2e 已验证该模式的 URL 拼装、method、信封解析。其余 API 可后续按需补齐。

## 后续

- **base PR**：base/bitable(27) + base/base(4) + baike(5) + common(1) + minutes(1) = 38