### PR TITLE
test: convert 8 residual API Potemkin to e2e/url-assertion（#351 收尾 P2）

### DIFF
--- a/crates/openlark-auth/src/auth/oauth/old/default/index.rs
+++ b/crates/openlark-auth/src/auth/oauth/old/default/index.rs
@@ -194,21 +194,29 @@ impl OAuthServiceOld {
 pub type AuthorizationBuilder = AuthorizationRequestBuilder;
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// OAuth 授权是重定向流程（无 HTTP 调用），验证构建的授权 URL 含必填参数。
+    #[tokio::test]
+    async fn test_authorization_url_contains_required_params() {
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .build();
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let resp = AuthorizationRequestBuilder::new(config)
+            .app_id("test_app")
+            .redirect_uri("http://localhost/cb")
+            .execute()
+            .await
+            .expect("构建授权 URL 应成功");
+
+        let url = resp.data.authorization_url;
+        assert!(url.contains("app_id="), "URL 应含 app_id: {url}");
+        assert!(
+            url.contains("redirect_uri="),
+            "URL 应含 redirect_uri: {url}"
+        );
     }
 }

--- a/crates/openlark-auth/src/passport/passport/v1/session/logout.rs
+++ b/crates/openlark-auth/src/passport/passport/v1/session/logout.rs
@@ -66,21 +66,39 @@ impl ApiResponseTrait for LogoutResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/passport/v1/sessions/logout
+    #[tokio::test]
+    async fn test_logout_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/passport/v1/sessions/logout"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "result": "success" }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        LogoutRequest::new(config)
+            .user_id("test001")
+            .execute()
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-auth/src/passport/passport/v1/session/query.rs
+++ b/crates/openlark-auth/src/passport/passport/v1/session/query.rs
@@ -89,21 +89,39 @@ pub struct SessionInfo {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/passport/v1/sessions/query
+    #[tokio::test]
+    async fn test_query_session_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/passport/v1/sessions/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "items": [] }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        QuerySessionRequest::new(config)
+            .user_ids(vec!["test001".to_string()])
+            .execute()
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/event/event/v1/outbound_ip/list.rs
+++ b/crates/openlark-communication/src/event/event/v1/outbound_ip/list.rs
@@ -38,22 +38,38 @@ impl ListOutboundIpRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET /open-apis/event/v1/outbound_ip
+    #[tokio::test]
+    async fn test_list_outbound_ip_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/open-apis/event/v1/outbound_ip"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {  }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        ListOutboundIpRequest::new(config)
+            .execute()
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v2/feed_card/bot_time_sentive.rs
+++ b/crates/openlark-communication/src/im/im/v2/feed_card/bot_time_sentive.rs
@@ -77,21 +77,43 @@ impl BotTimeSentiveRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PATCH /open-apis/im/v2/feed_cards/bot_time_sentive
+    #[tokio::test]
+    async fn test_bot_time_sentive_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/im/v2/feed_cards/bot_time_sentive"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let body: FeedCardTimeSensitiveBody = serde_json::from_value(json!({
+            "time_sensitive": true,
+            "user_ids": ["test001"]
+        }))
+        .expect("body 构造");
+        BotTimeSentiveRequest::new(config)
+            .user_id_type(UserIdType::OpenId)
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im/v2/feed_card/patch.rs
+++ b/crates/openlark-communication/src/im/im/v2/feed_card/patch.rs
@@ -89,21 +89,44 @@ impl PatchFeedCardRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：PATCH /open-apis/im/v2/feed_cards/test001
+    #[tokio::test]
+    async fn test_patch_feed_card_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/open-apis/im/v2/feed_cards/test001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        let body: FeedCardTimeSensitiveBody = serde_json::from_value(json!({
+            "time_sensitive": true,
+            "user_ids": ["test001"]
+        }))
+        .expect("body 构造");
+        PatchFeedCardRequest::new(config)
+            .feed_card_id("test001")
+            .user_id_type(UserIdType::OpenId)
+            .execute(body)
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-communication/src/im/im_message/old/default/v4/batch_send.rs
+++ b/crates/openlark-communication/src/im/im_message/old/default/v4/batch_send.rs
@@ -47,21 +47,38 @@ impl BatchSendMessagesRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：POST /open-apis/message/v4/batch_send/
+    #[tokio::test]
+    async fn test_batch_send_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/message/v4/batch_send/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {  }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+
+        BatchSendMessagesRequest::new(config)
+            .execute(json!({}))
+            .await
+            .expect("请求应成功");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/get.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/get.rs
@@ -56,22 +56,43 @@ impl SystemStatusGetRequest {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
+    /// 端到端：GET /open-apis/personal-settings/personal-settings/v1/system-status/get
+    #[tokio::test]
+    async fn test_get_system_status_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/open-apis/personal-settings/personal-settings/v1/system-status/get",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": { "data": {} }
+            })))
+            .mount(&server)
+            .await;
 
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+        let config = std::sync::Arc::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let resp = SystemStatusGetRequest::new(config)
+            .execute()
+            .await
+            .expect("请求应成功");
+        resp.data.expect("响应 data 不应为空");
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
     }
 }


### PR DESCRIPTION
## 概述

#351 收尾 Phase 2：将 auth/communication/user 残留的 8 个 API 占位 `serde_json` roundtrip 转为真实测试。

## 改动

| 文件 | 测试类型 | 说明 |
|---|---|---|
| user system_status/get | wiremock e2e | GET，Arc<Config> |
| auth session/logout | wiremock e2e | POST，result:String |
| auth session/query | wiremock e2e | POST，items:Vec |
| auth oauth/old/default | URL 断言 | 重定向流程（无 HTTP），断言授权 URL 含 app_id/redirect_uri |
| communication outbound_ip/list | wiremock e2e | GET，Value 响应 |
| communication batch_send | wiremock e2e | POST body:Value（旧 v4 API） |
| communication feed_card/patch | wiremock e2e | PATCH，FeedCardTimeSensitiveBody + user_id_type(UserIdType::OpenId) |
| communication feed_card/bot_time_sentive | wiremock e2e | PATCH，同上 |

## 残留（非本 PR 范围）

- **auth refresh_access_token**：`with_supported_access_token_types(App)` 触发 app_access_token 注入，需双 mock（token 端点 + refresh 端点），单独处理
- **application ~62 stub**：#382（残破 stub，非真实实现）

## 验证

- `cargo test -p openlark-user/-auth/-communication --lib`：全 pass
- clippy all-features ✓ / fmt ✓

依赖 #405（placeholder 清除，独立文件不冲突）。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes; no production API or transport logic modified.
> 
> **Overview**
> Replaces generic `serde_json` roundtrip stubs in eight API modules with tests that exercise the real request builders.
> 
> **Seven endpoints** now use **wiremock** e2e tests: `Config` points at a mock server with token cache disabled, the mock returns `code: 0` success JSON for the documented method/path, the client `execute()` runs, and tests assert exactly one HTTP request was received. Covered areas include passport session logout/query, event outbound IP list, legacy v4 batch send, IM v2 feed card patch and bot time-sensitive PATCH, and personal settings system status GET (with `Arc<Config>` and response `data` checked).
> 
> **OAuth old default authorization** has no outbound HTTP (redirect URL only); its test builds an authorization URL via `AuthorizationRequestBuilder` and asserts `app_id` and `redirect_uri` appear in the URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f2c9ecf69819542c94e7d38eedd31da20dc9c58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->