### PR TITLE
test(hr): okr 37 wiremock e2e（#351 P4 okr）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **hr okr 37 真实端点占位测试 → wiremock e2e**（#351 第 14 批，P4 hr okr）：
+  okr/v1（progress_record/period/period_rule/image/okr/review/user 12）+ okr/v2 全子域
+  （category/cycle/objective/key_result/alignment/indicator 25）占位 roundtrip → wiremock 端到端。
+  v2 含 Arc<Config> + path builder + `execute(body: Value)` 形态；`user/okr/list` 按代码实际
+  path（`/users/{id}/okrs`，非 enum 的 user_okrs/list）mock。域级 mod.rs 聚合占位删除。
+  **非 breaking**：纯测试替换/新增。
+
 - **hr performance 21 真实端点占位测试 → wiremock e2e**（#351 第 13 批，P4 hr performance）：
   performance/v1（semester/stage_task/review_data 4）+ performance/v2 全子域（activity/
   additional_information*/indicator/metric_*/question/review_*/reviewee/user_* 17）

--- a/crates/openlark-hr/src/okr/mod.rs
+++ b/crates/openlark-hr/src/okr/mod.rs
@@ -31,23 +31,3 @@ impl Okr {
         okr::OkrV2::new(self.config.clone())
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-hr/src/okr/okr/v1/image/upload.rs
+++ b/crates/openlark-hr/src/okr/okr/v1/image/upload.rs
@@ -116,21 +116,53 @@ impl ApiResponseTrait for UploadResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v1_image_upload_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"image_id": "test", "image_url": "test"}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/okr/v1/images/upload"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = UploadRequest::new(
+            config,
+            1,
+            "sample_image_name".to_string(),
+            "sample_image_content".to_string(),
+        )
+        .execute()
+        .await
+        .expect("okr_v1_image_upload 应成功");
+
+        assert_eq!(data.image_id, "test");
+        assert_eq!(data.image_url, "test");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/okr/v1/images/upload");
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v1/okr/batch_get.rs
+++ b/crates/openlark-hr/src/okr/okr/v1/okr/batch_get.rs
@@ -117,21 +117,46 @@ impl ApiResponseTrait for BatchGetResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_batch_get_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{"items": []}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/okr/v1/okrs/batch_get"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = BatchGetRequest::new(config, vec!["id_001".to_string()])
+            .execute()
+            .await
+            .expect("batch_get 应成功");
+
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/okr/v1/okrs/batch_get");
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v1/period/create.rs
+++ b/crates/openlark-hr/src/okr/okr/v1/period/create.rs
@@ -225,4 +225,53 @@ mod tests {
         })();
         assert!(result.is_err());
     }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v1_period_create_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"period_id": "test", "name": "test", "start_time": 0, "end_time": 0, "status": 0, "created_at": 0}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/okr/v1/periods"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = CreateRequest::new(
+            config,
+            "sample_name".to_string(),
+            1_700_000_000,
+            1_700_000_000,
+        )
+        .execute()
+        .await
+        .expect("okr_v1_period_create 应成功");
+
+        assert_eq!(data.period_id, "test");
+        assert_eq!(data.name, "test");
+        let _ = data.start_time;
+        let _ = data.end_time;
+        let _ = data.status;
+        let _ = data.created_at;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/okr/v1/periods");
+    }
 }

