### PR TITLE
test(hr): attendance 39 wiremock e2e（#351 P4 attendance）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **hr attendance 39 真实端点占位测试 → wiremock e2e**（#351 第 15 批，P4 hr attendance）：
+  attendance/v1 全子域（group/shift/user_flow/user_task/user_approval/user_daily_shift/
+  user_setting/user_stats_*/file/archive_rule/leave_*/approval_info 39）占位 roundtrip →
+  wiremock 端到端。覆盖 path 参数 builder、必填 list/date 校验、以及 enum path 中字面 `{}`
+  的 `.replace` 行为。域级 mod.rs 聚合占位删除。hire/feishu_people 按子域后续 PR。
+  **非 breaking**：纯测试替换/新增。
+
 - **hr okr 37 真实端点占位测试 → wiremock e2e**（#351 第 14 批，P4 hr okr）：
   okr/v1（progress_record/period/period_rule/image/okr/review/user 12）+ okr/v2 全子域
   （category/cycle/objective/key_result/alignment/indicator 25）占位 roundtrip → wiremock 端到端。

--- a/crates/openlark-hr/src/attendance/attendance/v1/approval_info/process.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/approval_info/process.rs
@@ -119,11 +119,54 @@ impl ApiResponseTrait for ProcessResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
     fn test_process_request_builder_new() {
         let request = ProcessRequest::new(TestConfigBuilder::new().build(), "test".to_string(), 1);
         let _ = request;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_approval_info_process_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"success": false, "approval_instance_id": "test"}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/attendance/v1/approval_infos/process"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ProcessRequest::new(config, "approval_instance_001".to_string(), 1)
