### PR TITLE
test(hr): ehr/payroll/compensation 35 wiremock e2e（#351 P4 PR A）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **hr ehr/payroll/compensation 35 真实端点占位测试 → wiremock e2e**（#351 第 12 批，P4 hr PR A）：
+  ehr/v1（employee list + attachment get 2）+ payroll/v1 全子域（acct_item/cost_allocation_*/
+  datasource/datasource_record/paygroup/payment_activity*/payment_detail 12）+
+  compensation/v1 全子域（archive/change_reason/indicator/item*/lump_sum_payment/plan/
+  recurring_payment/social_* 21）占位 `serde_json` roundtrip → wiremock 端到端。
+  模式：Config 非 Arc + `XxxApiV1` enum `to_url()` + `response.data.ok_or_else` +
+  `.enable_token_cache(false)`。已有真实 builder/validation 测试的文件（attachment get、
+  social_plan query、datasource_record save）保留并追加 e2e；三域 `mod.rs` 聚合占位测试删除。
+  performance/okr/attendance/hire/feishu_people 留后续 PR。**非 breaking**：纯测试替换/新增。
+
 - **docs 清除 38 个 Potemkin 丢弃式测试 + 15 wiremock e2e**（#351 第 11 批，P3 docs PR A）：
   baike（entity extract/match 2）+ ccm/drive（export_task/file version/import_task/media/permission/member 13）
   共 15 文件，每文件含 `let _ = request.execute().await` + `assert!(result.is_ok())` 的 Potemkin 丢弃式——调 execute

--- a/crates/openlark-hr/src/compensation_management/compensation/v1/archive/create.rs
+++ b/crates/openlark-hr/src/compensation_management/compensation/v1/archive/create.rs
@@ -65,21 +65,48 @@ impl ApiResponseTrait for CreateResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_create_archive_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/compensation/v1/archives"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = CreateRequest::new(config)
+            .execute()
+            .await
+            .expect("创建薪资档案应成功");
+
+        assert!(data.archive_id.is_none());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/compensation/v1/archives"
+        );
     }
 }

--- a/crates/openlark-hr/src/compensation_management/compensation/v1/archive/query.rs
+++ b/crates/openlark-hr/src/compensation_management/compensation/v1/archive/query.rs
@@ -110,21 +110,50 @@ impl ApiResponseTrait for QueryResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_query_archives_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/compensation/v1/archives/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config)
+            .execute()
+            .await
+            .expect("查询薪资档案应成功");
+
+        assert!(!data.has_more);
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/compensation/v1/archives/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/compensation_management/compensation/v1/change_reason/list.rs
+++ b/crates/openlark-hr/src/compensation_management/compensation/v1/change_reason/list.rs
@@ -79,21 +79,48 @@ impl ApiResponseTrait for ListResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_list_change_reasons_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{"items": []}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/compensation/v1/change_reasons"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config)
+            .execute()
+            .await
+            .expect("查询调薪原因应成功");
+
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/compensation/v1/change_reasons"
+        );
     }
 }

--- a/crates/openlark-hr/src/compensation_management/compensation/v1/indicator/list.rs
+++ b/crates/openlark-hr/src/compensation_management/compensation/v1/indicator/list.rs
@@ -114,21 +114,50 @@ impl ApiResponseTrait for ListResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_list_indicators_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/compensation/v1/indicators"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config)
+            .execute()
+            .await
+            .expect("查询指标应成功");
+
+        assert!(!data.has_more);
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/compensation/v1/indicators"
+        );
     }
 }

--- a/crates/openlark-hr/src/compensation_management/compensation/v1/item/list.rs
+++ b/crates/openlark-hr/src/compensation_management/compensation/v1/item/list.rs
@@ -114,21 +114,47 @@ impl ApiResponseTrait for ListResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_list_items_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/compensation/v1/items"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config)
+            .execute()
+            .await
+            .expect("查询薪资项应成功");
+
+        assert!(!data.has_more);
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/compensation/v1/items");
     }
 }

