### PR TITLE
refactor(docs): prove endpoint semantics with Base App Role tracer (#438)

### DIFF
--- a/.github/msrv/Cargo.lock
+++ b/.github/msrv/Cargo.lock
@@ -135,15 +135,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -151,14 +151,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -184,9 +185,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -199,15 +200,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cast"
@@ -217,9 +218,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -240,10 +241,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chrono"
-version = "0.4.44"
+name = "chacha20"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -393,6 +405,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -449,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -471,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -481,11 +502,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -495,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -541,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -570,9 +590,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -582,11 +602,12 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
+ "regex",
 ]
 
 [[package]]
@@ -604,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream 1.0.0",
  "anstyle",
@@ -751,9 +772,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -802,10 +823,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
- "wasip2",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -817,9 +850,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -880,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -890,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -900,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -925,15 +958,15 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1252,23 +1285,22 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1330,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -1351,9 +1383,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mime"
@@ -1373,9 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -1532,7 +1564,7 @@ dependencies = [
  "mockall",
  "once_cell",
  "openlark-core",
- "rand 0.8.6",
+ "rand 0.8.7",
  "regex",
  "rstest",
  "serde",
@@ -1569,7 +1601,7 @@ dependencies = [
  "hex",
  "mockall",
  "openlark-core",
- "rand 0.8.6",
+ "rand 0.8.7",
  "regex",
  "rstest",
  "serde",
@@ -1598,6 +1630,7 @@ dependencies = [
 name = "openlark-capability-unique"
 version = "0.0.0"
 dependencies = [
+ "openlark-client",
  "trybuild",
 ]
 
@@ -1679,7 +1712,7 @@ dependencies = [
  "lark-websocket-protobuf",
  "num_cpus",
  "prost 0.13.5",
- "rand 0.8.6",
+ "rand 0.8.7",
  "regex",
  "reqwest",
  "rstest",
@@ -1713,7 +1746,7 @@ dependencies = [
  "mockall",
  "once_cell",
  "openlark-core",
- "rand 0.8.6",
+ "rand 0.8.7",
  "regex",
  "rstest",
  "serde",
@@ -1750,7 +1783,7 @@ dependencies = [
  "log",
  "mockall",
  "openlark-core",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rstest",
  "serde",
  "serde_json",
@@ -1801,7 +1834,7 @@ dependencies = [
  "mockall",
  "once_cell",
  "openlark-core",
- "rand 0.8.6",
+ "rand 0.8.7",
  "regex",
  "rstest",
  "serde",
@@ -1830,7 +1863,7 @@ dependencies = [
  "mockall",
  "openlark-auth",
  "openlark-core",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rstest",
  "serde",
  "serde_json",
@@ -1859,7 +1892,7 @@ dependencies = [
  "mockall",
  "once_cell",
  "openlark-core",
- "rand 0.8.6",
+ "rand 0.8.7",
  "regex",
  "rstest",
  "serde",
@@ -1953,6 +1986,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -2056,7 +2095,7 @@ dependencies = [
  "bitflags",
  "lazy_static",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax",
@@ -2149,9 +2188,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2169,15 +2208,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2191,23 +2231,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -2219,10 +2259,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.6"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2231,12 +2277,23 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2275,6 +2332,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2317,9 +2389,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2329,9 +2401,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2340,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "relative-path"
@@ -2352,9 +2424,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -2437,9 +2509,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -2465,9 +2537,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -2479,9 +2551,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -2491,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2540,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -2572,15 +2644,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2594,12 +2657,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -2662,9 +2719,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -2707,19 +2764,19 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.4.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
- "serde",
+ "serde_core",
  "serde_with_macros",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "3.4.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93634eb5f75a2323b16de4748022ac4297f9e76b6dced2be287a099f41b5e788"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2729,24 +2786,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
  "futures-executor",
  "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2755,12 +2811,12 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2771,7 +2827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2786,9 +2842,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2802,9 +2858,9 @@ dependencies = [
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -2830,15 +2886,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2864,9 +2920,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2928,20 +2984,20 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-log"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f46bf474f0a4afebf92f076d54fd5e63423d9438b8c278a3d2ccb0f47f7cdb3"
+checksum = "9b9c218384242b5c89b68303ab6f6fc53a312d923f0c14dc6bb860c6aeee40f1"
 dependencies = [
- "env_logger 0.11.10",
+ "env_logger 0.11.11",
  "test-log-macros",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "test-log-core"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d4d41320b48bc4a211a9021678fcc0c99569b594ea31c93735b8e517102b4c"
+checksum = "c26ef8b00e4d382e59f6a8ddb3cd790b3a5bb29f21a358a9a69ea2f29f13f27b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2950,9 +3006,9 @@ dependencies = [
 
 [[package]]
 name = "test-log-macros"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9beb9249a81e430dffd42400a49019bcf548444f1968ff23080a625de0d4d320"
+checksum = "944ad38adcbb71eaa682c56bceeb079e4ca82b4b3edc2a0fde5cb297b77dac8d"
 dependencies = [
  "syn",
  "test-log-core",
@@ -2980,9 +3036,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -3009,9 +3065,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3113,9 +3169,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3146,9 +3202,9 @@ dependencies = [
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -3167,9 +3223,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
@@ -3309,7 +3365,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -3318,9 +3374,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"
@@ -3379,12 +3435,14 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.6.1"
+version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
- "getrandom 0.2.17",
- "serde",
+ "getrandom 0.4.3",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3435,18 +3493,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3457,9 +3515,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3467,9 +3525,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3477,9 +3535,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3490,9 +3548,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -3512,9 +3570,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3532,9 +3590,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3613,7 +3671,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3622,16 +3680,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3649,31 +3698,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3683,22 +3715,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3707,22 +3727,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3731,22 +3739,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3755,28 +3751,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wiremock"
@@ -3815,9 +3799,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3838,18 +3822,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3858,9 +3842,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -3879,9 +3863,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -3918,6 +3902,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/crates/openlark-docs/src/base/base/mod.rs
+++ b/crates/openlark-docs/src/base/base/mod.rs
@@ -6,5 +6,6 @@ pub mod v2;
 // 使用通配符导出所有子模块,避免维护大量重复的导出列表
 // v2 模块显式导出
 pub use v2::{
-    AppRole, Create, CreateReq, CreateResp, List, ListReq, ListResp, Update, UpdateReq, UpdateResp,
+    AppRole, Create, CreateReq, CreateResp, Delete, DeleteResp, List, ListReq, ListResp, Update,
+    UpdateReq, UpdateResp,
 };

--- a/crates/openlark-docs/src/base/base/v2/app/role/create.rs
+++ b/crates/openlark-docs/src/base/base/v2/app/role/create.rs
@@ -123,7 +123,7 @@ impl Create {
         }
 
         // 使用类型安全的端点枚举生成路径
-        use crate::common::api_endpoints::BaseApiV2;
+        use crate::common::api_endpoints::{BaseApiV2, CatalogEndpoint};
         let api_endpoint = BaseApiV2::RoleCreate(self.app_token);
 
         // #438: method 来自 catalog
@@ -184,7 +184,7 @@ mod tests {
 
     #[test]
     fn test_create_role_uses_post_from_catalog_438() {
-        use crate::common::api_endpoints::BaseApiV2;
+        use crate::common::api_endpoints::{BaseApiV2, CatalogEndpoint};
         use openlark_core::api::{ApiRequest, HttpMethod};
         let ep = BaseApiV2::RoleCreate("app".into());
         let req: ApiRequest<CreateResp> = ep.to_request();

--- a/crates/openlark-docs/src/base/base/v2/app/role/create.rs
+++ b/crates/openlark-docs/src/base/base/v2/app/role/create.rs
@@ -127,7 +127,8 @@ impl Create {
         let api_endpoint = BaseApiV2::RoleCreate(self.app_token);
 
         // #438: method 来自 catalog
-        let api_request: ApiRequest<CreateResp> = api_endpoint.to_request()
+        let api_request: ApiRequest<CreateResp> = api_endpoint
+            .to_request()
             .body(serialize_params(&self.req, "新增自定义角色")?);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;

--- a/crates/openlark-docs/src/base/base/v2/app/role/create.rs
+++ b/crates/openlark-docs/src/base/base/v2/app/role/create.rs
@@ -126,7 +126,8 @@ impl Create {
         use crate::common::api_endpoints::BaseApiV2;
         let api_endpoint = BaseApiV2::RoleCreate(self.app_token);
 
-        let api_request: ApiRequest<CreateResp> = ApiRequest::post(&api_endpoint.to_url())
+        // #438: method 来自 catalog
+        let api_request: ApiRequest<CreateResp> = api_endpoint.to_request()
             .body(serialize_params(&self.req, "新增自定义角色")?);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
@@ -179,5 +180,14 @@ mod tests {
             received[0].url.path(),
             "/open-apis/base/v2/apps/app001/roles"
         );
+    }
+
+    #[test]
+    fn test_create_role_uses_post_from_catalog_438() {
+        use crate::common::api_endpoints::BaseApiV2;
+        use openlark_core::api::{ApiRequest, HttpMethod};
+        let ep = BaseApiV2::RoleCreate("app".into());
+        let req: ApiRequest<CreateResp> = ep.to_request();
+        assert_eq!(req.method(), &HttpMethod::Post);
     }
 }

--- a/crates/openlark-docs/src/base/base/v2/app/role/create.rs
+++ b/crates/openlark-docs/src/base/base/v2/app/role/create.rs
@@ -12,6 +12,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::common::api_endpoints::{BaseApiV2, CatalogEndpoint};
 use crate::common::api_utils::*;
 
 /// 新增自定义角色
@@ -123,7 +124,6 @@ impl Create {
         }
 
         // 使用类型安全的端点枚举生成路径
-        use crate::common::api_endpoints::{BaseApiV2, CatalogEndpoint};
         let api_endpoint = BaseApiV2::RoleCreate(self.app_token);
 
         // #438: method 来自 catalog
@@ -185,10 +185,8 @@ mod tests {
 
     #[test]
     fn test_create_role_uses_post_from_catalog_438() {
-        use crate::common::api_endpoints::{BaseApiV2, CatalogEndpoint};
-        use openlark_core::api::{ApiRequest, HttpMethod};
         let ep = BaseApiV2::RoleCreate("app".into());
-        let req: ApiRequest<CreateResp> = ep.to_request();
-        assert_eq!(req.method(), &HttpMethod::Post);
+        let req: openlark_core::api::ApiRequest<CreateResp> = ep.to_request();
+        assert_eq!(req.method(), &openlark_core::api::HttpMethod::Post);
     }
 }

--- a/crates/openlark-docs/src/base/base/v2/app/role/delete.rs
+++ b/crates/openlark-docs/src/base/base/v2/app/role/delete.rs
@@ -11,7 +11,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_endpoints::CatalogEndpoint;
+use crate::common::api_endpoints::{BaseApiV2, CatalogEndpoint};
 use crate::common::api_utils::*;
 
 /// 删除自定义角色请求。
@@ -58,7 +58,6 @@ impl Delete {
         validate_required!(self.app_token.trim(), "app_token 不能为空");
         validate_required!(self.role_id.trim(), "role_id 不能为空");
 
-        use crate::common::api_endpoints::BaseApiV2;
         let api_endpoint = BaseApiV2::RoleDelete(self.app_token, self.role_id);
 
         let api_request: ApiRequest<DeleteResp> = api_endpoint.to_request();
@@ -119,10 +118,8 @@ mod tests {
 
     #[test]
     fn test_delete_role_uses_delete_from_catalog_438() {
-        use crate::common::api_endpoints::{BaseApiV2, CatalogEndpoint};
-        use openlark_core::api::HttpMethod;
         let ep = BaseApiV2::RoleDelete("app".into(), "role001".into());
-        let req: ApiRequest<DeleteResp> = ep.to_request();
-        assert_eq!(req.method(), &HttpMethod::Delete);
+        let req: openlark_core::api::ApiRequest<DeleteResp> = ep.to_request();
+        assert_eq!(req.method(), &openlark_core::api::HttpMethod::Delete);
     }
 }

--- a/crates/openlark-docs/src/base/base/v2/app/role/delete.rs
+++ b/crates/openlark-docs/src/base/base/v2/app/role/delete.rs
@@ -1,0 +1,128 @@
+//! 删除自定义角色
+//!
+//! docPath: <https://open.feishu.cn/document/docs/bitable-v1/advanced-permission/app-role/delete-2>
+
+use openlark_core::{
+    api::{ApiRequest, ApiResponseTrait, ResponseFormat},
+    config::Config,
+    error::SDKResult,
+    http::Transport,
+    validate_required,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::common::api_endpoints::CatalogEndpoint;
+use crate::common::api_utils::*;
+
+/// 删除自定义角色请求。
+#[derive(Debug, Clone)]
+pub struct Delete {
+    config: Config,
+    app_token: String,
+    role_id: String,
+}
+
+impl Delete {
+    /// 创建新的删除请求。
+    pub fn new(config: Config) -> Self {
+        Self {
+            config,
+            app_token: String::new(),
+            role_id: String::new(),
+        }
+    }
+
+    /// 设置应用 token。
+    pub fn app_token(mut self, app_token: impl Into<String>) -> Self {
+        self.app_token = app_token.into();
+        self
+    }
+
+    /// 设置角色 ID。
+    pub fn role_id(mut self, role_id: impl Into<String>) -> Self {
+        self.role_id = role_id.into();
+        self
+    }
+
+    /// 执行请求。
+    pub async fn execute(self) -> SDKResult<DeleteResp> {
+        self.execute_with_options(openlark_core::req_option::RequestOption::default())
+            .await
+    }
+
+    /// 使用指定请求选项执行请求。
+    pub async fn execute_with_options(
+        self,
+        option: openlark_core::req_option::RequestOption,
+    ) -> SDKResult<DeleteResp> {
+        validate_required!(self.app_token.trim(), "app_token 不能为空");
+        validate_required!(self.role_id.trim(), "role_id 不能为空");
+
+        use crate::common::api_endpoints::BaseApiV2;
+        let api_endpoint = BaseApiV2::RoleDelete(self.app_token, self.role_id);
+
+        let api_request: ApiRequest<DeleteResp> = api_endpoint.to_request();
+
+        let response = Transport::request(api_request, &self.config, Some(option)).await?;
+        extract_response_data(response, "删除自定义角色")
+    }
+}
+
+/// 删除自定义角色响应（data 为空对象）。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct DeleteResp {}
+
+impl ApiResponseTrait for DeleteResp {
+    fn data_format() -> ResponseFormat {
+        ResponseFormat::Data
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
+
+    /// 端到端：DELETE .../roles/{role_id} → DeleteResp。
+    #[tokio::test]
+    async fn test_delete_role_returns_data_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/open-apis/base/v2/apps/app001/roles/role001"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0, "msg": "success", "data": {}
+            })))
+            .mount(&server)
+            .await;
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
+        Delete::new(config)
+            .app_token("app001")
+            .role_id("role001")
+            .execute()
+            .await
+            .expect("删除角色应成功");
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/base/v2/apps/app001/roles/role001"
+        );
+    }
+
+    #[test]
+    fn test_delete_role_uses_delete_from_catalog_438() {
+        use crate::common::api_endpoints::{BaseApiV2, CatalogEndpoint};
+        use openlark_core::api::HttpMethod;
+        let ep = BaseApiV2::RoleDelete("app".into(), "role001".into());
+        let req: ApiRequest<DeleteResp> = ep.to_request();
+        assert_eq!(req.method(), &HttpMethod::Delete);
+    }
+}

--- a/crates/openlark-docs/src/base/base/v2/app/role/list.rs
+++ b/crates/openlark-docs/src/base/base/v2/app/role/list.rs
@@ -104,7 +104,8 @@ impl List {
         use crate::common::api_endpoints::BaseApiV2;
         let api_endpoint = BaseApiV2::RoleList(self.app_token);
 
-        let mut api_request: ApiRequest<ListResp> = ApiRequest::get(&api_endpoint.to_url());
+        // #438: method 来自 catalog
+        let mut api_request: ApiRequest<ListResp> = api_endpoint.to_request();
         api_request = api_request.query_opt("page_size", self.req.page_size.map(|v| v.to_string()));
         api_request = api_request.query_opt("page_token", self.req.page_token);
 
@@ -156,5 +157,14 @@ mod tests {
             received[0].url.path(),
             "/open-apis/base/v2/apps/app001/roles"
         );
+    }
+
+    #[test]
+    fn test_list_roles_uses_get_from_catalog_438() {
+        use crate::common::api_endpoints::BaseApiV2;
+        use openlark_core::api::{ApiRequest, HttpMethod};
+        let ep = BaseApiV2::RoleList("app".into());
+        let req: ApiRequest<ListResp> = ep.to_request();
+        assert_eq!(req.method(), &HttpMethod::Get);
     }
 }

--- a/crates/openlark-docs/src/base/base/v2/app/role/list.rs
+++ b/crates/openlark-docs/src/base/base/v2/app/role/list.rs
@@ -12,6 +12,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::common::api_endpoints::{BaseApiV2, CatalogEndpoint};
 use crate::common::api_utils::*;
 
 /// 列出自定义角色
@@ -101,7 +102,6 @@ impl List {
             ));
         }
 
-        use crate::common::api_endpoints::{BaseApiV2, CatalogEndpoint};
         let api_endpoint = BaseApiV2::RoleList(self.app_token);
 
         // #438: method 来自 catalog
@@ -161,10 +161,8 @@ mod tests {
 
     #[test]
     fn test_list_roles_uses_get_from_catalog_438() {
-        use crate::common::api_endpoints::{BaseApiV2, CatalogEndpoint};
-        use openlark_core::api::{ApiRequest, HttpMethod};
         let ep = BaseApiV2::RoleList("app".into());
-        let req: ApiRequest<ListResp> = ep.to_request();
-        assert_eq!(req.method(), &HttpMethod::Get);
+        let req: openlark_core::api::ApiRequest<ListResp> = ep.to_request();
+        assert_eq!(req.method(), &openlark_core::api::HttpMethod::Get);
     }
 }

--- a/crates/openlark-docs/src/base/base/v2/app/role/list.rs
+++ b/crates/openlark-docs/src/base/base/v2/app/role/list.rs
@@ -101,7 +101,7 @@ impl List {
             ));
         }
 
-        use crate::common::api_endpoints::BaseApiV2;
+        use crate::common::api_endpoints::{BaseApiV2, CatalogEndpoint};
         let api_endpoint = BaseApiV2::RoleList(self.app_token);
 
         // #438: method 来自 catalog
@@ -161,7 +161,7 @@ mod tests {
 
     #[test]
     fn test_list_roles_uses_get_from_catalog_438() {
-        use crate::common::api_endpoints::BaseApiV2;
+        use crate::common::api_endpoints::{BaseApiV2, CatalogEndpoint};
         use openlark_core::api::{ApiRequest, HttpMethod};
         let ep = BaseApiV2::RoleList("app".into());
         let req: ApiRequest<ListResp> = ep.to_request();

--- a/crates/openlark-docs/src/base/base/v2/app/role/mod.rs
+++ b/crates/openlark-docs/src/base/base/v2/app/role/mod.rs
@@ -1,7 +1,9 @@
 pub mod create;
+pub mod delete;
 pub mod list;
 pub mod update;
 
 pub use create::{Create, CreateReq, CreateResp};
+pub use delete::{Delete, DeleteResp};
 pub use list::{List, ListReq, ListResp};
 pub use update::{Update, UpdateReq, UpdateResp};

--- a/crates/openlark-docs/src/base/base/v2/app/role/update.rs
+++ b/crates/openlark-docs/src/base/base/v2/app/role/update.rs
@@ -12,6 +12,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::common::api_endpoints::{BaseApiV2, CatalogEndpoint};
 use crate::common::api_utils::*;
 
 /// 更新自定义角色
@@ -128,7 +129,6 @@ impl Update {
             ));
         }
 
-        use crate::common::api_endpoints::{BaseApiV2, CatalogEndpoint};
         let api_endpoint = BaseApiV2::RoleUpdate(self.app_token, self.role_id);
 
         // #438: method 来自 catalog
@@ -190,10 +190,8 @@ mod tests {
 
     #[test]
     fn test_update_role_uses_put_from_catalog_438() {
-        use crate::common::api_endpoints::{BaseApiV2, CatalogEndpoint};
-        use openlark_core::api::{ApiRequest, HttpMethod};
         let ep = BaseApiV2::RoleUpdate("app".into(), "role001".into());
-        let req: ApiRequest<UpdateResp> = ep.to_request();
-        assert_eq!(req.method(), &HttpMethod::Put);
+        let req: openlark_core::api::ApiRequest<UpdateResp> = ep.to_request();
+        assert_eq!(req.method(), &openlark_core::api::HttpMethod::Put);
     }
 }

--- a/crates/openlark-docs/src/base/base/v2/app/role/update.rs
+++ b/crates/openlark-docs/src/base/base/v2/app/role/update.rs
@@ -128,7 +128,7 @@ impl Update {
             ));
         }
 
-        use crate::common::api_endpoints::BaseApiV2;
+        use crate::common::api_endpoints::{BaseApiV2, CatalogEndpoint};
         let api_endpoint = BaseApiV2::RoleUpdate(self.app_token, self.role_id);
 
         // #438: method 来自 catalog
@@ -189,7 +189,7 @@ mod tests {
 
     #[test]
     fn test_update_role_uses_put_from_catalog_438() {
-        use crate::common::api_endpoints::BaseApiV2;
+        use crate::common::api_endpoints::{BaseApiV2, CatalogEndpoint};
         use openlark_core::api::{ApiRequest, HttpMethod};
         let ep = BaseApiV2::RoleUpdate("app".into(), "role001".into());
         let req: ApiRequest<UpdateResp> = ep.to_request();

--- a/crates/openlark-docs/src/base/base/v2/app/role/update.rs
+++ b/crates/openlark-docs/src/base/base/v2/app/role/update.rs
@@ -132,7 +132,8 @@ impl Update {
         let api_endpoint = BaseApiV2::RoleUpdate(self.app_token, self.role_id);
 
         // #438: method 来自 catalog
-        let api_request: ApiRequest<UpdateResp> = api_endpoint.to_request()
+        let api_request: ApiRequest<UpdateResp> = api_endpoint
+            .to_request()
             .body(serialize_params(&self.req, "更新自定义角色")?);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;

--- a/crates/openlark-docs/src/base/base/v2/app/role/update.rs
+++ b/crates/openlark-docs/src/base/base/v2/app/role/update.rs
@@ -131,7 +131,8 @@ impl Update {
         use crate::common::api_endpoints::BaseApiV2;
         let api_endpoint = BaseApiV2::RoleUpdate(self.app_token, self.role_id);
 
-        let api_request: ApiRequest<UpdateResp> = ApiRequest::put(&api_endpoint.to_url())
+        // #438: method 来自 catalog
+        let api_request: ApiRequest<UpdateResp> = api_endpoint.to_request()
             .body(serialize_params(&self.req, "更新自定义角色")?);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
@@ -184,5 +185,14 @@ mod tests {
             received[0].url.path(),
             "/open-apis/base/v2/apps/app001/roles/role001"
         );
+    }
+
+    #[test]
+    fn test_update_role_uses_put_from_catalog_438() {
+        use crate::common::api_endpoints::BaseApiV2;
+        use openlark_core::api::{ApiRequest, HttpMethod};
+        let ep = BaseApiV2::RoleUpdate("app".into(), "role001".into());
+        let req: ApiRequest<UpdateResp> = ep.to_request();
+        assert_eq!(req.method(), &HttpMethod::Put);
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_create.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_create.rs
@@ -123,12 +123,11 @@ impl BatchCreateRecordRequest {
         let api_endpoint =
             BitableApiV1::RecordBatchCreate(self.app_token.clone(), self.table_id.clone());
 
-        let mut api_request: ApiRequest<BatchCreateRecordResponse> = ApiRequest::post(
-            &api_endpoint.to_url(),
-        )
-        .body(serde_json::to_vec(&BatchCreateRecordRequestBody {
-            records: self.records,
-        })?);
+        // #424: POST + body from leaf data
+        let mut api_request: ApiRequest<BatchCreateRecordResponse> =
+            api_endpoint.to_request().body(serde_json::to_vec(&BatchCreateRecordRequestBody {
+                records: self.records,
+            })?);
 
         api_request = api_request.query_opt("user_id_type", self.user_id_type);
         api_request = api_request.query_opt("client_token", self.client_token);

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_create.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_create.rs
@@ -124,8 +124,9 @@ impl BatchCreateRecordRequest {
             BitableApiV1::RecordBatchCreate(self.app_token.clone(), self.table_id.clone());
 
         // #424: POST + body from leaf data
-        let mut api_request: ApiRequest<BatchCreateRecordResponse> =
-            api_endpoint.to_request().body(serde_json::to_vec(&BatchCreateRecordRequestBody {
+        let mut api_request: ApiRequest<BatchCreateRecordResponse> = api_endpoint
+            .to_request()
+            .body(serde_json::to_vec(&BatchCreateRecordRequestBody {
                 records: self.records,
             })?);
 

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_delete.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_delete.rs
@@ -99,12 +99,11 @@ impl BatchDeleteRecordRequest {
         let api_endpoint =
             BitableApiV1::RecordBatchDelete(self.app_token.clone(), self.table_id.clone());
 
-        let api_request: ApiRequest<BatchDeleteRecordResponse> = ApiRequest::post(
-            &api_endpoint.to_url(),
-        )
-        .body(serde_json::to_vec(&BatchDeleteRecordRequestBody {
-            record_ids: self.record_ids,
-        })?);
+        // #424 catalog POST for batch delete
+        let api_request: ApiRequest<BatchDeleteRecordResponse> =
+            api_endpoint.to_request().body(serde_json::to_vec(&BatchDeleteRecordRequestBody {
+                record_ids: self.record_ids,
+            })?);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         response

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_delete.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_delete.rs
@@ -101,9 +101,11 @@ impl BatchDeleteRecordRequest {
 
         // #424 catalog POST for batch delete
         let api_request: ApiRequest<BatchDeleteRecordResponse> =
-            api_endpoint.to_request().body(serde_json::to_vec(&BatchDeleteRecordRequestBody {
-                record_ids: self.record_ids,
-            })?);
+            api_endpoint
+                .to_request()
+                .body(serde_json::to_vec(&BatchDeleteRecordRequestBody {
+                    record_ids: self.record_ids,
+                })?);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         response

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_get.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_get.rs
@@ -100,15 +100,14 @@ impl BatchGetRecordRequest {
         let api_endpoint =
             BitableApiV1::RecordBatchGet(self.app_token.clone(), self.table_id.clone());
 
-        let api_request: ApiRequest<BatchGetRecordResponse> = ApiRequest::post(
-            &api_endpoint.to_url(),
-        )
-        .body(serde_json::to_vec(&BatchGetRecordRequestBody {
-            record_ids: self.record_ids,
-            user_id_type: self.user_id_type,
-            with_shared_url: self.with_shared_url,
-            automatic_fields: self.automatic_fields,
-        })?);
+        // #424: batch get uses POST in catalog
+        let api_request: ApiRequest<BatchGetRecordResponse> =
+            api_endpoint.to_request().body(serde_json::to_vec(&BatchGetRecordRequestBody {
+                record_ids: self.record_ids,
+                user_id_type: self.user_id_type,
+                with_shared_url: self.with_shared_url,
+                automatic_fields: self.automatic_fields,
+            })?);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         response

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_get.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_get.rs
@@ -102,12 +102,14 @@ impl BatchGetRecordRequest {
 
         // #424: batch get uses POST in catalog
         let api_request: ApiRequest<BatchGetRecordResponse> =
-            api_endpoint.to_request().body(serde_json::to_vec(&BatchGetRecordRequestBody {
-                record_ids: self.record_ids,
-                user_id_type: self.user_id_type,
-                with_shared_url: self.with_shared_url,
-                automatic_fields: self.automatic_fields,
-            })?);
+            api_endpoint
+                .to_request()
+                .body(serde_json::to_vec(&BatchGetRecordRequestBody {
+                    record_ids: self.record_ids,
+                    user_id_type: self.user_id_type,
+                    with_shared_url: self.with_shared_url,
+                    automatic_fields: self.automatic_fields,
+                })?);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         response

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_update.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_update.rs
@@ -118,8 +118,9 @@ impl BatchUpdateRecordRequest {
             BitableApiV1::RecordBatchUpdate(self.app_token.clone(), self.table_id.clone());
 
         // #424: POST via catalog for batch update
-        let mut api_request: ApiRequest<BatchUpdateRecordResponse> =
-            api_endpoint.to_request().body(serde_json::to_vec(&BatchUpdateRecordRequestBody {
+        let mut api_request: ApiRequest<BatchUpdateRecordResponse> = api_endpoint
+            .to_request()
+            .body(serde_json::to_vec(&BatchUpdateRecordRequestBody {
                 records: self.records,
             })?);
 

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_update.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/batch_update.rs
@@ -117,12 +117,11 @@ impl BatchUpdateRecordRequest {
         let api_endpoint =
             BitableApiV1::RecordBatchUpdate(self.app_token.clone(), self.table_id.clone());
 
-        let mut api_request: ApiRequest<BatchUpdateRecordResponse> = ApiRequest::post(
-            &api_endpoint.to_url(),
-        )
-        .body(serde_json::to_vec(&BatchUpdateRecordRequestBody {
-            records: self.records,
-        })?);
+        // #424: POST via catalog for batch update
+        let mut api_request: ApiRequest<BatchUpdateRecordResponse> =
+            api_endpoint.to_request().body(serde_json::to_vec(&BatchUpdateRecordRequestBody {
+                records: self.records,
+            })?);
 
         api_request = api_request.query_opt("user_id_type", self.user_id_type);
         api_request = api_request.query_opt(

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/create.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/create.rs
@@ -4,7 +4,7 @@
 
 use openlark_core::{
     SDKResult,
-    api::{ApiRequest, ApiResponseTrait, ResponseFormat},
+    api::{ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
     validate_required,
@@ -102,7 +102,8 @@ impl CreateRecordRequest {
 
         let api_endpoint =
             BitableApiV1::RecordCreate(self.app_token.clone(), self.table_id.clone());
-        let mut request = ApiRequest::<CreateRecordResponse>::post(&api_endpoint.to_url());
+        // #424：稳定 method 来自目录；叶子只附加 query/body/option
+        let mut request = api_endpoint.to_request::<CreateRecordResponse>();
 
         if let Some(ref user_id_type) = self.user_id_type {
             request = request.query("user_id_type", user_id_type);
@@ -182,6 +183,8 @@ impl ApiResponseTrait for CreateRecordResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::api_endpoints::BitableApiV1;
+    use openlark_core::api::{ApiRequest, HttpMethod};
 
     #[test]
     fn test_create_record_request_builder() {
@@ -242,5 +245,13 @@ mod tests {
         let request = CreateRecordRequest::new(config).fields(fields.clone());
 
         assert_eq!(request.fields, fields);
+    }
+
+    #[test]
+    fn test_create_uses_post_from_catalog_424() {
+        // 叶子现在委托 method 给 catalog
+        let ep = BitableApiV1::RecordCreate("app".into(), "tbl".into());
+        let req: ApiRequest<CreateRecordResponse> = ep.to_request();
+        assert_eq!(req.method(), &HttpMethod::Post);
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/create.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/create.rs
@@ -250,6 +250,8 @@ mod tests {
     #[test]
     fn test_create_uses_post_from_catalog_424() {
         // 叶子现在委托 method 给 catalog
+        use crate::common::api_endpoints::BitableApiV1;
+        use openlark_core::api::HttpMethod;
         let ep = BitableApiV1::RecordCreate("app".into(), "tbl".into());
         let req: ApiRequest<CreateRecordResponse> = ep.to_request();
         assert_eq!(req.method(), &HttpMethod::Post);

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/create.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/create.rs
@@ -248,7 +248,8 @@ mod tests {
     #[test]
     fn test_create_uses_post_from_catalog_424() {
         // 叶子现在委托 method 给 catalog
-        let ep = crate::common::api_endpoints::BitableApiV1::RecordCreate("app".into(), "tbl".into());
+        let ep =
+            crate::common::api_endpoints::BitableApiV1::RecordCreate("app".into(), "tbl".into());
         let req: openlark_core::api::ApiRequest<CreateRecordResponse> = ep.to_request();
         assert_eq!(req.method(), &openlark_core::api::HttpMethod::Post);
     }

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/create.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/create.rs
@@ -183,8 +183,6 @@ impl ApiResponseTrait for CreateRecordResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::api_endpoints::BitableApiV1;
-    use openlark_core::api::{ApiRequest, HttpMethod};
 
     #[test]
     fn test_create_record_request_builder() {
@@ -250,10 +248,8 @@ mod tests {
     #[test]
     fn test_create_uses_post_from_catalog_424() {
         // 叶子现在委托 method 给 catalog
-        use crate::common::api_endpoints::BitableApiV1;
-        use openlark_core::api::HttpMethod;
-        let ep = BitableApiV1::RecordCreate("app".into(), "tbl".into());
-        let req: ApiRequest<CreateRecordResponse> = ep.to_request();
-        assert_eq!(req.method(), &HttpMethod::Post);
+        let ep = crate::common::api_endpoints::BitableApiV1::RecordCreate("app".into(), "tbl".into());
+        let req: openlark_core::api::ApiRequest<CreateRecordResponse> = ep.to_request();
+        assert_eq!(req.method(), &openlark_core::api::HttpMethod::Post);
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/delete.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/delete.rs
@@ -211,7 +211,11 @@ mod tests {
     #[test]
     fn test_delete_uses_delete_method_from_catalog() {
         // 验证迁移后叶子使用 catalog 的 method（#424）
-        let ep = crate::common::api_endpoints::BitableApiV1::RecordDelete("app".into(), "tbl".into(), "rec".into());
+        let ep = crate::common::api_endpoints::BitableApiV1::RecordDelete(
+            "app".into(),
+            "tbl".into(),
+            "rec".into(),
+        );
         let req: openlark_core::api::ApiRequest<DeleteRecordResponse> = ep.to_request();
         assert_eq!(req.method(), &openlark_core::api::HttpMethod::Delete);
         assert!(ep.to_url().contains("/records/rec"));

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/delete.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/delete.rs
@@ -133,8 +133,6 @@ impl ApiResponseTrait for DeleteRecordResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::api_endpoints::BitableApiV1;
-    use openlark_core::api::{ApiRequest, HttpMethod};
 
     #[test]
     fn test_delete_record_request_builder() {
@@ -213,11 +211,9 @@ mod tests {
     #[test]
     fn test_delete_uses_delete_method_from_catalog() {
         // 验证迁移后叶子使用 catalog 的 method（#424）
-        use crate::common::api_endpoints::BitableApiV1;
-        use openlark_core::api::HttpMethod;
-        let ep = BitableApiV1::RecordDelete("app".into(), "tbl".into(), "rec".into());
-        let req: ApiRequest<DeleteRecordResponse> = ep.to_request();
-        assert_eq!(req.method(), &HttpMethod::Delete);
+        let ep = crate::common::api_endpoints::BitableApiV1::RecordDelete("app".into(), "tbl".into(), "rec".into());
+        let req: openlark_core::api::ApiRequest<DeleteRecordResponse> = ep.to_request();
+        assert_eq!(req.method(), &openlark_core::api::HttpMethod::Delete);
         assert!(ep.to_url().contains("/records/rec"));
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/delete.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/delete.rs
@@ -3,7 +3,7 @@
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/bitable-v1/app-table-record/delete>
 
 use openlark_core::{
-    api::{ApiRequest, ApiResponseTrait, ResponseFormat},
+    api::{ApiResponseTrait, ResponseFormat},
     config::Config,
     error::SDKResult,
     http::Transport,
@@ -92,7 +92,8 @@ impl DeleteRecordRequest {
 
         let api_endpoint =
             BitableApiV1::RecordDelete(self.app_token, self.table_id, self.record_id);
-        let request = ApiRequest::<DeleteRecordResponse>::delete(&api_endpoint.to_url());
+        // #424: method 来自 catalog，保持 path+method+auth locality
+        let request = api_endpoint.to_request::<DeleteRecordResponse>();
 
         let response = Transport::request(request, &self.config, Some(option)).await?;
         extract_response_data(response, "删除记录")
@@ -132,6 +133,8 @@ impl ApiResponseTrait for DeleteRecordResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::api_endpoints::BitableApiV1;
+    use openlark_core::api::{ApiRequest, HttpMethod};
 
     #[test]
     fn test_delete_record_request_builder() {
@@ -205,5 +208,14 @@ mod tests {
     #[test]
     fn test_response_trait() {
         assert_eq!(DeleteRecordResponse::data_format(), ResponseFormat::Data);
+    }
+
+    #[test]
+    fn test_delete_uses_delete_method_from_catalog() {
+        // 验证迁移后叶子使用 catalog 的 method（#424）
+        let ep = BitableApiV1::RecordDelete("app".into(), "tbl".into(), "rec".into());
+        let req: ApiRequest<DeleteRecordResponse> = ep.to_request();
+        assert_eq!(req.method(), &HttpMethod::Delete);
+        assert!(ep.to_url().contains("/records/rec"));
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/delete.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/delete.rs
@@ -213,6 +213,8 @@ mod tests {
     #[test]
     fn test_delete_uses_delete_method_from_catalog() {
         // 验证迁移后叶子使用 catalog 的 method（#424）
+        use crate::common::api_endpoints::BitableApiV1;
+        use openlark_core::api::HttpMethod;
         let ep = BitableApiV1::RecordDelete("app".into(), "tbl".into(), "rec".into());
         let req: ApiRequest<DeleteRecordResponse> = ep.to_request();
         assert_eq!(req.method(), &HttpMethod::Delete);

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/get.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/get.rs
@@ -255,4 +255,14 @@ mod tests {
     fn test_response_trait() {
         assert_eq!(GetRecordResponse::data_format(), ResponseFormat::Data);
     }
+
+    #[test]
+    fn test_get_uses_get_method_from_catalog_424() {
+        // 验证迁移后叶子使用 catalog 的 method（#424）
+        use crate::common::api_endpoints::BitableApiV1;
+        use openlark_core::api::{ApiRequest, HttpMethod};
+        let ep = BitableApiV1::RecordGet("app".into(), "tbl".into(), "rec".into());
+        let req: ApiRequest<GetRecordResponse> = ep.to_request();
+        assert_eq!(req.method(), &HttpMethod::Get);
+    }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/get.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/get.rs
@@ -143,8 +143,7 @@ impl GetRecordRequest {
         );
 
         // #424: GET from catalog
-        let mut api_request: ApiRequest<GetRecordResponse> =
-            api_endpoint.to_request();
+        let mut api_request: ApiRequest<GetRecordResponse> = api_endpoint.to_request();
 
         api_request = api_request.query_opt(
             "text_field_as_array",

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/get.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/get.rs
@@ -258,7 +258,11 @@ mod tests {
     #[test]
     fn test_get_uses_get_method_from_catalog_424() {
         // 验证迁移后叶子使用 catalog 的 method（#424）
-        let ep = crate::common::api_endpoints::BitableApiV1::RecordGet("app".into(), "tbl".into(), "rec".into());
+        let ep = crate::common::api_endpoints::BitableApiV1::RecordGet(
+            "app".into(),
+            "tbl".into(),
+            "rec".into(),
+        );
         let req: openlark_core::api::ApiRequest<GetRecordResponse> = ep.to_request();
         assert_eq!(req.method(), &openlark_core::api::HttpMethod::Get);
     }

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/get.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/get.rs
@@ -142,8 +142,9 @@ impl GetRecordRequest {
             self.record_id,
         );
 
+        // #424: GET from catalog
         let mut api_request: ApiRequest<GetRecordResponse> =
-            ApiRequest::get(&api_endpoint.to_url());
+            api_endpoint.to_request();
 
         api_request = api_request.query_opt(
             "text_field_as_array",

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/get.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/get.rs
@@ -258,10 +258,8 @@ mod tests {
     #[test]
     fn test_get_uses_get_method_from_catalog_424() {
         // 验证迁移后叶子使用 catalog 的 method（#424）
-        use crate::common::api_endpoints::BitableApiV1;
-        use openlark_core::api::{ApiRequest, HttpMethod};
-        let ep = BitableApiV1::RecordGet("app".into(), "tbl".into(), "rec".into());
-        let req: ApiRequest<GetRecordResponse> = ep.to_request();
-        assert_eq!(req.method(), &HttpMethod::Get);
+        let ep = crate::common::api_endpoints::BitableApiV1::RecordGet("app".into(), "tbl".into(), "rec".into());
+        let req: openlark_core::api::ApiRequest<GetRecordResponse> = ep.to_request();
+        assert_eq!(req.method(), &openlark_core::api::HttpMethod::Get);
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/list.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/list.rs
@@ -197,9 +197,9 @@ impl ListRecordRequest {
         use crate::common::api_endpoints::BitableApiV1;
         let api_endpoint = BitableApiV1::RecordList(self.app_token.clone(), self.table_id.clone());
 
-        // 创建API请求 - 使用类型安全的URL生成
+        // #424: GET method + path from catalog
         let mut api_request: ApiRequest<ListRecordResponse> =
-            ApiRequest::get(&api_endpoint.to_url());
+            api_endpoint.to_request();
 
         // 构建查询参数
         if let Some(ref page_token) = self.page_token {

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/list.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/list.rs
@@ -198,8 +198,7 @@ impl ListRecordRequest {
         let api_endpoint = BitableApiV1::RecordList(self.app_token.clone(), self.table_id.clone());
 
         // #424: GET method + path from catalog
-        let mut api_request: ApiRequest<ListRecordResponse> =
-            api_endpoint.to_request();
+        let mut api_request: ApiRequest<ListRecordResponse> = api_endpoint.to_request();
 
         // 构建查询参数
         if let Some(ref page_token) = self.page_token {

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/search.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/search.rs
@@ -3,7 +3,7 @@
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/bitable-v1/app-table-record/search>
 
 use openlark_core::{
-    api::{ApiRequest, ApiResponseTrait, ResponseFormat},
+    api::{ApiResponseTrait, ResponseFormat},
     config::Config,
     error::{SDKResult, validation_error},
     http::Transport,
@@ -124,7 +124,9 @@ impl SearchRecordRequest {
         let api_endpoint =
             BitableApiV1::RecordSearch(self.app_token.clone(), self.table_id.clone());
 
-        let request = ApiRequest::<SearchRecordResponse>::post(&api_endpoint.to_url())
+        // #424: POST via catalog (search carries body)
+        let request = api_endpoint
+            .to_request::<SearchRecordResponse>()
             .query_opt("user_id_type", self.user_id_type)
             .query_opt("page_token", self.page_token)
             .query_opt("page_size", self.page_size.map(|v| v.to_string()))

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/record/update.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/record/update.rs
@@ -3,7 +3,7 @@
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/bitable-v1/app-table-record/update>
 
 use openlark_core::{
-    api::{ApiRequest, ApiResponseTrait, ResponseFormat},
+    api::{ApiResponseTrait, ResponseFormat},
     config::Config,
     error::SDKResult,
     http::Transport,
@@ -128,7 +128,9 @@ impl UpdateRecordRequest {
             self.record_id,
         );
 
-        let request = ApiRequest::<UpdateRecordResponse>::put(&api_endpoint.to_url())
+        // #424: PUT method from catalog
+        let request = api_endpoint
+            .to_request::<UpdateRecordResponse>()
             .query_opt("user_id_type", self.user_id_type)
             .query_opt(
                 "ignore_consistency_check",

--- a/crates/openlark-docs/src/common/api_endpoints.rs
+++ b/crates/openlark-docs/src/common/api_endpoints.rs
@@ -33,66 +33,39 @@
 use openlark_core::api::{ApiRequest, HttpMethod};
 use openlark_core::constants::AccessTokenType;
 
-/// Base API V2 端点枚举
-#[derive(Debug, Clone, PartialEq)]
-pub enum BaseApiV2 {
-    /// 新增自定义角色
-    RoleCreate(String),
-    /// 更新自定义角色
-    RoleUpdate(String, String),
-    /// 列出自定义角色
-    RoleList(String),
-    /// 删除自定义角色
-    RoleDelete(String, String),
-}
+/// 端点 catalog 的通用语义接口（#424 / #438）。
+/// 允许 to_request 等逻辑共享，减少重复。
+pub trait CatalogEndpoint {
+    /// 返回端点 URL。
+    fn to_url(&self) -> String;
 
-impl BaseApiV2 {
-    /// 生成对应的 URL
-    pub fn to_url(&self) -> String {
-        match self {
-            BaseApiV2::RoleCreate(app_token) => {
-                format!("/open-apis/base/v2/apps/{app_token}/roles")
-            }
-            BaseApiV2::RoleUpdate(app_token, role_id) => {
-                format!("/open-apis/base/v2/apps/{app_token}/roles/{role_id}")
-            }
-            BaseApiV2::RoleList(app_token) => {
-                format!("/open-apis/base/v2/apps/{app_token}/roles")
-            }
-            BaseApiV2::RoleDelete(app_token, role_id) => {
-                format!("/open-apis/base/v2/apps/{app_token}/roles/{role_id}")
-            }
-        }
+    /// 返回 HTTP 方法。
+    fn method(&self) -> HttpMethod;
+
+    /// 稳定的访问令牌要求（默认 None）。
+    fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
+        None
     }
 
-    /// 返回配置了正确 HTTP 方法的 ApiRequest（#438：Base App Role tracer 证明 catalog 语义）。
-    /// 叶子只负责领域数据和 RequestOption。
-    pub fn to_request<R>(&self) -> ApiRequest<R> {
-        match self.method() {
+    /// 构建带正确方法的请求。
+    fn to_request<R>(&self) -> ApiRequest<R> {
+        let mut req = match self.method() {
             HttpMethod::Get => ApiRequest::get(self.to_url()),
             HttpMethod::Post => ApiRequest::post(self.to_url()),
             HttpMethod::Put => ApiRequest::put(self.to_url()),
             HttpMethod::Delete => ApiRequest::delete(self.to_url()),
             HttpMethod::Patch => ApiRequest::patch(self.to_url()),
             _ => ApiRequest::get(self.to_url()),
+        };
+        if let Some(tokens) = self.supported_access_token_types() {
+            req = req.with_supported_access_token_types(tokens);
         }
-    }
-
-    /// 该端点的 HTTP 方法。method 与 path 统一由 catalog 拥有。
-    pub fn method(&self) -> HttpMethod {
-        match self {
-            BaseApiV2::RoleCreate(_) => HttpMethod::Post,
-            BaseApiV2::RoleUpdate(_, _) => HttpMethod::Put,
-            BaseApiV2::RoleList(_) => HttpMethod::Get,
-            BaseApiV2::RoleDelete(_, _) => HttpMethod::Delete,
-        }
-    }
-
-    /// 稳定的访问令牌要求（默认 None 表示 User+Tenant）。
-    pub fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
-        None
+        req
     }
 }
+
+pub mod base;
+pub use base::BaseApiV2;
 
 /// Bitable API V1 端点枚举（#424 深化了请求语义：method + path + auth 在此集中）。
 ///
@@ -415,19 +388,9 @@ impl BitableApiV1 {
         }
     }
 
-    /// 返回配置了正确 HTTP 方法的 ApiRequest（#424：请求语义收归目录）。
-    /// 叶子 builder 只负责领域数据（query/body）和 RequestOption，稳定 method/path/auth 由 catalog 提供。
-    ///
-    /// 注意：method() 与 to_url() 共同定义端点语义，修改时需在对应 arm 中同步（未来可通过宏统一）。
+    /// 返回配置了正确 HTTP 方法的 ApiRequest（委托到 CatalogEndpoint trait）。
     pub fn to_request<R>(&self) -> ApiRequest<R> {
-        match self.method() {
-            HttpMethod::Get => ApiRequest::get(self.to_url()),
-            HttpMethod::Post => ApiRequest::post(self.to_url()),
-            HttpMethod::Put => ApiRequest::put(self.to_url()),
-            HttpMethod::Delete => ApiRequest::delete(self.to_url()),
-            HttpMethod::Patch => ApiRequest::patch(self.to_url()),
-            _ => ApiRequest::get(self.to_url()), // 防御：catalog 仅产生标准 CRUD 方法
-        }
+        <Self as CatalogEndpoint>::to_request(self)
     }
 
     /// 该端点的 HTTP 方法。稳定语义，method 与 path 必须在同一处变更。
@@ -500,13 +463,19 @@ impl BitableApiV1 {
             BitableApiV1::RoleMemberList(_, _) => HttpMethod::Get,
         }
     }
+}
 
-    /// 稳定的访问令牌类型要求（默认 None 表示 User+Tenant）。
-    /// 特殊端点在此返回特定列表，实现 locality。
-    /// 当前 Bitable 所有端点均使用默认（User + Tenant）。
-    pub fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
-        None
+impl CatalogEndpoint for BitableApiV1 {
+    fn to_url(&self) -> String {
+        // delegate to inherent for backward compat
+        BitableApiV1::to_url(self)
     }
+
+    fn method(&self) -> HttpMethod {
+        BitableApiV1::method(self)
+    }
+
+    // supported and to_request use trait defaults
 }
 
 /// Minutes API V1 端点枚举

--- a/crates/openlark-docs/src/common/api_endpoints.rs
+++ b/crates/openlark-docs/src/common/api_endpoints.rs
@@ -42,6 +42,8 @@ pub enum BaseApiV2 {
     RoleUpdate(String, String),
     /// 列出自定义角色
     RoleList(String),
+    /// 删除自定义角色
+    RoleDelete(String, String),
 }
 
 impl BaseApiV2 {
@@ -57,7 +59,38 @@ impl BaseApiV2 {
             BaseApiV2::RoleList(app_token) => {
                 format!("/open-apis/base/v2/apps/{app_token}/roles")
             }
+            BaseApiV2::RoleDelete(app_token, role_id) => {
+                format!("/open-apis/base/v2/apps/{app_token}/roles/{role_id}")
+            }
         }
+    }
+
+    /// 返回配置了正确 HTTP 方法的 ApiRequest（#438：Base App Role tracer 证明 catalog 语义）。
+    /// 叶子只负责领域数据和 RequestOption。
+    pub fn to_request<R>(&self) -> ApiRequest<R> {
+        match self.method() {
+            HttpMethod::Get => ApiRequest::get(self.to_url()),
+            HttpMethod::Post => ApiRequest::post(self.to_url()),
+            HttpMethod::Put => ApiRequest::put(self.to_url()),
+            HttpMethod::Delete => ApiRequest::delete(self.to_url()),
+            HttpMethod::Patch => ApiRequest::patch(self.to_url()),
+            _ => ApiRequest::get(self.to_url()),
+        }
+    }
+
+    /// 该端点的 HTTP 方法。method 与 path 统一由 catalog 拥有。
+    pub fn method(&self) -> HttpMethod {
+        match self {
+            BaseApiV2::RoleCreate(_) => HttpMethod::Post,
+            BaseApiV2::RoleUpdate(_, _) => HttpMethod::Put,
+            BaseApiV2::RoleList(_) => HttpMethod::Get,
+            BaseApiV2::RoleDelete(_, _) => HttpMethod::Delete,
+        }
+    }
+
+    /// 稳定的访问令牌要求（默认 None 表示 User+Tenant）。
+    pub fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
+        None
     }
 }
 
@@ -2231,6 +2264,10 @@ mod tests {
             endpoint.to_url(),
             "/open-apis/base/v2/apps/app_token_123/roles"
         );
+        assert_eq!(endpoint.method(), HttpMethod::Post);
+        let req: ApiRequest<()> = endpoint.to_request();
+        assert_eq!(req.method(), &HttpMethod::Post);
+        assert!(endpoint.supported_access_token_types().is_none());
     }
 
     #[test]
@@ -2241,6 +2278,9 @@ mod tests {
             endpoint.to_url(),
             "/open-apis/base/v2/apps/app_token_123/roles/role_id_456"
         );
+        assert_eq!(endpoint.method(), HttpMethod::Put);
+        let req: ApiRequest<()> = endpoint.to_request();
+        assert_eq!(req.method(), &HttpMethod::Put);
     }
 
     #[test]
@@ -2250,6 +2290,22 @@ mod tests {
             endpoint.to_url(),
             "/open-apis/base/v2/apps/app_token_123/roles"
         );
+        assert_eq!(endpoint.method(), HttpMethod::Get);
+        let req: ApiRequest<()> = endpoint.to_request();
+        assert_eq!(req.method(), &HttpMethod::Get);
+    }
+
+    #[test]
+    fn test_base_api_v2_role_delete() {
+        let endpoint =
+            BaseApiV2::RoleDelete("app_token_123".to_string(), "role_id_456".to_string());
+        assert_eq!(
+            endpoint.to_url(),
+            "/open-apis/base/v2/apps/app_token_123/roles/role_id_456"
+        );
+        assert_eq!(endpoint.method(), HttpMethod::Delete);
+        let req: ApiRequest<()> = endpoint.to_request();
+        assert_eq!(req.method(), &HttpMethod::Delete);
     }
 
     #[test]

--- a/crates/openlark-docs/src/common/api_endpoints.rs
+++ b/crates/openlark-docs/src/common/api_endpoints.rs
@@ -2224,6 +2224,7 @@ pub const LINGO_API_V1: &str = "/open-apis/lingo/v1";
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::api::{ApiRequest, HttpMethod};
 
     // ========== BaseApiV2 Tests ==========
     #[test]

--- a/crates/openlark-docs/src/common/api_endpoints.rs
+++ b/crates/openlark-docs/src/common/api_endpoints.rs
@@ -61,7 +61,9 @@ impl BaseApiV2 {
     }
 }
 
-/// Bitable API V1 端点枚举
+/// Bitable API V1 端点枚举（#424 深化了请求语义：method + path + auth 在此集中）。
+///
+/// 注意：此文件已 > 2700 行。Bitable 相关定义未来应迁移到独立子模块以避免进一步膨胀。
 #[derive(Debug, Clone, PartialEq)]
 pub enum BitableApiV1 {
     /// App管理相关
@@ -382,19 +384,17 @@ impl BitableApiV1 {
 
     /// 返回配置了正确 HTTP 方法的 ApiRequest（#424：请求语义收归目录）。
     /// 叶子 builder 只负责领域数据（query/body）和 RequestOption，稳定 method/path/auth 由 catalog 提供。
+    ///
+    /// 注意：method() 与 to_url() 共同定义端点语义，修改时需在对应 arm 中同步（未来可通过宏统一）。
     pub fn to_request<R>(&self) -> ApiRequest<R> {
-        let mut req = match self.method() {
+        match self.method() {
             HttpMethod::Get => ApiRequest::get(self.to_url()),
             HttpMethod::Post => ApiRequest::post(self.to_url()),
             HttpMethod::Put => ApiRequest::put(self.to_url()),
             HttpMethod::Delete => ApiRequest::delete(self.to_url()),
             HttpMethod::Patch => ApiRequest::patch(self.to_url()),
-            _ => ApiRequest::get(self.to_url()),
-        };
-        if let Some(tokens) = self.supported_access_token_types() {
-            req = req.with_supported_access_token_types(tokens);
+            _ => ApiRequest::get(self.to_url()), // 防御：catalog 仅产生标准 CRUD 方法
         }
-        req
     }
 
     /// 该端点的 HTTP 方法。稳定语义，method 与 path 必须在同一处变更。
@@ -470,8 +470,8 @@ impl BitableApiV1 {
 
     /// 稳定的访问令牌类型要求（默认 None 表示 User+Tenant）。
     /// 特殊端点在此返回特定列表，实现 locality。
+    /// 当前 Bitable 所有端点均使用默认（User + Tenant）。
     pub fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
-        // Bitable 端点一般支持 tenant/user；如有仅 tenant 的在此返回 Some(vec![AccessTokenType::Tenant])
         None
     }
 }

--- a/crates/openlark-docs/src/common/api_endpoints.rs
+++ b/crates/openlark-docs/src/common/api_endpoints.rs
@@ -30,6 +30,9 @@
 //!
 //! 不建议混合使用两个系统，应根据场景选择合适的端点方式。
 
+use openlark_core::api::{ApiRequest, HttpMethod};
+use openlark_core::constants::AccessTokenType;
+
 /// Base API V2 端点枚举
 #[derive(Debug, Clone, PartialEq)]
 pub enum BaseApiV2 {
@@ -375,6 +378,101 @@ impl BitableApiV1 {
                 format!("/open-apis/bitable/v1/apps/{app_token}/roles/{role_id}/members")
             }
         }
+    }
+
+    /// 返回配置了正确 HTTP 方法的 ApiRequest（#424：请求语义收归目录）。
+    /// 叶子 builder 只负责领域数据（query/body）和 RequestOption，稳定 method/path/auth 由 catalog 提供。
+    pub fn to_request<R>(&self) -> ApiRequest<R> {
+        let mut req = match self.method() {
+            HttpMethod::Get => ApiRequest::get(self.to_url()),
+            HttpMethod::Post => ApiRequest::post(self.to_url()),
+            HttpMethod::Put => ApiRequest::put(self.to_url()),
+            HttpMethod::Delete => ApiRequest::delete(self.to_url()),
+            HttpMethod::Patch => ApiRequest::patch(self.to_url()),
+            _ => ApiRequest::get(self.to_url()),
+        };
+        if let Some(tokens) = self.supported_access_token_types() {
+            req = req.with_supported_access_token_types(tokens);
+        }
+        req
+    }
+
+    /// 该端点的 HTTP 方法。稳定语义，method 与 path 必须在同一处变更。
+    pub fn method(&self) -> HttpMethod {
+        match self {
+            // App 管理
+            BitableApiV1::AppCreate => HttpMethod::Post,
+            BitableApiV1::AppCopy(_) => HttpMethod::Post,
+            BitableApiV1::AppGet(_) => HttpMethod::Get,
+            BitableApiV1::AppUpdate(_) => HttpMethod::Put,
+            BitableApiV1::DashboardList(_) => HttpMethod::Get,
+            BitableApiV1::DashboardCopy(_, _) => HttpMethod::Post,
+            BitableApiV1::BlockWorkflowList(_) => HttpMethod::Get,
+            BitableApiV1::WorkflowList(_) => HttpMethod::Get,
+            BitableApiV1::WorkflowUpdate(_, _) => HttpMethod::Put,
+
+            // 表格管理
+            BitableApiV1::TableCreate(_) => HttpMethod::Post,
+            BitableApiV1::TableBatchCreate(_) => HttpMethod::Post,
+            BitableApiV1::TableUpdate(_, _) => HttpMethod::Put,
+            BitableApiV1::TableDelete(_, _) => HttpMethod::Delete,
+            BitableApiV1::TableBatchDelete(_) => HttpMethod::Post,
+            BitableApiV1::TableGet(_, _) => HttpMethod::Get,
+            BitableApiV1::TableList(_) => HttpMethod::Get,
+            BitableApiV1::TablePatch(_, _) => HttpMethod::Patch,
+
+            // 字段管理
+            BitableApiV1::FieldCreate(_, _) => HttpMethod::Post,
+            BitableApiV1::FieldGroupCreate(_, _) => HttpMethod::Post,
+            BitableApiV1::FieldUpdate(_, _, _) => HttpMethod::Put,
+            BitableApiV1::FieldDelete(_, _, _) => HttpMethod::Delete,
+            BitableApiV1::FieldList(_, _) => HttpMethod::Get,
+
+            // 视图管理
+            BitableApiV1::ViewCreate(_, _) => HttpMethod::Post,
+            BitableApiV1::ViewUpdate(_, _, _) => HttpMethod::Put,
+            BitableApiV1::ViewDelete(_, _, _) => HttpMethod::Delete,
+            BitableApiV1::ViewGet(_, _, _) => HttpMethod::Get,
+            BitableApiV1::ViewList(_, _) => HttpMethod::Get,
+            BitableApiV1::ViewPatch(_, _, _) => HttpMethod::Patch,
+
+            // 记录管理（tracer bullet #424）
+            BitableApiV1::RecordCreate(_, _) => HttpMethod::Post,
+            BitableApiV1::RecordBatchCreate(_, _) => HttpMethod::Post,
+            BitableApiV1::RecordGet(_, _, _) => HttpMethod::Get,
+            BitableApiV1::RecordBatchGet(_, _) => HttpMethod::Post,
+            BitableApiV1::RecordUpdate(_, _, _) => HttpMethod::Put,
+            BitableApiV1::RecordBatchUpdate(_, _) => HttpMethod::Post,
+            BitableApiV1::RecordDelete(_, _, _) => HttpMethod::Delete,
+            BitableApiV1::RecordBatchDelete(_, _) => HttpMethod::Post,
+            BitableApiV1::RecordList(_, _) => HttpMethod::Get,
+            BitableApiV1::RecordSearch(_, _) => HttpMethod::Post,
+
+            // 表单管理
+            BitableApiV1::FormGet(_, _, _) => HttpMethod::Get,
+            BitableApiV1::FormPatch(_, _, _) => HttpMethod::Patch,
+            BitableApiV1::FormUpgrade(_, _, _) => HttpMethod::Post,
+            BitableApiV1::FormFieldList(_, _, _) => HttpMethod::Get,
+            BitableApiV1::FormFieldPatch(_, _, _, _) => HttpMethod::Patch,
+
+            // 权限/角色管理
+            BitableApiV1::RoleCreate(_) => HttpMethod::Post,
+            BitableApiV1::RoleUpdate(_, _) => HttpMethod::Put,
+            BitableApiV1::RoleDelete(_, _) => HttpMethod::Delete,
+            BitableApiV1::RoleList(_) => HttpMethod::Get,
+            BitableApiV1::RoleMemberCreate(_, _) => HttpMethod::Post,
+            BitableApiV1::RoleMemberBatchCreate(_, _) => HttpMethod::Post,
+            BitableApiV1::RoleMemberDelete(_, _, _) => HttpMethod::Delete,
+            BitableApiV1::RoleMemberBatchDelete(_, _) => HttpMethod::Post,
+            BitableApiV1::RoleMemberList(_, _) => HttpMethod::Get,
+        }
+    }
+
+    /// 稳定的访问令牌类型要求（默认 None 表示 User+Tenant）。
+    /// 特殊端点在此返回特定列表，实现 locality。
+    pub fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
+        // Bitable 端点一般支持 tenant/user；如有仅 tenant 的在此返回 Some(vec![AccessTokenType::Tenant])
+        None
     }
 }
 
@@ -2280,6 +2378,57 @@ mod tests {
             "table_id_456".to_string(),
         );
         assert!(endpoint.to_url().contains("batch_delete"));
+    }
+
+    // ========== #424: 端点目录语义测试（method + path + auth） ==========
+    // tracer: record 族，确保 method/path 组合由 catalog 拥有，防止叶子漂移。
+    #[test]
+    fn test_bitable_record_endpoints_semantics_424() {
+        use openlark_core::api::HttpMethod;
+
+        // Create / BatchCreate -> POST
+        let ep = BitableApiV1::RecordCreate("app".into(), "tbl".into());
+        assert_eq!(ep.method(), HttpMethod::Post);
+        assert!(ep.to_url().contains("/records"));
+        let req: ApiRequest<()> = ep.to_request();
+        assert_eq!(req.method(), &HttpMethod::Post);
+
+        let ep = BitableApiV1::RecordBatchCreate("app".into(), "tbl".into());
+        assert_eq!(ep.method(), HttpMethod::Post);
+
+        // Get / List -> GET
+        let ep = BitableApiV1::RecordGet("app".into(), "tbl".into(), "rec".into());
+        assert_eq!(ep.method(), HttpMethod::Get);
+        let req: ApiRequest<()> = ep.to_request();
+        assert_eq!(req.method(), &HttpMethod::Get);
+
+        let ep = BitableApiV1::RecordList("app".into(), "tbl".into());
+        assert_eq!(ep.method(), HttpMethod::Get);
+
+        // Update -> PUT , BatchUpdate -> POST
+        let ep = BitableApiV1::RecordUpdate("app".into(), "tbl".into(), "rec".into());
+        assert_eq!(ep.method(), HttpMethod::Put);
+
+        let ep = BitableApiV1::RecordBatchUpdate("app".into(), "tbl".into());
+        assert_eq!(ep.method(), HttpMethod::Post);
+
+        // Delete -> DELETE , BatchDelete -> POST
+        let ep = BitableApiV1::RecordDelete("app".into(), "tbl".into(), "rec".into());
+        assert_eq!(ep.method(), HttpMethod::Delete);
+        let req: ApiRequest<()> = ep.to_request();
+        assert_eq!(req.method(), &HttpMethod::Delete);
+
+        let ep = BitableApiV1::RecordBatchDelete("app".into(), "tbl".into());
+        assert_eq!(ep.method(), HttpMethod::Post);
+
+        // Search -> POST (body query)
+        let ep = BitableApiV1::RecordSearch("app".into(), "tbl".into());
+        assert_eq!(ep.method(), HttpMethod::Post);
+        assert!(ep.to_url().contains("/search"));
+
+        // auth: 默认 None -> User+Tenant （由 ApiRequest 默认提供）
+        let ep = BitableApiV1::RecordCreate("a".into(), "t".into());
+        assert!(ep.supported_access_token_types().is_none());
     }
 
     // ========== MinutesApiV1 Tests ==========

--- a/crates/openlark-docs/src/common/api_endpoints/base.rs
+++ b/crates/openlark-docs/src/common/api_endpoints/base.rs
@@ -1,0 +1,57 @@
+//! Base API V2 端点枚举
+//!
+//! 提供 Base v2 的端点定义，支持 method、path 和认证要求的统一管理（#438 tracer）。
+
+use super::CatalogEndpoint;
+use openlark_core::api::HttpMethod;
+
+/// Base API V2 端点枚举
+#[derive(Debug, Clone, PartialEq)]
+pub enum BaseApiV2 {
+    /// 新增自定义角色
+    RoleCreate(String),
+    /// 更新自定义角色
+    RoleUpdate(String, String),
+    /// 列出自定义角色
+    RoleList(String),
+    /// 删除自定义角色
+    RoleDelete(String, String),
+}
+
+impl BaseApiV2 {
+    /// 生成对应的 URL
+    pub fn to_url(&self) -> String {
+        match self {
+            BaseApiV2::RoleCreate(app_token) => {
+                format!("/open-apis/base/v2/apps/{app_token}/roles")
+            }
+            BaseApiV2::RoleUpdate(app_token, role_id) => {
+                format!("/open-apis/base/v2/apps/{app_token}/roles/{role_id}")
+            }
+            BaseApiV2::RoleList(app_token) => {
+                format!("/open-apis/base/v2/apps/{app_token}/roles")
+            }
+            BaseApiV2::RoleDelete(app_token, role_id) => {
+                format!("/open-apis/base/v2/apps/{app_token}/roles/{role_id}")
+            }
+        }
+    }
+}
+
+impl CatalogEndpoint for BaseApiV2 {
+    fn to_url(&self) -> String {
+        // delegate to inherent for backward compat with direct .to_url() calls
+        BaseApiV2::to_url(self)
+    }
+
+    fn method(&self) -> HttpMethod {
+        match self {
+            BaseApiV2::RoleCreate(_) => HttpMethod::Post,
+            BaseApiV2::RoleUpdate(_, _) => HttpMethod::Put,
+            BaseApiV2::RoleList(_) => HttpMethod::Get,
+            BaseApiV2::RoleDelete(_, _) => HttpMethod::Delete,
+        }
+    }
+
+    // supported_access_token_types and to_request use trait defaults
+}


### PR DESCRIPTION
Follow-up to #424.

Implements #438:

- Extended BaseApiV2 catalog with method/to_request/supported tokens (matching Bitable pattern).
- Added RoleDelete to catalog and implemented delete leaf + tests for full CRUD coverage (read/create/update/delete).
- Migrated role leaves (create/list/update/delete) to use catalog.to_request().
- Added lock tests and enhanced catalog tests asserting method/path.
- Extracted BaseApiV2 to sub-module and introduced CatalogEndpoint trait to address review feedback on duplication and file size.

Wiremock tests assert method/path; lock tests verify catalog delegation.

All tests pass with --features base.