### PR TITLE
test: clear 35 model/mod/service placeholder roundtrip（#351 收尾）

### DIFF
--- a/crates/openlark-ai/src/ai/document_ai/v1/mod.rs
+++ b/crates/openlark-ai/src/ai/document_ai/v1/mod.rs
@@ -146,24 +146,3 @@ impl DocumentAiV1 {
         vehicle_license::VehicleLicenseService::new(self.config.clone())
     }
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-ai/src/ai/translation/v1/mod.rs
+++ b/crates/openlark-ai/src/ai/translation/v1/mod.rs
@@ -22,24 +22,3 @@ impl TranslationV1 {
         text::Text::new(self.config.clone())
     }
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-ai/src/ai/translation/v1/text/mod.rs
+++ b/crates/openlark-ai/src/ai/translation/v1/text/mod.rs
@@ -29,24 +29,3 @@ impl Text {
         detect::TextDetectRequestBuilder::new((*self.config).clone())
     }
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}


### PR DESCRIPTION
## 概述

#351 收尾（Phase 1）：清除非 API 文件的占位 `serde_json` roundtrip 测试。

## 改动

移除 **35 个非 API 文件**（basename = `models.rs`/`mod.rs`/`service.rs`/`utils.rs`）的占位测试块（`test_serialization_roundtrip` + `test_deserialization_from_json`，测试 `{"test":"value"}`，与实际 struct/service 无关）。

| crate | 文件数 | 说明 |
|---|---|---|
| mail | 16 | mailgroup/public_mailbox/user_mailbox 子模块 mod.rs + service.rs |
| ai | 7 | document_ai/ocr/speech/translation mod.rs |
| application | 7 | v1/v6 app mod.rs + models.rs + service.rs（非 stub） |
| auth | 3 | authen/v3/oidc mod.rs |
| bot | 1 | service.rs（BotService 注册表） |
| client | 1 | utils.rs（EnvConfig 工具） |

这些文件无 API 端点，不属于 wiremock e2e 范畴。脚本仅在「测试模块全部为占位」时清除，保留模块后的 `pub mod` 声明等非测试代码。

## 验证

- `cargo clippy --workspace --all-targets --all-features -- -Dwarnings`：0 error
- `cargo test` 受影响 crate（ai/auth/mail/bot/client）全 pass
- `cargo fmt --check` ✓

## 后续

- Phase 2：auth/communication/user 残留 API 文件转 e2e（待另 PR）
- application ~62 stub：#382 单独跟踪（本 PR 只清非 stub 的 model/service 占位）

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only deletions with no runtime or API behavior changes; risk is limited to slightly less redundant test noise, not functional regressions.
> 
> **Overview**
> **#351 Phase 1 cleanup:** strips identical `#[cfg(test)]` blocks from **35 non-API module files** (`mod.rs`, `models.rs`, `service.rs`, `utils.rs`) across **mail, ai, application, auth, bot, and client**.
> 
> Each removed block only ran `test_serialization_roundtrip` and `test_deserialization_from_json` against generic `serde_json::Value` payloads (`{"test":"value"}`), with **no coverage of real request/response types or services**. Production code (facades like `DocumentAiV1`, `TranslationV1`, `Text`, etc.) is unchanged.
> 
> In the diff shown for **openlark-ai**, the same placeholder tests are deleted from `document_ai/v1/mod.rs`, `translation/v1/mod.rs`, and `translation/v1/text/mod.rs`; sibling OCR/speech modules may still carry placeholders until the broader sweep lands in the full PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f318944bc6f36409ea31bf3fabb893a880bcd36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->