--- a/crates/openlark-hr/src/compensation_management/compensation/v1/item_category/list.rs
+++ b/crates/openlark-hr/src/compensation_management/compensation/v1/item_category/list.rs
@@ -79,21 +79,48 @@ impl ApiResponseTrait for ListResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_list_item_categories_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{"items": []}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/compensation/v1/item_categories"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config)
+            .execute()
+            .await
+            .expect("查询薪资项类别应成功");
+
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/compensation/v1/item_categories"
+        );
     }
 }

--- a/crates/openlark-hr/src/compensation_management/compensation/v1/lump_sum_payment/batch_create.rs
+++ b/crates/openlark-hr/src/compensation_management/compensation/v1/lump_sum_payment/batch_create.rs
@@ -75,21 +75,50 @@ impl ApiResponseTrait for BatchCreateResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_batch_create_lump_sum_payment_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/compensation/v1/lump_sum_payment/batch_create",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = BatchCreateRequest::new(config)
+            .execute()
+            .await
+            .expect("批量创建一次性支付应成功");
+
+        assert!(data.results.is_none());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/compensation/v1/lump_sum_payment/batch_create"
+        );
     }
 }

--- a/crates/openlark-hr/src/compensation_management/compensation/v1/lump_sum_payment/batch_remove.rs
+++ b/crates/openlark-hr/src/compensation_management/compensation/v1/lump_sum_payment/batch_remove.rs
@@ -75,21 +75,50 @@ impl ApiResponseTrait for BatchRemoveResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_batch_remove_lump_sum_payment_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/compensation/v1/lump_sum_payment/batch_remove",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = BatchRemoveRequest::new(config)
+            .execute()
+            .await
+            .expect("批量删除一次性支付应成功");
+
+        assert!(data.results.is_none());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/compensation/v1/lump_sum_payment/batch_remove"
+        );
     }
 }

--- a/crates/openlark-hr/src/compensation_management/compensation/v1/lump_sum_payment/batch_update.rs
+++ b/crates/openlark-hr/src/compensation_management/compensation/v1/lump_sum_payment/batch_update.rs
@@ -75,21 +75,50 @@ impl ApiResponseTrait for BatchUpdateResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_batch_update_lump_sum_payment_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/compensation/v1/lump_sum_payment/batch_update",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = BatchUpdateRequest::new(config)
+            .execute()
+            .await
+            .expect("批量更新一次性支付应成功");
+
+        assert!(data.results.is_none());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/compensation/v1/lump_sum_payment/batch_update"
+        );
     }
 }

--- a/crates/openlark-hr/src/compensation_management/compensation/v1/lump_sum_payment/query.rs
+++ b/crates/openlark-hr/src/compensation_management/compensation/v1/lump_sum_payment/query.rs
@@ -110,21 +110,50 @@ impl ApiResponseTrait for QueryResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_query_lump_sum_payment_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/compensation/v1/lump_sum_payment/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config)
+            .execute()
+            .await
+            .expect("查询一次性支付应成功");
+
+        assert!(!data.has_more);
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/compensation/v1/lump_sum_payment/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/compensation_management/compensation/v1/lump_sum_payment/query_detail.rs
+++ b/crates/openlark-hr/src/compensation_management/compensation/v1/lump_sum_payment/query_detail.rs
@@ -110,21 +110,52 @@ impl ApiResponseTrait for QueryDetailResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_query_detail_lump_sum_payment_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/compensation/v1/lump_sum_payment/query_detail",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryDetailRequest::new(config)
+            .execute()
+            .await
+            .expect("查询一次性支付明细应成功");
+
+        assert!(!data.has_more);
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/compensation/v1/lump_sum_payment/query_detail"
+        );
     }
 }

--- a/crates/openlark-hr/src/compensation_management/compensation/v1/plan/list.rs
+++ b/crates/openlark-hr/src/compensation_management/compensation/v1/plan/list.rs
@@ -114,21 +114,47 @@ impl ApiResponseTrait for ListResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_list_plans_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/compensation/v1/plans"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config)
+            .execute()
+            .await
+            .expect("查询薪资方案应成功");
+
+        assert!(!data.has_more);
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/compensation/v1/plans");
     }
 }

