### PR TITLE
refactor(client): add compiled capability catalog with bot tracer (#434)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **client：编译期能力目录 tracer（#434 / #423）**：新增 `capability` catalog，
+  以 `bot` 为 tracer 用同一声明同时生成 `Client::bot` 字段与 registry 诊断元数据；
+  启用 `bot` feature 时 `client.bot` 可用且 `registry.has_service("bot")`；禁用时
+  两处均不可用。其余业务域仍走 `declare_client!` + `registry/catalog.rs` 旧路径。
+
 - **core：加深 `Transport::request` 请求执行（#422 / #430–#433）**：
   - 内部收敛为 `request_execution` 深模块（构建 + 认证 + 解码）；删除纯委托
     `ReqTranslator` 与一行式 `HeaderBuilder`。

--- a/crates/openlark-client/src/capability/catalog.rs
+++ b/crates/openlark-client/src/capability/catalog.rs
@@ -3,14 +3,19 @@
 //! #434 tracer：目前仅 `bot` 走本目录；其余业务域仍使用
 //! `declare_client!` + `registry/catalog.rs` 双声明旧路径。
 //! 后续 #435 / #436 将把其余域迁入 [`for_each_compiled_capability`]。
+//! 在 #435 真正扩容前不再增加新的通用宏层。
 //!
 //! 统一声明同时包含：
 //! - Client 构造：`feature` / `field` / `ty` / `doc` / `init`
 //! - 诊断元数据：`name` / `description` / `dependencies` / `provides` / `priority`
+//!
+//! 两个 callback 各自只消费一半字段（另一半为死匹配），以保证「单源」而非「两份声明」。
 
 /// 对每个已声明的编译期能力调用 `$callback! { ...entries }`。
 ///
-/// Client 与 registry 均通过此 callback 消费同一列表，避免双声明漂移。
+/// 现有 callback：
+/// - `generate_catalog_registry` — registry 诊断投影
+/// - `append_catalog_entries` — 追加进 `declare_client!` 的 Client 构造投影
 macro_rules! for_each_compiled_capability {
     ($callback:ident) => {
         $callback! {

--- a/crates/openlark-client/src/capability/catalog.rs
+++ b/crates/openlark-client/src/capability/catalog.rs
@@ -1,0 +1,85 @@
+//! 编译期能力目录（单一事实来源）
+//!
+//! #434 tracer：目前仅 `bot` 走本目录；其余业务域仍使用
+//! `declare_client!` + `registry/catalog.rs` 双声明旧路径。
+//! 后续 #435 / #436 将把其余域迁入 [`for_each_compiled_capability`]。
+//!
+//! 统一声明同时包含：
+//! - Client 构造：`feature` / `field` / `ty` / `doc` / `init`
+//! - 诊断元数据：`name` / `description` / `dependencies` / `provides` / `priority`
+
+/// 对每个已声明的编译期能力调用 `$callback! { ...entries }`。
+///
+/// Client 与 registry 均通过此 callback 消费同一列表，避免双声明漂移。
+macro_rules! for_each_compiled_capability {
+    ($callback:ident) => {
+        $callback! {
+            {
+                feature: "bot",
+                field: bot,
+                ty: openlark_bot::BotClient,
+                doc: "Bot meta 调用链入口：client.bot.search_bot() ...",
+                init: |_core_config, _base_core_config| {
+                    openlark_bot::BotClient::new(_core_config.clone())
+                },
+                name: "bot",
+                description: "飞书机器人服务，提供机器人搜索等功能",
+                dependencies: ["auth"],
+                provides: ["bot"],
+                priority: 4,
+            },
+        }
+    };
+}
+
+pub(crate) use for_each_compiled_capability;
+
+// 由统一声明生成 registry 注册与测试辅助
+for_each_compiled_capability!(generate_catalog_registry);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::{DefaultServiceRegistry, ServiceRegistry};
+
+    #[test]
+    fn catalog_names_reflect_bot_feature() {
+        let names = catalog_capability_names();
+
+        #[cfg(feature = "bot")]
+        {
+            assert_eq!(names, vec!["bot"]);
+        }
+
+        #[cfg(not(feature = "bot"))]
+        {
+            assert!(names.is_empty());
+        }
+    }
+
+    #[test]
+    fn register_catalog_capabilities_matches_bot_feature() {
+        let mut registry = DefaultServiceRegistry::new();
+        register_catalog_capabilities(&mut registry).unwrap();
+
+        #[cfg(feature = "bot")]
+        {
+            assert!(registry.has_service("bot"));
+            let entry = registry.get_service("bot").unwrap();
+            assert_eq!(entry.metadata.name, "bot");
+            assert_eq!(
+                entry.metadata.description.as_deref(),
+                Some("飞书机器人服务，提供机器人搜索等功能")
+            );
+            assert_eq!(entry.metadata.dependencies, vec!["auth".to_string()]);
+            assert_eq!(entry.metadata.provides, vec!["bot".to_string()]);
+            assert_eq!(entry.metadata.priority, 4);
+            assert!(entry.instance.is_none());
+        }
+
+        #[cfg(not(feature = "bot"))]
+        {
+            assert!(!registry.has_service("bot"));
+        }
+    }
+}

--- a/crates/openlark-client/src/capability/macros.rs
+++ b/crates/openlark-client/src/capability/macros.rs
@@ -1,13 +1,19 @@
 //! 编译期能力目录宏
 //!
 //! callback 模式：`for_each_compiled_capability!`（定义于 `catalog.rs`）持有统一声明，
-//! 本模块的 `generate_catalog_registry!` 与 `client` 侧 callback 分别消费同一条目列表。
+//! 本模块的 `generate_catalog_registry!` 与 `client` 侧 `append_catalog_entries!`
+//! 分别投影同一条目列表（Client 构造 vs registry 诊断）。
+//!
+//! #434 仅为 bot tracer：在 #435 真正扩容前不再扩大宏面（避免 Speculative Generality）。
 
 /// 由 `for_each_compiled_capability!` 展开：生成 registry 注册与测试辅助。
+///
+/// 死匹配（field/ty/doc/init）：统一条目同时含构造与诊断字段，本侧只消费诊断字段；
+/// 与 `append_catalog_entries!` 对称，是双投影的固有成本（#434 review）。
 macro_rules! generate_catalog_registry {
     ($({
         feature: $feature:literal,
-        // Client 构造字段：由 client 侧 callback 消费，registry 路径仅保留匹配形状
+        // Client 构造字段：由 append_catalog_entries! 消费；此处仅匹配统一条目形状
         field: $_field:ident,
         ty: $_ty:ty,
         doc: $_doc:literal,
@@ -27,7 +33,7 @@ macro_rules! generate_catalog_registry {
                 {
                     use crate::registry::{ServiceMetadata, ServiceRegistry, ServiceStatus};
 
-                    // Client 侧字段/ty/doc/init 由 client callback 消费；此处只写诊断元数据。
+                    // 只写诊断元数据；构造字段已在匹配中吸收。
                     let metadata = ServiceMetadata {
                         name: $name.to_string(),
                         version: "1.0.0".to_string(),

--- a/crates/openlark-client/src/capability/macros.rs
+++ b/crates/openlark-client/src/capability/macros.rs
@@ -1,0 +1,64 @@
+//! 编译期能力目录宏
+//!
+//! callback 模式：`for_each_compiled_capability!`（定义于 `catalog.rs`）持有统一声明，
+//! 本模块的 `generate_catalog_registry!` 与 `client` 侧 callback 分别消费同一条目列表。
+
+/// 由 `for_each_compiled_capability!` 展开：生成 registry 注册与测试辅助。
+macro_rules! generate_catalog_registry {
+    ($({
+        feature: $feature:literal,
+        // Client 构造字段：由 client 侧 callback 消费，registry 路径仅保留匹配形状
+        field: $_field:ident,
+        ty: $_ty:ty,
+        doc: $_doc:literal,
+        init: |$_core_config:ident, $_base_core_config:ident| $_init:block,
+        name: $name:literal,
+        description: $description:literal,
+        dependencies: [$($dependency:literal),* $(,)?],
+        provides: [$($capability:literal),* $(,)?],
+        priority: $priority:literal $(,)?
+    }),* $(,)?) => {
+        /// 将 catalog 中已编译的能力注册为 registry 元数据（metadata-only）。
+        pub(crate) fn register_catalog_capabilities(
+            registry: &mut crate::DefaultServiceRegistry,
+        ) -> crate::Result<()> {
+            $(
+                #[cfg(feature = $feature)]
+                {
+                    use crate::registry::{ServiceMetadata, ServiceRegistry, ServiceStatus};
+
+                    // Client 侧字段/ty/doc/init 由 client callback 消费；此处只写诊断元数据。
+                    let metadata = ServiceMetadata {
+                        name: $name.to_string(),
+                        version: "1.0.0".to_string(),
+                        description: Some($description.to_string()),
+                        dependencies: vec![$($dependency.to_string()),*],
+                        provides: vec![$($capability.to_string()),*],
+                        status: ServiceStatus::Uninitialized,
+                        priority: $priority,
+                    };
+                    ServiceRegistry::register_service(registry, metadata)
+                        .map_err(crate::error::registry_error)?;
+                }
+            )*
+
+            let _ = registry;
+            Ok(())
+        }
+
+        /// 当前编译进包的 catalog 能力名（仅测试/诊断使用）。
+        #[cfg(test)]
+        pub(crate) fn catalog_capability_names() -> Vec<&'static str> {
+            [
+                None::<&'static str>,
+                $(
+                    #[cfg(feature = $feature)]
+                    Some($name),
+                )*
+            ]
+            .into_iter()
+            .flatten()
+            .collect()
+        }
+    };
+}

--- a/crates/openlark-client/src/capability/mod.rs
+++ b/crates/openlark-client/src/capability/mod.rs
@@ -1,0 +1,15 @@
+//! 编译期能力目录（compiled-capability catalog）
+//!
+//! 将 Cargo feature、Client 字段构造与 registry 诊断元数据收敛到同一声明
+//!（见 issue #423 / #434）。当前仅 `bot` 作为 tracer bullet 走此路径；
+//! 其余业务域仍由 `declare_client!` 与 `registry/catalog.rs` 分别维护。
+//!
+//! 统一声明入口：[`for_each_compiled_capability`]。
+
+#[macro_use]
+mod macros;
+
+mod catalog;
+
+pub(crate) use catalog::for_each_compiled_capability;
+pub(crate) use catalog::register_catalog_capabilities;

--- a/crates/openlark-client/src/capability/mod.rs
+++ b/crates/openlark-client/src/capability/mod.rs
@@ -5,6 +5,7 @@
 //! 其余业务域仍由 `declare_client!` 与 `registry/catalog.rs` 分别维护。
 //!
 //! 统一声明入口：[`for_each_compiled_capability`]。
+//! 宏面刻意保持最小（单列表 + 两投影 callback）；#435 扩容前不继续抽象。
 
 #[macro_use]
 mod macros;

--- a/crates/openlark-client/src/client.rs
+++ b/crates/openlark-client/src/client.rs
@@ -45,14 +45,19 @@ impl AuthClient {
 }
 
 // legacy 业务域仍走 declare_client 双声明；catalog 域（目前仅 bot）通过
-// for_each_compiled_capability callback 合并进同一 Client 结构体。
-macro_rules! declare_client_with_catalog {
+// for_each_compiled_capability callback 追加进同一 Client 结构体。
+//
+// 命名：本宏是「包裹 declare_client! 并追加 catalog 条目」，不是「声明 catalog 本身」。
+// 死匹配（name/description/...）：统一条目同时含构造与诊断字段，本侧只消费构造字段；
+// 与 generate_catalog_registry! 对称，是双投影的固有成本，而非重复逻辑（#434 review）。
+macro_rules! append_catalog_entries {
     ($({
         feature: $c_feature:literal,
         field: $c_field:ident,
         ty: $c_ty:ty,
         doc: $c_doc:literal,
         init: |$c_core:ident, $c_base:ident| $c_init:block,
+        // 诊断字段：由 registry 投影消费；此处仅匹配统一条目形状
         name: $_name:literal,
         description: $_description:literal,
         dependencies: [$( $_dep:literal ),* $(,)?],
@@ -200,7 +205,7 @@ macro_rules! declare_client_with_catalog {
                     openlark_security::SecurityClient::new(security_config)
                 },
             },
-            // capability catalog 条目（#434 bot tracer；后续域迁入后仅改 catalog）
+            // capability catalog 条目（#434 bot tracer；#435/#436 迁域时只改 catalog 声明）
             $(
                 {
                     feature: $c_feature,
@@ -214,7 +219,7 @@ macro_rules! declare_client_with_catalog {
     };
 }
 
-crate::capability::for_each_compiled_capability!(declare_client_with_catalog);
+crate::capability::for_each_compiled_capability!(append_catalog_entries);
 
 impl Client {
     /// 🔥 从环境变量创建客户端

--- a/crates/openlark-client/src/client.rs
+++ b/crates/openlark-client/src/client.rs
@@ -44,148 +44,177 @@ impl AuthClient {
     }
 }
 
-declare_client! {
-    {
-        feature: "cardkit",
-        field: cardkit,
-        ty: openlark_cardkit::CardkitClient,
-        doc: "CardKit meta 调用链：client.cardkit.v1.card.create(...)",
-        init: |_core_config, _base_core_config| {
-            openlark_cardkit::CardkitClient::new(_core_config.clone())
-        },
-    },
-    {
-        feature: "auth",
-        field: auth,
-        ty: AuthClient,
-        doc: "Auth meta 调用链入口：client.auth.app / client.auth.user / client.auth.oauth",
-        init: |_core_config, _base_core_config| {
-            AuthClient::new(_base_core_config.clone())
-        },
-    },
-    {
-        feature: "docs",
-        field: docs,
-        ty: openlark_docs::DocsClient,
-        doc: "Docs meta 调用链入口：client.docs.config() / 各 async helper（如 search_bitable_records_all）...",
-        init: |_core_config, _base_core_config| {
-            openlark_docs::DocsClient::new(_core_config.clone())
-        },
-    },
-    {
-        feature: "communication",
-        field: communication,
-        ty: openlark_communication::CommunicationClient,
-        doc: "Communication meta 调用链入口：client.communication.im / client.communication.contact ...",
-        init: |_core_config, _base_core_config| {
-            openlark_communication::CommunicationClient::new(_core_config.clone())
-        },
-    },
-    {
-        feature: "hr",
-        field: hr,
-        ty: openlark_hr::HrClient,
-        doc: "HR meta 调用链入口：client.hr.attendance / client.hr.corehr / client.hr.hire ...",
-        init: |_core_config, _base_core_config| {
-            openlark_hr::HrClient::new(_core_config.clone())
-        },
-    },
-    {
-        feature: "meeting",
-        field: meeting,
-        ty: openlark_meeting::MeetingClient,
-        doc: "Meeting meta 调用链入口：client.meeting.vc.v1.note.get(...) 等（ADR 0001：room/meeting/reserve 空壳已砍，真实 builder 经 strict 路径）",
-        init: |_core_config, _base_core_config| {
-            openlark_meeting::MeetingClient::new(_core_config.clone())
-        },
-    },
-    {
-        feature: "ai",
-        field: ai,
-        ty: openlark_ai::AiClient,
-        doc: "AI meta 调用链入口：client.ai.chat.create() ...",
-        init: |_core_config, _base_core_config| {
-            openlark_ai::AiClient::new(_core_config.clone())
-        },
-    },
-    {
-        feature: "workflow",
-        field: workflow,
-        ty: crate::WorkflowClient,
-        doc: "Workflow meta 调用链入口：client.workflow.v2().task().create() ...",
-        init: |_core_config, _base_core_config| {
-            crate::WorkflowClient::new(_core_config.clone())
-        },
-    },
-    {
-        feature: "platform",
-        field: platform,
-        ty: crate::PlatformClient,
-        doc: "Platform meta 调用链入口：client.platform.app_engine... ...",
-        init: |_core_config, _base_core_config| {
-            crate::PlatformClient::new(_core_config.clone())
-        },
-    },
-    {
-        feature: "application",
-        field: application,
-        ty: crate::ApplicationClient,
-        doc: "Application meta 调用链入口：client.application.applet... ...",
-        init: |_core_config, _base_core_config| {
-            crate::ApplicationClient::new(_core_config.clone())
-        },
-    },
-    {
-        feature: "helpdesk",
-        field: helpdesk,
-        ty: crate::HelpdeskClient,
-        doc: "Helpdesk meta 调用链入口：client.helpdesk.ticket... ...",
-        init: |_core_config, _base_core_config| {
-            crate::HelpdeskClient::new(_core_config.clone())
-        },
-    },
-    {
-        feature: "mail",
-        field: mail,
-        ty: crate::MailClient,
-        doc: "Mail meta 调用链入口：client.mail.group... ...",
-        init: |_core_config, _base_core_config| {
-            crate::MailClient::new(_core_config.clone())
-        },
-    },
-    {
-        feature: "analytics",
-        field: analytics,
-        ty: crate::AnalyticsClient,
-        doc: "Analytics meta 调用链入口：client.analytics.report... ...",
-        init: |_core_config, _base_core_config| {
-            crate::AnalyticsClient::new(_core_config.clone())
-        },
-    },
-    {
-        feature: "user",
-        field: user,
-        ty: crate::UserClient,
-        doc: "User meta 调用链入口：client.user.system_status... ...",
-        init: |_core_config, _base_core_config| {
-            crate::UserClient::new(_core_config.clone())
-        },
-    },
-    {
-        feature: "security",
-        field: security,
-        ty: crate::SecurityClient,
-        doc: "Security meta 调用链入口：client.security.acs... ...",
-        init: |_core_config, _base_core_config| {
-            let security_config = openlark_security::config::SecurityConfig::new(
-                _core_config.app_id().to_string(),
-                _core_config.app_secret().to_string(),
-            )
-            .with_base_url(_core_config.base_url());
-            openlark_security::SecurityClient::new(security_config)
-        },
-    },
+// legacy 业务域仍走 declare_client 双声明；catalog 域（目前仅 bot）通过
+// for_each_compiled_capability callback 合并进同一 Client 结构体。
+macro_rules! declare_client_with_catalog {
+    ($({
+        feature: $c_feature:literal,
+        field: $c_field:ident,
+        ty: $c_ty:ty,
+        doc: $c_doc:literal,
+        init: |$c_core:ident, $c_base:ident| $c_init:block,
+        name: $_name:literal,
+        description: $_description:literal,
+        dependencies: [$( $_dep:literal ),* $(,)?],
+        provides: [$( $_cap:literal ),* $(,)?],
+        priority: $_priority:literal $(,)?
+    }),* $(,)?) => {
+        declare_client! {
+            {
+                feature: "cardkit",
+                field: cardkit,
+                ty: openlark_cardkit::CardkitClient,
+                doc: "CardKit meta 调用链：client.cardkit.v1.card.create(...)",
+                init: |_core_config, _base_core_config| {
+                    openlark_cardkit::CardkitClient::new(_core_config.clone())
+                },
+            },
+            {
+                feature: "auth",
+                field: auth,
+                ty: AuthClient,
+                doc: "Auth meta 调用链入口：client.auth.app / client.auth.user / client.auth.oauth",
+                init: |_core_config, _base_core_config| {
+                    AuthClient::new(_base_core_config.clone())
+                },
+            },
+            {
+                feature: "docs",
+                field: docs,
+                ty: openlark_docs::DocsClient,
+                doc: "Docs meta 调用链入口：client.docs.config() / 各 async helper（如 search_bitable_records_all）...",
+                init: |_core_config, _base_core_config| {
+                    openlark_docs::DocsClient::new(_core_config.clone())
+                },
+            },
+            {
+                feature: "communication",
+                field: communication,
+                ty: openlark_communication::CommunicationClient,
+                doc: "Communication meta 调用链入口：client.communication.im / client.communication.contact ...",
+                init: |_core_config, _base_core_config| {
+                    openlark_communication::CommunicationClient::new(_core_config.clone())
+                },
+            },
+            {
+                feature: "hr",
+                field: hr,
+                ty: openlark_hr::HrClient,
+                doc: "HR meta 调用链入口：client.hr.attendance / client.hr.corehr / client.hr.hire ...",
+                init: |_core_config, _base_core_config| {
+                    openlark_hr::HrClient::new(_core_config.clone())
+                },
+            },
+            {
+                feature: "meeting",
+                field: meeting,
+                ty: openlark_meeting::MeetingClient,
+                doc: "Meeting meta 调用链入口：client.meeting.vc.v1.note.get(...) 等（ADR 0001：room/meeting/reserve 空壳已砍，真实 builder 经 strict 路径）",
+                init: |_core_config, _base_core_config| {
+                    openlark_meeting::MeetingClient::new(_core_config.clone())
+                },
+            },
+            {
+                feature: "ai",
+                field: ai,
+                ty: openlark_ai::AiClient,
+                doc: "AI meta 调用链入口：client.ai.chat.create() ...",
+                init: |_core_config, _base_core_config| {
+                    openlark_ai::AiClient::new(_core_config.clone())
+                },
+            },
+            {
+                feature: "workflow",
+                field: workflow,
+                ty: crate::WorkflowClient,
+                doc: "Workflow meta 调用链入口：client.workflow.v2().task().create() ...",
+                init: |_core_config, _base_core_config| {
+                    crate::WorkflowClient::new(_core_config.clone())
+                },
+            },
+            {
+                feature: "platform",
+                field: platform,
+                ty: crate::PlatformClient,
+                doc: "Platform meta 调用链入口：client.platform.app_engine... ...",
+                init: |_core_config, _base_core_config| {
+                    crate::PlatformClient::new(_core_config.clone())
+                },
+            },
+            {
+                feature: "application",
+                field: application,
+                ty: crate::ApplicationClient,
+                doc: "Application meta 调用链入口：client.application.applet... ...",
+                init: |_core_config, _base_core_config| {
+                    crate::ApplicationClient::new(_core_config.clone())
+                },
+            },
+            {
+                feature: "helpdesk",
+                field: helpdesk,
+                ty: crate::HelpdeskClient,
+                doc: "Helpdesk meta 调用链入口：client.helpdesk.ticket... ...",
+                init: |_core_config, _base_core_config| {
+                    crate::HelpdeskClient::new(_core_config.clone())
+                },
+            },
+            {
+                feature: "mail",
+                field: mail,
+                ty: crate::MailClient,
+                doc: "Mail meta 调用链入口：client.mail.group... ...",
+                init: |_core_config, _base_core_config| {
+                    crate::MailClient::new(_core_config.clone())
+                },
+            },
+            {
+                feature: "analytics",
+                field: analytics,
+                ty: crate::AnalyticsClient,
+                doc: "Analytics meta 调用链入口：client.analytics.report... ...",
+                init: |_core_config, _base_core_config| {
+                    crate::AnalyticsClient::new(_core_config.clone())
+                },
+            },
+            {
+                feature: "user",
+                field: user,
+                ty: crate::UserClient,
+                doc: "User meta 调用链入口：client.user.system_status... ...",
+                init: |_core_config, _base_core_config| {
+                    crate::UserClient::new(_core_config.clone())
+                },
+            },
+            {
+                feature: "security",
+                field: security,
+                ty: crate::SecurityClient,
+                doc: "Security meta 调用链入口：client.security.acs... ...",
+                init: |_core_config, _base_core_config| {
+                    let security_config = openlark_security::config::SecurityConfig::new(
+                        _core_config.app_id().to_string(),
+                        _core_config.app_secret().to_string(),
+                    )
+                    .with_base_url(_core_config.base_url());
+                    openlark_security::SecurityClient::new(security_config)
+                },
+            },
+            // capability catalog 条目（#434 bot tracer；后续域迁入后仅改 catalog）
+            $(
+                {
+                    feature: $c_feature,
+                    field: $c_field,
+                    ty: $c_ty,
+                    doc: $c_doc,
+                    init: |$c_core, $c_base| $c_init,
+                },
+            )*
+        }
+    };
 }
+
+crate::capability::for_each_compiled_capability!(declare_client_with_catalog);
 
 impl Client {
     /// 🔥 从环境变量创建客户端

--- a/crates/openlark-client/src/client/tests.rs
+++ b/crates/openlark-client/src/client/tests.rs
@@ -673,3 +673,68 @@ fn test_communication_service_access() {
 
     let _comm = &client.communication;
 }
+
+// ===== #434: compiled-capability catalog bot tracer =====
+// 最高运行时 seam：`Client::registry()` 与 Client 字段对 bot feature 的一致性。
+
+#[test]
+fn bot_capability_client_and_registry_agree() {
+    use crate::registry::ServiceRegistry;
+
+    let client = Client::builder()
+        .app_id("test_app_id")
+        .app_secret("test_app_secret")
+        .build()
+        .unwrap();
+
+    #[cfg(feature = "bot")]
+    {
+        // Client 字段可用
+        let _bot = &client.bot;
+        // registry 报告 bot，且元数据完整
+        assert!(
+            client.registry().has_service("bot"),
+            "bot feature 启用时 registry 必须报告 bot"
+        );
+        let entry = client.registry().get_service("bot").unwrap();
+        assert_eq!(entry.metadata.name, "bot");
+        assert_eq!(
+            entry.metadata.description.as_deref(),
+            Some("飞书机器人服务，提供机器人搜索等功能")
+        );
+        assert_eq!(entry.metadata.dependencies, vec!["auth".to_string()]);
+        assert_eq!(entry.metadata.provides, vec!["bot".to_string()]);
+        assert_eq!(entry.metadata.priority, 4);
+        // metadata-only：无 runtime instance
+        assert!(entry.instance.is_none());
+    }
+
+    #[cfg(not(feature = "bot"))]
+    {
+        assert!(
+            !client.registry().has_service("bot"),
+            "bot feature 禁用时 registry 不得报告 bot"
+        );
+    }
+}
+
+#[test]
+fn legacy_domains_still_register_via_old_path() {
+    use crate::registry::ServiceRegistry;
+
+    let client = Client::builder()
+        .app_id("test_app_id")
+        .app_secret("test_app_secret")
+        .build()
+        .unwrap();
+
+    // 默认 feature 含 auth；确认旧路径未被 capability catalog 破坏
+    #[cfg(feature = "auth")]
+    assert!(client.registry().has_service("auth"));
+
+    #[cfg(feature = "communication")]
+    assert!(client.registry().has_service("communication"));
+
+    #[cfg(not(feature = "hr"))]
+    assert!(!client.registry().has_service("hr"));
+}

--- a/crates/openlark-client/src/lib.rs
+++ b/crates/openlark-client/src/lib.rs
@@ -236,6 +236,8 @@
 //! ```
 
 // 核心模块
+/// 编译期能力目录（Client 字段 + registry 元数据统一声明，#434 tracer: bot）
+pub(crate) mod capability;
 pub mod client;
 pub mod error;
 pub mod features;

--- a/crates/openlark-client/src/registry/bootstrap.rs
+++ b/crates/openlark-client/src/registry/bootstrap.rs
@@ -59,7 +59,15 @@ macro_rules! compiled_services {
 
 #[path = "catalog.rs"]
 mod catalog;
-pub(crate) use catalog::register_compiled_services;
+
+/// 注册所有已编译服务元数据：legacy `registry/catalog` + capability catalog（#434 bot tracer）。
+pub(crate) fn register_compiled_services(
+    registry: &mut super::DefaultServiceRegistry,
+) -> crate::Result<()> {
+    catalog::register_compiled_services(registry)?;
+    crate::capability::register_catalog_capabilities(registry)?;
+    Ok(())
+}
 
 #[cfg(test)]
 use catalog::compiled_service_names;
@@ -223,6 +231,31 @@ mod tests {
         assert_feature_service!("mail", "mail");
         assert_feature_service!("analytics", "analytics");
         assert_feature_service!("user", "user");
+        // bot 走 capability catalog（#434），不在 legacy compiled_service_names 中
+    }
+
+    #[test]
+    fn test_register_compiled_services_includes_catalog_bot() {
+        use super::super::ServiceRegistry;
+
+        let mut registry = DefaultServiceRegistry::new();
+        register_compiled_services(&mut registry).unwrap();
+
+        #[cfg(feature = "bot")]
+        assert!(
+            registry.has_service("bot"),
+            "bot feature 启用时 register_compiled_services 必须注册 bot"
+        );
+
+        #[cfg(not(feature = "bot"))]
+        assert!(
+            !registry.has_service("bot"),
+            "bot feature 禁用时 register_compiled_services 不得注册 bot"
+        );
+
+        // legacy 路径仍工作
+        #[cfg(feature = "auth")]
+        assert!(registry.has_service("auth"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- 新增 `openlark-client` 编译期能力目录（`capability`），以 **bot** 为 tracer：同一声明同时生成 `Client::bot` 字段与 registry 诊断元数据
- 启用 `bot` feature 时 `client.bot` 可用且 `registry.has_service("bot")`；禁用时两处均不可用
- 其余业务域仍走 `declare_client!` + `registry/catalog.rs` 旧路径（为 #435 / #436 分阶段迁移留口）
- 跟进 code review：重命名 `append_catalog_entries!`、标明双投影死匹配意图、#435 前冻结宏面

Closes #434

## Test plan

- [x] `cargo clippy -p openlark-client --features "auth,bot" --all-targets -- -D warnings`
- [x] `cargo clippy -p openlark-client --no-default-features --features auth --all-targets -- -D warnings`
- [x] `cargo check -p openlark-client --all-features` / `--no-default-features`
- [x] `cargo test -p openlark-client --features "auth,bot" --lib`（106 passed）
- [x] `cargo test -p openlark-client --no-default-features --lib`（103 passed）
- [x] bot 开/关：`bot_capability_client_and_registry_agree`、catalog registry 测试