### PR TITLE
test(docs): base/bitable/baike/common/minutes 25 e2e + 清 35 文件占位 roundtrip（#351 P3）

### DIFF
--- a/crates/openlark-docs/src/baike/baike/v1/file/download.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/file/download.rs
@@ -46,21 +46,40 @@ impl DownloadFileRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：GET /open-apis/baike/v1/files/{file_token}/download → 二进制内容。
+    #[tokio::test]
+    async fn test_download_file_returns_data_on_success() {
+        let server = MockServer::start().await;
+        let body = b"baike binary payload".to_vec();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/baike/v1/files/ftk001/download"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = DownloadFileRequest::new(config, "ftk001")
+            .execute()
+            .await
+            .expect("下载文件应成功");
+        let data = resp.data.expect("响应应包含二进制数据");
+        assert_eq!(data, body);
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/baike/v1/files/ftk001/download"
+        );
     }
 }

--- a/crates/openlark-docs/src/baike/lingo/v1/file/download.rs
+++ b/crates/openlark-docs/src/baike/lingo/v1/file/download.rs
@@ -48,21 +48,40 @@ impl DownloadFileRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：GET /open-apis/lingo/v1/files/{file_token}/download → 二进制内容。
+    #[tokio::test]
+    async fn test_download_file_returns_data_on_success() {
+        let server = MockServer::start().await;
+        let body = b"lingo binary payload".to_vec();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/lingo/v1/files/ftk001/download"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = DownloadFileRequest::new(config, "ftk001")
+            .execute()
+            .await
+            .expect("下载文件应成功");
+        let data = resp.data.expect("响应应包含二进制数据");
+        assert_eq!(data, body);
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/lingo/v1/files/ftk001/download"
+        );
     }
 }

--- a/crates/openlark-docs/src/base/base/v2/app/role/create.rs
+++ b/crates/openlark-docs/src/base/base/v2/app/role/create.rs
@@ -142,21 +142,42 @@ impl ApiResponseTrait for CreateResp {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：POST /open-apis/base/v2/apps/{app_token}/roles → CreateResp。
+    #[tokio::test]
+    async fn test_create_role_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/base/v2/apps/app001/roles"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = Create::new(config)
+            .app_token("app001")
+            .role_name("角色")
+            .table_roles(vec![json!({})])
+            .execute()
+            .await
+            .expect("创建角色应成功");
+        assert!(resp.role.is_none());
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/base/v2/apps/app001/roles"
+        );
     }
 }

--- a/crates/openlark-docs/src/base/base/v2/app/role/list.rs
+++ b/crates/openlark-docs/src/base/base/v2/app/role/list.rs
@@ -121,21 +121,40 @@ impl ApiResponseTrait for ListResp {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：GET .../roles → ListResp。
+    #[tokio::test]
+    async fn test_list_roles_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/base/v2/apps/app001/roles"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "items": [], "has_more": false }
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = List::new(config)
+            .app_token("app001")
+            .execute()
+            .await
+            .expect("列出角色应成功");
+        assert!(resp.items.is_empty());
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/base/v2/apps/app001/roles"
+        );
     }
 }

--- a/crates/openlark-docs/src/base/base/v2/app/role/update.rs
+++ b/crates/openlark-docs/src/base/base/v2/app/role/update.rs
@@ -147,21 +147,42 @@ impl ApiResponseTrait for UpdateResp {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：PUT .../roles/{role_id} → UpdateResp。
+    #[tokio::test]
+    async fn test_update_role_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/base/v2/apps/app001/roles/role001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let resp = Update::new(config)
+            .app_token("app001")
+            .role_id("role001")
+            .role_name("新角色名")
+            .execute()
+            .await
+            .expect("更新角色应成功");
+        assert!(resp.role.is_none());
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/base/v2/apps/app001/roles/role001"
+        );
     }
 }