--- a/crates/openlark-hr/src/compensation_management/compensation/v1/recurring_payment/batch_create.rs
+++ b/crates/openlark-hr/src/compensation_management/compensation/v1/recurring_payment/batch_create.rs
@@ -75,21 +75,50 @@ impl ApiResponseTrait for BatchCreateResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_batch_create_recurring_payment_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/compensation/v1/recurring_payment/batch_create",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = BatchCreateRequest::new(config)
+            .execute()
+            .await
+            .expect("批量创建经常性支付应成功");
+
+        assert!(data.results.is_none());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/compensation/v1/recurring_payment/batch_create"
+        );
     }
 }

--- a/crates/openlark-hr/src/compensation_management/compensation/v1/recurring_payment/batch_remove.rs
+++ b/crates/openlark-hr/src/compensation_management/compensation/v1/recurring_payment/batch_remove.rs
@@ -75,21 +75,50 @@ impl ApiResponseTrait for BatchRemoveResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_batch_remove_recurring_payment_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/compensation/v1/recurring_payment/batch_remove",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = BatchRemoveRequest::new(config)
+            .execute()
+            .await
+            .expect("批量删除经常性支付应成功");
+
+        assert!(data.results.is_none());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/compensation/v1/recurring_payment/batch_remove"
+        );
     }
 }

--- a/crates/openlark-hr/src/compensation_management/compensation/v1/recurring_payment/batch_update.rs
+++ b/crates/openlark-hr/src/compensation_management/compensation/v1/recurring_payment/batch_update.rs
@@ -75,21 +75,50 @@ impl ApiResponseTrait for BatchUpdateResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_batch_update_recurring_payment_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/compensation/v1/recurring_payment/batch_update",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = BatchUpdateRequest::new(config)
+            .execute()
+            .await
+            .expect("批量更新经常性支付应成功");
+
+        assert!(data.results.is_none());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/compensation/v1/recurring_payment/batch_update"
+        );
     }
 }

--- a/crates/openlark-hr/src/compensation_management/compensation/v1/recurring_payment/query.rs
+++ b/crates/openlark-hr/src/compensation_management/compensation/v1/recurring_payment/query.rs
@@ -110,21 +110,50 @@ impl ApiResponseTrait for QueryResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_query_recurring_payment_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/compensation/v1/recurring_payment/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config)
+            .execute()
+            .await
+            .expect("查询经常性支付应成功");
+
+        assert!(!data.has_more);
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/compensation/v1/recurring_payment/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/compensation_management/compensation/v1/social_archive/query.rs
+++ b/crates/openlark-hr/src/compensation_management/compensation/v1/social_archive/query.rs
@@ -110,21 +110,50 @@ impl ApiResponseTrait for QueryResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_query_social_archive_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/compensation/v1/social_archive/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config)
+            .execute()
+            .await
+            .expect("查询社保档案应成功");
+
+        assert!(!data.has_more);
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/compensation/v1/social_archive/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/compensation_management/compensation/v1/social_archive_adjust_record/query.rs
+++ b/crates/openlark-hr/src/compensation_management/compensation/v1/social_archive_adjust_record/query.rs
@@ -110,21 +110,52 @@ impl ApiResponseTrait for QueryResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_query_social_archive_adjust_record_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/compensation/v1/social_archive_adjust_record/query",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config)
+            .execute()
+            .await
+            .expect("查询社保档案调整记录应成功");
+
+        assert!(!data.has_more);
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/compensation/v1/social_archive_adjust_record/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/compensation_management/compensation/v1/social_insurance/list.rs
+++ b/crates/openlark-hr/src/compensation_management/compensation/v1/social_insurance/list.rs
@@ -79,21 +79,48 @@ impl ApiResponseTrait for ListResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_list_social_insurances_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{"items": []}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/compensation/v1/social_insurances"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config)
+            .execute()
+            .await
+            .expect("查询险种应成功");
+
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/compensation/v1/social_insurances"
+        );
     }
 }

--- a/crates/openlark-hr/src/compensation_management/compensation/v1/social_plan/list.rs
+++ b/crates/openlark-hr/src/compensation_management/compensation/v1/social_plan/list.rs
@@ -128,21 +128,50 @@ impl ApiResponseTrait for ListResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_list_social_plans_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/compensation/v1/social_plans"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config, 1_700_000_000)
+            .execute()
+            .await
+            .expect("查询参保方案应成功");
+
+        assert!(!data.has_more);
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/compensation/v1/social_plans"
+        );
     }
 }

