### PR TITLE
test(hr): performance 21 wiremock e2e（#351 P4 performance）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **hr performance 21 真实端点占位测试 → wiremock e2e**（#351 第 13 批，P4 hr performance）：
+  performance/v1（semester/stage_task/review_data 4）+ performance/v2 全子域（activity/
+  additional_information*/indicator/metric_*/question/review_*/reviewee/user_* 17）
+  占位 `serde_json` roundtrip → wiremock 端到端。模式同 PR A（Config 非 Arc + enum to_url +
+  enable_token_cache(false)）。域级 `mod.rs` 聚合占位删除。okr/attendance/hire/feishu_people
+  按子域后续 PR。**非 breaking**：纯测试替换/新增。
+
 - **hr ehr/payroll/compensation 35 真实端点占位测试 → wiremock e2e**（#351 第 12 批，P4 hr PR A）：
   ehr/v1（employee list + attachment get 2）+ payroll/v1 全子域（acct_item/cost_allocation_*/
   datasource/datasource_record/paygroup/payment_activity*/payment_detail 12）+

--- a/crates/openlark-hr/src/performance/mod.rs
+++ b/crates/openlark-hr/src/performance/mod.rs
@@ -26,24 +26,3 @@ impl Performance {
         &self.config
     }
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-hr/src/performance/performance/v1/review_data/query.rs
+++ b/crates/openlark-hr/src/performance/performance/v1/review_data/query.rs
@@ -130,21 +130,50 @@ impl ApiResponseTrait for QueryResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_performance_v1_review_data_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/performance/v1/review_datas/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config, "cycle_001".to_string())
+            .execute()
+            .await
+            .expect("performance_v1_review_data_query 应成功");
+
+        assert!(data.items.is_empty());
+        assert!(!data.has_more);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/performance/v1/review_datas/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/performance/performance/v1/semester/list.rs
+++ b/crates/openlark-hr/src/performance/performance/v1/semester/list.rs
@@ -128,21 +128,50 @@ impl ApiResponseTrait for ListResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_performance_v1_semester_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/performance/v1/semesters"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config)
+            .execute()
+            .await
+            .expect("performance_v1_semester_list 应成功");
+
+        assert!(data.items.is_empty());
+        assert!(!data.has_more);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/performance/v1/semesters"
+        );
     }
 }

--- a/crates/openlark-hr/src/performance/performance/v1/stage_task/find_by_page.rs
+++ b/crates/openlark-hr/src/performance/performance/v1/stage_task/find_by_page.rs
@@ -119,21 +119,50 @@ impl ApiResponseTrait for FindByPageResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_performance_v1_stage_task_find_by_page_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/performance/v1/stage_tasks/find_by_page"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = FindByPageRequest::new(config, "cycle_001".to_string())
+            .execute()
+            .await
+            .expect("performance_v1_stage_task_find_by_page 应成功");
+
+        assert!(data.items.is_empty());
+        assert!(!data.has_more);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/performance/v1/stage_tasks/find_by_page"
+        );
     }
 }

--- a/crates/openlark-hr/src/performance/performance/v1/stage_task/find_by_user_list.rs
+++ b/crates/openlark-hr/src/performance/performance/v1/stage_task/find_by_user_list.rs
@@ -119,21 +119,51 @@ impl ApiResponseTrait for FindByUserListResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_performance_v1_stage_task_find_by_user_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{"items": []}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/performance/v1/stage_tasks/find_by_user_list",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = FindByUserListRequest::new(config, "cycle_001".to_string())
+            .add_user_id("user_001".to_string())
+            .execute()
+            .await
+            .expect("performance_v1_stage_task_find_by_user_list 应成功");
+
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/performance/v1/stage_tasks/find_by_user_list"
+        );
     }
 }

--- a/crates/openlark-hr/src/performance/performance/v2/activity/query.rs
+++ b/crates/openlark-hr/src/performance/performance/v2/activity/query.rs
@@ -126,21 +126,50 @@ impl ApiResponseTrait for QueryResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_performance_v2_activity_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/performance/v2/activity/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config)
+            .execute()
+            .await
+            .expect("performance_v2_activity_query 应成功");
+
+        assert!(data.items.is_empty());
+        assert!(!data.has_more);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/performance/v2/activity/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/performance/performance/v2/additional_information/import.rs
+++ b/crates/openlark-hr/src/performance/performance/v2/additional_information/import.rs
@@ -120,21 +120,52 @@ impl ApiResponseTrait for ImportResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_performance_v2_additional_information_import_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"success_count": 0, "failed_count": 0}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/performance/v2/additional_informations/import",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ImportRequest::new(config, "cycle_001".to_string())
+            .execute()
+            .await
+            .expect("performance_v2_additional_information_import 应成功");
+
+        let _ = data.success_count;
+        let _ = data.failed_count;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/performance/v2/additional_informations/import"
+        );
     }
 }