--- a/crates/openlark-docs/src/base/base/v2/models.rs
+++ b/crates/openlark-docs/src/base/base/v2/models.rs
@@ -22,24 +22,3 @@ pub struct AppRole {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub base_rule: Option<serde_json::Value>,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/base/bitable/v1/app/copy.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/copy.rs
@@ -164,21 +164,39 @@ impl AppService {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：POST .../apps/{app_token}/copy → CopyAppResponse。
+    #[tokio::test]
+    async fn test_copy_app_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/bitable/v1/apps/app001/copy"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "app": { "app_token": "app001", "name": "副本" } }
+            })))
+            .mount(&server).await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        CopyAppRequest::new(config)
+            .app_token("app001")
+            .name("副本")
+            .execute()
+            .await
+            .expect("复制多维表格应成功");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/bitable/v1/apps/app001/copy"
+        );
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/create.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/create.rs
@@ -139,21 +139,35 @@ impl AppService {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：POST /open-apis/bitable/v1/apps → CreateAppResponse。
+    #[tokio::test]
+    async fn test_create_app_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/bitable/v1/apps"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "app": { "app_token": "app001", "name": "测试应用" } }
+            })))
+            .mount(&server).await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        CreateAppRequest::new(config)
+            .name("测试应用")
+            .execute()
+            .await
+            .expect("创建多维表格应成功");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/bitable/v1/apps");
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/dashboard/copy.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/dashboard/copy.rs
@@ -100,21 +100,43 @@ impl ApiResponseTrait for CopyDashboardResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：POST .../dashboards/{block_id}/copy → CopyDashboardResponse。
+    #[tokio::test]
+    async fn test_copy_dashboard_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/bitable/v1/apps/app001/dashboards/blk001/copy",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "block_id": "blk001", "name": "仪表盘" }
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        CopyDashboardRequest::new(config)
+            .app_token("app001")
+            .block_id("blk001")
+            .name("副本")
+            .execute()
+            .await
+            .expect("复制仪表盘应成功");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/bitable/v1/apps/app001/dashboards/blk001/copy"
+        );
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/dashboard/list.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/dashboard/list.rs
@@ -105,21 +105,39 @@ impl ApiResponseTrait for ListDashboardsResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：GET .../dashboards → ListDashboardsResponse。
+    #[tokio::test]
+    async fn test_list_dashboards_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/bitable/v1/apps/app001/dashboards"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "dashboards": [], "has_more": false }
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        ListDashboardsRequest::new(config)
+            .app_token("app001")
+            .execute()
+            .await
+            .expect("列出仪表盘应成功");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/bitable/v1/apps/app001/dashboards"
+        );
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/dashboard/mod.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/dashboard/mod.rs
@@ -66,24 +66,3 @@ pub struct Permission {
     /// 权限值
     pub value: String,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/base/bitable/v1/app/get.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/get.rs
@@ -97,21 +97,35 @@ impl AppService {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：GET .../apps/{app_token} → GetAppResponse。
+    #[tokio::test]
+    async fn test_get_app_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/bitable/v1/apps/app001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "app": { "app_token": "app001", "name": "测试" } }
+            })))
+            .mount(&server).await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        GetAppRequest::new(config)
+            .app_token("app001")
+            .execute()
+            .await
+            .expect("获取多维表格应成功");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/bitable/v1/apps/app001");
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/models.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/models.rs
@@ -199,24 +199,3 @@ impl UpdateAppRequest {
         Ok(())
     }
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/base/bitable/v1/app/role/member/batch_create.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/role/member/batch_create.rs
@@ -122,21 +122,46 @@ impl ApiResponseTrait for BatchCreateRoleMemberResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：POST .../members/batch_create → BatchCreateRoleMemberResponse。
+    #[tokio::test]
+    async fn test_batch_create_role_member_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/bitable/v1/apps/app001/roles/role001/members/batch_create",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        BatchCreateRoleMemberRequest::new(config)
+            .app_token("app001".into())
+            .role_id("role001".into())
+            .member_list(vec![RoleMemberId {
+                id_type: Default::default(),
+                id: "ou001".into(),
+            }])
+            .execute()
+            .await
+            .expect("批量添加角色成员应成功");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/bitable/v1/apps/app001/roles/role001/members/batch_create"
+        );
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/role/member/batch_delete.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/role/member/batch_delete.rs
@@ -122,21 +122,46 @@ impl ApiResponseTrait for BatchDeleteRoleMemberResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：POST .../members/batch_delete → BatchDeleteRoleMemberResponse。
+    #[tokio::test]
+    async fn test_batch_delete_role_member_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/bitable/v1/apps/app001/roles/role001/members/batch_delete",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        BatchDeleteRoleMemberRequest::new(config)
+            .app_token("app001".into())
+            .role_id("role001".into())
+            .member_list(vec![RoleMemberId {
+                id_type: Default::default(),
+                id: "ou001".into(),
+            }])
+            .execute()
+            .await
+            .expect("批量删除角色成员应成功");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/bitable/v1/apps/app001/roles/role001/members/batch_delete"
+        );
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/role/member/models.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/role/member/models.rs
@@ -79,24 +79,3 @@ pub struct RoleMemberInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub open_department_id: Option<String>,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/base/bitable/v1/app/role/models.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/role/models.rs
@@ -63,24 +63,3 @@ pub struct Role {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_roles: Option<Vec<BlockRole>>,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/base/bitable/v1/app/role/update.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/role/update.rs
@@ -140,21 +140,49 @@ impl ApiResponseTrait for UpdateAppRoleResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：PUT .../roles/{role_id} → UpdateAppRoleResponse。
+    #[tokio::test]
+    async fn test_update_app_role_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/bitable/v1/apps/app001/roles/role001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "role": { "role_name": "角色名", "table_roles": [] } }
+            })))
+            .mount(&server).await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        UpdateAppRoleRequest::new(config)
+            .app_token("app001".into())
+            .role_id("role001".into())
+            .role_name("角色名".into())
+            .table_roles(vec![TableRole {
+                table_perm: 0,
+                table_name: None,
+                table_id: None,
+                rec_rule: None,
+                field_perm: None,
+                allow_add_record: None,
+                allow_delete_record: None,
+            }])
+            .execute()
+            .await
+            .expect("更新角色应成功");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/bitable/v1/apps/app001/roles/role001"
+        );
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/batch_create.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/batch_create.rs
@@ -125,21 +125,42 @@ impl ApiResponseTrait for BatchCreateTableResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：POST .../tables/batch_create → BatchCreateTableResponse。
+    #[tokio::test]
+    async fn test_batch_create_table_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/bitable/v1/apps/app001/tables/batch_create",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "table_ids": [] }
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        BatchCreateTableRequest::new(config)
+            .app_token("app001")
+            .tables(vec![TableData::new("表1")])
+            .execute()
+            .await
+            .expect("批量创建数据表应成功");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/bitable/v1/apps/app001/tables/batch_create"
+        );
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/batch_delete.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/batch_delete.rs
@@ -120,21 +120,42 @@ impl ApiResponseTrait for BatchDeleteTableResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：POST .../tables/batch_delete → BatchDeleteTableResponse。
+    #[tokio::test]
+    async fn test_batch_delete_table_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/bitable/v1/apps/app001/tables/batch_delete",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        BatchDeleteTableRequest::new(config)
+            .app_token("app001")
+            .table_ids(vec!["tbl001".into()])
+            .execute()
+            .await
+            .expect("批量删除数据表应成功");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/bitable/v1/apps/app001/tables/batch_delete"
+        );
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/field/delete.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/field/delete.rs
@@ -109,21 +109,43 @@ impl ApiResponseTrait for DeleteFieldResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：DELETE .../fields/{field_id} → DeleteFieldResponse。
+    #[tokio::test]
+    async fn test_delete_field_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/bitable/v1/apps/app001/tables/tbl001/fields/fld001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "field_id": "fld001", "deleted": true }
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        DeleteFieldRequest::new(config)
+            .app_token("app001".into())
+            .table_id("tbl001".into())
+            .field_id("fld001".into())
+            .execute()
+            .await
+            .expect("删除字段应成功");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/bitable/v1/apps/app001/tables/tbl001/fields/fld001"
+        );
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/field/list.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/field/list.rs
@@ -165,21 +165,42 @@ impl ApiResponseTrait for ListFieldResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：GET .../fields → ListFieldResponse。
+    #[tokio::test]
+    async fn test_list_field_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/bitable/v1/apps/app001/tables/tbl001/fields",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "has_more": false, "total": 0, "items": [] }
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        ListFieldRequest::new(config)
+            .app_token("app001".into())
+            .table_id("tbl001".into())
+            .execute()
+            .await
+            .expect("列出字段应成功");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/bitable/v1/apps/app001/tables/tbl001/fields"
+        );
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/form/field/models.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/form/field/models.rs
@@ -62,24 +62,3 @@ impl Default for PatchFormFieldRequest {
         Self::new()
     }
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/form/field/patch.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/form/field/patch.rs
@@ -242,21 +242,42 @@ pub type PatchFormFieldQuestionBuilder = PatchFormFieldQuestionRequestBuilder;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：PATCH .../forms/{form_id}/fields/{field_id} → PatchFormFieldResponse。
+    #[tokio::test]
+    async fn test_patch_form_field_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/bitable/v1/apps/app001/tables/tbl001/forms/form001/fields/fld001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "field": { "title": "标题", "required": false, "visible": true } }
+            })))
+            .mount(&server).await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        PatchFormFieldQuestionRequest::new(config)
+            .app_token("app001".into())
+            .table_id("tbl001".into())
+            .form_id("form001".into())
+            .field_id("fld001".into())
+            .title("标题".into())
+            .execute()
+            .await
+            .expect("更新表单字段应成功");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/bitable/v1/apps/app001/tables/tbl001/forms/form001/fields/fld001"
+        );
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/form/models.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/form/models.rs
@@ -20,24 +20,3 @@ pub struct Form {
     /// 是否限制每人只可提交一次
     pub submit_limit_once: bool,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/patch.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/patch.rs
@@ -170,21 +170,41 @@ impl ApiResponseTrait for PatchTableResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：PATCH .../tables/{table_id} → PatchTableResponse。
+    #[tokio::test]
+    async fn test_patch_table_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/bitable/v1/apps/app001/tables/tbl001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        PatchTableRequest::new(config)
+            .app_token("app001".into())
+            .table_id("tbl001".into())
+            .name("新表名".into())
+            .execute()
+            .await
+            .expect("更新数据表应成功");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/bitable/v1/apps/app001/tables/tbl001"
+        );
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_get.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_get.rs
@@ -151,21 +151,43 @@ impl ApiResponseTrait for BatchGetRecordResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：POST .../records/batch_get → BatchGetRecordResponse。
+    #[tokio::test]
+    async fn test_batch_get_record_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/bitable/v1/apps/app001/tables/tbl001/records/batch_get",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        BatchGetRecordRequest::new(config)
+            .app_token("app001".into())
+            .table_id("tbl001".into())
+            .record_ids(vec!["rec001".into()])
+            .execute()
+            .await
+            .expect("批量查询记录应成功");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/bitable/v1/apps/app001/tables/tbl001/records/batch_get"
+        );
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/models.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/models.rs
@@ -45,24 +45,3 @@ pub struct Record {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub record_url: Option<String>,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/search.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/search.rs
@@ -270,21 +270,42 @@ impl ApiResponseTrait for SearchRecordResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：POST .../records/search → SearchRecordResponse。
+    #[tokio::test]
+    async fn test_search_record_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/bitable/v1/apps/app001/tables/tbl001/records/search",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "items": [], "has_more": false, "total": 0 }
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        SearchRecordRequest::new(config)
+            .app_token("app001".into())
+            .table_id("tbl001".into())
+            .execute()
+            .await
+            .expect("查询记录应成功");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/bitable/v1/apps/app001/tables/tbl001/records/search"
+        );
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/view/patch.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/view/patch.rs
@@ -178,21 +178,47 @@ impl PatchViewRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
+    /// 端到端：PATCH .../views/{view_id} → PatchViewResponse（view）。
+    #[tokio::test]
+    async fn test_patch_view_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/bitable/v1/apps/app001/tables/tbl001/views/vw001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success",
+                "data": { "view": { "view_id": "vw001", "view_name": "视图名", "view_type": "grid" } }
+            })))
+            .mount(&server).await;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = PatchViewRequest::new(config)
+            .app_token("app001".into())
+            .table_id("tbl001".into())
+            .view_id("vw001".into())
+            .payload(PatchViewData::new("视图名"))
+            .execute()
+            .await
+            .expect("更新视图应成功");
+        assert_eq!(resp.view.view_id, "vw001");
+        assert_eq!(resp.view.view_name, "视图名");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/bitable/v1/apps/app001/tables/tbl001/views/vw001"
+        );
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/update.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/update.rs
@@ -152,21 +152,36 @@ impl AppService {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：PUT .../apps/{app_token} → UpdateAppResponse。
+    #[tokio::test]
+    async fn test_update_app_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/bitable/v1/apps/app001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "app": { "app_token": "app001", "name": "新名称" } }
+            })))
+            .mount(&server).await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        UpdateAppRequest::new(config)
+            .app_token("app001")
+            .name("新名称")
+            .execute()
+            .await
+            .expect("更新多维表格应成功");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/bitable/v1/apps/app001");
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/workflow/list.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/workflow/list.rs
@@ -106,21 +106,39 @@ impl ListWorkflowRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：GET .../workflows → ListWorkflowResponse。
+    #[tokio::test]
+    async fn test_list_workflow_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/bitable/v1/apps/app001/workflows"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "workflows": [] }
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        ListWorkflowRequest::new(config)
+            .app_token("app001")
+            .execute()
+            .await
+            .expect("列出工作流应成功");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/bitable/v1/apps/app001/workflows"
+        );
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/workflow/update.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/workflow/update.rs
@@ -113,21 +113,40 @@ impl UpdateWorkflowRequest {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    /// 端到端：PUT .../workflows/{workflow_id} → UpdateWorkflowResponse。
+    #[tokio::test]
+    async fn test_update_workflow_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/bitable/v1/apps/app001/workflows/wf001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        UpdateWorkflowRequest::new(config)
+            .app_token("app001")
+            .workflow_id("wf001")
+            .execute()
+            .await
+            .expect("更新工作流应成功");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/bitable/v1/apps/app001/workflows/wf001"
+        );
     }
 }