+            .execute()
+            .await
+            .expect("attendance_v1_approval_info_process 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/approval_infos/process"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/archive_rule/del_report.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/archive_rule/del_report.rs
@@ -124,21 +124,54 @@ impl ApiResponseTrait for DelReportResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_archive_rule_del_report_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"success": false, "deleted_count": 0}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/attendance/v1/archive_rule/del_report"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = DelReportRequest::new(
+            config,
+            "archive_rule_001".to_string(),
+            vec!["id_001".to_string()],
+            vec![1_700_000_000],
+        )
+        .execute()
+        .await
+        .expect("attendance_v1_archive_rule_del_report 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/archive_rule/del_report"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/archive_rule/list.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/archive_rule/list.rs
@@ -122,11 +122,54 @@ impl ApiResponseTrait for ListResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
     fn test_list_request_builder_new() {
         let request = ListRequest::new(TestConfigBuilder::new().build()).page_size(1);
         let _ = request;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_archive_rule_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/attendance/v1/archive_rule"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config)
+            .execute()
+            .await
+            .expect("attendance_v1_archive_rule_list 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/archive_rule"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/archive_rule/upload_report.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/archive_rule/upload_report.rs
@@ -131,21 +131,59 @@ impl ApiResponseTrait for UploadReportResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_archive_rule_upload_report_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(
+            r#"{"success": false, "inserted_count": 0, "updated_count": 0, "failed_count": 0}"#,
+        )
+        .unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/attendance/v1/archive_rule/upload_report"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = UploadReportRequest::new(
+            config,
+            "archive_rule_001".to_string(),
+            vec![ReportData {
+                employee_id: "employee_id_1".to_string(),
+                stat_date: 1,
+                field_data: vec![],
+            }],
+        )
+        .execute()
+        .await
+        .expect("attendance_v1_archive_rule_upload_report 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/archive_rule/upload_report"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/archive_rule/user_stats_fields_query.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/archive_rule/user_stats_fields_query.rs
@@ -103,6 +103,7 @@ impl ApiResponseTrait for UserStatsFieldsQueryResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -110,5 +111,48 @@ mod tests {
         let request = UserStatsFieldsQueryRequest::new(TestConfigBuilder::new().build())
             .archive_rule_id("test".to_string());
         let _ = request;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_archive_rule_user_stats_fields_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{"fields": []}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/attendance/v1/archive_rule/user_stats_fields_query",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = UserStatsFieldsQueryRequest::new(config)
+            .execute()
+            .await
+            .expect("attendance_v1_archive_rule_user_stats_fields_query 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/archive_rule/user_stats_fields_query"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/file/download.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/file/download.rs
@@ -83,11 +83,54 @@ impl ApiResponseTrait for DownloadResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
     fn test_download_request_builder_new() {
         let request = DownloadRequest::new(TestConfigBuilder::new().build(), "test".to_string());
         let _ = request;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_file_download_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"photo_id": "test", "user_id": "test", "photo_data": "test", "content_type": "test"}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/attendance/v1/files/photo_001/download"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = DownloadRequest::new(config, "photo_001".to_string())
+            .execute()
+            .await
+            .expect("attendance_v1_file_download 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/files/photo_001/download"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/file/upload.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/file/upload.rs
@@ -177,21 +177,56 @@ impl ApiResponseTrait for UploadResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_file_upload_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(
+            r#"{"success": false, "photo_id": "test", "user_id": "test", "upload_time": 0}"#,
+        )
+        .unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/attendance/v1/files/upload"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = UploadRequest::new(
+            config,
+            "user_001".to_string(),
+            "sample_file_name".to_string(),
+            vec![1u8],
+        )
+        .execute()
+        .await
+        .expect("attendance_v1_file_upload 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/files/upload"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/group/create.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/group/create.rs
@@ -344,4 +344,43 @@ mod tests {
 
         assert!(result.is_err());
     }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_group_create_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{"group_id": "test"}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/attendance/v1/groups"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = CreateGroupRequest::new(config)
+            .group_name("group_name_val".to_string())
+            .execute()
+            .await
+            .expect("attendance_v1_group_create 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/attendance/v1/groups");
+    }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/group/delete.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/group/delete.rs
@@ -79,6 +79,7 @@ impl ApiResponseTrait for DeleteGroupResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -94,5 +95,47 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().expect("创建 tokio runtime 失败");
         let result = rt.block_on(request.execute());
         assert!(result.is_err());
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_group_delete_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{"result": false}"#).unwrap();
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/attendance/v1/groups/group_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = DeleteGroupRequest::new(config)
+            .group_id("group_001".to_string())
+            .execute()
+            .await
+            .expect("attendance_v1_group_delete 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/groups/group_001"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/group/get.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/group/get.rs
@@ -79,6 +79,7 @@ impl ApiResponseTrait for GetGroupResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -94,5 +95,50 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().expect("创建 tokio runtime 失败");
         let result = rt.block_on(request.execute());
         assert!(result.is_err());
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_group_get_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(
+            r#"{"group": {"group_id": "test", "group_name": "test", "group_type": 0}}"#,
+        )
+        .unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/attendance/v1/groups/group_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = GetGroupRequest::new(config)
+            .group_id("group_001".to_string())
+            .execute()
+            .await
+            .expect("attendance_v1_group_get 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/groups/group_001"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/group/list.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/group/list.rs
@@ -92,11 +92,51 @@ impl ApiResponseTrait for ListGroupResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
     fn test_list_group_request_builder_new() {
         let request = ListGroupRequest::new(TestConfigBuilder::new().build()).page_size(1);
         let _ = request;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_group_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"group_list": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/attendance/v1/groups"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListGroupRequest::new(config)
+            .execute()
+            .await
+            .expect("attendance_v1_group_list 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/attendance/v1/groups");
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/group/list_user.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/group/list_user.rs
@@ -122,11 +122,54 @@ impl ApiResponseTrait for ListUserResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
     fn test_list_user_request_builder_new() {
         let request = ListUserRequest::new(TestConfigBuilder::new().build(), "test".to_string());
         let _ = request;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_group_list_user_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/attendance/v1/groups/group_001/list_user"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListUserRequest::new(config, "group_001".to_string())
+            .execute()
+            .await
+            .expect("attendance_v1_group_list_user 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/groups/group_001/list_user"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/group/search.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/group/search.rs
@@ -106,6 +106,7 @@ impl ApiResponseTrait for SearchGroupResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -121,5 +122,48 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().expect("创建 tokio runtime 失败");
         let result = rt.block_on(request.execute());
         assert!(result.is_err());
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_group_search_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"group_list": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/attendance/v1/groups/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = SearchGroupRequest::new(config)
+            .group_name("group_name_val".to_string())
+            .execute()
+            .await
+            .expect("attendance_v1_group_search 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/groups/search"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/leave_accrual_record/patch.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/leave_accrual_record/patch.rs
@@ -107,21 +107,53 @@ impl ApiResponseTrait for PatchResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_leave_accrual_record_patch_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(
+            r#"{"success": false, "record_id": "test", "remaining_days": 0.0}"#,
+        )
+        .unwrap();
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/open-apis/attendance/v1/leave_accrual_record/record_001",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = PatchRequest::new(config, "record_001".to_string(), 1.0)
+            .execute()
+            .await
+            .expect("attendance_v1_leave_accrual_record_patch 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/leave_accrual_record/record_001"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/leave_employ_expire_record/get.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/leave_employ_expire_record/get.rs
@@ -155,11 +155,56 @@ impl ApiResponseTrait for GetResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
     fn test_get_request_builder_new() {
         let request = GetRequest::new(TestConfigBuilder::new().build(), 1, 1);
         let _ = request;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_leave_employ_expire_record_get_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/attendance/v1/leave_employ_expire_records/1700000000-1700000000",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = GetRequest::new(config, 1_700_000_000, 1_700_000_000)
+            .execute()
+            .await
+            .expect("attendance_v1_leave_employ_expire_record_get 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/leave_employ_expire_records/1700000000-1700000000"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/shift/create.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/shift/create.rs
@@ -292,6 +292,7 @@ impl ApiResponseTrait for CreateShiftResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -307,5 +308,55 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().expect("创建 tokio runtime 失败");
         let result = rt.block_on(request.execute());
         assert!(result.is_err());
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_shift_create_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"shift_id": "shift_001"}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/attendance/v1/shifts"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = CreateShiftRequest::new(config)
+            .shift_name("ci_shift".to_string())
+            .add_punch_time(PunchTime {
+                on_duty_time: 540,
+                off_duty_time: 1080,
+                earliest_on_duty_time: None,
+                latest_off_duty_time: None,
+                on_duty_places: None,
+                off_duty_places: None,
+                on_duty_wifis: None,
+                off_duty_wifis: None,
+            })
+            .execute()
+            .await
+            .expect("attendance_v1_shift_create 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/attendance/v1/shifts");
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/shift/delete.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/shift/delete.rs
@@ -79,6 +79,7 @@ impl ApiResponseTrait for DeleteShiftResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -94,5 +95,47 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().expect("创建 tokio runtime 失败");
         let result = rt.block_on(request.execute());
         assert!(result.is_err());
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_shift_delete_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{"result": false}"#).unwrap();
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/attendance/v1/shifts/shift_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = DeleteShiftRequest::new(config)
+            .shift_id("shift_001".to_string())
+            .execute()
+            .await
+            .expect("attendance_v1_shift_delete 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/shifts/shift_001"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/shift/get.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/shift/get.rs
@@ -79,6 +79,7 @@ impl ApiResponseTrait for GetShiftResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -94,5 +95,48 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().expect("创建 tokio runtime 失败");
         let result = rt.block_on(request.execute());
         assert!(result.is_err());
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_shift_get_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"shift": {"shift_id": "test", "shift_name": "test", "shift_type": 0, "punch_times": []}}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/attendance/v1/shifts/shift_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = GetShiftRequest::new(config)
+            .shift_id("shift_001".to_string())
+            .execute()
+            .await
+            .expect("attendance_v1_shift_get 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/shifts/shift_001"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/shift/list.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/shift/list.rs
@@ -92,11 +92,51 @@ impl ApiResponseTrait for ListShiftResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
     fn test_list_shift_request_builder_new() {
         let request = ListShiftRequest::new(TestConfigBuilder::new().build()).page_size(1);
         let _ = request;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_shift_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"shift_list": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/attendance/v1/shifts"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListShiftRequest::new(config)
+            .execute()
+            .await
+            .expect("attendance_v1_shift_list 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/attendance/v1/shifts");
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/shift/query.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/shift/query.rs
@@ -106,6 +106,7 @@ impl ApiResponseTrait for QueryShiftResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -121,5 +122,48 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().expect("创建 tokio runtime 失败");
         let result = rt.block_on(request.execute());
         assert!(result.is_err());
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_shift_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"shift_list": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/attendance/v1/shifts/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryShiftRequest::new(config)
+            .shift_name("shift_name_val".to_string())
+            .execute()
+            .await
+            .expect("attendance_v1_shift_query 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/shifts/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_approval/create.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_approval/create.rs
@@ -137,6 +137,7 @@ impl ApiResponseTrait for CreateResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -149,5 +150,47 @@ mod tests {
             1,
         );
         let _ = request;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_user_approval_create_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"success": true, "approval_id": "appr_001"}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/attendance/v1/user_approvals"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = CreateRequest::new(config, "user_001".to_string(), 1, 1, 1_700_000_000)
+            .execute()
+            .await
+            .expect("attendance_v1_user_approval_create 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/user_approvals"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_approval/query.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_approval/query.rs
@@ -189,6 +189,7 @@ impl ApiResponseTrait for QueryResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -196,5 +197,47 @@ mod tests {
         let request =
             QueryRequest::new(TestConfigBuilder::new().build()).user_id("test".to_string());
         let _ = request;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_user_approval_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/attendance/v1/user_approvals/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config)
+            .execute()
+            .await
+            .expect("attendance_v1_user_approval_query 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/user_approvals/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_daily_shift/batch_create.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_daily_shift/batch_create.rs
@@ -113,21 +113,60 @@ impl ApiResponseTrait for BatchCreateResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_user_daily_shift_batch_create_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"success": false, "processed_count": 0, "failed_count": 0}"#)
+                .unwrap();
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/attendance/v1/user_daily_shifts/batch_create",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = BatchCreateRequest::new(
+            config,
+            vec![UserDailyShift {
+                user_id: "user_id_1".to_string(),
+                date: 1,
+                shift_id: "shift_id_1".to_string(),
+                work_hours: None,
+            }],
+        )
+        .execute()
+        .await
+        .expect("attendance_v1_user_daily_shift_batch_create 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/user_daily_shifts/batch_create"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_daily_shift/batch_create_temp.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_daily_shift/batch_create_temp.rs
@@ -112,21 +112,61 @@ impl ApiResponseTrait for BatchCreateTempResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_user_daily_shift_batch_create_temp_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"success": false, "processed_count": 0, "failed_count": 0}"#)
+                .unwrap();
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/attendance/v1/user_daily_shifts/batch_create_temp",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = BatchCreateTempRequest::new(
+            config,
+            vec![TempShift {
+                user_id: "user_id_1".to_string(),
+                date: 1,
+                shift_id: "shift_id_1".to_string(),
+                is_temp: true,
+                work_hours: None,
+            }],
+        )
+        .execute()
+        .await
+        .expect("attendance_v1_user_daily_shift_batch_create_temp 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/user_daily_shifts/batch_create_temp"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_daily_shift/query.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_daily_shift/query.rs
@@ -184,11 +184,54 @@ impl ApiResponseTrait for QueryResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
     fn test_query_request_builder_new() {
         let request = QueryRequest::new(TestConfigBuilder::new().build(), 1, 1);
         let _ = request;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_user_daily_shift_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/attendance/v1/user_daily_shifts/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config, 1_700_000_000, 1_700_000_000)
+            .execute()
+            .await
+            .expect("attendance_v1_user_daily_shift_query 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/user_daily_shifts/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_flow/batch_create.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_flow/batch_create.rs
@@ -110,6 +110,7 @@ impl ApiResponseTrait for BatchCreateUserFlowResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -124,5 +125,64 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().expect("创建 tokio runtime 失败");
         let result = rt.block_on(request.execute());
         assert!(result.is_err());
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_user_flow_batch_create_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{"results": []}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/attendance/v1/user_flows/batch_create"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = BatchCreateUserFlowRequest::new(config)
+            .add_flow_record(UserFlowRecord {
+                user_id: "user_id_1".to_string(),
+                punch_time: "2024-01-01 09:00:00".to_string(),
+                punch_type: 1,
+                punch_method: 1,
+                punch_place_name: None,
+                punch_place_id: None,
+                longitude: None,
+                latitude: None,
+                wifi_name: None,
+                wifi_mac: None,
+                device_id: None,
+                device_name: None,
+                remark: None,
+                photo_list: None,
+                out_address: None,
+                out_remark: None,
+            })
+            .execute()
+            .await
+            .expect("attendance_v1_user_flow_batch_create 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/user_flows/batch_create"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_flow/batch_del.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_flow/batch_del.rs
@@ -106,6 +106,7 @@ impl ApiResponseTrait for BatchDelUserFlowResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -121,5 +122,47 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().expect("创建 tokio runtime 失败");
         let result = rt.block_on(request.execute());
         assert!(result.is_err());
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_user_flow_batch_del_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{"results": []}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/attendance/v1/user_flows/batch_del"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = BatchDelUserFlowRequest::new(config)
+            .add_user_flow_id("id_001".to_string())
+            .execute()
+            .await
+            .expect("attendance_v1_user_flow_batch_del 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/user_flows/batch_del"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_flow/get.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_flow/get.rs
@@ -95,6 +95,7 @@ impl ApiResponseTrait for GetUserFlowResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -110,5 +111,48 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().expect("创建 tokio runtime 失败");
         let result = rt.block_on(request.execute());
         assert!(result.is_err());
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_user_flow_get_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"flow_info": {"user_flow_id": "test", "user_id": "test", "punch_date": "test", "punch_time": "test", "punch_type": 0, "punch_method": 0}}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/attendance/v1/user_flows/user_flow_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = GetUserFlowRequest::new(config)
+            .user_flow_id("user_flow_001".to_string())
+            .execute()
+            .await
+            .expect("attendance_v1_user_flow_get 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/user_flows/user_flow_001"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_flow/query.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_flow/query.rs
@@ -137,6 +137,7 @@ impl ApiResponseTrait for QueryUserFlowResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -152,5 +153,50 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().expect("创建 tokio runtime 失败");
         let result = rt.block_on(request.execute());
         assert!(result.is_err());
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_user_flow_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"flow_list": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/attendance/v1/user_flows/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryUserFlowRequest::new(config)
+            .start_date("20240101".to_string())
+            .end_date("20240131".to_string())
+            .user_ids(vec!["id_001".to_string()])
+            .execute()
+            .await
+            .expect("attendance_v1_user_flow_query 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/user_flows/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_setting/modify.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_setting/modify.rs
@@ -106,6 +106,7 @@ impl ApiResponseTrait for ModifyResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -113,5 +114,47 @@ mod tests {
         let request =
             ModifyRequest::new(TestConfigBuilder::new().build(), "test".to_string(), true);
         let _ = request;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_user_setting_modify_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"success": false, "user_id": "test"}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/attendance/v1/user_settings/modify"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ModifyRequest::new(config, "user_001".to_string(), true)
+            .execute()
+            .await
+            .expect("attendance_v1_user_setting_modify 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/user_settings/modify"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_setting/query.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_setting/query.rs
@@ -110,11 +110,54 @@ impl ApiResponseTrait for QueryResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
     fn test_query_request_builder_new() {
         let request = QueryRequest::new(TestConfigBuilder::new().build(), vec!["test".to_string()]);
         let _ = request;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_user_setting_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/attendance/v1/user_settings/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config, vec!["id_001".to_string()])
+            .execute()
+            .await
+            .expect("attendance_v1_user_setting_query 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/user_settings/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_stats_data/query.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_stats_data/query.rs
@@ -200,6 +200,7 @@ impl ApiResponseTrait for QueryResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -215,5 +216,50 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().expect("创建 tokio runtime 失败");
         let result = rt.block_on(request.execute());
         assert!(result.is_err());
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_user_stats_data_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/attendance/v1/user_stats_datas/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config)
+            .start_date("20240101".to_string())
+            .end_date("20240131".to_string())
+            .user_ids(vec!["user_001".to_string()])
+            .execute()
+            .await
+            .expect("attendance_v1_user_stats_data_query 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/user_stats_datas/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_stats_field/query.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_stats_field/query.rs
@@ -172,6 +172,7 @@ impl ApiResponseTrait for QueryResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -179,5 +180,50 @@ mod tests {
         let request =
             QueryRequest::new(TestConfigBuilder::new().build()).unit_id("test".to_string());
         let _ = request;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_user_stats_field_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"stat_fields": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/attendance/v1/user_stats_fields/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config)
+            .add_user_id("id_001".to_string())
+            .start_date("20240101".to_string())
+            .end_date("20240131".to_string())
+            .execute()
+            .await
+            .expect("attendance_v1_user_stats_field_query 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/user_stats_fields/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_stats_view/query.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_stats_view/query.rs
@@ -106,6 +106,7 @@ impl ApiResponseTrait for QueryResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -113,5 +114,47 @@ mod tests {
         let request =
             QueryRequest::new(TestConfigBuilder::new().build()).group_id("test".to_string());
         let _ = request;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_user_stats_view_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/attendance/v1/user_stats_views/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config)
+            .execute()
+            .await
+            .expect("attendance_v1_user_stats_view_query 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/user_stats_views/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_stats_view/update.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_stats_view/update.rs
@@ -129,6 +129,7 @@ impl ApiResponseTrait for UpdateResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -140,5 +141,52 @@ mod tests {
             vec!["test".to_string()],
         );
         let _ = request;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_user_stats_view_update_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"success": false, "view_id": "test"}"#).unwrap();
+        Mock::given(method("PUT"))
+            .and(path("/open-apis/attendance/v1/user_stats_views/view_001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = UpdateRequest::new(
+            config,
+            "view_001".to_string(),
+            "sample_name".to_string(),
+            vec!["id_001".to_string()],
+        )
+        .execute()
+        .await
+        .expect("attendance_v1_user_stats_view_update 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/user_stats_views/view_001"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_task/query.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_task/query.rs
@@ -137,6 +137,7 @@ impl ApiResponseTrait for QueryUserTaskResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -152,5 +153,50 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().expect("创建 tokio runtime 失败");
         let result = rt.block_on(request.execute());
         assert!(result.is_err());
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_user_task_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"records": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/attendance/v1/user_tasks/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryUserTaskRequest::new(config)
+            .start_date("20240101".to_string())
+            .end_date("20240131".to_string())
+            .user_ids(vec!["id_001".to_string()])
+            .execute()
+            .await
+            .expect("attendance_v1_user_task_query 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/user_tasks/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_task_remedy/create.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_task_remedy/create.rs
@@ -127,6 +127,7 @@ impl ApiResponseTrait for CreateResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -139,5 +140,55 @@ mod tests {
             "test".to_string(),
         );
         let _ = request;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_user_task_remedy_create_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(
+            r#"{"success": false, "remedy_id": "test", "approval_instance_id": "test"}"#,
+        )
+        .unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/attendance/v1/user_task_remedys"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = CreateRequest::new(
+            config,
+            "user_001".to_string(),
+            1_700_000_000,
+            1_700_000_000,
+            "reason_001".to_string(),
+        )
+        .execute()
+        .await
+        .expect("attendance_v1_user_task_remedy_create 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/user_task_remedys"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_task_remedy/query.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_task_remedy/query.rs
@@ -177,6 +177,7 @@ impl ApiResponseTrait for QueryResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -184,5 +185,47 @@ mod tests {
         let request =
             QueryRequest::new(TestConfigBuilder::new().build()).user_id("test".to_string());
         let _ = request;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_user_task_remedy_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/attendance/v1/user_task_remedys/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config)
+            .execute()
+            .await
+            .expect("attendance_v1_user_task_remedy_query 应成功");
+
+        let _ = &data;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/user_task_remedys/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_task_remedy/query_user_allowed_remedys.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_task_remedy/query_user_allowed_remedys.rs
@@ -91,6 +91,7 @@ impl ApiResponseTrait for QueryUserAllowedRemedysResponse {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use openlark_core::config::Config;
     use openlark_core::testing::prelude::TestConfigBuilder;
 
     #[test]
@@ -100,5 +101,49 @@ mod tests {
             "test".to_string(),
         );
         let _ = request;
+    }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_attendance_v1_user_task_remedy_query_user_allowed_remedys_returns_data_on_success()
+     {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{"items": []}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/attendance/v1/user_task_remedys/query_user_allowed_remedys",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryUserAllowedRemedysRequest::new(config, "user_001".to_string())
+            .execute()
+            .await
+            .expect("attendance_v1_user_task_remedy_query_user_allowed_remedys 应成功");
+
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/attendance/v1/user_task_remedys/query_user_allowed_remedys"
+        );
     }
 }

--- a/crates/openlark-hr/src/attendance/mod.rs
+++ b/crates/openlark-hr/src/attendance/mod.rs
@@ -26,23 +26,3 @@ impl Attendance {
         &self.config
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/docs/API_E2E_TEST_STRATEGY.md
+++ b/docs/API_E2E_TEST_STRATEGY.md
@@ -135,7 +135,7 @@ assert!(query.contains("device_type=gate"));
 | `openlark-workflow` | 132 | 154 | ✅ 清 roundtrip 占位；endpoint 已有 to_url/builder 测试，完整 e2e 可后续 | P3 |
 | `openlark-docs` | 172 | 263 | ✅ Potemkin 清理 + sheets/docx/wiki/drive/base 等 e2e | P3 |
 | `openlark-communication` | 190 | 227 | ✅ 28+35 body 类 wiremock e2e | P3 |
-| `openlark-hr` | 599 | 625 | 🚧 **按子域分 PR**：ehr+payroll+compensation ✅ / performance ✅ / okr ✅ / 余 attendance·hire·feishu_people | P4 |
+| `openlark-hr` | 599 | 625 | 🚧 **按子域分 PR**：ehr+payroll+compensation ✅ / performance ✅ / okr ✅ / attendance ✅ / 余 hire·feishu_people | P4 |
 
 **选型原则**：
 - pilot 选小而全（覆盖 GET/POST/LIST/DELETE/PATCH 等所有形状）的 crate，建立可复制范本 → `openlark-security`。
@@ -148,7 +148,7 @@ assert!(query.contains("device_type=gate"));
 - [x] pilot crate（`openlark-security`）全量替换为 wiremock 端到端（含移除 `src/lib.rs` 中的占位 roundtrip 测试）
 - [x] `cargo test -p openlark-security --all-features` 通过（79 项，含 39 个新增 e2e）
 - [x] P1–P3 业务 crate 按批完成（cardkit/user/analytics/helpdesk/application/mail/platform/meeting/workflow/docs/communication）
-- [ ] P4 `openlark-hr`：按子域分 PR（ehr+payroll+compensation ✅；performance ✅；okr ✅；后续 attendance / hire / feishu_people）
+- [ ] P4 `openlark-hr`：按子域分 PR（ehr+payroll+compensation ✅；performance ✅；okr ✅；attendance ✅；后续 hire / feishu_people）
 
 ## 6. 相关文档
 


### PR DESCRIPTION
## Summary

- #351 P4：**attendance** v1 全 39 端点 wiremock e2e
- 覆盖 path builder、必填 list/date 校验、enum path 字面 `{}` 的 `.replace` 行为
- 删除域级 `mod.rs` 聚合占位；hire/feishu_people 留后续 PR

## Stack

1. ehr/payroll/compensation → `main`
2. performance → compensation
3. okr → performance
4. **本 PR**（base: `test/hr-e2e-okr`）

## Test plan

- [x] `cargo test -p openlark-hr --lib --all-features -- attendance::`
- [ ] CI 全绿

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only migration with no production code changes; risk is limited to CI/runtime test maintenance, not runtime SDK behavior.
> 
> **Overview**
> Continues **#351 P4** for `openlark-hr` by swapping **attendance/v1** placeholder `serde_json` roundtrip (and similar stub) tests for **wiremock** end-to-end tests across **39** real endpoints (group, shift, user_flow, user_task, user_approval, user_daily_shift, user_setting, user_stats_*, file, archive_rule, leave_*, approval_info).
> 
> Each new test follows the established pattern: `Config` pointed at a `MockServer`, `enable_token_cache(false)`, `execute()` through `Transport`, mock `{code, msg, data}`, and assertions on **typed response parsing** plus the **HTTP path/method** actually sent (including path-param `.replace("{}", …)` cases such as file download and leave accrual patch).
> 
> Existing **builder** and **validation** unit tests are kept where they already existed; generic serialization-only placeholders are removed. Domain-level aggregate placeholder tests in `attendance/mod.rs` are deleted. **CHANGELOG** and **`docs/API_E2E_TEST_STRATEGY.md`** mark attendance as done; hire/feishu_people remain for follow-up PRs.
> 
> **Non-breaking:** test-only changes; no `execute()` or public API behavior changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2747f5f0ddfd15c7eea3e08f2e37c6467597567c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->