--- a/crates/openlark-hr/src/performance/performance/v2/additional_information/query.rs
+++ b/crates/openlark-hr/src/performance/performance/v2/additional_information/query.rs
@@ -117,21 +117,51 @@ impl ApiResponseTrait for QueryResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_performance_v2_additional_information_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{"items": []}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path(
+                "/open-apis/performance/v2/additional_informations/query",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config, "cycle_001".to_string())
+            .add_user_id("user_001".to_string())
+            .execute()
+            .await
+            .expect("performance_v2_additional_information_query 应成功");
+
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/performance/v2/additional_informations/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/performance/performance/v2/additional_informations/batch/delete.rs
+++ b/crates/openlark-hr/src/performance/performance/v2/additional_informations/batch/delete.rs
@@ -108,21 +108,50 @@ impl ApiResponseTrait for DeleteResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_performance_v2_additional_informations_batch_delete_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{"success_count": 0}"#).unwrap();
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/open-apis/performance/v2/additional_informations/batch",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = DeleteRequest::new(config, "cycle_001".to_string())
+            .execute()
+            .await
+            .expect("performance_v2_additional_informations_batch_delete 应成功");
+
+        let _ = data.success_count;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/performance/v2/additional_informations/batch"
+        );
     }
 }

--- a/crates/openlark-hr/src/performance/performance/v2/indicator/query.rs
+++ b/crates/openlark-hr/src/performance/performance/v2/indicator/query.rs
@@ -126,21 +126,50 @@ impl ApiResponseTrait for QueryResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_performance_v2_indicator_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/performance/v2/indicators/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config)
+            .execute()
+            .await
+            .expect("performance_v2_indicator_query 应成功");
+
+        assert!(data.items.is_empty());
+        assert!(!data.has_more);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/performance/v2/indicators/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/performance/performance/v2/metric_detail/import.rs
+++ b/crates/openlark-hr/src/performance/performance/v2/metric_detail/import.rs
@@ -180,4 +180,47 @@ mod tests {
         })();
         assert!(result.is_err());
     }
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_performance_v2_metric_detail_import_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"success_count": 0, "failed_count": 0}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/performance/v2/metric_details/import"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
+
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ImportRequest::new(config, "cycle_001".to_string())
+            .execute()
+            .await
+            .expect("performance_v2_metric_detail_import 应成功");
+
+        let _ = data.success_count;
+        let _ = data.failed_count;
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/performance/v2/metric_details/import"
+        );
+    }
 }

--- a/crates/openlark-hr/src/performance/performance/v2/metric_detail/query.rs
+++ b/crates/openlark-hr/src/performance/performance/v2/metric_detail/query.rs
@@ -131,21 +131,50 @@ impl ApiResponseTrait for QueryResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_performance_v2_metric_detail_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/performance/v2/metric_details/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config, "cycle_001".to_string())
+            .execute()
+            .await
+            .expect("performance_v2_metric_detail_query 应成功");
+
+        assert!(data.items.is_empty());
+        assert!(!data.has_more);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/performance/v2/metric_details/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/performance/performance/v2/metric_field/query.rs
+++ b/crates/openlark-hr/src/performance/performance/v2/metric_field/query.rs
@@ -121,21 +121,50 @@ impl ApiResponseTrait for QueryResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_performance_v2_metric_field_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/performance/v2/metric_fields/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config, "metric_lib_001".to_string())
+            .execute()
+            .await
+            .expect("performance_v2_metric_field_query 应成功");
+
+        assert!(data.items.is_empty());
+        assert!(!data.has_more);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/performance/v2/metric_fields/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/performance/performance/v2/metric_lib/query.rs
+++ b/crates/openlark-hr/src/performance/performance/v2/metric_lib/query.rs
@@ -126,21 +126,50 @@ impl ApiResponseTrait for QueryResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_performance_v2_metric_lib_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/performance/v2/metric_libs/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config)
+            .execute()
+            .await
+            .expect("performance_v2_metric_lib_query 应成功");
+
+        assert!(data.items.is_empty());
+        assert!(!data.has_more);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/performance/v2/metric_libs/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/performance/performance/v2/metric_tag/list.rs
+++ b/crates/openlark-hr/src/performance/performance/v2/metric_tag/list.rs
@@ -79,21 +79,48 @@ impl ApiResponseTrait for ListResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_performance_v2_metric_tag_list_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{"items": []}"#).unwrap();
+        Mock::given(method("GET"))
+            .and(path("/open-apis/performance/v2/metric_tags"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = ListRequest::new(config)
+            .execute()
+            .await
+            .expect("performance_v2_metric_tag_list 应成功");
+
+        assert!(data.items.is_empty());
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/performance/v2/metric_tags"
+        );
     }
 }