--- a/crates/openlark-hr/src/okr/okr/v1/period/list.rs
+++ b/crates/openlark-hr/src/okr/okr/v1/period/list.rs
@@ -131,21 +131,48 @@ impl ApiResponseTrait for ListResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v1_period_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/okr/v1/periods"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config)
+            .execute()
+            .await
+            .expect("okr_v1_period_list 应成功");
+
+        assert!(data.items.is_empty());
+        let _ = data.has_more;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/okr/v1/periods");
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v1/period/patch.rs
+++ b/crates/openlark-hr/src/okr/okr/v1/period/patch.rs
@@ -109,21 +109,52 @@ impl ApiResponseTrait for PatchResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v1_period_patch_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"period_id": "test", "status": 0, "updated_at": 0}"#).unwrap();
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/okr/v1/periods/period_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = PatchRequest::new(config, "period_001".to_string(), 1)
+            .execute()
+            .await
+            .expect("okr_v1_period_patch 应成功");
+
+        assert_eq!(data.period_id, "test");
+        let _ = data.status;
+        let _ = data.updated_at;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v1/periods/period_001"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v1/period_rule/list.rs
+++ b/crates/openlark-hr/src/okr/okr/v1/period_rule/list.rs
@@ -105,21 +105,46 @@ impl ApiResponseTrait for ListResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v1_period_rule_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{"items": []}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/okr/v1/period_rules"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config)
+            .execute()
+            .await
+            .expect("okr_v1_period_rule_list 应成功");
+
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/okr/v1/period_rules");
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v1/progress_record/create.rs
+++ b/crates/openlark-hr/src/okr/okr/v1/progress_record/create.rs
@@ -152,21 +152,56 @@ impl ApiResponseTrait for CreateResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v1_progress_record_create_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"progress_id": "test", "okr_id": "test", "content": "test", "progress_rate": 0, "created_at": 0}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/okr/v1/progress_records"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = CreateRequest::new(
+            config,
+            "okr_001".to_string(),
+            "sample_content".to_string(),
+            1,
+        )
+        .execute()
+        .await
+        .expect("okr_v1_progress_record_create 应成功");
+
+        assert_eq!(data.progress_id, "test");
+        assert_eq!(data.okr_id, "test");
+        assert_eq!(data.content, "test");
+        let _ = data.progress_rate;
+        let _ = data.created_at;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/okr/v1/progress_records");
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v1/progress_record/delete.rs
+++ b/crates/openlark-hr/src/okr/okr/v1/progress_record/delete.rs
@@ -76,21 +76,49 @@ impl ApiResponseTrait for DeleteResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v1_progress_record_delete_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{"result": false}"#).unwrap();
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/okr/v1/progress_records/progress_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = DeleteRequest::new(config, "progress_001".to_string())
+            .execute()
+            .await
+            .expect("okr_v1_progress_record_delete 应成功");
+
+        let _ = data.result;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v1/progress_records/progress_001"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v1/progress_record/get.rs
+++ b/crates/openlark-hr/src/okr/okr/v1/progress_record/get.rs
@@ -94,21 +94,56 @@ impl ApiResponseTrait for GetResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v1_progress_record_get_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"progress_id": "test", "okr_id": "test", "content": "test", "progress_rate": 0, "creator_id": "test", "created_at": 0, "updated_at": 0}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/okr/v1/progress_records/progress_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = GetRequest::new(config, "progress_001".to_string())
+            .execute()
+            .await
+            .expect("okr_v1_progress_record_get 应成功");
+
+        assert_eq!(data.progress_id, "test");
+        assert_eq!(data.okr_id, "test");
+        assert_eq!(data.content, "test");
+        let _ = data.progress_rate;
+        assert_eq!(data.creator_id, "test");
+        let _ = data.created_at;
+        let _ = data.updated_at;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v1/progress_records/progress_001"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v1/progress_record/update.rs
+++ b/crates/openlark-hr/src/okr/okr/v1/progress_record/update.rs
@@ -125,21 +125,59 @@ impl ApiResponseTrait for UpdateResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v1_progress_record_update_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"progress_id": "test", "okr_id": "test", "content": "test", "progress_rate": 0, "updated_at": 0}"#).unwrap();
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/okr/v1/progress_records/progress_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = UpdateRequest::new(
+            config,
+            "progress_001".to_string(),
+            "sample_content".to_string(),
+            1,
+        )
+        .execute()
+        .await
+        .expect("okr_v1_progress_record_update 应成功");
+
+        assert_eq!(data.progress_id, "test");
+        assert_eq!(data.okr_id, "test");
+        assert_eq!(data.content, "test");
+        let _ = data.progress_rate;
+        let _ = data.updated_at;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v1/progress_records/progress_001"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v1/review/query.rs
+++ b/crates/openlark-hr/src/okr/okr/v1/review/query.rs
@@ -132,21 +132,48 @@ impl ApiResponseTrait for QueryResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v1_review_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/okr/v1/reviews/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config, "period_001".to_string())
+            .execute()
+            .await
+            .expect("okr_v1_review_query 应成功");
+
+        assert!(data.items.is_empty());
+        let _ = data.has_more;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/okr/v1/reviews/query");
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v1/user/okr/list.rs
+++ b/crates/openlark-hr/src/okr/okr/v1/user/okr/list.rs
@@ -136,21 +136,51 @@ impl ApiResponseTrait for ListResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/okr/v1/users/user_001/okrs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config, "user_001".to_string())
+            .execute()
+            .await
+            .expect("list 应成功");
+
+        assert!(data.items.is_empty());
+        let _ = data.has_more;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v1/users/user_001/okrs"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/alignment/delete.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/alignment/delete.rs
@@ -69,6 +69,7 @@ impl ApiResponseTrait for DeleteAlignmentResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     #[test]
     fn builder_initializes() {
         let config = Arc::new(Config::default());
@@ -80,5 +81,47 @@ mod tests {
         let json = serde_json::json!({});
         let resp: DeleteAlignmentResponse = serde_json::from_value(json).expect("反序列化失败");
         let _ = resp;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_alignment_delete_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/okr/v2/alignments/alignment_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .alignment_id("alignment_001")
+            .execute()
+            .await
+            .expect("okr_v2_alignment_delete 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/alignments/alignment_001"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/alignment/get.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/alignment/get.rs
@@ -73,6 +73,7 @@ impl ApiResponseTrait for GetAlignmentResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     #[test]
     fn builder_initializes() {
         let config = Arc::new(Config::default());
@@ -98,5 +99,59 @@ mod tests {
         assert_eq!(resp.alignment.id, "A-123");
         assert_eq!(resp.alignment.from_entity_type, 1);
         assert_eq!(resp.alignment.to_owner.owner_type, "user");
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_alignment_get_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body = json!({
+            "alignment": {
+                "id": "A-123",
+                "create_time": "1700000000000",
+                "update_time": "1700000000000",
+                "from_owner": {"owner_type": "user", "user_id": "ou_from"},
+                "to_owner": {"owner_type": "user", "user_id": "ou_to"},
+                "from_entity_type": 1,
+                "from_entity_id": "E-1",
+                "to_entity_type": 2,
+                "to_entity_id": "E-2"
+            }
+        });
+        Mock::given(method("GET"))
+            .and(path("/open-apis/okr/v2/alignments/alignment_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .alignment_id("alignment_001")
+            .execute()
+            .await
+            .expect("okr_v2_alignment_get 应成功");
+
+        let _ = &data.alignment;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/alignments/alignment_001"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/category/list.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/category/list.rs
@@ -101,6 +101,7 @@ pub struct CategoryName {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
 
     #[test]
     fn builder_initializes() {
@@ -144,5 +145,43 @@ mod tests {
         assert_eq!(items[0].name.zh, Some("中文".to_string()));
         assert_eq!(items[0].name.en, Some("英文".to_string()));
         assert_eq!(items[0].name.ja, Some("日文".to_string()));
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_category_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/okr/v2/categories"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .execute()
+            .await
+            .expect("okr_v2_category_list 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/okr/v2/categories");
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/cycle/list.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/cycle/list.rs
@@ -149,6 +149,7 @@ pub struct CycleOwner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
 
     #[test]
     fn builder_initializes() {
@@ -208,5 +209,44 @@ mod tests {
         assert_eq!(cycle.owner.owner_type, "user");
         assert_eq!(cycle.cycle_status, Some(1));
         assert_eq!(cycle.score, Some(0.5));
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_cycle_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/okr/v2/cycles"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .user_id("user_id_001")
+            .execute()
+            .await
+            .expect("okr_v2_cycle_list 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/okr/v2/cycles");
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/cycle/objective/create.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/cycle/objective/create.rs
@@ -84,6 +84,7 @@ impl ApiResponseTrait for CreateCycleObjectiveResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
 
     #[test]
     fn builder_initializes() {
@@ -107,5 +108,47 @@ mod tests {
         let resp: CreateCycleObjectiveResponse =
             serde_json::from_value(json).expect("反序列化失败");
         assert_eq!(resp.objective_id, Some("7342342398472398473".to_string()));
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_cycle_objective_create_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/okr/v2/cycles/cycle_001/objectives"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .cycle_id("cycle_001")
+            .execute(serde_json::json!({}))
+            .await
+            .expect("okr_v2_cycle_objective_create 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/cycles/cycle_001/objectives"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/cycle/objective/list.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/cycle/objective/list.rs
@@ -81,6 +81,7 @@ impl ApiResponseTrait for ListCycleObjectiveResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
 
     #[test]
     fn builder_initializes() {
@@ -127,5 +128,47 @@ mod tests {
         assert_eq!(objective.owner.owner_type, "user");
         assert_eq!(objective.score, Some(0.8));
         assert!(objective.content.is_none());
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_cycle_objective_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/okr/v2/cycles/cycle_001/objectives"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .cycle_id("cycle_001")
+            .execute()
+            .await
+            .expect("okr_v2_cycle_objective_list 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/cycles/cycle_001/objectives"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/cycle/objectives_position.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/cycle/objectives_position.rs
@@ -90,6 +90,7 @@ impl ApiResponseTrait for UpdateCycleObjectivesPositionResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
 
     #[test]
     fn builder_initializes() {
@@ -132,5 +133,49 @@ mod tests {
         let objective = &resp.items.unwrap()[0];
         assert_eq!(objective.id, "7342342398472398473");
         assert_eq!(objective.position, 1);
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_cycle_objectives_position_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("PUT"))
+            .and(path(
+                "/open-apis/okr/v2/cycles/cycle_001/objectives_position",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .cycle_id("cycle_001")
+            .execute(serde_json::json!({}))
+            .await
+            .expect("okr_v2_cycle_objectives_position 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/cycles/cycle_001/objectives_position"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/cycle/objectives_weight.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/cycle/objectives_weight.rs
@@ -90,6 +90,7 @@ impl ApiResponseTrait for UpdateCycleObjectivesWeightResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
 
     #[test]
     fn builder_initializes() {
@@ -129,5 +130,47 @@ mod tests {
         let objective = &resp.items.unwrap()[0];
         assert_eq!(objective.id, "7342342398472398473");
         assert_eq!(objective.weight, Some(0.5));
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_cycle_objectives_weight_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/okr/v2/cycles/cycle_001/objectives_weight"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .cycle_id("cycle_001")
+            .execute(serde_json::json!({}))
+            .await
+            .expect("okr_v2_cycle_objectives_weight 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/cycles/cycle_001/objectives_weight"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/indicator/patch.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/indicator/patch.rs
@@ -85,6 +85,7 @@ impl ApiResponseTrait for PatchIndicatorResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     #[test]
     fn builder_initializes() {
         let config = Arc::new(Config::default());
@@ -124,5 +125,47 @@ mod tests {
         let json = serde_json::json!({});
         let resp: PatchIndicatorResponse = serde_json::from_value(json).expect("反序列化失败");
         assert!(resp.indicator.is_none());
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_indicator_patch_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/okr/v2/indicators/indicator_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .indicator_id("indicator_001")
+            .execute(serde_json::json!({}))
+            .await
+            .expect("okr_v2_indicator_patch 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/indicators/indicator_001"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/key_result/delete.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/key_result/delete.rs
@@ -69,6 +69,7 @@ impl ApiResponseTrait for DeleteKeyResultResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
 
     #[test]
     fn builder_initializes() {
@@ -81,5 +82,47 @@ mod tests {
         let json = serde_json::json!({});
         let resp: DeleteKeyResultResponse = serde_json::from_value(json).expect("反序列化失败");
         let _ = resp;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_key_result_delete_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/okr/v2/key_results/key_result_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .key_result_id("key_result_001")
+            .execute()
+            .await
+            .expect("okr_v2_key_result_delete 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/key_results/key_result_001"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/key_result/get.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/key_result/get.rs
@@ -73,6 +73,7 @@ impl ApiResponseTrait for GetKeyResultResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
 
     #[test]
     fn builder_initializes() {
@@ -105,5 +106,59 @@ mod tests {
         assert_eq!(resp.key_result.weight, Some(0.5));
         assert_eq!(resp.key_result.deadline, Some("1700000000000".to_string()));
         assert!(resp.key_result.content.is_none());
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_key_result_get_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body = json!({
+            "key_result": {
+                "id": "KR-123",
+                "create_time": "1700000000000",
+                "update_time": "1700000000000",
+                "owner": {"owner_type": "user", "user_id": "ou_xxx"},
+                "objective_id": "O-123",
+                "position": 1,
+                "score": 0.8,
+                "weight": 0.5,
+                "deadline": "1700000000000"
+            }
+        });
+        Mock::given(method("GET"))
+            .and(path("/open-apis/okr/v2/key_results/key_result_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .key_result_id("key_result_001")
+            .execute()
+            .await
+            .expect("okr_v2_key_result_get 应成功");
+
+        let _ = &data.key_result;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/key_results/key_result_001"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/key_result/indicator/list.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/key_result/indicator/list.rs
@@ -75,6 +75,7 @@ impl ApiResponseTrait for ListKeyResultIndicatorResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
 
     #[test]
     fn builder_initializes() {
@@ -118,5 +119,49 @@ mod tests {
         let resp: ListKeyResultIndicatorResponse =
             serde_json::from_value(json).expect("反序列化失败");
         assert!(resp.indicator.is_none());
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_key_result_indicator_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/okr/v2/key_results/key_result_001/indicators",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .key_result_id("key_result_001")
+            .execute()
+            .await
+            .expect("okr_v2_key_result_indicator_list 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/key_results/key_result_001/indicators"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/key_result/patch.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/key_result/patch.rs
@@ -85,6 +85,7 @@ impl ApiResponseTrait for PatchKeyResultResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
 
     #[test]
     fn builder_initializes() {
@@ -120,5 +121,47 @@ mod tests {
         let json = serde_json::json!({});
         let resp: PatchKeyResultResponse = serde_json::from_value(json).expect("反序列化失败");
         assert!(resp.key_result.is_none());
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_key_result_patch_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/okr/v2/key_results/key_result_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .key_result_id("key_result_001")
+            .execute(serde_json::json!({}))
+            .await
+            .expect("okr_v2_key_result_patch 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/key_results/key_result_001"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/key_result/progress/list.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/key_result/progress/list.rs
@@ -125,6 +125,7 @@ pub struct KeyResultProgressRate {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
 
     #[test]
     fn builder_initializes() {
@@ -179,5 +180,49 @@ mod tests {
         assert!(resp.items.is_none());
         assert!(resp.has_more.is_none());
         assert!(resp.page_token.is_none());
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_key_result_progress_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/okr/v2/key_results/key_result_001/progresses",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .key_result_id("key_result_001")
+            .execute()
+            .await
+            .expect("okr_v2_key_result_progress_list 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/key_results/key_result_001/progresses"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/objective/alignment/create.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/objective/alignment/create.rs
@@ -89,6 +89,7 @@ impl ApiResponseTrait for CreateObjectiveAlignmentResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     #[test]
     fn builder_initializes() {
         let config = Arc::new(Config::default());
@@ -103,5 +104,49 @@ mod tests {
         let resp: CreateObjectiveAlignmentResponse =
             serde_json::from_value(json).expect("反序列化失败");
         assert_eq!(resp.alignment_id, Some("A-123".to_string()));
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_objective_alignment_create_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/okr/v2/objectives/objective_001/alignments",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .objective_id("objective_001")
+            .execute(serde_json::json!({}))
+            .await
+            .expect("okr_v2_objective_alignment_create 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/objectives/objective_001/alignments"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/objective/alignment/list.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/objective/alignment/list.rs
@@ -81,6 +81,7 @@ impl ApiResponseTrait for ListObjectiveAlignmentResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     #[test]
     fn builder_initializes() {
         let config = Arc::new(Config::default());
@@ -115,5 +116,49 @@ mod tests {
         assert_eq!(items[0].id, "AL-1");
         assert_eq!(items[0].from_entity_type, 2);
         assert_eq!(items[0].from_owner.user_id, Some("ou_from".to_string()));
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_objective_alignment_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/okr/v2/objectives/objective_001/alignments",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .objective_id("objective_001")
+            .execute()
+            .await
+            .expect("okr_v2_objective_alignment_list 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/objectives/objective_001/alignments"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/objective/delete.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/objective/delete.rs
@@ -69,6 +69,7 @@ impl ApiResponseTrait for DeleteObjectiveResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     #[test]
     fn builder_initializes() {
         let config = Arc::new(Config::default());
@@ -80,5 +81,47 @@ mod tests {
         let resp: DeleteObjectiveResponse =
             serde_json::from_value(serde_json::json!({})).expect("空响应反序列化失败");
         let _ = resp;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_objective_delete_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/okr/v2/objectives/objective_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .objective_id("objective_001")
+            .execute()
+            .await
+            .expect("okr_v2_objective_delete 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/objectives/objective_001"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/objective/get.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/objective/get.rs
@@ -74,6 +74,7 @@ impl ApiResponseTrait for GetObjectiveResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     #[test]
     fn builder_initializes() {
         let config = Arc::new(Config::default());
@@ -102,5 +103,60 @@ mod tests {
         assert_eq!(resp.objective.owner.owner_type, "user");
         assert_eq!(resp.objective.score, Some(0.8));
         assert!(resp.objective.content.is_none());
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_objective_get_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body = json!({
+            "objective": {
+                "id": "O-123",
+                "create_time": "1700000000000",
+                "update_time": "1700000000000",
+                "owner": {"owner_type": "user", "user_id": "ou_xxx"},
+                "cycle_id": "C-1",
+                "position": 1,
+                "score": 0.8,
+                "weight": 0.5,
+                "deadline": "1700000000000",
+                "category_id": "cat-1"
+            }
+        });
+        Mock::given(method("GET"))
+            .and(path("/open-apis/okr/v2/objectives/objective_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .objective_id("objective_001")
+            .execute()
+            .await
+            .expect("okr_v2_objective_get 应成功");
+
+        let _ = &data.objective;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/objectives/objective_001"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/objective/indicator/list.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/objective/indicator/list.rs
@@ -75,6 +75,7 @@ impl ApiResponseTrait for ListObjectiveIndicatorResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     #[test]
     fn builder_initializes() {
         let config = Arc::new(Config::default());
@@ -107,5 +108,49 @@ mod tests {
         assert_eq!(indicator.entity_type, 2);
         assert_eq!(indicator.start_value, Some(0.0));
         assert_eq!(indicator.unit.as_ref().unwrap().unit_value, "PERCENT");
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_objective_indicator_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/okr/v2/objectives/objective_001/indicators",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .objective_id("objective_001")
+            .execute()
+            .await
+            .expect("okr_v2_objective_indicator_list 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/objectives/objective_001/indicators"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/objective/key_result/create.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/objective/key_result/create.rs
@@ -89,6 +89,7 @@ impl ApiResponseTrait for CreateObjectiveKeyResultResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     #[test]
     fn builder_initializes() {
         let config = Arc::new(Config::default());
@@ -103,5 +104,49 @@ mod tests {
         let resp: CreateObjectiveKeyResultResponse =
             serde_json::from_value(json).expect("反序列化失败");
         assert_eq!(resp.key_result_id, Some("KR-123".to_string()));
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_objective_key_result_create_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/okr/v2/objectives/objective_001/key_results",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .objective_id("objective_001")
+            .execute(serde_json::json!({}))
+            .await
+            .expect("okr_v2_objective_key_result_create 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/objectives/objective_001/key_results"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/objective/key_result/list.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/objective/key_result/list.rs
@@ -81,6 +81,7 @@ impl ApiResponseTrait for ListObjectiveKeyResultResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     #[test]
     fn builder_initializes() {
         let config = Arc::new(Config::default());
@@ -114,5 +115,49 @@ mod tests {
         assert_eq!(items[0].id, "KR-1");
         assert_eq!(items[0].objective_id, "O-123");
         assert_eq!(items[0].position, 1);
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_objective_key_result_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/okr/v2/objectives/objective_001/key_results",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .objective_id("objective_001")
+            .execute()
+            .await
+            .expect("okr_v2_objective_key_result_list 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/objectives/objective_001/key_results"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/objective/key_results_position.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/objective/key_results_position.rs
@@ -90,6 +90,7 @@ impl ApiResponseTrait for UpdateObjectiveKeyResultsPositionResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     #[test]
     fn builder_initializes() {
         let config = Arc::new(Config::default());
@@ -116,5 +117,49 @@ mod tests {
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].id, "KR-1");
         assert_eq!(items[0].position, 1);
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_objective_key_results_position_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("PUT"))
+            .and(path(
+                "/open-apis/okr/v2/objectives/objective_001/key_results_position",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .objective_id("objective_001")
+            .execute(serde_json::json!({}))
+            .await
+            .expect("okr_v2_objective_key_results_position 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/objectives/objective_001/key_results_position"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/objective/key_results_weight.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/objective/key_results_weight.rs
@@ -90,6 +90,7 @@ impl ApiResponseTrait for UpdateObjectiveKeyResultsWeightResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     #[test]
     fn builder_initializes() {
         let config = Arc::new(Config::default());
@@ -117,5 +118,49 @@ mod tests {
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].id, "KR-1");
         assert_eq!(items[0].weight, Some(0.5));
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_objective_key_results_weight_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("PUT"))
+            .and(path(
+                "/open-apis/okr/v2/objectives/objective_001/key_results_weight",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .objective_id("objective_001")
+            .execute(serde_json::json!({}))
+            .await
+            .expect("okr_v2_objective_key_results_weight 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/objectives/objective_001/key_results_weight"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/objective/patch.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/objective/patch.rs
@@ -85,6 +85,7 @@ impl ApiResponseTrait for PatchObjectiveResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     #[test]
     fn builder_initializes() {
         let config = Arc::new(Config::default());
@@ -113,5 +114,47 @@ mod tests {
         assert_eq!(resp.objective.as_ref().unwrap().owner.owner_type, "user");
         assert_eq!(resp.objective.as_ref().unwrap().score, Some(0.8));
         assert!(resp.objective.as_ref().unwrap().content.is_none());
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_objective_patch_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/okr/v2/objectives/objective_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .objective_id("objective_001")
+            .execute(serde_json::json!({}))
+            .await
+            .expect("okr_v2_objective_patch 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/objectives/objective_001"
+        );
     }
 }

--- a/crates/openlark-hr/src/okr/okr/v2/objective/progress/list.rs
+++ b/crates/openlark-hr/src/okr/okr/v2/objective/progress/list.rs
@@ -125,6 +125,7 @@ pub struct ProgressRate {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     #[test]
     fn builder_initializes() {
         let config = Arc::new(Config::default());
@@ -158,5 +159,49 @@ mod tests {
         let rate = items[0].progress_rate.as_ref().unwrap();
         assert_eq!(rate.progress_percent, Some(0.5));
         assert_eq!(rate.progress_status, Some(1));
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_okr_v2_objective_progress_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/okr/v2/objectives/objective_001/progresses",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = Request::new(std::sync::Arc::new(config))
+            .objective_id("objective_001")
+            .execute()
+            .await
+            .expect("okr_v2_objective_progress_list 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/okr/v2/objectives/objective_001/progresses"
+        );
     }
 }

--- a/docs/API_E2E_TEST_STRATEGY.md
+++ b/docs/API_E2E_TEST_STRATEGY.md
@@ -135,7 +135,7 @@ assert!(query.contains("device_type=gate"));
 | `openlark-workflow` | 132 | 154 | ✅ 清 roundtrip 占位；endpoint 已有 to_url/builder 测试，完整 e2e 可后续 | P3 |
 | `openlark-docs` | 172 | 263 | ✅ Potemkin 清理 + sheets/docx/wiki/drive/base 等 e2e | P3 |
 | `openlark-communication` | 190 | 227 | ✅ 28+35 body 类 wiremock e2e | P3 |
-| `openlark-hr` | 599 | 625 | 🚧 **按子域分 PR**：ehr+payroll+compensation ✅ / performance ✅ / 余 okr·attendance·hire·feishu_people | P4 |
+| `openlark-hr` | 599 | 625 | 🚧 **按子域分 PR**：ehr+payroll+compensation ✅ / performance ✅ / okr ✅ / 余 attendance·hire·feishu_people | P4 |
 
 **选型原则**：
 - pilot 选小而全（覆盖 GET/POST/LIST/DELETE/PATCH 等所有形状）的 crate，建立可复制范本 → `openlark-security`。
@@ -148,7 +148,7 @@ assert!(query.contains("device_type=gate"));
 - [x] pilot crate（`openlark-security`）全量替换为 wiremock 端到端（含移除 `src/lib.rs` 中的占位 roundtrip 测试）
 - [x] `cargo test -p openlark-security --all-features` 通过（79 项，含 39 个新增 e2e）
 - [x] P1–P3 业务 crate 按批完成（cardkit/user/analytics/helpdesk/application/mail/platform/meeting/workflow/docs/communication）
-- [ ] P4 `openlark-hr`：按子域分 PR（ehr+payroll+compensation ✅；performance ✅；后续 okr / attendance / hire / feishu_people）
+- [ ] P4 `openlark-hr`：按子域分 PR（ehr+payroll+compensation ✅；performance ✅；okr ✅；后续 attendance / hire / feishu_people）
 
 ## 6. 相关文档
 


### PR DESCRIPTION
## Summary

- #351 P4：**okr** v1（12）+ v2（25）共 37 端点 wiremock e2e
- 覆盖 `Arc<Config>`、path builder、`execute(body: Value)` 形态
- `user/okr/list` 按代码实际 path（`/users/{id}/okrs`）mock

## Stack

1. ehr/payroll/compensation → `main`
2. performance → compensation
3. **本 PR**（base: `test/hr-e2e-performance`）
4. attendance → 本分支

## Test plan

- [x] `cargo test -p openlark-hr --lib --all-features -- okr::`
- [ ] CI 全绿

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and documentation updates only; no runtime API or behavior changes in library code.
> 
> **Overview**
> Replaces **37** OKR placeholder `serde_json` roundtrip tests with **wiremock** end-to-end tests under `openlark-hr`, continuing #351 P4 HR migration (batch 14).
> 
> **okr/v1 (12 endpoints)** — progress records, periods, period rules, image upload, OKR batch get, review query, and user OKR list now exercise `Request::execute()` through `Transport` against mocked `{code, msg, data}` responses, with `Config::enable_token_cache(false)` and assertions on parsed fields plus the HTTP path. Existing builder/validation tests (e.g. period create) are kept where present.
> 
> **okr/v2 (25 endpoints)** — same e2e pattern for category, cycle, objective, key result, alignment, and indicator APIs, including **`Arc<Config>`**, path builders, and **`execute(body: Value)`** where the client already does. Prior deserialize/builder unit tests remain alongside the new async tests.
> 
> **Cleanup/docs** — removes aggregate placeholder tests from `okr/mod.rs`. **`user/okr/list`** mocks **`/open-apis/okr/v1/users/{id}/okrs`** (implementation path), not enum-style `user_okrs/list`. Updates `CHANGELOG.md` and `docs/API_E2E_TEST_STRATEGY.md` to mark okr ✅.
> 
> **Non-breaking:** production `execute` code unchanged; test-only additions/replacements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fad1343815d07d830862f7a150f499742dc04f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->