--- a/crates/openlark-hr/src/compensation_management/compensation/v1/social_plan/query.rs
+++ b/crates/openlark-hr/src/compensation_management/compensation/v1/social_plan/query.rs
@@ -195,4 +195,45 @@ mod tests {
         );
         assert!(valid_request.validate().is_ok());
     }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_query_social_plans_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{"items": []}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/compensation/v1/social_plans/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config, vec!["plan_001".to_string()], 1_700_000_000)
+            .execute()
+            .await
+            .expect("批量查询参保方案应成功");
+
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/compensation/v1/social_plans/query"
+        );
+    }
 }

--- a/crates/openlark-hr/src/compensation_management/mod.rs
+++ b/crates/openlark-hr/src/compensation_management/mod.rs
@@ -24,24 +24,3 @@ impl CompensationManagement {
         &self.config
     }
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-hr/src/ehr/ehr/v1/attachment/get.rs
+++ b/crates/openlark-hr/src/ehr/ehr/v1/attachment/get.rs
@@ -156,4 +156,53 @@ mod tests {
             GetRequest::new(create_test_config(), "att_1".to_string(), "u_1".to_string());
         assert!(valid_request.validate().is_ok());
     }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_get_attachment_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{"name": "resume.pdf", "file_type": "pdf", "size": 1024, "download_url": "https://example.com/r.pdf", "token": "tok_1"}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/ehr/v1/attachments/att_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = GetRequest::new(config, "att_001".to_string(), "u_001".to_string())
+            .execute()
+            .await
+            .expect("下载人员附件应成功");
+
+        assert_eq!(data.name, "resume.pdf");
+        assert_eq!(data.size, 1024);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/ehr/v1/attachments/att_001"
+        );
+        assert!(
+            received[0]
+                .url
+                .query()
+                .unwrap_or("")
+                .contains("user_id=u_001")
+        );
+    }
 }

--- a/crates/openlark-hr/src/ehr/ehr/v1/employee/list.rs
+++ b/crates/openlark-hr/src/ehr/ehr/v1/employee/list.rs
@@ -162,21 +162,48 @@ impl ApiResponseTrait for ListResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_list_employees_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/ehr/v1/employees"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config)
+            .execute()
+            .await
+            .expect("批量获取员工花名册应成功");
+
+        assert!(!data.has_more);
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/ehr/v1/employees");
     }
 }

--- a/crates/openlark-hr/src/ehr/mod.rs
+++ b/crates/openlark-hr/src/ehr/mod.rs
@@ -26,23 +26,3 @@ impl Ehr {
         &self.config
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-hr/src/payroll/mod.rs
+++ b/crates/openlark-hr/src/payroll/mod.rs
@@ -26,24 +26,3 @@ impl Payroll {
         &self.config
     }
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-hr/src/payroll/payroll/v1/acct_item/list.rs
+++ b/crates/openlark-hr/src/payroll/payroll/v1/acct_item/list.rs
@@ -124,21 +124,47 @@ impl ApiResponseTrait for ListResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_list_acct_items_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/payroll/v1/acct_items"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config)
+            .execute()
+            .await
+            .expect("批量查询算薪项应成功");
+
+        assert!(!data.has_more);
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/payroll/v1/acct_items");
     }
 }

--- a/crates/openlark-hr/src/payroll/payroll/v1/cost_allocation_detail/list.rs
+++ b/crates/openlark-hr/src/payroll/payroll/v1/cost_allocation_detail/list.rs
@@ -148,21 +148,50 @@ impl ApiResponseTrait for ListResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_list_cost_allocation_details_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/payroll/v1/cost_allocation_details"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config)
+            .execute()
+            .await
+            .expect("查询成本分摊明细应成功");
+
+        assert!(!data.has_more);
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/payroll/v1/cost_allocation_details"
+        );
     }
 }

