### PR TITLE
fix(websocket): close-reason retention, CI guard, multipart withhold

### DIFF
--- a/crates/openlark-client/src/ws_client/full_session_tests.rs
+++ b/crates/openlark-client/src/ws_client/full_session_tests.rs
@@ -1132,12 +1132,12 @@ async fn full_session_backlog_does_not_block_app_ping() {
     assert_normal_close(open_result);
 }
 
-/// 多包降级：sum>1 但 message_id 为空时按单包派发（package 降级分支，会话级断言）。
+/// 非法多包（空 message_id）：扣留、不派发、无 ACK（#421 US2）。
 #[tokio::test]
-async fn full_session_multipart_empty_message_id_degrades_and_dispatches() {
+async fn full_session_multipart_empty_message_id_does_not_dispatch() {
     let calls = Arc::new(AtomicUsize::new(0));
     let last_payload = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let partial = b"degraded-empty-mid";
+    let partial = b"withheld-empty-mid";
 
     let event_handler = EventDispatcherHandler::builder()
         .register_raw(
@@ -1150,13 +1150,12 @@ async fn full_session_multipart_empty_message_id_degrades_and_dispatches() {
         .expect("register")
         .build();
 
-    let (open_result, ()) = run_session(
+    let (open_result, data_responses) = run_session(
         LocalSessionHarness::start().await,
         event_handler,
         SessionOptions::default(),
         move |mut peer| async move {
             let _ = timeout(SESSION_TIMEOUT, peer.next()).await;
-            // message_id 空 + sum=2：无法聚合，立即派发本片 payload
             let mut frame = multipart_event_frame("", Some(2), Some(0), partial);
             frame.headers.retain(|h| h.key != "message_id");
             frame.headers.push(Header {
@@ -1165,32 +1164,50 @@ async fn full_session_multipart_empty_message_id_degrades_and_dispatches() {
             });
             peer.send(Message::Binary(frame.encode_to_vec().into()))
                 .await
-                .expect("send degraded multipart");
-            let _ = recv_data_response_frame(&mut peer).await;
+                .expect("send invalid multipart");
+
+            let mut data_responses = 0usize;
+            let deadline = tokio::time::Instant::now() + Duration::from_millis(200);
+            loop {
+                let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                if remaining.is_zero() {
+                    break;
+                }
+                match timeout(remaining, peer.next()).await {
+                    Ok(Some(Ok(Message::Binary(data)))) => {
+                        let frame = Frame::decode(&*data).expect("decode");
+                        if frame.method == 1 {
+                            data_responses += 1;
+                        }
+                    }
+                    Ok(Some(Ok(Message::Ping(_) | Message::Pong(_)))) => continue,
+                    Ok(Some(Ok(_))) | Ok(Some(Err(_))) | Ok(None) | Err(_) => break,
+                }
+            }
+
             peer.close(Some(CloseFrame {
                 code: CloseCode::Normal,
-                reason: "empty message_id degrade".into(),
+                reason: "empty message_id withhold".into(),
             }))
             .await
             .ok();
+            data_responses
         },
     )
     .await;
 
-    assert_eq!(calls.load(Ordering::SeqCst), 1);
-    assert_eq!(
-        last_payload.lock().expect("mutex").as_slice(),
-        partial.as_slice()
-    );
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    assert_eq!(data_responses, 0);
+    assert!(last_payload.lock().expect("mutex").is_empty());
     assert_normal_close(open_result);
 }
 
-/// 多包降级：seq>=sum 时按单包派发（package 越界分支）。
+/// 非法多包（seq>=sum）：扣留、不派发、无 ACK（#421 US2）。
 #[tokio::test]
-async fn full_session_multipart_seq_out_of_range_degrades_and_dispatches() {
+async fn full_session_multipart_seq_out_of_range_does_not_dispatch() {
     let calls = Arc::new(AtomicUsize::new(0));
     let last_payload = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let oob = b"degraded-oob-seq";
+    let oob = b"withheld-oob-seq";
 
     let event_handler = EventDispatcherHandler::builder()
         .register_raw(
@@ -1203,7 +1220,7 @@ async fn full_session_multipart_seq_out_of_range_degrades_and_dispatches() {
         .expect("register")
         .build();
 
-    let (open_result, ()) = run_session(
+    let (open_result, data_responses) = run_session(
         LocalSessionHarness::start().await,
         event_handler,
         SessionOptions::default(),
@@ -1216,22 +1233,40 @@ async fn full_session_multipart_seq_out_of_range_degrades_and_dispatches() {
             ))
             .await
             .expect("send oob multipart");
-            let _ = recv_data_response_frame(&mut peer).await;
+
+            let mut data_responses = 0usize;
+            let deadline = tokio::time::Instant::now() + Duration::from_millis(200);
+            loop {
+                let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                if remaining.is_zero() {
+                    break;
+                }
+                match timeout(remaining, peer.next()).await {
+                    Ok(Some(Ok(Message::Binary(data)))) => {
+                        let frame = Frame::decode(&*data).expect("decode");
+                        if frame.method == 1 {
+                            data_responses += 1;
+                        }
+                    }
+                    Ok(Some(Ok(Message::Ping(_) | Message::Pong(_)))) => continue,
+                    Ok(Some(Ok(_))) | Ok(Some(Err(_))) | Ok(None) | Err(_) => break,
+                }
+            }
+
             peer.close(Some(CloseFrame {
                 code: CloseCode::Normal,
-                reason: "seq oob degrade".into(),
+                reason: "seq oob withhold".into(),
             }))
             .await
             .ok();
+            data_responses
         },
     )
     .await;
 
-    assert_eq!(calls.load(Ordering::SeqCst), 1);
-    assert_eq!(
-        last_payload.lock().expect("mutex").as_slice(),
-        oob.as_slice()
-    );
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    assert_eq!(data_responses, 0);
+    assert!(last_payload.lock().expect("mutex").is_empty());
     assert_normal_close(open_result);
 }
 

--- a/crates/openlark-client/src/ws_client/full_session_tests.rs
+++ b/crates/openlark-client/src/ws_client/full_session_tests.rs
@@ -2,6 +2,8 @@
 //!
 //! 测试 seam：[`LarkWsClient::open`] / `open_with` + 本地 endpoint + WS peer。
 
+#![cfg(feature = "websocket")]
+
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;

--- a/crates/openlark-client/src/ws_client/full_session_tests.rs
+++ b/crates/openlark-client/src/ws_client/full_session_tests.rs
@@ -319,6 +319,21 @@ fn invalid_method_frame() -> Frame {
     }
 }
 
+/// 构造一个 server→client 的 WebSocket Binary 帧（无 mask；payload_len ≤ 65535）。
+/// 用于 peer 端 tungstenite 已进入 CLOSING、无法再 `send` 时绕过其状态机违约发送数据帧。
+fn raw_binary_ws_frame(payload: &[u8]) -> Vec<u8> {
+    let mut frame = Vec::with_capacity(2 + payload.len());
+    frame.push(0x82); // FIN + opcode 2 (binary)；server→client 不 mask
+    if payload.len() <= 125 {
+        frame.push(payload.len() as u8);
+    } else {
+        frame.push(126);
+        frame.extend_from_slice(&(payload.len() as u16).to_be_bytes());
+    }
+    frame.extend_from_slice(payload);
+    frame
+}
+
 fn assert_normal_close(result: WsClientResult<()>) {
     match result {
         Err(WsClientError::ConnectionClosed {
@@ -916,6 +931,72 @@ async fn full_session_close_reason_preserved_with_inflight_handler() {
     }
 }
 
+/// 远端先发 Close(Away)（服务端记录 WithReason(Away)），再违约发数据帧：client 端
+/// tungstenite 此时已 CLOSING，违约帧在协议层报错。该后续错误不得覆盖已记录的
+/// Away 关闭原因，必须经 `ConnectionClosed { Some(Away) }` 返回（#421 US9）。
+#[tokio::test]
+async fn full_session_data_after_remote_close_preserves_close_reason() {
+    use std::thread;
+    use tokio::io::AsyncWriteExt;
+
+    struct SlowHandler;
+    impl EventHandler for SlowHandler {
+        fn handle(&self, _: &[u8]) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            thread::sleep(Duration::from_millis(300));
+            Ok(())
+        }
+    }
+
+    let event_handler = EventDispatcherHandler::builder()
+        .register_raw(EventDispatcherHandler::RAW_EVENT_KEY, SlowHandler)
+        .expect("register")
+        .build();
+
+    let (open_result, ()) = run_session(
+        LocalSessionHarness::start().await,
+        event_handler,
+        SessionOptions::default(),
+        |mut peer| async move {
+            let _ = timeout(SESSION_TIMEOUT, peer.next()).await;
+            // 先投递一个 event 让 handler 进入 inflight（否则收到 Close 后会话立即
+            // idle 终止，来不及观察后续违约 Binary 的处理）
+            peer.send(Message::Binary(
+                event_data_frame(br#"{"header":{"event_type":"slow"},"event":{}}"#)
+                    .encode_to_vec()
+                    .into(),
+            ))
+            .await
+            .expect("send event");
+            tokio::time::sleep(Duration::from_millis(30)).await;
+            // 发 Close(Away)：服务端 begin_close(Some(Away)) → Closing + WithReason(Away)
+            peer.send(Message::Close(Some(CloseFrame {
+                code: CloseCode::Away,
+                reason: "server restarting".into(),
+            })))
+            .await
+            .expect("send close");
+            // peer 端 tungstenite 已 CLOSING，无法再 send Binary；用 raw write 违约发送
+            let late = event_data_frame(br#"{"header":{"event_type":"late"}}"#).encode_to_vec();
+            peer.get_mut()
+                .write_all(&raw_binary_ws_frame(&late))
+                .await
+                .expect("raw write late binary");
+            while let Some(Ok(_)) = peer.next().await {}
+        },
+    )
+    .await;
+
+    match open_result {
+        Err(WsClientError::ConnectionClosed {
+            reason: Some(WsCloseReason { code, message }),
+        }) => {
+            assert_eq!(code, CloseCode::Away);
+            assert_eq!(message, "server restarting");
+        }
+        other => panic!("expected ConnectionClosed with Away reason, got: {other:?}"),
+    }
+}
+
 /// 慢 EventHandler 不应阻塞 app-level ping 发出（串行 worker + spawn_blocking）。
 #[tokio::test]
 async fn full_session_slow_handler_does_not_block_app_ping() {
@@ -1157,10 +1238,7 @@ async fn full_session_multipart_seq_out_of_range_degrades_and_dispatches() {
 async fn full_session_handler_panic_is_session_error() {
     struct PanicHandler;
     impl EventHandler for PanicHandler {
-        fn handle(
-            &self,
-            _payload: &[u8],
-        ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        fn handle(&self, _payload: &[u8]) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             panic!("intentional handler panic for full_session test");
         }
     }
@@ -1204,10 +1282,7 @@ async fn full_session_backlog_full_is_session_error() {
         hold_ms: u64,
     }
     impl EventHandler for HoldFirstHandler {
-        fn handle(
-            &self,
-            _payload: &[u8],
-        ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        fn handle(&self, _payload: &[u8]) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             thread::sleep(Duration::from_millis(self.hold_ms));
             Ok(())
         }

--- a/crates/openlark-client/src/ws_client/full_session_tests.rs
+++ b/crates/openlark-client/src/ws_client/full_session_tests.rs
@@ -349,6 +349,33 @@ fn assert_normal_close(result: WsClientResult<()>) {
     }
 }
 
+/// 在 `window` 内统计入站数据响应帧数（忽略 Ping/Pong）；超时或流结束则返回已计数。
+/// 用于「不应派发 / 无 ACK」负向断言，避免三处 deadline 轮询复制粘贴。
+async fn count_data_responses_within(
+    peer: &mut WebSocketStream<tokio::net::TcpStream>,
+    window: Duration,
+) -> usize {
+    let mut data_responses = 0usize;
+    let deadline = tokio::time::Instant::now() + window;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match timeout(remaining, peer.next()).await {
+            Ok(Some(Ok(Message::Binary(data)))) => {
+                let frame = Frame::decode(&*data).expect("decode");
+                if frame.method == FRAME_METHOD_DATA {
+                    data_responses += 1;
+                }
+            }
+            Ok(Some(Ok(Message::Ping(_) | Message::Pong(_)))) => continue,
+            Ok(Some(Ok(_))) | Ok(Some(Err(_))) | Ok(None) | Err(_) => break,
+        }
+    }
+    data_responses
+}
+
 #[tokio::test]
 async fn full_session_dispatches_handler_and_emits_response_frame() {
     let calls = Arc::new(AtomicUsize::new(0));
@@ -547,24 +574,8 @@ async fn full_session_multipart_incomplete_does_not_dispatch() {
             .await
             .expect("send incomplete");
 
-            let mut data_responses = 0usize;
-            let deadline = tokio::time::Instant::now() + Duration::from_millis(200);
-            loop {
-                let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-                if remaining.is_zero() {
-                    break;
-                }
-                match timeout(remaining, peer.next()).await {
-                    Ok(Some(Ok(Message::Binary(data)))) => {
-                        let frame = Frame::decode(&*data).expect("decode");
-                        if frame.method == 1 {
-                            data_responses += 1;
-                        }
-                    }
-                    Ok(Some(Ok(Message::Ping(_) | Message::Pong(_)))) => continue,
-                    Ok(Some(Ok(_))) | Ok(Some(Err(_))) | Ok(None) | Err(_) => break,
-                }
-            }
+            let data_responses =
+                count_data_responses_within(&mut peer, Duration::from_millis(200)).await;
 
             peer.close(Some(CloseFrame {
                 code: CloseCode::Normal,
@@ -1166,24 +1177,8 @@ async fn full_session_multipart_empty_message_id_does_not_dispatch() {
                 .await
                 .expect("send invalid multipart");
 
-            let mut data_responses = 0usize;
-            let deadline = tokio::time::Instant::now() + Duration::from_millis(200);
-            loop {
-                let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-                if remaining.is_zero() {
-                    break;
-                }
-                match timeout(remaining, peer.next()).await {
-                    Ok(Some(Ok(Message::Binary(data)))) => {
-                        let frame = Frame::decode(&*data).expect("decode");
-                        if frame.method == 1 {
-                            data_responses += 1;
-                        }
-                    }
-                    Ok(Some(Ok(Message::Ping(_) | Message::Pong(_)))) => continue,
-                    Ok(Some(Ok(_))) | Ok(Some(Err(_))) | Ok(None) | Err(_) => break,
-                }
-            }
+            let data_responses =
+                count_data_responses_within(&mut peer, Duration::from_millis(200)).await;
 
             peer.close(Some(CloseFrame {
                 code: CloseCode::Normal,
@@ -1234,24 +1229,8 @@ async fn full_session_multipart_seq_out_of_range_does_not_dispatch() {
             .await
             .expect("send oob multipart");
 
-            let mut data_responses = 0usize;
-            let deadline = tokio::time::Instant::now() + Duration::from_millis(200);
-            loop {
-                let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-                if remaining.is_zero() {
-                    break;
-                }
-                match timeout(remaining, peer.next()).await {
-                    Ok(Some(Ok(Message::Binary(data)))) => {
-                        let frame = Frame::decode(&*data).expect("decode");
-                        if frame.method == 1 {
-                            data_responses += 1;
-                        }
-                    }
-                    Ok(Some(Ok(Message::Ping(_) | Message::Pong(_)))) => continue,
-                    Ok(Some(Ok(_))) | Ok(Some(Err(_))) | Ok(None) | Err(_) => break,
-                }
-            }
+            let data_responses =
+                count_data_responses_within(&mut peer, Duration::from_millis(200)).await;
 
             peer.close(Some(CloseFrame {
                 code: CloseCode::Normal,

--- a/crates/openlark-client/src/ws_client/mod.rs
+++ b/crates/openlark-client/src/ws_client/mod.rs
@@ -19,5 +19,5 @@ pub use client::{
 #[cfg(test)]
 mod tests;
 
-#[cfg(all(test, feature = "websocket"))]
+#[cfg(test)]
 mod full_session_tests;

--- a/crates/openlark-client/src/ws_client/package.rs
+++ b/crates/openlark-client/src/ws_client/package.rs
@@ -84,9 +84,7 @@ pub(crate) fn assemble_frame(
     }
 
     if seq >= sum {
-        error!(
-            "收到分包帧但 seq 越界，扣留不派发（sum={sum}, seq={seq}, message_id={msg_id}）"
-        );
+        error!("收到分包帧但 seq 越界，扣留不派发（sum={sum}, seq={seq}, message_id={msg_id}）");
         return None;
     }
 

--- a/crates/openlark-client/src/ws_client/package.rs
+++ b/crates/openlark-client/src/ws_client/package.rs
@@ -53,7 +53,8 @@ impl FramePackageBuffer {
     }
 }
 
-/// 处理分包：未齐返回 `None`；齐了返回组合后的帧。
+/// 处理分包：未齐或非法多包（空 `message_id` / `seq` 越界）返回 `None`（不派发）；
+/// 齐了返回组合后的帧。
 pub(crate) fn assemble_frame(
     buffers: &mut HashMap<String, FramePackageBuffer>,
     mut frame: Frame,
@@ -76,18 +77,20 @@ pub(crate) fn assemble_frame(
         return Some(frame);
     }
 
+    // 多包必须可聚合：空 message_id / seq 越界时扣留帧，禁止把残片当完整事件派发（#421 US2）。
     if msg_id.is_empty() {
-        debug!("收到分包帧但 message_id 为空，无法聚合，降级为单包处理（sum={sum}, seq={seq}）");
-        frame.payload = Some(payload);
-        return Some(frame);
+        error!(
+            "multipart frame missing message_id; withhold without dispatch (sum={sum}, seq={seq})"
+        );
+        return None;
     }
 
     if seq >= sum {
-        debug!(
-            "收到分包帧但 seq 越界，降级为单包处理（sum={sum}, seq={seq}, message_id={msg_id}）"
+        error!(
+            "multipart frame seq out of range; withhold without dispatch \
+             (sum={sum}, seq={seq}, message_id={msg_id})"
         );
-        frame.payload = Some(payload);
-        return Some(frame);
+        return None;
     }
 
     let buffer = buffers.entry(msg_id.to_string()).or_insert_with(|| {

--- a/crates/openlark-client/src/ws_client/package.rs
+++ b/crates/openlark-client/src/ws_client/package.rs
@@ -79,16 +79,13 @@ pub(crate) fn assemble_frame(
 
     // 多包必须可聚合：空 message_id / seq 越界时扣留帧，禁止把残片当完整事件派发（#421 US2）。
     if msg_id.is_empty() {
-        error!(
-            "multipart frame missing message_id; withhold without dispatch (sum={sum}, seq={seq})"
-        );
+        error!("收到分包帧但 message_id 为空，扣留不派发（sum={sum}, seq={seq}）");
         return None;
     }
 
     if seq >= sum {
         error!(
-            "multipart frame seq out of range; withhold without dispatch \
-             (sum={sum}, seq={seq}, message_id={msg_id})"
+            "收到分包帧但 seq 越界，扣留不派发（sum={sum}, seq={seq}, message_id={msg_id}）"
         );
         return None;
     }

--- a/crates/openlark-client/src/ws_client/session.rs
+++ b/crates/openlark-client/src/ws_client/session.rs
@@ -279,8 +279,8 @@ impl Session {
                         }
                     }
                     item = self.stream.next(), if stream_open && self.state != SessionState::Closed => {
-                        match item.transpose()? {
-                            Some(msg) => {
+                        match item.transpose() {
+                            Ok(Some(msg)) => {
                                 if msg.is_ping() {
                                     last_activity = Instant::now();
                                 }
@@ -294,9 +294,20 @@ impl Session {
                                 }
                                 self.handle_message(msg, &job_tx).await?;
                             }
-                            None => {
+                            Ok(None) => {
                                 stream_open = false;
                                 self.begin_close(None)?;
+                            }
+                            Err(e) => {
+                                // 远端已正常 Close（带 reason）后，后续传输/协议错误不得
+                                // 覆盖已记录的关闭原因（#421 US9）
+                                if let Some(reason) = self.drain_close_reason() {
+                                    self.state = SessionState::Closed;
+                                    return Err(WsClientError::ConnectionClosed {
+                                        reason: Some(reason),
+                                    });
+                                }
+                                return Err(e.into());
                             }
                         }
                     }

--- a/crates/openlark-client/src/ws_client/session.rs
+++ b/crates/openlark-client/src/ws_client/session.rs
@@ -301,9 +301,12 @@ impl Session {
                             }
                             Err(e) => {
                                 // 远端已正常 Close（带 reason）后，后续传输/协议错误不得
-                                // 覆盖已记录的关闭原因（#421 US9）
+                                // 覆盖已记录的关闭原因（#421 US9）；与 outcome-error 对称
                                 if let Some(reason) = self.drain_close_reason() {
                                     self.state = SessionState::Closed;
+                                    warn!(
+                                        "stream error after remote close: {e}; returning close reason"
+                                    );
                                     return Err(WsClientError::ConnectionClosed {
                                         reason: Some(reason),
                                     });

--- a/crates/openlark-client/src/ws_client/session.rs
+++ b/crates/openlark-client/src/ws_client/session.rs
@@ -226,11 +226,12 @@ impl Session {
 
     pub(crate) async fn run(mut self) -> WsClientResult<()> {
         let mut last_activity = Instant::now();
-        let checkout_period = self
+        // 心跳过期轮询周期（非业务 checkout）；钳在 [50ms, 1s] 与 timeout 之间。
+        let heartbeat_check_period = self
             .heartbeat_timeout
             .min(Duration::from_secs(1))
             .max(Duration::from_millis(50));
-        let mut checkout_timeout = tokio::time::interval(checkout_period);
+        let mut heartbeat_check_interval = tokio::time::interval(heartbeat_check_period);
 
         let (job_tx, mut job_rx) = mpsc::channel::<Frame>(HANDLER_QUEUE_CAP);
         let (outcome_tx, mut outcome_rx) = mpsc::channel::<HandlerOutcome>(HANDLER_QUEUE_CAP);
@@ -343,7 +344,7 @@ impl Session {
                     _ = self.ping_frame_interval.tick(), if self.state == SessionState::Active => {
                         self.send_app_ping().await?;
                     }
-                    _ = checkout_timeout.tick(), if self.state == SessionState::Active => {
+                    _ = heartbeat_check_interval.tick(), if self.state == SessionState::Active => {
                         if last_activity.elapsed() > self.heartbeat_timeout {
                             self.begin_close(None)?;
                         }

--- a/crates/openlark-client/src/ws_client/tests.rs
+++ b/crates/openlark-client/src/ws_client/tests.rs
@@ -344,7 +344,10 @@ fn assemble_multipart_empty_message_id_degrades_to_single() {
     let result = assemble(&mut buffers, frame);
     assert!(result.is_some());
     assert_eq!(result.unwrap().payload, Some(payload));
-    assert!(buffers.is_empty(), "degraded path must not retain package buffer");
+    assert!(
+        buffers.is_empty(),
+        "degraded path must not retain package buffer"
+    );
 }
 
 /// sum>1 但 seq>=sum：越界无法写入缓冲，降级为单包立即派发。

--- a/crates/openlark-client/src/ws_client/tests.rs
+++ b/crates/openlark-client/src/ws_client/tests.rs
@@ -307,11 +307,10 @@ fn test_process_frame_packages_sum_change_resets_buffer() {
     assert_eq!(result.unwrap().payload, Some(b"BCD".to_vec()));
 }
 
-/// sum>1 但 message_id 为空：无法聚合，降级为单包立即派发（当前行为；与 US2 有张力）。
+/// sum>1 但 message_id 为空：无法聚合，扣留且不派发（#421 US2 禁止残片泄漏）。
 #[test]
-fn assemble_multipart_empty_message_id_degrades_to_single() {
+fn assemble_multipart_empty_message_id_is_withheld() {
     let mut buffers = HashMap::new();
-    let payload = b"orphan-part".to_vec();
     let frame = Frame {
         seq_id: 1,
         log_id: 1,
@@ -337,24 +336,21 @@ fn assemble_multipart_empty_message_id_degrades_to_single() {
         ],
         payload_encoding: None,
         payload_type: None,
-        payload: Some(payload.clone()),
+        payload: Some(b"orphan-part".to_vec()),
         log_id_new: None,
     };
 
-    let result = assemble(&mut buffers, frame);
-    assert!(result.is_some());
-    assert_eq!(result.unwrap().payload, Some(payload));
+    assert!(assemble(&mut buffers, frame).is_none());
     assert!(
         buffers.is_empty(),
-        "degraded path must not retain package buffer"
+        "withheld path must not retain package buffer"
     );
 }
 
-/// sum>1 但 seq>=sum：越界无法写入缓冲，降级为单包立即派发。
+/// sum>1 但 seq>=sum：越界残片扣留且不派发。
 #[test]
-fn assemble_multipart_seq_out_of_range_degrades_to_single() {
+fn assemble_multipart_seq_out_of_range_is_withheld() {
     let mut buffers = HashMap::new();
-    let payload = b"oob-part".to_vec();
     let frame = Frame {
         seq_id: 9,
         log_id: 1,
@@ -380,12 +376,10 @@ fn assemble_multipart_seq_out_of_range_degrades_to_single() {
         ],
         payload_encoding: None,
         payload_type: None,
-        payload: Some(payload.clone()),
+        payload: Some(b"oob-part".to_vec()),
         log_id_new: None,
     };
 
-    let result = assemble(&mut buffers, frame);
-    assert!(result.is_some());
-    assert_eq!(result.unwrap().payload, Some(payload));
+    assert!(assemble(&mut buffers, frame).is_none());
     assert!(buffers.is_empty());
 }


### PR DESCRIPTION
## Summary

Follow-ups to PR #448 / epic #421 after Codex review:

1. **Preserve remote close reason on post-close stream errors** (US9)
2. **Make `full_session_tests` reachable to the CI mod-reachability guard**
3. **Withhold invalid multipart fragments** (US2) — stop dispatching empty `message_id` / `seq >= sum` as complete events

## 1. Close reason retention

**Root cause:** After a peer `Close(Away)`, client-side tungstenite enters CLOSING. A subsequent late Binary raises `ReceivedAfterClosing`. The session used `item.transpose()?`, which dropped `close_intent`’s Away reason.

**Fix:** On stream `Err`, drain `close_intent`; if `WithReason`, return `ConnectionClosed { Some(reason) }`, otherwise forward the transport error. Mirrors the outcome-error branch.

**Test:** `full_session_data_after_remote_close_preserves_close_reason` (raw WS binary after close to bypass peer tungstenite CLOSING).

## 2. CI mod reachability

`check_mod_reachability.py` only treats `#[cfg(test)]` as test-only. `#[cfg(all(test, feature = "websocket"))]` was flagged as an orphan.

**Fix:** `#[cfg(test)]` on the mod + file-level `#![cfg(feature = "websocket")]`.

## 3. Multipart withhold (Codex Spec)

**Issue:** `assemble_frame` treated empty `message_id` or `seq >= sum` as single-frame complete events, leaking partial payloads to handlers (#421 US2).

**Fix:** Return `None` (withhold, no buffer, no dispatch). Rename `checkout_*` → `heartbeat_check_*` for clarity.

**Tests:** unit + full-session assert `calls == 0` / no ACK for both cases.

## Out of scope (documented, not changed)

- 0.18 public API contraction without deprecation cycle (CHANGELOG design-contraction)
- Bounded queue + `BacklogFull` (intentional memory bound / backpressure)
- `open` returning `Err(ConnectionClosed)` on normal close (0.18 Breaking)

## Test plan

- [x] `cargo test -p openlark-client --features websocket --lib ws_client`
- [x] Close-reason red→green full-session test
- [x] Multipart withhold unit + full-session tests
- [ ] CI green on this PR

Refs #421 #448