### PR TITLE
test(communication): 35 body 类 API wiremock e2e（#351 P3 PR B）

### DIFF
--- a/crates/openlark-communication/src/contact/contact/old/default/v2/department/batch_add.rs
+++ b/crates/openlark-communication/src/contact/contact/old/default/v2/department/batch_add.rs
@@ -46,21 +46,39 @@ impl BatchAddDepartmentsRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/contact/v2/department/batch_add
+    #[tokio::test]
+    async fn test_batch_add_departments_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/contact/v2/department/batch_add"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body = json!({});
+        BatchAddDepartmentsRequest::new(config)
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/contact/contact/old/default/v2/user/batch_add.rs
+++ b/crates/openlark-communication/src/contact/contact/old/default/v2/user/batch_add.rs
@@ -46,21 +46,39 @@ impl BatchAddUsersRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/contact/v2/user/batch_add
+    #[tokio::test]
+    async fn test_batch_add_users_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/contact/v2/user/batch_add"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body = json!({});
+        BatchAddUsersRequest::new(config)
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/contact/contact/v3/employee_type_enum/create.rs
+++ b/crates/openlark-communication/src/contact/contact/v3/employee_type_enum/create.rs
@@ -70,21 +70,42 @@ impl CreateEmployeeTypeEnumRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/contact/v3/employee_type_enums
+    #[tokio::test]
+    async fn test_create_employee_type_enum_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/contact/v3/employee_type_enums"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "employee_type_enum": {} }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: CreateEmployeeTypeEnumBody = serde_json::from_value(
+            json!({ "content": "test001", "enum_type": 0, "enum_status": 0 }),
+        )
+        .expect("body 构造");
+        CreateEmployeeTypeEnumRequest::new(config)
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/contact/contact/v3/employee_type_enum/update.rs
+++ b/crates/openlark-communication/src/contact/contact/v3/employee_type_enum/update.rs
@@ -85,21 +85,43 @@ impl UpdateEmployeeTypeEnumRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PUT /open-apis/contact/v3/employee_type_enums/test001
+    #[tokio::test]
+    async fn test_update_employee_type_enum_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/contact/v3/employee_type_enums/test001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "employee_type_enum": {} }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: UpdateEmployeeTypeEnumBody = serde_json::from_value(
+            json!({ "content": "test001", "enum_type": 0, "enum_status": 0 }),
+        )
+        .expect("body 构造");
+        UpdateEmployeeTypeEnumRequest::new(config)
+            .enum_id("test001".to_string())
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/contact/contact/v3/functional_role/create.rs
+++ b/crates/openlark-communication/src/contact/contact/v3/functional_role/create.rs
@@ -63,21 +63,40 @@ impl CreateFunctionalRoleRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/contact/v3/functional_roles
+    #[tokio::test]
+    async fn test_create_functional_role_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/contact/v3/functional_roles"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "role_id": "test001" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: CreateFunctionalRoleBody =
+            serde_json::from_value(json!({ "role_name": "test001" })).expect("body 构造");
+        CreateFunctionalRoleRequest::new(config)
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/contact/contact/v3/functional_role/update.rs
+++ b/crates/openlark-communication/src/contact/contact/v3/functional_role/update.rs
@@ -74,21 +74,41 @@ impl UpdateFunctionalRoleRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PUT /open-apis/contact/v3/functional_roles/test001
+    #[tokio::test]
+    async fn test_update_functional_role_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/contact/v3/functional_roles/test001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: UpdateFunctionalRoleBody =
+            serde_json::from_value(json!({ "role_name": "test001" })).expect("body 构造");
+        UpdateFunctionalRoleRequest::new(config)
+            .role_id("test001".to_string())
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/contact/contact/v3/job_family/update.rs
+++ b/crates/openlark-communication/src/contact/contact/v3/job_family/update.rs
@@ -92,21 +92,40 @@ impl UpdateJobFamilyRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PUT /open-apis/contact/v3/job_families/test001
+    #[tokio::test]
+    async fn test_update_job_family_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/contact/v3/job_families/test001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "job_family": {} }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: UpdateJobFamilyBody = serde_json::from_value(json!({})).expect("body 构造");
+        UpdateJobFamilyRequest::new(config)
+            .job_family_id("test001".to_string())
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/contact/contact/v3/job_level/update.rs
+++ b/crates/openlark-communication/src/contact/contact/v3/job_level/update.rs
@@ -89,21 +89,40 @@ impl UpdateJobLevelRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PUT /open-apis/contact/v3/job_levels/test001
+    #[tokio::test]
+    async fn test_update_job_level_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/contact/v3/job_levels/test001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "job_level": {} }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: UpdateJobLevelBody = serde_json::from_value(json!({})).expect("body 构造");
+        UpdateJobLevelRequest::new(config)
+            .job_level_id("test001".to_string())
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/contact/contact/v3/unit/bind_department.rs
+++ b/crates/openlark-communication/src/contact/contact/v3/unit/bind_department.rs
@@ -69,21 +69,41 @@ impl BindDepartmentRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/contact/v3/unit/bind_department
+    #[tokio::test]
+    async fn test_bind_department_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/contact/v3/unit/bind_department"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: BindDepartmentBody =
+            serde_json::from_value(json!({ "unit_id": "test001", "department_id": "test001" }))
+                .expect("body 构造");
+        BindDepartmentRequest::new(config)
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/contact/contact/v3/unit/patch.rs
+++ b/crates/openlark-communication/src/contact/contact/v3/unit/patch.rs
@@ -76,21 +76,41 @@ impl PatchUnitRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PATCH /open-apis/contact/v3/unit/test001
+    #[tokio::test]
+    async fn test_patch_unit_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/contact/v3/unit/test001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: PatchUnitBody =
+            serde_json::from_value(json!({ "name": "test001" })).expect("body 构造");
+        PatchUnitRequest::new(config)
+            .unit_id("test001".to_string())
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/contact/contact/v3/unit/unbind_department.rs
+++ b/crates/openlark-communication/src/contact/contact/v3/unit/unbind_department.rs
@@ -69,21 +69,41 @@ impl UnbindDepartmentRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/contact/v3/unit/unbind_department
+    #[tokio::test]
+    async fn test_unbind_department_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/contact/v3/unit/unbind_department"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: UnbindDepartmentBody =
+            serde_json::from_value(json!({ "unit_id": "test001", "department_id": "test001" }))
+                .expect("body 构造");
+        UnbindDepartmentRequest::new(config)
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/card/old/default/v1/card/update.rs
+++ b/crates/openlark-communication/src/im/card/old/default/v1/card/update.rs
@@ -65,21 +65,40 @@ impl UpdateCardRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/interactive/v1/card/update
+    #[tokio::test]
+    async fn test_update_card_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/interactive/v1/card/update"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: UpdateCardBody =
+            serde_json::from_value(json!({ "token": "test001", "card": {} })).expect("body 构造");
+        UpdateCardRequest::new(config)
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v1/chat/announcement/patch.rs
+++ b/crates/openlark-communication/src/im/im/v1/chat/announcement/patch.rs
@@ -73,21 +73,42 @@ impl PatchChatAnnouncementRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PATCH /open-apis/im/v1/chats/test001/announcement
+    #[tokio::test]
+    async fn test_patch_chat_announcement_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/im/v1/chats/test001/announcement"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: PatchChatAnnouncementBody =
+            serde_json::from_value(json!({ "revision": "test001", "requests": ["test001"] }))
+                .expect("body 构造");
+        PatchChatAnnouncementRequest::new(config)
+            .chat_id("test001".to_string())
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v1/chat/managers/add_managers.rs
+++ b/crates/openlark-communication/src/im/im/v1/chat/managers/add_managers.rs
@@ -86,21 +86,41 @@ impl AddChatManagersRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/im/v1/chats/test001/managers/add_managers
+    #[tokio::test]
+    async fn test_add_chat_managers_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/im/v1/chats/test001/managers/add_managers"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: ChatManagersBody =
+            serde_json::from_value(json!({ "manager_ids": ["test001"] })).expect("body 构造");
+        AddChatManagersRequest::new(config)
+            .chat_id("test001".to_string())
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v1/chat/managers/delete_managers.rs
+++ b/crates/openlark-communication/src/im/im/v1/chat/managers/delete_managers.rs
@@ -86,21 +86,43 @@ impl DeleteChatManagersRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/im/v1/chats/test001/managers/delete_managers
+    #[tokio::test]
+    async fn test_delete_chat_managers_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/im/v1/chats/test001/managers/delete_managers",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: ChatManagersBody =
+            serde_json::from_value(json!({ "manager_ids": ["test001"] })).expect("body 构造");
+        DeleteChatManagersRequest::new(config)
+            .chat_id("test001".to_string())
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v1/chat/members/create.rs
+++ b/crates/openlark-communication/src/im/im/v1/chat/members/create.rs
@@ -97,21 +97,41 @@ impl CreateChatMembersRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/im/v1/chats/test001/members
+    #[tokio::test]
+    async fn test_create_chat_members_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/im/v1/chats/test001/members"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: CreateChatMembersBody =
+            serde_json::from_value(json!({ "id_list": ["test001"] })).expect("body 构造");
+        CreateChatMembersRequest::new(config)
+            .chat_id("test001".to_string())
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v1/chat/members/delete.rs
+++ b/crates/openlark-communication/src/im/im/v1/chat/members/delete.rs
@@ -86,21 +86,41 @@ impl DeleteChatMembersRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：DELETE /open-apis/im/v1/chats/test001/members
+    #[tokio::test]
+    async fn test_delete_chat_members_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/im/v1/chats/test001/members"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: DeleteChatMembersBody =
+            serde_json::from_value(json!({ "id_list": ["test001"] })).expect("body 构造");
+        DeleteChatMembersRequest::new(config)
+            .chat_id("test001".to_string())
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v1/chat/members/get.rs
+++ b/crates/openlark-communication/src/im/im/v1/chat/members/get.rs
@@ -93,21 +93,39 @@ impl GetChatMembersRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET /open-apis/im/v1/chats/test001/members
+    #[tokio::test]
+    async fn test_get_chat_members_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/im/v1/chats/test001/members"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        GetChatMembersRequest::new(config)
+            .chat_id("test001".to_string())
+            .execute()
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v1/chat/menu_item/patch.rs
+++ b/crates/openlark-communication/src/im/im/v1/chat/menu_item/patch.rs
@@ -75,21 +75,41 @@ impl PatchChatMenuItemRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PATCH /open-apis/im/v1/chats/test001/menu_items/test001
+    #[tokio::test]
+    async fn test_patch_chat_menu_item_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/im/v1/chats/test001/menu_items/test001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body = json!({});
+        PatchChatMenuItemRequest::new(config)
+            .chat_id("test001".to_string())
+            .menu_item_id("test001".to_string())
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v1/chat/menu_tree/create.rs
+++ b/crates/openlark-communication/src/im/im/v1/chat/menu_tree/create.rs
@@ -64,21 +64,40 @@ impl CreateChatMenuTreeRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/im/v1/chats/test001/menu_tree
+    #[tokio::test]
+    async fn test_create_chat_menu_tree_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/im/v1/chats/test001/menu_tree"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body = json!({});
+        CreateChatMenuTreeRequest::new(config)
+            .chat_id("test001".to_string())
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v1/chat/menu_tree/delete.rs
+++ b/crates/openlark-communication/src/im/im/v1/chat/menu_tree/delete.rs
@@ -69,21 +69,42 @@ impl DeleteChatMenuTreeRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：DELETE /open-apis/im/v1/chats/test001/menu_tree
+    #[tokio::test]
+    async fn test_delete_chat_menu_tree_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/im/v1/chats/test001/menu_tree"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: ChatMenuTopLevelIdsBody =
+            serde_json::from_value(json!({ "chat_menu_top_level_ids": ["test001"] }))
+                .expect("body 构造");
+        DeleteChatMenuTreeRequest::new(config)
+            .chat_id("test001".to_string())
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v1/chat/menu_tree/sort.rs
+++ b/crates/openlark-communication/src/im/im/v1/chat/menu_tree/sort.rs
@@ -69,21 +69,42 @@ impl SortChatMenuTreeRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/im/v1/chats/test001/menu_tree/sort
+    #[tokio::test]
+    async fn test_sort_chat_menu_tree_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/im/v1/chats/test001/menu_tree/sort"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: ChatMenuTopLevelIdsBody =
+            serde_json::from_value(json!({ "chat_menu_top_level_ids": ["test001"] }))
+                .expect("body 构造");
+        SortChatMenuTreeRequest::new(config)
+            .chat_id("test001".to_string())
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v1/chat/moderation/get.rs
+++ b/crates/openlark-communication/src/im/im/v1/chat/moderation/get.rs
@@ -93,21 +93,39 @@ impl GetChatModerationRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET /open-apis/im/v1/chats/test001/moderation
+    #[tokio::test]
+    async fn test_get_chat_moderation_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/im/v1/chats/test001/moderation"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "moderation_setting": "all" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        GetChatModerationRequest::new(config)
+            .chat_id("test001".to_string())
+            .execute()
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v1/chat/moderation/update.rs
+++ b/crates/openlark-communication/src/im/im/v1/chat/moderation/update.rs
@@ -78,21 +78,40 @@ impl UpdateChatModerationRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PUT /open-apis/im/v1/chats/test001/moderation
+    #[tokio::test]
+    async fn test_update_chat_moderation_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/im/v1/chats/test001/moderation"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: UpdateChatModerationBody = serde_json::from_value(json!({})).expect("body 构造");
+        UpdateChatModerationRequest::new(config)
+            .chat_id("test001".to_string())
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v1/chat/tab/create.rs
+++ b/crates/openlark-communication/src/im/im/v1/chat/tab/create.rs
@@ -64,21 +64,40 @@ impl CreateChatTabRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/im/v1/chats/test001/chat_tabs
+    #[tokio::test]
+    async fn test_create_chat_tab_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/im/v1/chats/test001/chat_tabs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body = json!({});
+        CreateChatTabRequest::new(config)
+            .chat_id("test001".to_string())
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v1/chat/tab/delete_tabs.rs
+++ b/crates/openlark-communication/src/im/im/v1/chat/tab/delete_tabs.rs
@@ -71,21 +71,41 @@ impl DeleteChatTabsRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：DELETE /open-apis/im/v1/chats/test001/chat_tabs/delete_tabs
+    #[tokio::test]
+    async fn test_delete_chat_tabs_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/im/v1/chats/test001/chat_tabs/delete_tabs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: TabIdsBody =
+            serde_json::from_value(json!({ "tab_ids": ["test001"] })).expect("body 构造");
+        DeleteChatTabsRequest::new(config)
+            .chat_id("test001".to_string())
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v1/chat/tab/sort_tabs.rs
+++ b/crates/openlark-communication/src/im/im/v1/chat/tab/sort_tabs.rs
@@ -72,21 +72,41 @@ impl SortChatTabsRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/im/v1/chats/test001/chat_tabs/sort_tabs
+    #[tokio::test]
+    async fn test_sort_chat_tabs_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/im/v1/chats/test001/chat_tabs/sort_tabs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: TabIdsBody =
+            serde_json::from_value(json!({ "tab_ids": ["test001"] })).expect("body 构造");
+        SortChatTabsRequest::new(config)
+            .chat_id("test001".to_string())
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v1/chat/tab/update_tabs.rs
+++ b/crates/openlark-communication/src/im/im/v1/chat/tab/update_tabs.rs
@@ -66,21 +66,40 @@ impl UpdateChatTabsRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/im/v1/chats/test001/chat_tabs/update_tabs
+    #[tokio::test]
+    async fn test_update_chat_tabs_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/im/v1/chats/test001/chat_tabs/update_tabs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body = json!({});
+        UpdateChatTabsRequest::new(config)
+            .chat_id("test001".to_string())
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v2/app_feed_card/batch/delete.rs
+++ b/crates/openlark-communication/src/im/im/v2/app_feed_card/batch/delete.rs
@@ -64,21 +64,39 @@ impl DeleteAppFeedCardsRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：DELETE /open-apis/im/v2/app_feed_card/batch
+    #[tokio::test]
+    async fn test_delete_app_feed_cards_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/im/v2/app_feed_card/batch"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body = json!({});
+        DeleteAppFeedCardsRequest::new(config)
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v2/app_feed_card/batch/update.rs
+++ b/crates/openlark-communication/src/im/im/v2/app_feed_card/batch/update.rs
@@ -64,21 +64,39 @@ impl UpdateAppFeedCardsRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PUT /open-apis/im/v2/app_feed_card/batch
+    #[tokio::test]
+    async fn test_update_app_feed_cards_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/im/v2/app_feed_card/batch"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body = json!({});
+        UpdateAppFeedCardsRequest::new(config)
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v2/app_feed_card/create.rs
+++ b/crates/openlark-communication/src/im/im/v2/app_feed_card/create.rs
@@ -64,21 +64,39 @@ impl CreateAppFeedCardRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/im/v2/app_feed_card
+    #[tokio::test]
+    async fn test_create_app_feed_card_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/im/v2/app_feed_card"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body = json!({});
+        CreateAppFeedCardRequest::new(config)
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v2/biz_entity_tag_relation/create.rs
+++ b/crates/openlark-communication/src/im/im/v2/biz_entity_tag_relation/create.rs
@@ -55,21 +55,42 @@ impl CreateBizEntityTagRelationRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/im/v2/biz_entity_tag_relation
+    #[tokio::test]
+    async fn test_create_biz_entity_tag_relation_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/im/v2/biz_entity_tag_relation"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: BizEntityTagRelationBody = serde_json::from_value(
+            json!({ "tag_biz_type": "test001", "biz_entity_id": "test001" }),
+        )
+        .expect("body 构造");
+        CreateBizEntityTagRelationRequest::new(config)
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v2/biz_entity_tag_relation/update.rs
+++ b/crates/openlark-communication/src/im/im/v2/biz_entity_tag_relation/update.rs
@@ -55,21 +55,42 @@ impl UpdateBizEntityTagRelationRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PUT /open-apis/im/v2/biz_entity_tag_relation
+    #[tokio::test]
+    async fn test_update_biz_entity_tag_relation_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/im/v2/biz_entity_tag_relation"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: BizEntityTagRelationBody = serde_json::from_value(
+            json!({ "tag_biz_type": "test001", "biz_entity_id": "test001" }),
+        )
+        .expect("body 构造");
+        UpdateBizEntityTagRelationRequest::new(config)
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v2/chat_button/update.rs
+++ b/crates/openlark-communication/src/im/im/v2/chat_button/update.rs
@@ -66,21 +66,39 @@ impl UpdateChatButtonRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PUT /open-apis/im/v2/chat_button
+    #[tokio::test]
+    async fn test_update_chat_button_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/im/v2/chat_button"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body = json!({});
+        UpdateChatButtonRequest::new(config)
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v2/tag/create.rs
+++ b/crates/openlark-communication/src/im/im/v2/tag/create.rs
@@ -48,21 +48,39 @@ impl CreateTagRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/im/v2/tags
+    #[tokio::test]
+    async fn test_create_tag_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/im/v2/tags"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body = json!({});
+        CreateTagRequest::new(config)
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v2/tag/patch.rs
+++ b/crates/openlark-communication/src/im/im/v2/tag/patch.rs
@@ -65,21 +65,40 @@ impl PatchTagRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PATCH /open-apis/im/v2/tags/test001
+    #[tokio::test]
+    async fn test_patch_tag_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/im/v2/tags/test001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body = json!({});
+        PatchTagRequest::new(config)
+            .tag_id("test001".to_string())
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v2/url_preview/batch_update.rs
+++ b/crates/openlark-communication/src/im/im/v2/url_preview/batch_update.rs
@@ -57,21 +57,40 @@ impl BatchUpdateUrlPreviewRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/im/v2/url_previews/batch_update
+    #[tokio::test]
+    async fn test_batch_update_url_preview_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/im/v2/url_previews/batch_update"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: BatchUpdateUrlPreviewBody =
+            serde_json::from_value(json!({ "preview_tokens": ["test001"] })).expect("body 构造");
+        BatchUpdateUrlPreviewRequest::new(config)
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im_ephemeral/old/default/v1/delete.rs
+++ b/crates/openlark-communication/src/im/im_ephemeral/old/default/v1/delete.rs
@@ -58,21 +58,40 @@ impl DeleteEphemeralRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/ephemeral/v1/delete
+    #[tokio::test]
+    async fn test_delete_ephemeral_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/ephemeral/v1/delete"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: DeleteEphemeralBody =
+            serde_json::from_value(json!({ "message_id": "test001" })).expect("body 构造");
+        DeleteEphemeralRequest::new(config)
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im_ephemeral/old/default/v1/send.rs
+++ b/crates/openlark-communication/src/im/im_ephemeral/old/default/v1/send.rs
@@ -62,21 +62,41 @@ impl SendEphemeralRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/ephemeral/v1/send
+    #[tokio::test]
+    async fn test_send_ephemeral_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/ephemeral/v1/send"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let body: SendEphemeralBody =
+            serde_json::from_value(json!({ "user_id_list": ["test001"], "card": {} }))
+                .expect("body 构造");
+        SendEphemeralRequest::new(config)
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }


### PR DESCRIPTION
## 背景

#351 P3 第 10 批：`openlark-communication` 残留 44 个 body 类 API 的 Potemkin → wiremock e2e。

继 PR A（#394，28 简单 GET/DELETE/LIST e2e）后，本轮处理 body 类 create/update/patch/delete API。

## 改造内容（39 文件，35 e2e）

### body 构造模式（关键创新）

body 类型多无 Default/构造器，用 `serde_json::from_value` 按字段类型自动生成 JSON：
- `Vec<T>` → `["test001"]`（非空，过校验）
- `String` → `"test001"`
- `bool` → `false`，`i32` → `0`
- `Option<T>` → 跳过
- `serde_json::Value` → 直接 `json!({})`

### contact/v3（9 e2e）
employee_type_enum/functional_role/job_family/job_level create+update、unit bind/unbind/patch

### im/v1（16 e2e）
chat managers/menu_tree/tab/members/announcement/moderation 全套 create+update+delete+sort

### im/v2（8 e2e）+ card/ephemeral（3）+ contact/old（2）
biz_entity_tag_relation/chat_button/tag/app_feed_card/url_preview 等

## 验证

- `cargo test --all-features --lib`：685 全过
- `cargo clippy --all-targets --all-features -- -Dwarnings`：通过
- `cargo clippy --all-targets --no-default-features -- -Dwarnings`：通过