--- a/crates/openlark-hr/src/payroll/payroll/v1/cost_allocation_plan/list.rs
+++ b/crates/openlark-hr/src/payroll/payroll/v1/cost_allocation_plan/list.rs
@@ -126,21 +126,50 @@ impl ApiResponseTrait for ListResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_list_cost_allocation_plans_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/payroll/v1/cost_allocation_plans"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config)
+            .execute()
+            .await
+            .expect("查询成本分摊方案应成功");
+
+        assert!(!data.has_more);
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/payroll/v1/cost_allocation_plans"
+        );
     }
 }

--- a/crates/openlark-hr/src/payroll/payroll/v1/cost_allocation_report/list.rs
+++ b/crates/openlark-hr/src/payroll/payroll/v1/cost_allocation_report/list.rs
@@ -151,21 +151,50 @@ impl ApiResponseTrait for ListResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_list_cost_allocation_reports_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/payroll/v1/cost_allocation_reports"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config)
+            .execute()
+            .await
+            .expect("查询成本分摊报告应成功");
+
+        assert!(!data.has_more);
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/payroll/v1/cost_allocation_reports"
+        );
     }
 }

--- a/crates/openlark-hr/src/payroll/payroll/v1/datasource/list.rs
+++ b/crates/openlark-hr/src/payroll/payroll/v1/datasource/list.rs
@@ -122,21 +122,47 @@ impl ApiResponseTrait for ListResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_list_datasources_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/payroll/v1/datasources"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config)
+            .execute()
+            .await
+            .expect("查询数据源应成功");
+
+        assert!(!data.has_more);
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/payroll/v1/datasources");
     }
 }

--- a/crates/openlark-hr/src/payroll/payroll/v1/datasource_record/query.rs
+++ b/crates/openlark-hr/src/payroll/payroll/v1/datasource_record/query.rs
@@ -169,21 +169,50 @@ impl ApiResponseTrait for QueryResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_query_datasource_records_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/payroll/v1/datasource_records/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config)
+            .execute()
+            .await
+            .expect("查询数据源记录应成功");
+
+        assert!(!data.has_more);
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/payroll/v1/datasource_records/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/payroll/payroll/v1/datasource_record/save.rs
+++ b/crates/openlark-hr/src/payroll/payroll/v1/datasource_record/save.rs
@@ -232,4 +232,60 @@ mod tests {
 
         assert!(result.is_err());
     }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_save_datasource_records_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"success": true, "processed_count": 1, "failed_count": 0}"#)
+                .unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/payroll/v1/datasource_records/save"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = SaveRequest::new(
+            config,
+            "ds_001".to_string(),
+            vec!["emp_001".to_string()],
+            vec![DatasourceRecord {
+                employee_id: "emp_001".to_string(),
+                items: vec![DatasourceRecordItem {
+                    field_name: "amount".to_string(),
+                    value: serde_json::json!(100),
+                }],
+            }],
+        )
+        .execute()
+        .await
+        .expect("保存数据源记录应成功");
+
+        assert!(data.success);
+        assert_eq!(data.processed_count, 1);
+        assert_eq!(data.failed_count, 0);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/payroll/v1/datasource_records/save"
+        );
+    }
 }

--- a/crates/openlark-hr/src/payroll/payroll/v1/paygroup/list.rs
+++ b/crates/openlark-hr/src/payroll/payroll/v1/paygroup/list.rs
@@ -126,21 +126,47 @@ impl ApiResponseTrait for ListResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_list_paygroups_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/payroll/v1/paygroups"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config)
+            .execute()
+            .await
+            .expect("查询薪资组应成功");
+
+        assert!(!data.has_more);
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/payroll/v1/paygroups");
     }
 }

--- a/crates/openlark-hr/src/payroll/payroll/v1/payment_activity/archive.rs
+++ b/crates/openlark-hr/src/payroll/payroll/v1/payment_activity/archive.rs
@@ -80,21 +80,52 @@ impl ApiResponseTrait for ArchiveResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_archive_payment_activity_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(
+            r#"{"success": true, "activity_id": "act_001", "archived_at": 1700000000}"#,
+        )
+        .unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/payroll/v1/payment_activitys/archive"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ArchiveRequest::new(config, "act_001".to_string())
+            .execute()
+            .await
+            .expect("封存发薪活动应成功");
+
+        assert!(data.success);
+        assert_eq!(data.activity_id, "act_001");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/payroll/v1/payment_activitys/archive"
+        );
     }
 }

