### PR TITLE
test(hr): clear 12 model/mod placeholder roundtrip（#351 P4 cleanup）

### DIFF
--- a/crates/openlark-hr/src/feishu_people/corehr/v1/company/models.rs
+++ b/crates/openlark-hr/src/feishu_people/corehr/v1/company/models.rs
@@ -172,24 +172,3 @@ pub struct ActiveResponse {
     /// 激活结果
     pub result: bool,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-hr/src/feishu_people/corehr/v1/contract/models.rs
+++ b/crates/openlark-hr/src/feishu_people/corehr/v1/contract/models.rs
@@ -289,23 +289,3 @@ pub struct SearchResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page_token: Option<String>,
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-hr/src/feishu_people/corehr/v1/department/models.rs
+++ b/crates/openlark-hr/src/feishu_people/corehr/v1/department/models.rs
@@ -368,23 +368,3 @@ pub struct OperationLogsResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page_token: Option<String>,
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-hr/src/feishu_people/corehr/v1/employee_type/models.rs
+++ b/crates/openlark-hr/src/feishu_people/corehr/v1/employee_type/models.rs
@@ -117,22 +117,3 @@ pub struct PatchResponse {
     /// 更新结果
     pub result: bool,
 }
-
-#[cfg(test)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-hr/src/feishu_people/corehr/v1/job/models.rs
+++ b/crates/openlark-hr/src/feishu_people/corehr/v1/job/models.rs
@@ -193,24 +193,3 @@ pub struct PatchResponse {
     /// 更新结果
     pub result: bool,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-hr/src/feishu_people/corehr/v1/job_data/models.rs
+++ b/crates/openlark-hr/src/feishu_people/corehr/v1/job_data/models.rs
@@ -169,22 +169,3 @@ pub struct PatchResponse {
     /// 更新结果
     pub result: bool,
 }
-
-#[cfg(test)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-hr/src/feishu_people/corehr/v1/job_family/models.rs
+++ b/crates/openlark-hr/src/feishu_people/corehr/v1/job_family/models.rs
@@ -126,23 +126,3 @@ pub struct PatchResponse {
     /// 更新结果
     pub result: bool,
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-hr/src/feishu_people/corehr/v1/job_level/models.rs
+++ b/crates/openlark-hr/src/feishu_people/corehr/v1/job_level/models.rs
@@ -135,23 +135,3 @@ pub struct PatchResponse {
     /// 更新结果
     pub result: bool,
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-hr/src/feishu_people/corehr/v1/leave/models.rs
+++ b/crates/openlark-hr/src/feishu_people/corehr/v1/leave/models.rs
@@ -110,24 +110,3 @@ pub struct LeaveBalancesResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page_token: Option<String>,
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-hr/src/feishu_people/corehr/v1/location/models.rs
+++ b/crates/openlark-hr/src/feishu_people/corehr/v1/location/models.rs
@@ -156,23 +156,3 @@ pub struct PatchResponse {
     /// 更新结果
     pub result: bool,
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-hr/src/feishu_people/mod.rs
+++ b/crates/openlark-hr/src/feishu_people/mod.rs
@@ -24,23 +24,3 @@ impl Corehr {
         &self.config
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-hr/src/hire/mod.rs
+++ b/crates/openlark-hr/src/hire/mod.rs
@@ -26,23 +26,3 @@ impl Hire {
         &self.config
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}


### PR DESCRIPTION
## 概述

#351 P4 收尾：清除 hr crate 最后 12 个 model/mod 文件的占位 `serde_json` roundtrip 测试。

## 改动

- 移除 12 个文件的占位测试块（`test_serialization_roundtrip` + `test_deserialization_from_json`，测试 `{"test":"value"}`）
- 涉及：10 个 `models.rs`（department/company/contract/job/job_data/job_family/job_level/leave/location/employee_type）+ 2 个 `mod.rs`（hire/feishu_people）
- 这些文件是模型/模块定义，无 API 端点，不属于 wiremock e2e 范畴，直接清除占位

## 里程碑

`grep '"test": "value"' crates/openlark-hr/src/` = **0**。hr crate Potemkin roundtrip 反模式全消除。

## 验证

- `cargo test -p openlark-hr --lib`：790 passed（移除 24 个占位测试）
- clippy ×2 ✓ / `cargo fmt --check` ✓

依赖 #401/#402/#403（已合并）。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only deletions with no runtime or API behavior changes; remaining lib tests still pass per PR verification.
> 
> **Overview**
> **#351 P4 cleanup:** strips the last placeholder `#[cfg(test)]` blocks from `openlark-hr` that only exercised generic `serde_json::Value` parsing (`{"test":"value"}` / `{"field":"data"}`), not the CoreHR/hire types in those files.
> 
> Removals span **10** `feishu_people/corehr/v1/*/models.rs` modules (company, contract, department, employee_type, job, job_data, job_family, job_level, leave, location) plus **`feishu_people/mod.rs`** and **`hire/mod.rs`**. Production model and service-entry code is unchanged; **24** no-op unit tests go away and the Potemkin roundtrip pattern is gone from the crate (`"test": "value"` grep hits **0**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b79f7e1ca5ec547f1008d2bfd745d9961e9f12e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->