### PR TITLE
test: clear remaining 32 model/mod/service placeholder（#351 收尾 fixup）

### DIFF
--- a/crates/openlark-ai/src/ai/optical_char_recognition/v1/image/mod.rs
+++ b/crates/openlark-ai/src/ai/optical_char_recognition/v1/image/mod.rs
@@ -22,24 +22,3 @@ impl Image {
         basic_recognize::BasicRecognizeRequestBuilder::new((*self.config).clone())
     }
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-ai/src/ai/optical_char_recognition/v1/mod.rs
+++ b/crates/openlark-ai/src/ai/optical_char_recognition/v1/mod.rs
@@ -22,24 +22,3 @@ impl OcrV1 {
         image::Image::new(self.config.clone())
     }
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-ai/src/ai/speech_to_text/v1/mod.rs
+++ b/crates/openlark-ai/src/ai/speech_to_text/v1/mod.rs
@@ -22,24 +22,3 @@ impl SpeechToTextV1 {
         speech::Speech::new(self.config.clone())
     }
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-ai/src/ai/speech_to_text/v1/speech/mod.rs
+++ b/crates/openlark-ai/src/ai/speech_to_text/v1/speech/mod.rs
@@ -29,24 +29,3 @@ impl Speech {
         stream_recognize::StreamRecognizeRequestBuilder::new((*self.config).clone())
     }
 }