--- a/crates/openlark-hr/src/payroll/payroll/v1/payment_activity/list.rs
+++ b/crates/openlark-hr/src/payroll/payroll/v1/payment_activity/list.rs
@@ -152,21 +152,50 @@ impl ApiResponseTrait for ListResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_list_payment_activities_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/payroll/v1/payment_activitys"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config)
+            .execute()
+            .await
+            .expect("查询发薪活动应成功");
+
+        assert!(!data.has_more);
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/payroll/v1/payment_activitys"
+        );
     }
 }

--- a/crates/openlark-hr/src/payroll/payroll/v1/payment_activity_detail/list.rs
+++ b/crates/openlark-hr/src/payroll/payroll/v1/payment_activity_detail/list.rs
@@ -141,21 +141,50 @@ impl ApiResponseTrait for ListResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_list_payment_activity_details_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/payroll/v1/payment_activity_details"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config)
+            .execute()
+            .await
+            .expect("查询发薪活动明细应成功");
+
+        assert!(!data.has_more);
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/payroll/v1/payment_activity_details"
+        );
     }
 }

--- a/crates/openlark-hr/src/payroll/payroll/v1/payment_detail/query.rs
+++ b/crates/openlark-hr/src/payroll/payroll/v1/payment_detail/query.rs
@@ -183,21 +183,50 @@ pub struct DeductionItem {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_query_payment_details_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/payroll/v1/payment_detail/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config, "act_001".to_string())
+            .execute()
+            .await
+            .expect("查询发薪明细应成功");
+
+        assert!(!data.has_more);
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/payroll/v1/payment_detail/query"
+        );
     }
 }

--- a/docs/API_E2E_TEST_STRATEGY.md
+++ b/docs/API_E2E_TEST_STRATEGY.md
@@ -122,20 +122,20 @@ assert!(query.contains("device_type=gate"));
 
 | Crate | API 文件数 | 含 mod tests 文件 | 现状 | 优先级 |
 |-------|-----------|------------------|------|--------|
-| `openlark-security` | 39 | 32 | ✅ **本 PR pilot（全量改造）** | P0 |
-| `openlark-cardkit` | 10 | 18 | 小，适合第 2 批 | P1 |
-| `openlark-user` | 7 | 10 | 小，适合第 2 批 | P1 |
+| `openlark-security` | 39 | 32 | ✅ pilot 全量 wiremock e2e | P0 |
+| `openlark-cardkit` | 10 | 18 | ✅ 全量 wiremock e2e | P1 |
+| `openlark-user` | 7 | 10 | ✅ wiremock e2e（幻影 get 见 #377） | P1 |
 | `openlark-auth` | 15 | 26 | ✅ 已是 wiremock e2e（范本） | — |
