### PR TITLE
refactor(client): delegate create_config_from_env to Config::from_env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`allow_custom_base_url` 与构造入口一致性（#415–#416）**：Client 两条公开构造路径
   均完整传播自定义域名放行标志，并执行同一白名单规则。
 
+- **`utils::create_config_from_env` 委托 core env 解释（#413 收尾）**：删除手写
+  `OPENLARK_*` 二次解析，改为 `check_env_config` 预检 + `Config::from_env()`。
+  与 `ConfigBuilder::load_from_env` / `ClientBuilder::from_env` 共用规则；未设
+  `OPENLARK_ENABLE_LOG` 时与 core 一致默认为 `true`（此前该工具函数默认为 `false`）。
+
 ### Breaking
 
 - **#350 P9 接口形状撒谎修正（workflow + analytics；platform/user 已先行）**：

--- a/crates/openlark-client/src/lib.rs
+++ b/crates/openlark-client/src/lib.rs
@@ -729,6 +729,45 @@ mod tests {
     }
 
     #[test]
+    fn test_create_config_from_env_uses_canonical_env_interpretation() {
+        // 委托 Config::from_env：ENABLE_LOG 用 parse_env_bool（"0"→false），
+        // 缺省 enable_log 保持 core 默认 true（不再手写默认 false）。
+        test_utils::with_env_vars(
+            &[
+                ("OPENLARK_APP_ID", Some("test_app_id")),
+                ("OPENLARK_APP_SECRET", Some("test_secret")),
+                ("OPENLARK_TIMEOUT", Some("45")),
+                ("OPENLARK_ENABLE_LOG", Some("0")),
+                ("OPENLARK_RETRY_COUNT", Some("5")),
+            ],
+            || {
+                let config = utils::create_config_from_env().unwrap();
+                assert_eq!(
+                    config.req_timeout(),
+                    Some(std::time::Duration::from_secs(45))
+                );
+                assert!(!config.enable_log());
+                assert_eq!(config.retry_count(), 5);
+            },
+        );
+
+        test_utils::with_env_vars(
+            &[
+                ("OPENLARK_APP_ID", Some("test_app_id")),
+                ("OPENLARK_APP_SECRET", Some("test_secret")),
+                ("OPENLARK_ENABLE_LOG", None),
+            ],
+            || {
+                let config = utils::create_config_from_env().unwrap();
+                assert!(
+                    config.enable_log(),
+                    "未设 OPENLARK_ENABLE_LOG 时应为 core 默认 true"
+                );
+            },
+        );
+    }
+
+    #[test]
     fn test_create_config_from_env_missing_vars() {
         test_utils::with_env_vars(
             &[("OPENLARK_APP_ID", None), ("OPENLARK_APP_SECRET", None)],

--- a/crates/openlark-client/src/utils.rs
+++ b/crates/openlark-client/src/utils.rs
@@ -101,42 +101,16 @@ pub fn check_env_config() -> Result<EnvConfig> {
 
 /// 🔧 从环境变量创建配置
 ///
-/// 自动读取环境变量并创建客户端配置
+/// 先经 [`check_env_config`] 做运维向必填/格式预检，再委托 core
+/// [`Config::from_env`] 解释全部 `OPENLARK_*`（与 `ConfigBuilder::load_from_env` /
+/// `ClientBuilder::from_env` 共用同一套规则与默认值）。
 ///
 /// # 返回
 /// - `Ok(Config)`: 成功创建配置
 /// - `Err(Error)`: 配置创建失败，包含详细错误信息
 pub fn create_config_from_env() -> Result<Config> {
-    // 校验环境变量并获取已校验的凭证
-    let env_cfg = check_env_config()?;
-
-    let app_id = env_cfg.app_id;
-    let app_secret = env_cfg.app_secret;
-
-    let base_url =
-        env::var("OPENLARK_BASE_URL").unwrap_or_else(|_| "https://open.feishu.cn".to_string());
-
-    let timeout = env::var("OPENLARK_TIMEOUT")
-        .ok()
-        .and_then(|t| t.parse().ok())
-        .map(std::time::Duration::from_secs);
-
-    let enable_log = env::var("OPENLARK_ENABLE_LOG")
-        .ok()
-        .and_then(|l| l.parse().ok())
-        .unwrap_or(false);
-
-    let mut builder = Config::builder()
-        .app_id(app_id)
-        .app_secret(app_secret)
-        .base_url(base_url)
-        .enable_log(enable_log);
-
-    if let Some(timeout_duration) = timeout {
-        builder = builder.req_timeout(timeout_duration);
-    }
-
-    Ok(builder.build())
+    check_env_config()?;
+    Ok(Config::from_env())
 }
 
 /// 📊 获取配置摘要


### PR DESCRIPTION
## Summary

- Close out #413 residual: `utils::create_config_from_env` no longer re-parses `OPENLARK_*` by hand.
- Keep `check_env_config` for strict required/format preflight; load fields via `Config::from_env()` so rules match `ConfigBuilder::load_from_env` / `ClientBuilder::from_env`.
- Align unset `OPENLARK_ENABLE_LOG` with core default `true` (was hard-coded `false` in this helper).
- Tests lock timeout / enable_log / retry_count through the canonical path; CHANGELOG note under Unreleased.

## Test plan

- [x] `cargo test -p openlark-client --lib test_create_config_from_env`
- [x] `cargo clippy -p openlark-client --all-targets --all-features -- -Dwarnings`
- [ ] CI green on this PR

Related: #413