## 残留（5 文件）

- `event/v1/connection/get` + `outbound_ip/list`：已有真实反序列化测试（非 Potemkin）
- `feed_card/patch`：需 `UserIdType` 枚举构造，待手动处理
- `batch_send` / `bot_time_sentive`：复杂参数，待后续

## 踩坑

- 非 String setter（`member_id_type: MemberIdType`、`page_size: i32`）被脚本误加 → 移除（mock 不校验 query）
- body 的 Vec 字段多校验非空 → `[]` 改 `["test001"]`
- 响应有必填实体字段（如 `JobFamilyResponse.job_family`）→ 按 struct 补 mock

**communication crate Potemkin roundtrip 基本消除**（PR A + B = 63 e2e + 23 model 清除）。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in the communication crate; no runtime behavior or public API surface is modified.
> 
> **Overview**
> Replaces **placeholder** `serde_json` roundtrip tests in `openlark-communication` with **`#[tokio::test]` wiremock e2e** tests that exercise `Transport::request`, path/method matching, and `extract_response_data` on success responses.
> 
> Coverage spans **contact** (v2 batch add, v3 employee types, roles, job family/level, unit bind/unbind/patch), **IM v1** (chat members, managers, menus, tabs, announcement, moderation), **IM v2** (tags, app feed cards, URL preview, biz entity tag relation, chat button), plus **interactive card update** and **ephemeral** send/delete. Request bodies are built with `serde_json::from_value` / `json!` where typed bodies need non-empty vectors or required fields; mocks return `code: 0` payloads shaped for response structs when needed.
> 
> **No production API code changes**—only `#[cfg(test)]` modules. Removes `#[allow(unused_imports)]` where tests now use real imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d735d07d200bb11e13d8e3d22eadb807b4f6a0a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->