-| `openlark-analytics` | 20 | 25 | 中 | P2 |
-| `openlark-helpdesk` | 57 | 75 | 中（需补 wiremock dev-dep） | P2 |
-| `openlark-application` | 96 | 104 | 大，宜拆子 issue | P3 |
-| `openlark-mail` | 108 | 130 | 大，宜拆子 issue | P3 |
-| `openlark-platform` | 125 | 131 | 大，宜拆子 issue | P3 |
-| `openlark-meeting` | 125 | 134 | 大，宜拆子 issue | P3 |
-| `openlark-workflow` | 132 | 154 | 大，宜拆子 issue | P3 |
-| `openlark-docs` | 172 | 263 | 大 + 既有 Potemkin 需先清理 | P3 |
-| `openlark-communication` | 190 | 227 | 大，宜拆子 issue | P3 |
-| `openlark-hr` | 599 | 625 | 最大，按子域多次拆分 | P4 |
+| `openlark-analytics` | 20 | 25 | ✅ 全量 wiremock e2e | P2 |
+| `openlark-helpdesk` | 57 | 75 | ✅ 全量 wiremock e2e | P2 |
+| `openlark-application` | 96 | 104 | ✅ 真实端点 36 e2e；幻影 stub 见 #382 | P3 |
+| `openlark-mail` | 108 | 130 | ✅ 34 真实端点 wiremock e2e | P3 |
+| `openlark-platform` | 125 | 131 | ✅ 76 endpoint e2e，占位 0 残留 | P3 |
+| `openlark-meeting` | 125 | 134 | ✅ 90 endpoint e2e，占位 0 残留 | P3 |
+| `openlark-workflow` | 132 | 154 | ✅ 清 roundtrip 占位；endpoint 已有 to_url/builder 测试，完整 e2e 可后续 | P3 |
+| `openlark-docs` | 172 | 263 | ✅ Potemkin 清理 + sheets/docx/wiki/drive/base 等 e2e | P3 |
+| `openlark-communication` | 190 | 227 | ✅ 28+35 body 类 wiremock e2e | P3 |
+| `openlark-hr` | 599 | 625 | 🚧 **进行中**：PR A ehr+payroll+compensation 35 e2e；余 performance/okr/attendance/hire/feishu_people | P4 |
 
 **选型原则**：
 - pilot 选小而全（覆盖 GET/POST/LIST/DELETE/PATCH 等所有形状）的 crate，建立可复制范本 → `openlark-security`。
@@ -147,7 +147,8 @@ assert!(query.contains("device_type=gate"));
 - [x] 测试策略文档（本文件）
 - [x] pilot crate（`openlark-security`）全量替换为 wiremock 端到端（含移除 `src/lib.rs` 中的占位 roundtrip 测试）
 - [x] `cargo test -p openlark-security --all-features` 通过（79 项，含 39 个新增 e2e）
-- [ ] 后续 crate：按上表分批建子 issue
+- [x] P1–P3 业务 crate 按批完成（cardkit/user/analytics/helpdesk/application/mail/platform/meeting/workflow/docs/communication）
+- [ ] P4 `openlark-hr`：按子域分批（PR A: ehr+payroll+compensation ✅；后续 performance/okr/attendance/hire/feishu_people）
 
 ## 6. 相关文档
 


### PR DESCRIPTION
## Summary

- #351 P4 第一批：`openlark-hr` 的 **ehr + payroll + compensation** 共 35 个真实端点
- 占位 `serde_json` roundtrip → wiremock 端到端（Builder → execute → Transport → mock → assert）
- 删除三域 `mod.rs` 聚合占位测试；更新策略文档与 CHANGELOG

## Stack

1. **本 PR**（base: `main`）
2. performance → 本分支
3. okr → performance
4. attendance → okr

## Test plan

- [x] `cargo test -p openlark-hr --lib --all-features`（相关 e2e 通过）
- [x] `cargo clippy -p openlark-hr --all-targets --all-features -- -D warnings`
- [ ] CI 全绿

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime API modifications; large diff is repetitive e2e boilerplate across many files.
> 
> **Overview**
> **#351 P4 PR A** advances `openlark-hr` test hygiene for **ehr**, **payroll**, and **compensation** by swapping meaningless `serde_json` roundtrip placeholders for **wiremock** end-to-end tests on **35 real API endpoints**.
> 
> Placeholder tests that only parsed generic JSON are removed from per-endpoint modules and from **`ehr` / `payroll` / `compensation_management` `mod.rs`** aggregates. Each affected endpoint gains a **`test_*_returns_data_on_success`** async test that runs **Builder → `execute` → Transport → mock server**, asserts typed **`data`** parsing, and checks **HTTP method + path** (and query where relevant, e.g. attachment `user_id`). Tests use **`Config`** with **`base_url(server.uri())`** and **`.enable_token_cache(false)`**, matching the established #351 pattern.
> 
> Files that already had **builder / validation** coverage (**attachment get**, **social_plan query**, **datasource_record save**) keep those tests and **add** e2e alongside. **CHANGELOG** and **`docs/API_E2E_TEST_STRATEGY.md`** record this batch; remaining HR subdomains (performance, okr, attendance, hire, feishu_people) are explicitly deferred.
> 
> **No production API or `execute` behavior changes**—tests and docs only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b353154bb92fb955853d7cfbb5275b37d75ed38c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->