-
-#[cfg(test)]
-mod tests {
-
-    use serde_json;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-application/src/application/application/v1/app/mod.rs
+++ b/crates/openlark-application/src/application/application/v1/app/mod.rs
@@ -46,27 +46,6 @@ impl App {
 pub use get::GetAppRequest;
 // models 模块显式导出
 pub use models::GetAppResponse;
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}
-
 pub mod create;
 pub mod delete;
 pub mod list;

--- a/crates/openlark-application/src/application/application/v1/app/models.rs
+++ b/crates/openlark-application/src/application/application/v1/app/models.rs
@@ -12,23 +12,3 @@ pub struct GetAppResponse {
     /// 应用描述。
     pub description: Option<String>,
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-application/src/application/application/v1/mod.rs
+++ b/crates/openlark-application/src/application/application/v1/mod.rs
@@ -24,27 +24,6 @@ impl ApplicationV1 {
         app::App::new(self.config.clone())
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}
-
 pub mod app_badge;
 pub mod app_recommend_rule;
 pub mod app_usage;

--- a/crates/openlark-application/src/application/application/v6/app/mod.rs
+++ b/crates/openlark-application/src/application/application/v6/app/mod.rs
@@ -26,28 +26,6 @@ impl App {
 pub use get::GetAppRequest;
 // models 模块显式导出
 pub use models::GetAppResponse;
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}
-
 pub mod create;
 pub mod delete;
 pub mod list;

--- a/crates/openlark-application/src/application/application/v6/app/models.rs
+++ b/crates/openlark-application/src/application/application/v6/app/models.rs
@@ -12,24 +12,3 @@ pub struct GetAppResponse {
     /// 描述。
     pub description: Option<String>,
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-application/src/application/application/v6/mod.rs
+++ b/crates/openlark-application/src/application/application/v6/mod.rs
@@ -25,28 +25,6 @@ impl ApplicationV6 {
         app::App::new(self.config.clone())
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}
-
 pub mod app_badge;
 pub mod app_recommend_rule;
 pub mod app_usage;

--- a/crates/openlark-application/src/service.rs
+++ b/crates/openlark-application/src/service.rs
@@ -48,23 +48,3 @@ impl ApplicationService {
         crate::workplace::workplace::v1::WorkplaceV1::new(self._config.clone())
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-auth/src/auth/auth/v3/auth/mod.rs
+++ b/crates/openlark-auth/src/auth/auth/v3/auth/mod.rs
@@ -67,23 +67,3 @@ impl AuthServiceV3 {
         AppTicketResendRequestBuilder::new(self.config.clone())
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-auth/src/auth/authen/v1/mod.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/mod.rs
@@ -64,23 +64,3 @@ impl AuthenServiceV1 {
         OidcService::new(self.config.clone())
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-auth/src/auth/authen/v1/oidc/mod.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/oidc/mod.rs
@@ -39,23 +39,3 @@ impl OidcService {
         OidcRefreshAccessTokenRequestBuilder::new(self.config.clone())
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-bot/src/service.rs
+++ b/crates/openlark-bot/src/service.rs
@@ -29,13 +29,3 @@ impl BotService {
         crate::bot::bot::v4::bot::search::SearchBotRequest::new(self.config.clone())
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-    #[test]
-    fn test_serialization_roundtrip() {
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-}

--- a/crates/openlark-client/src/utils.rs
+++ b/crates/openlark-client/src/utils.rs
@@ -327,23 +327,3 @@ pub struct DiagnosticIssue {
     /// 📝 问题描述
     pub description: String,
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/alias/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/alias/mod.rs
@@ -43,23 +43,3 @@ impl Alias {
         )
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/mod.rs
@@ -74,23 +74,3 @@ pub use models::{
     CreateMailGroupBody, CreateMailGroupResponse, DeleteMailGroupResponse, GetMailGroupResponse,
     MailGroupItem, MailGroupListResponse, UpdateMailGroupBody, UpdateMailGroupResponse,
 };
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/mod.rs
@@ -86,23 +86,3 @@ impl PermissionMember {
         )
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-mail/src/mail/mail/v1/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mod.rs
@@ -51,23 +51,3 @@ impl MailV1 {
         multi_entity::MultiEntity::new(self.config.clone())
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/alias/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/alias/mod.rs
@@ -52,23 +52,3 @@ pub use models::{
     CreatePublicMailboxAliasBody, CreatePublicMailboxAliasResponse,
     DeletePublicMailboxAliasResponse, PublicMailboxAliasItem, PublicMailboxAliasListResponse,
 };
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/mod.rs
@@ -65,27 +65,6 @@ pub use models::{
     DeletePublicMailboxMemberResponse, GetPublicMailboxMemberResponse, PublicMailboxMemberItem,
     PublicMailboxMemberListResponse,
 };
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}
-
 pub mod batch_create;
 pub mod batch_delete;
 pub mod clear;

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/mod.rs
@@ -90,25 +90,4 @@ pub use models::{
     PublicMailboxItem, PublicMailboxListResponse, UpdatePublicMailboxBody,
     UpdatePublicMailboxResponse,
 };
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}
-
 pub mod remove_to_recycle_bin;

--- a/crates/openlark-mail/src/mail/mail/v1/user/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user/mod.rs
@@ -17,25 +17,4 @@ impl User {
         Self { config }
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}
-
 pub mod query;

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/alias/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/alias/mod.rs
@@ -43,23 +43,3 @@ impl Alias {
         )
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/event/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/event/mod.rs
@@ -35,25 +35,4 @@ impl Event {
         )
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}
-
 pub mod subscription;

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/folder/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/folder/mod.rs
@@ -54,25 +54,5 @@ impl Folder {
         )
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}
 /// get 模块。
 pub mod get;

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/mail_contact/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/mail_contact/mod.rs
@@ -54,23 +54,3 @@ impl MailContact {
         )
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/mod.rs
@@ -70,26 +70,6 @@ impl Message {
         recall::Recall::new(self.config.clone(), self.mailbox_id.clone(), message_id)
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}
 /// batch_get 模块。
 pub mod batch_get;
 /// batch_modify 模块。

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/mod.rs
@@ -96,26 +96,6 @@ impl UserMailbox {
         )
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}
 /// accessible_mailboxes 模块。
 pub mod accessible_mailboxes;
 /// draft 模块。

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/mod.rs
@@ -46,25 +46,4 @@ impl Rule {
         reorder::ReorderMailboxRuleRequest::new(self.config.clone(), self.mailbox_id.clone())
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}
-
 pub mod update;

--- a/crates/openlark-mail/src/service.rs
+++ b/crates/openlark-mail/src/service.rs
@@ -29,23 +29,3 @@ impl MailService {
         crate::mail::mail::v1::MailV1::new(self.config.clone())
     }
 }
-
-#[cfg(test)]
-#[allow(unused_imports)]
-mod tests {
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
-    }
-}


### PR DESCRIPTION
## 概述

修复 #405 的不完整落地：`#405` 因脚本输出经管道截断（`| head`）触发 SIGPIPE，仅实际清除了 3/35 文件。本 PR 补清剩余 32 个非 API 占位。

## 根因

`python3 clear_script.py | head -1` —— `head` 读完首行 stdout 后关闭管道，Python 下一次 `print` 触发 SIGPIPE 中断，仅前 1-2 个文件写入完成。改为 `> log 2>&1` 全量运行后正常清 32 个。

## 改动

清除 32 个非 API 文件（basename = models/mod/service/utils）的占位 `serde_json` roundtrip：
- mail 15 / ai 4 / auth 3 / application 7（非 stub 的 model/mod）/ bot 1 / client 1 / 等

## 收尾状态

全仓剩余 Potemkin：
- **application 60 stub** → #382（残破 stub，非真实实现）
- **auth refresh_access_token 1** → `with_supported_access_token_types(App)` 触发 app token 注入，需双 mock（token 端点 + refresh 端点），单独处理

其余 crate 占位全消除（docs/communication/hr/attendance/okr/performance/ehr/payroll/compensation 等）。

## 验证

- `cargo clippy --workspace --all-targets --all-features -- -Dwarnings`：0 error
- `cargo fmt --check` ✓

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only deletions of non-functional placeholder tests; no library or API behavior changes.
> 
> **Overview**
> Completes the #351 / #405 cleanup by **deleting** identical placeholder `#[cfg(test)]` blocks from **32** files whose basenames are `mod`, `models`, `service`, or `utils`—no changes to runtime API or request builders.
> 
> Each removed block only ran generic `serde_json::Value` parse/assert tests and never exercised the host module’s types or behavior (Potemkin coverage). Affected areas include **openlark-mail** (15), **openlark-application** (7), **openlark-ai** (4), **openlark-auth** (3), plus **openlark-bot** `service.rs` and **openlark-client** `utils.rs`.
> 
> This is a follow-up fixup after an incomplete earlier run (#405); production code paths are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e11ddefd8e3dc5e3b8a65ec6e452691a6cea460. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->