--- a/crates/openlark-docs/src/common/chain.rs
+++ b/crates/openlark-docs/src/common/chain.rs
@@ -1033,22 +1033,6 @@ fn find_unique_wiki_node_by_title(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
 
     #[test]
     fn test_typed_page_last_page_state() {

--- a/crates/openlark-docs/src/minutes/minutes/v1/minute/models.rs
+++ b/crates/openlark-docs/src/minutes/minutes/v1/minute/models.rs
@@ -72,24 +72,3 @@ pub struct UserViewDetail {
     /// 用户的最近查看时间 timestamp（ms 级别，字符串）
     pub view_time: String,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}


### PR DESCRIPTION
## 背景

#351 P3 第 8 批：`openlark-docs` base/bitable + base/base + baike + common + minutes 占位 roundtrip → wiremock e2e。

继 PR A（#391）和 PR B（#392）后，本轮清除 docs crate 剩余全部 `test_serialization_roundtrip` 占位测试。**至此 docs crate Potemkin roundtrip 反模式全消除。**

## 改造内容（35 文件）

### base/bitable（27 文件，20 e2e + 7 model 清除）

20 个 API 文件 e2e（Builder 模式）：app create/get/copy/update、role update + member batch_create/batch_delete、dashboard list/copy、table patch/batch_create/batch_delete、record batch_get/search、form/field/patch、field list/delete、view/patch、workflow list/update。

7 个 models.rs 清除 Potemkin。

### base/base（4 文件，3 e2e + 1 model 清除）

v2/role create/update/list 3 e2e（BaseApiV2 枚举，Builder 模式）。

### baike（2 文件，2 e2e）

lingo + baike download 2 e2e——**二进制下载模式**（`set_body_bytes` + `resp.data` 断言），参考 drive/v1/media/download.rs 范本。

### common + minutes（2 文件）

- `common/chain.rs`：清除 2 个 Potemkin，保留既有 ~15 个真实分页测试
- `minutes/v1/minute/models.rs`：清除 Potemkin

## 验证

- `cargo test -p openlark-docs --all-features --lib`：919 全过
- `cargo clippy --all-targets --all-features -- -Dwarnings`：通过
- `cargo clippy --all-targets --no-default-features -- -Dwarnings`：通过
- `cargo fmt --check`：通过

## 踩坑

- bitable 响应多有必填字段（`App.app_token`、`View.view_id/view_type` 等），mock `{"data":{}}` 会致 data=None → 须按 struct 补齐
- 部分 API 校验请求必填字段（`name`/`table_ids`/`member_list`/`record_ids` 等不能空）
- `RoleMemberIdType` 文件级 import 被 clippy 判 unused → 改用 `Default::default()`

## 后续

docs crate 完成（PR A + B + 本 PR = 121 文件，83 e2e + 全部 Potemkin 清除）。剩 communication 301 + hr 891。