--- a/crates/openlark-hr/src/performance/performance/v2/metric_template/query.rs
+++ b/crates/openlark-hr/src/performance/performance/v2/metric_template/query.rs
@@ -121,21 +121,50 @@ impl ApiResponseTrait for QueryResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_performance_v2_metric_template_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/performance/v2/metric_templates/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config, "metric_lib_001".to_string())
+            .execute()
+            .await
+            .expect("performance_v2_metric_template_query 应成功");
+
+        assert!(data.items.is_empty());
+        assert!(!data.has_more);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/performance/v2/metric_templates/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/performance/performance/v2/question/query.rs
+++ b/crates/openlark-hr/src/performance/performance/v2/question/query.rs
@@ -121,21 +121,50 @@ impl ApiResponseTrait for QueryResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_performance_v2_question_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/performance/v2/questions/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config, "template_001".to_string())
+            .execute()
+            .await
+            .expect("performance_v2_question_query 应成功");
+
+        assert!(data.items.is_empty());
+        assert!(!data.has_more);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/performance/v2/questions/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/performance/performance/v2/review_data/query.rs
+++ b/crates/openlark-hr/src/performance/performance/v2/review_data/query.rs
@@ -133,21 +133,50 @@ impl ApiResponseTrait for QueryResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_performance_v2_review_data_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/performance/v2/review_datas/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config, "cycle_001".to_string())
+            .execute()
+            .await
+            .expect("performance_v2_review_data_query 应成功");
+
+        assert!(data.items.is_empty());
+        assert!(!data.has_more);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/performance/v2/review_datas/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/performance/performance/v2/review_template/query.rs
+++ b/crates/openlark-hr/src/performance/performance/v2/review_template/query.rs
@@ -126,21 +126,50 @@ impl ApiResponseTrait for QueryResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_performance_v2_review_template_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/performance/v2/review_templates/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config)
+            .execute()
+            .await
+            .expect("performance_v2_review_template_query 应成功");
+
+        assert!(data.items.is_empty());
+        assert!(!data.has_more);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/performance/v2/review_templates/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/performance/performance/v2/reviewee/query.rs
+++ b/crates/openlark-hr/src/performance/performance/v2/reviewee/query.rs
@@ -121,21 +121,50 @@ impl ApiResponseTrait for QueryResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_performance_v2_reviewee_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/performance/v2/reviewees/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config, "cycle_001".to_string())
+            .execute()
+            .await
+            .expect("performance_v2_reviewee_query 应成功");
+
+        assert!(data.items.is_empty());
+        assert!(!data.has_more);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/performance/v2/reviewees/query"
+        );
     }
 }

--- a/crates/openlark-hr/src/performance/performance/v2/user_group_user_rel/write.rs
+++ b/crates/openlark-hr/src/performance/performance/v2/user_group_user_rel/write.rs
@@ -122,21 +122,48 @@ impl ApiResponseTrait for WriteResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_performance_v2_user_group_user_rel_write_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value = serde_json::from_str(r#"{"success": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/performance/v2/user_group_user_rels/write"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = WriteRequest::new(config, "user_group_001".to_string())
+            .execute()
+            .await
+            .expect("performance_v2_user_group_user_rel_write 应成功");
+
+        assert!(!data.success);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/performance/v2/user_group_user_rels/write"
+        );
     }
 }

--- a/crates/openlark-hr/src/performance/performance/v2/user_info/query.rs
+++ b/crates/openlark-hr/src/performance/performance/v2/user_info/query.rs
@@ -121,21 +121,50 @@ impl ApiResponseTrait for QueryResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use openlark_core::config::Config;
 
-    use serde_json;
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    #[tokio::test]
+    async fn test_performance_v2_user_info_query_returns_data_on_success() {
+        use serde_json::json;
+        use wiremock::MockServer;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+        let server = MockServer::start().await;
+        let data_body: serde_json::Value =
+            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
+        Mock::given(method("POST"))
+            .and(path("/open-apis/performance/v2/user_info/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": data_body
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        let data = QueryRequest::new(config, "cycle_001".to_string())
+            .execute()
+            .await
+            .expect("performance_v2_user_info_query 应成功");
+
+        assert!(data.items.is_empty());
+        assert!(!data.has_more);
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/performance/v2/user_info/query"
+        );
     }
 }

--- a/docs/API_E2E_TEST_STRATEGY.md
+++ b/docs/API_E2E_TEST_STRATEGY.md
@@ -135,7 +135,7 @@ assert!(query.contains("device_type=gate"));
 | `openlark-workflow` | 132 | 154 | ✅ 清 roundtrip 占位；endpoint 已有 to_url/builder 测试，完整 e2e 可后续 | P3 |
 | `openlark-docs` | 172 | 263 | ✅ Potemkin 清理 + sheets/docx/wiki/drive/base 等 e2e | P3 |
 | `openlark-communication` | 190 | 227 | ✅ 28+35 body 类 wiremock e2e | P3 |
-| `openlark-hr` | 599 | 625 | 🚧 **进行中**：PR A ehr+payroll+compensation 35 e2e；余 performance/okr/attendance/hire/feishu_people | P4 |
+| `openlark-hr` | 599 | 625 | 🚧 **按子域分 PR**：ehr+payroll+compensation ✅ / performance ✅ / 余 okr·attendance·hire·feishu_people | P4 |
 
 **选型原则**：
 - pilot 选小而全（覆盖 GET/POST/LIST/DELETE/PATCH 等所有形状）的 crate，建立可复制范本 → `openlark-security`。
@@ -148,7 +148,7 @@ assert!(query.contains("device_type=gate"));
 - [x] pilot crate（`openlark-security`）全量替换为 wiremock 端到端（含移除 `src/lib.rs` 中的占位 roundtrip 测试）
 - [x] `cargo test -p openlark-security --all-features` 通过（79 项，含 39 个新增 e2e）
 - [x] P1–P3 业务 crate 按批完成（cardkit/user/analytics/helpdesk/application/mail/platform/meeting/workflow/docs/communication）
-- [ ] P4 `openlark-hr`：按子域分批（PR A: ehr+payroll+compensation ✅；后续 performance/okr/attendance/hire/feishu_people）
+- [ ] P4 `openlark-hr`：按子域分 PR（ehr+payroll+compensation ✅；performance ✅；后续 okr / attendance / hire / feishu_people）
 
 ## 6. 相关文档
 


### PR DESCRIPTION
## Summary

- #351 P4：**performance** v1/v2 全 21 端点 wiremock e2e
- 替换占位 roundtrip；删除域级 `mod.rs` 聚合占位
- 接续已合并的 #396（ehr/payroll/compensation）

> 原 #397 因栈底分支删除被 GitHub 自动关闭，本 PR 重建。

## Test plan

- [x] 原 #397 CI 已全绿
- [ ] 本 PR CI 再确认

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime or public API modifications; follows the established wiremock e2e pattern from prior hr batches.
> 
> **Overview**
> **#351 P4 `openlark-hr` performance** — replaces generic `serde_json` roundtrip placeholder tests with **wiremock end-to-end** coverage for all **21** performance API builders (v1: semester, stage_task, review_data; v2: activity, additional_information*, indicators, metric_*, questions, review_*, reviewee, user_*).
> 
> Each new test runs **Builder → `execute` → Transport** against a local mock (`Config` with mock `base_url` and **`enable_token_cache(false)`**), asserts typed response fields, and checks **`received_requests()`** for HTTP method and path. Domain-level aggregate placeholders in `performance/mod.rs` are removed. **`metric_detail/import`** keeps its existing builder/validation tests and adds e2e alongside them.
> 
> **Docs only:** `CHANGELOG.md` and `docs/API_E2E_TEST_STRATEGY.md` mark the performance sub-domain done; okr / attendance / hire / feishu_people remain for follow-up PRs. **No production or public API changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 169ccaab6e9e3a6f412b565bc43d18910ff271ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->