### PR TITLE
refactor(docs): migrate Docs and Docx endpoint semantics

### DIFF
--- a/crates/openlark-docs/src/ccm/docs/v1/content/get.rs
+++ b/crates/openlark-docs/src/ccm/docs/v1/content/get.rs
@@ -91,7 +91,8 @@ pub async fn get_docs_content(
 
     let api_endpoint = DocsApiV1::ContentGet;
 
-    let api_request: ApiRequest<GetDocsContentResponse> = ApiRequest::get(&api_endpoint.to_url())
+    let api_request: ApiRequest<GetDocsContentResponse> = api_endpoint
+        .to_request()
         .query("doc_token", &request.doc_token)
         .query("doc_type", &request.doc_type)
         .query("content_type", &request.content_type)

--- a/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/batch_update.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/batch_update.rs
@@ -95,9 +95,9 @@ impl BatchUpdateChatAnnouncementBlocksRequest {
 
         let api_endpoint = DocxApiV1::ChatAnnouncementBlockBatchUpdate(params.chat_id.clone());
 
-        let api_request: ApiRequest<BatchUpdateChatAnnouncementBlocksResponse> =
-            ApiRequest::patch(&api_endpoint.to_url())
-                .body(serialize_params(&params, "批量更新群公告块的内容")?);
+        let api_request: ApiRequest<BatchUpdateChatAnnouncementBlocksResponse> = api_endpoint
+            .to_request()
+            .body(serialize_params(&params, "批量更新群公告块的内容")?);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         extract_response_data(response, "批量更新群公告块的内容")

--- a/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/children/batch_delete.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/children/batch_delete.rs
@@ -90,7 +90,8 @@ impl BatchDeleteChatAnnouncementBlockChildrenRequest {
         );
 
         let api_request: ApiRequest<BatchDeleteChatAnnouncementBlockChildrenResponse> =
-            ApiRequest::delete(&api_endpoint.to_url())
+            api_endpoint
+                .to_request()
                 .body(serialize_params(&params, "删除群公告中的块")?);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;

--- a/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/children/create.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/children/create.rs
@@ -94,9 +94,9 @@ impl CreateChatAnnouncementBlockChildrenRequest {
             params.block_id.clone(),
         );
 
-        let api_request: ApiRequest<CreateChatAnnouncementBlockChildrenResponse> =
-            ApiRequest::post(&api_endpoint.to_url())
-                .body(serialize_params(&params, "在群公告中创建块")?);
+        let api_request: ApiRequest<CreateChatAnnouncementBlockChildrenResponse> = api_endpoint
+            .to_request()
+            .body(serialize_params(&params, "在群公告中创建块")?);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         extract_response_data(response, "在群公告中创建块")

--- a/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/children/get.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/children/get.rs
@@ -89,7 +89,7 @@ impl GetChatAnnouncementBlockChildrenRequest {
         );
 
         let mut api_request: ApiRequest<GetChatAnnouncementBlockChildrenResponse> =
-            ApiRequest::get(&api_endpoint.to_url());
+            api_endpoint.to_request();
 
         if let Some(page_size) = params.page_size {
             api_request = api_request.query("page_size", &page_size.to_string());

--- a/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/get.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/get.rs
@@ -85,8 +85,7 @@ impl GetChatAnnouncementBlockRequest {
         let api_endpoint =
             DocxApiV1::ChatAnnouncementBlockGet(params.chat_id.clone(), params.block_id.clone());
 
-        let api_request: ApiRequest<GetChatAnnouncementBlockResponse> =
-            ApiRequest::get(&api_endpoint.to_url());
+        let api_request: ApiRequest<GetChatAnnouncementBlockResponse> = api_endpoint.to_request();
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         extract_response_data(response, "获取群公告块的内容")

--- a/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/list.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/block/list.rs
@@ -85,7 +85,7 @@ impl GetChatAnnouncementBlocksRequest {
         let api_endpoint = DocxApiV1::ChatAnnouncementBlockList(params.chat_id.clone());
 
         let mut api_request: ApiRequest<GetChatAnnouncementBlocksResponse> =
-            ApiRequest::get(&api_endpoint.to_url());
+            api_endpoint.to_request();
 
         if let Some(page_size) = params.page_size {
             api_request = api_request.query("page_size", &page_size.to_string());

--- a/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/get.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/chat/announcement/get.rs
@@ -103,8 +103,7 @@ impl GetChatAnnouncementRequest {
         validate_required!(self.chat_id, "群聊ID不能为空");
 
         let api_endpoint = DocxApiV1::ChatAnnouncementGet(self.chat_id.clone());
-        let mut api_request: ApiRequest<GetChatAnnouncementResponse> =
-            ApiRequest::get(&api_endpoint.to_url());
+        let mut api_request: ApiRequest<GetChatAnnouncementResponse> = api_endpoint.to_request();
 
         if let Some(user_id_type) = self.user_id_type {
             api_request = api_request.query("user_id_type", &user_id_type);

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/batch_update.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/batch_update.rs
@@ -91,7 +91,7 @@ impl BatchUpdateDocumentBlocksRequest {
 
         let api_endpoint = DocxApiV1::DocumentBlockBatchUpdate(params.document_id.clone());
         let mut api_request: ApiRequest<BatchUpdateDocumentBlocksResponse> =
-            ApiRequest::patch(&api_endpoint.to_url());
+            api_endpoint.to_request();
         api_request = api_request.json_body(&params);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/children/batch_delete.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/children/batch_delete.rs
@@ -84,8 +84,9 @@ impl BatchDeleteDocumentBlockChildrenRequest {
             params.block_id.clone(),
         );
 
-        let mut api_request: ApiRequest<BatchDeleteDocumentBlockChildrenResponse> =
-            ApiRequest::delete(&api_endpoint.to_url()).body(serialize_params(&params, "删除块")?);
+        let mut api_request: ApiRequest<BatchDeleteDocumentBlockChildrenResponse> = api_endpoint
+            .to_request()
+            .body(serialize_params(&params, "删除块")?);
 
         if let Some(document_revision_id) = params.document_revision_id {
             api_request =
@@ -102,7 +103,7 @@ mod tests {
     use super::*;
     use serde_json::json;
     use wiremock::MockServer;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, ResponseTemplate};
 
     /// 端到端：DELETE .../blocks/{block_id}/children/batch_delete → BatchDeleteDocumentBlockChildrenResponse（document_revision_id）。
@@ -113,6 +114,7 @@ mod tests {
             .and(path(
                 "/open-apis/docx/v1/documents/doc1/blocks/blk1/children/batch_delete",
             ))
+            .and(header("Authorization", "Bearer test-tenant-token"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0, "msg": "success",
                 "data": { "document_revision_id": 2, "client_token": "ct001" }
@@ -128,13 +130,18 @@ mod tests {
             .build();
 
         let resp = BatchDeleteDocumentBlockChildrenRequest::new(config)
-            .execute(BatchDeleteDocumentBlockChildrenParams {
-                document_id: "doc1".into(),
-                block_id: "blk1".into(),
-                document_revision_id: None,
-                start_index: 0,
-                end_index: 1,
-            })
+            .execute_with_options(
+                BatchDeleteDocumentBlockChildrenParams {
+                    document_id: "doc1".into(),
+                    block_id: "blk1".into(),
+                    document_revision_id: Some(-1),
+                    start_index: 0,
+                    end_index: 1,
+                },
+                RequestOption::builder()
+                    .tenant_access_token("test-tenant-token")
+                    .build(),
+            )
             .await
             .expect("删除子块应成功");
         assert_eq!(resp.document_revision_id, 2);
@@ -145,5 +152,18 @@ mod tests {
             received[0].url.path(),
             "/open-apis/docx/v1/documents/doc1/blocks/blk1/children/batch_delete"
         );
+        let query: std::collections::HashMap<_, _> = received[0]
+            .url
+            .query_pairs()
+            .map(|(key, value)| (key.into_owned(), value.into_owned()))
+            .collect();
+        assert_eq!(
+            query.get("document_revision_id").map(String::as_str),
+            Some("-1")
+        );
+        let body: serde_json::Value =
+            serde_json::from_slice(&received[0].body).expect("请求体应为合法 JSON");
+        assert_eq!(body["start_index"], 0);
+        assert_eq!(body["end_index"], 1);
     }
 }

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/children/create.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/children/create.rs
@@ -97,8 +97,9 @@ impl CreateDocumentBlockChildrenRequest {
             params.block_id.clone(),
         );
 
-        let mut api_request: ApiRequest<CreateDocumentBlockChildrenResponse> =
-            ApiRequest::post(&api_endpoint.to_url()).body(serialize_params(&params, "创建块")?);
+        let mut api_request: ApiRequest<CreateDocumentBlockChildrenResponse> = api_endpoint
+            .to_request()
+            .body(serialize_params(&params, "创建块")?);
 
         if let Some(document_revision_id) = params.document_revision_id {
             api_request =

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/children/get.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/children/get.rs
@@ -86,7 +86,7 @@ impl GetDocumentBlockChildrenRequest {
             params.block_id.clone(),
         );
         let mut api_request: ApiRequest<GetDocumentBlockChildrenResponse> =
-            ApiRequest::get(&api_endpoint.to_url());
+            api_endpoint.to_request();
 
         if let Some(document_revision_id) = params.document_revision_id {
             api_request =

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/descendant/create.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/descendant/create.rs
@@ -109,8 +109,9 @@ impl CreateDocumentBlockDescendantRequest {
             params.block_id.clone(),
         );
 
-        let mut api_request: ApiRequest<CreateDocumentBlockDescendantResponse> =
-            ApiRequest::post(&api_endpoint.to_url()).body(serialize_params(&params, "创建嵌套块")?);
+        let mut api_request: ApiRequest<CreateDocumentBlockDescendantResponse> = api_endpoint
+            .to_request()
+            .body(serialize_params(&params, "创建嵌套块")?);
 
         if let Some(document_revision_id) = params.document_revision_id {
             api_request =

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/get.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/get.rs
@@ -74,8 +74,7 @@ impl GetDocumentBlockRequest {
 
         let api_endpoint =
             DocxApiV1::DocumentBlockGet(params.document_id.clone(), params.block_id.clone());
-        let mut api_request: ApiRequest<GetDocumentBlockResponse> =
-            ApiRequest::get(&api_endpoint.to_url());
+        let mut api_request: ApiRequest<GetDocumentBlockResponse> = api_endpoint.to_request();
 
         if let Some(document_revision_id) = params.document_revision_id {
             api_request =

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/list.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/list.rs
@@ -85,8 +85,7 @@ impl GetDocumentBlocksRequest {
         let api_endpoint = DocxApiV1::DocumentBlockList(params.document_id.clone());
 
         // 创建API请求
-        let mut api_request: ApiRequest<GetDocumentBlocksResponse> =
-            ApiRequest::get(&api_endpoint.to_url());
+        let mut api_request: ApiRequest<GetDocumentBlocksResponse> = api_endpoint.to_request();
 
         // 设置查询参数
         if let Some(page_size) = params.page_size {

--- a/crates/openlark-docs/src/ccm/docx/v1/document/block/patch.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/block/patch.rs
@@ -84,8 +84,7 @@ impl UpdateDocumentBlockRequest {
 
         let api_endpoint =
             DocxApiV1::DocumentBlockPatch(params.document_id.clone(), params.block_id.clone());
-        let mut api_request: ApiRequest<UpdateDocumentBlockResponse> =
-            ApiRequest::patch(&api_endpoint.to_url());
+        let mut api_request: ApiRequest<UpdateDocumentBlockResponse> = api_endpoint.to_request();
         api_request = api_request.json_body(&params);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
@@ -102,7 +101,7 @@ mod tests {
     };
     use serde_json::json;
     use wiremock::MockServer;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, ResponseTemplate};
 
     /// 端到端：PATCH .../blocks/{block_id} → UpdateDocumentBlockResponse（block）。
@@ -111,6 +110,7 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("PATCH"))
             .and(path("/open-apis/docx/v1/documents/doc1/blocks/blk1"))
+            .and(header("Authorization", "Bearer test-tenant-token"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0, "msg": "success",
                 "data": { "block": { "block_id": "blk1", "block_type": 1 } }
@@ -126,11 +126,18 @@ mod tests {
             .build();
 
         let resp = UpdateDocumentBlockRequest::new(config)
-            .execute(UpdateDocumentBlockParams {
-                document_id: "doc1".into(),
-                block_id: "blk1".into(),
-                update: BlockUpdateOperation::Raw(json!({})),
-            })
+            .execute_with_options(
+                UpdateDocumentBlockParams {
+                    document_id: "doc1".into(),
+                    block_id: "blk1".into(),
+                    update: BlockUpdateOperation::Raw(json!({
+                        "update_text_elements": { "elements": [] }
+                    })),
+                },
+                RequestOption::builder()
+                    .tenant_access_token("test-tenant-token")
+                    .build(),
+            )
             .await
             .expect("更新块内容应成功");
         assert_eq!(resp.block.block_id, "blk1");
@@ -141,6 +148,9 @@ mod tests {
             received[0].url.path(),
             "/open-apis/docx/v1/documents/doc1/blocks/blk1"
         );
+        let body: serde_json::Value =
+            serde_json::from_slice(&received[0].body).expect("请求体应为合法 JSON");
+        assert_eq!(body["update_text_elements"]["elements"], json!([]));
     }
 
     #[test]

--- a/crates/openlark-docs/src/ccm/docx/v1/document/convert.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/convert.rs
@@ -98,9 +98,9 @@ impl ConvertContentToBlocksRequest {
         let api_endpoint = DocxApiV1::DocumentConvert;
 
         // 创建API请求
-        let api_request: ApiRequest<ConvertContentToBlocksResponse> =
-            ApiRequest::post(&api_endpoint.to_url())
-                .body(serialize_params(&params, "Markdown/HTML 内容转换为文档块")?);
+        let api_request: ApiRequest<ConvertContentToBlocksResponse> = api_endpoint
+            .to_request()
+            .body(serialize_params(&params, "Markdown/HTML 内容转换为文档块")?);
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;

--- a/crates/openlark-docs/src/ccm/docx/v1/document/create.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/create.rs
@@ -104,9 +104,9 @@ impl CreateDocumentRequest {
             folder_token: self.folder_token,
         };
 
-        let api_request: ApiRequest<CreateDocumentResponse> =
-            ApiRequest::post(&api_endpoint.to_url())
-                .body(serialize_params(&request_body, "创建文档")?);
+        let api_request: ApiRequest<CreateDocumentResponse> = api_endpoint
+            .to_request()
+            .body(serialize_params(&request_body, "创建文档")?);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         extract_response_data(response, "创建")
@@ -118,7 +118,7 @@ mod tests {
     use super::*;
     use serde_json::json;
     use wiremock::MockServer;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, ResponseTemplate};
 
     /// 端到端：POST /open-apis/docx/v1/documents → CreateDocumentResponse（document）。
@@ -127,6 +127,7 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/open-apis/docx/v1/documents"))
+            .and(header("Authorization", "Bearer test-tenant-token"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0, "msg": "success",
                 "data": { "document": { "document_id": "doc1", "revision_id": 1 } }
@@ -143,7 +144,11 @@ mod tests {
 
         let resp = CreateDocumentRequest::new(config)
             .title("测试文档")
-            .execute()
+            .execute_with_options(
+                openlark_core::req_option::RequestOption::builder()
+                    .tenant_access_token("test-tenant-token")
+                    .build(),
+            )
             .await
             .expect("创建文档应成功");
         assert_eq!(resp.document.document_id, "doc1");

--- a/crates/openlark-docs/src/ccm/docx/v1/document/get.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/get.rs
@@ -118,7 +118,7 @@ impl GetDocumentRequest {
         validate_required!(self.document_id, "文档ID不能为空");
 
         let api_endpoint = DocxApiV1::DocumentGet(self.document_id.clone());
-        let api_request: ApiRequest<GetDocumentResponse> = ApiRequest::get(&api_endpoint.to_url());
+        let api_request: ApiRequest<GetDocumentResponse> = api_endpoint.to_request();
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         extract_response_data(response, "获取")

--- a/crates/openlark-docs/src/ccm/docx/v1/document/raw_content.rs
+++ b/crates/openlark-docs/src/ccm/docx/v1/document/raw_content.rs
@@ -75,8 +75,7 @@ impl GetDocumentRawContentRequest {
         let api_endpoint = DocxApiV1::DocumentRawContent(params.document_id.clone());
 
         // 创建API请求
-        let mut api_request: ApiRequest<GetDocumentRawContentResponse> =
-            ApiRequest::get(&api_endpoint.to_url());
+        let mut api_request: ApiRequest<GetDocumentRawContentResponse> = api_endpoint.to_request();
 
         if let Some(lang) = params.lang {
             api_request = api_request.query("lang", &lang.to_string());
@@ -93,7 +92,7 @@ mod tests {
     use super::*;
     use serde_json::json;
     use wiremock::MockServer;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, ResponseTemplate};
 
     /// 端到端：GET .../documents/{document_id}/raw_content → GetDocumentRawContentResponse（content）。
@@ -101,7 +100,8 @@ mod tests {
     async fn test_get_document_raw_content_returns_data_on_success() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .and(path("/open-apis/docx/v1/documents/doc1/raw_content"))
+            .and(path("/open-apis/docx/v1/documents/doc%201/raw_content"))
+            .and(header("Authorization", "Bearer test-tenant-token"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0, "msg": "success",
                 "data": { "content": "文档纯文本内容" }
@@ -117,10 +117,15 @@ mod tests {
             .build();
 
         let resp = GetDocumentRawContentRequest::new(config)
-            .execute(GetDocumentRawContentParams {
-                document_id: "doc1".into(),
-                lang: None,
-            })
+            .execute_with_options(
+                GetDocumentRawContentParams {
+                    document_id: "doc 1".into(),
+                    lang: Some(0),
+                },
+                RequestOption::builder()
+                    .tenant_access_token("test-tenant-token")
+                    .build(),
+            )
             .await
             .expect("获取文档纯文本应成功");
         assert_eq!(resp.content, "文档纯文本内容");
@@ -129,7 +134,8 @@ mod tests {
         assert_eq!(received.len(), 1);
         assert_eq!(
             received[0].url.path(),
-            "/open-apis/docx/v1/documents/doc1/raw_content"
+            "/open-apis/docx/v1/documents/doc%201/raw_content"
         );
+        assert_eq!(received[0].url.query(), Some("lang=0"));
     }
 }

--- a/crates/openlark-docs/src/common/api_endpoints.rs
+++ b/crates/openlark-docs/src/common/api_endpoints.rs
@@ -535,140 +535,11 @@ impl WikiApiV1 {
     }
 }
 
-/// Docs API V1 端点枚举
-#[derive(Debug, Clone, PartialEq)]
-pub enum DocsApiV1 {
-    /// 获取云文档内容
-    ContentGet,
-}
+pub mod docs;
+pub use docs::DocsApiV1;
 
-impl DocsApiV1 {
-    /// 生成对应的 URL
-    pub fn to_url(&self) -> String {
-        match self {
-            DocsApiV1::ContentGet => "/open-apis/docs/v1/content".to_string(),
-        }
-    }
-}
-
-/// Docx API V1 端点枚举
-#[derive(Debug, Clone, PartialEq)]
-pub enum DocxApiV1 {
-    // 群公告相关API (7个)
-    /// 获取群公告基本信息
-    ChatAnnouncementGet(String),
-    /// 获取群公告所有块
-    ChatAnnouncementBlockList(String),
-    /// 在群公告中创建块
-    ChatAnnouncementBlockChildrenCreate(String, String),
-    /// 批量更新群公告块的内容
-    ChatAnnouncementBlockBatchUpdate(String),
-    /// 获取群公告块的内容
-    ChatAnnouncementBlockGet(String, String),
-    /// 获取所有子块
-    ChatAnnouncementBlockChildrenGet(String, String),
-    /// 删除群公告中的块
-    ChatAnnouncementBlockChildrenBatchDelete(String, String),
-
-    // 文档相关API (12个)
-    /// 创建文档
-    DocumentCreate,
-    /// 获取文档基本信息
-    DocumentGet(String),
-    /// 获取文档纯文本内容
-    DocumentRawContent(String),
-    /// 获取文档所有块
-    DocumentBlockList(String),
-    /// 创建块
-    DocumentBlockChildrenCreate(String, String),
-    /// 创建嵌套块
-    DocumentBlockDescendantCreate(String, String),
-    /// 更新块的内容
-    DocumentBlockPatch(String, String),
-    /// 获取块的内容
-    DocumentBlockGet(String, String),
-    /// 批量更新块的内容
-    DocumentBlockBatchUpdate(String),
-    /// 获取所有子块
-    DocumentBlockChildrenGet(String, String),
-    /// 删除块
-    DocumentBlockChildrenBatchDelete(String, String),
-    /// Markdown/HTML 内容转换为文档块
-    DocumentConvert,
-}
-
-impl DocxApiV1 {
-    /// 生成对应的 URL
-    pub fn to_url(&self) -> String {
-        match self {
-            // 群公告相关API (7个)
-            DocxApiV1::ChatAnnouncementGet(chat_id) => {
-                format!("/open-apis/docx/v1/chats/{chat_id}/announcement")
-            }
-            DocxApiV1::ChatAnnouncementBlockList(chat_id) => {
-                format!("/open-apis/docx/v1/chats/{chat_id}/announcement/blocks")
-            }
-            DocxApiV1::ChatAnnouncementBlockChildrenCreate(chat_id, block_id) => {
-                format!(
-                    "/open-apis/docx/v1/chats/{chat_id}/announcement/blocks/{block_id}/children"
-                )
-            }
-            DocxApiV1::ChatAnnouncementBlockBatchUpdate(chat_id) => {
-                format!("/open-apis/docx/v1/chats/{chat_id}/announcement/blocks/batch_update")
-            }
-            DocxApiV1::ChatAnnouncementBlockGet(chat_id, block_id) => {
-                format!("/open-apis/docx/v1/chats/{chat_id}/announcement/blocks/{block_id}")
-            }
-            DocxApiV1::ChatAnnouncementBlockChildrenGet(chat_id, block_id) => {
-                format!(
-                    "/open-apis/docx/v1/chats/{chat_id}/announcement/blocks/{block_id}/children"
-                )
-            }
-            DocxApiV1::ChatAnnouncementBlockChildrenBatchDelete(chat_id, block_id) => {
-                format!(
-                    "/open-apis/docx/v1/chats/{chat_id}/announcement/blocks/{block_id}/children/batch_delete"
-                )
-            }
-
-            // 文档相关API (12个)
-            DocxApiV1::DocumentCreate => "/open-apis/docx/v1/documents".to_string(),
-            DocxApiV1::DocumentGet(document_id) => {
-                format!("/open-apis/docx/v1/documents/{document_id}")
-            }
-            DocxApiV1::DocumentRawContent(document_id) => {
-                format!("/open-apis/docx/v1/documents/{document_id}/raw_content")
-            }
-            DocxApiV1::DocumentBlockList(document_id) => {
-                format!("/open-apis/docx/v1/documents/{document_id}/blocks")
-            }
-            DocxApiV1::DocumentBlockChildrenCreate(document_id, block_id) => {
-                format!("/open-apis/docx/v1/documents/{document_id}/blocks/{block_id}/children")
-            }
-            DocxApiV1::DocumentBlockDescendantCreate(document_id, block_id) => {
-                format!("/open-apis/docx/v1/documents/{document_id}/blocks/{block_id}/descendant")
-            }
-            DocxApiV1::DocumentBlockPatch(document_id, block_id) => {
-                format!("/open-apis/docx/v1/documents/{document_id}/blocks/{block_id}")
-            }
-            DocxApiV1::DocumentBlockGet(document_id, block_id) => {
-                format!("/open-apis/docx/v1/documents/{document_id}/blocks/{block_id}")
-            }
-            DocxApiV1::DocumentBlockBatchUpdate(document_id) => {
-                format!("/open-apis/docx/v1/documents/{document_id}/blocks/batch_update")
-            }
-            DocxApiV1::DocumentBlockChildrenGet(document_id, block_id) => {
-                format!("/open-apis/docx/v1/documents/{document_id}/blocks/{block_id}/children")
-            }
-            DocxApiV1::DocumentBlockChildrenBatchDelete(document_id, block_id) => {
-                format!(
-                    "/open-apis/docx/v1/documents/{document_id}/blocks/{block_id}/children/batch_delete"
-                )
-            }
-            // 注意：该接口虽然归类在 docx-v1 文档下，但实际 HTTP URL 不包含 /v1
-            DocxApiV1::DocumentConvert => "/open-apis/docx/documents/blocks/convert".to_string(),
-        }
-    }
-}
+pub mod docx;
+pub use docx::DocxApiV1;
 
 /// Wiki API V2 端点枚举
 #[derive(Debug, Clone, PartialEq)]
@@ -792,6 +663,35 @@ impl CcmDocApiOld {
             }
         }
     }
+
+    /// 返回配置了稳定请求语义的请求。
+    pub fn to_request<R>(&self) -> ApiRequest<R> {
+        <Self as CatalogEndpoint>::to_request(self)
+    }
+
+    /// 返回端点的 HTTP 方法。
+    pub fn method(&self) -> HttpMethod {
+        match self {
+            Self::Create | Self::BatchUpdate(_) => HttpMethod::Post,
+            Self::Meta(_) | Self::SheetMeta(_) | Self::RawContent(_) | Self::Content(_) => {
+                HttpMethod::Get
+            }
+        }
+    }
+}
+
+impl CatalogEndpoint for CcmDocApiOld {
+    fn to_url(&self) -> String {
+        CcmDocApiOld::to_url(self)
+    }
+
+    fn method(&self) -> HttpMethod {
+        CcmDocApiOld::method(self)
+    }
+
+    fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
+        Some(vec![AccessTokenType::User, AccessTokenType::Tenant])
+    }
 }
 
 /// CCM Docs API Old V1 端点枚举
@@ -811,6 +711,33 @@ impl CcmDocsApiOld {
             CcmDocsApiOld::SearchObject => "/open-apis/suite/docs-api/search/object".to_string(),
             CcmDocsApiOld::Meta => "/open-apis/suite/docs-api/meta".to_string(),
         }
+    }
+
+    /// 返回配置了稳定请求语义的请求。
+    pub fn to_request<R>(&self) -> ApiRequest<R> {
+        <Self as CatalogEndpoint>::to_request(self)
+    }
+
+    /// 返回端点的 HTTP 方法。
+    pub fn method(&self) -> HttpMethod {
+        match self {
+            Self::SearchObject => HttpMethod::Post,
+            Self::Meta => HttpMethod::Get,
+        }
+    }
+}
+
+impl CatalogEndpoint for CcmDocsApiOld {
+    fn to_url(&self) -> String {
+        CcmDocsApiOld::to_url(self)
+    }
+
+    fn method(&self) -> HttpMethod {
+        CcmDocsApiOld::method(self)
+    }
+
+    fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
+        Some(vec![AccessTokenType::User, AccessTokenType::Tenant])
     }
 }
 

--- a/crates/openlark-docs/src/common/api_endpoints/docs.rs
+++ b/crates/openlark-docs/src/common/api_endpoints/docs.rs
@@ -1,0 +1,45 @@
+//! Docs API 端点目录。
+
+use super::CatalogEndpoint;
+use openlark_core::api::{ApiRequest, HttpMethod};
+use openlark_core::constants::AccessTokenType;
+
+/// Docs API V1 端点枚举
+#[derive(Debug, Clone, PartialEq)]
+pub enum DocsApiV1 {
+    /// 获取云文档内容
+    ContentGet,
+}
+
+impl DocsApiV1 {
+    /// 生成对应的 URL
+    pub fn to_url(&self) -> String {
+        match self {
+            DocsApiV1::ContentGet => "/open-apis/docs/v1/content".to_string(),
+        }
+    }
+
+    /// 返回配置了稳定请求语义的请求。
+    pub fn to_request<R>(&self) -> ApiRequest<R> {
+        <Self as CatalogEndpoint>::to_request(self)
+    }
+
+    /// 返回端点的 HTTP 方法。
+    pub fn method(&self) -> HttpMethod {
+        HttpMethod::Get
+    }
+}
+
+impl CatalogEndpoint for DocsApiV1 {
+    fn to_url(&self) -> String {
+        DocsApiV1::to_url(self)
+    }
+
+    fn method(&self) -> HttpMethod {
+        DocsApiV1::method(self)
+    }
+
+    fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
+        Some(vec![AccessTokenType::User, AccessTokenType::Tenant])
+    }
+}

--- a/crates/openlark-docs/src/common/api_endpoints/docx.rs
+++ b/crates/openlark-docs/src/common/api_endpoints/docx.rs
@@ -1,0 +1,168 @@
+//! Docx API 端点目录。
+
+use super::CatalogEndpoint;
+use openlark_core::api::{ApiRequest, HttpMethod};
+use openlark_core::constants::AccessTokenType;
+
+/// Docx API V1 端点枚举
+#[derive(Debug, Clone, PartialEq)]
+pub enum DocxApiV1 {
+    // 群公告相关API (7个)
+    /// 获取群公告基本信息
+    ChatAnnouncementGet(String),
+    /// 获取群公告所有块
+    ChatAnnouncementBlockList(String),
+    /// 在群公告中创建块
+    ChatAnnouncementBlockChildrenCreate(String, String),
+    /// 批量更新群公告块的内容
+    ChatAnnouncementBlockBatchUpdate(String),
+    /// 获取群公告块的内容
+    ChatAnnouncementBlockGet(String, String),
+    /// 获取所有子块
+    ChatAnnouncementBlockChildrenGet(String, String),
+    /// 删除群公告中的块
+    ChatAnnouncementBlockChildrenBatchDelete(String, String),
+
+    // 文档相关API (12个)
+    /// 创建文档
+    DocumentCreate,
+    /// 获取文档基本信息
+    DocumentGet(String),
+    /// 获取文档纯文本内容
+    DocumentRawContent(String),
+    /// 获取文档所有块
+    DocumentBlockList(String),
+    /// 创建块
+    DocumentBlockChildrenCreate(String, String),
+    /// 创建嵌套块
+    DocumentBlockDescendantCreate(String, String),
+    /// 更新块的内容
+    DocumentBlockPatch(String, String),
+    /// 获取块的内容
+    DocumentBlockGet(String, String),
+    /// 批量更新块的内容
+    DocumentBlockBatchUpdate(String),
+    /// 获取所有子块
+    DocumentBlockChildrenGet(String, String),
+    /// 删除块
+    DocumentBlockChildrenBatchDelete(String, String),
+    /// Markdown/HTML 内容转换为文档块
+    DocumentConvert,
+}
+
+impl DocxApiV1 {
+    /// 生成对应的 URL
+    pub fn to_url(&self) -> String {
+        match self {
+            // 群公告相关API (7个)
+            DocxApiV1::ChatAnnouncementGet(chat_id) => {
+                format!("/open-apis/docx/v1/chats/{chat_id}/announcement")
+            }
+            DocxApiV1::ChatAnnouncementBlockList(chat_id) => {
+                format!("/open-apis/docx/v1/chats/{chat_id}/announcement/blocks")
+            }
+            DocxApiV1::ChatAnnouncementBlockChildrenCreate(chat_id, block_id) => {
+                format!(
+                    "/open-apis/docx/v1/chats/{chat_id}/announcement/blocks/{block_id}/children"
+                )
+            }
+            DocxApiV1::ChatAnnouncementBlockBatchUpdate(chat_id) => {
+                format!("/open-apis/docx/v1/chats/{chat_id}/announcement/blocks/batch_update")
+            }
+            DocxApiV1::ChatAnnouncementBlockGet(chat_id, block_id) => {
+                format!("/open-apis/docx/v1/chats/{chat_id}/announcement/blocks/{block_id}")
+            }
+            DocxApiV1::ChatAnnouncementBlockChildrenGet(chat_id, block_id) => {
+                format!(
+                    "/open-apis/docx/v1/chats/{chat_id}/announcement/blocks/{block_id}/children"
+                )
+            }
+            DocxApiV1::ChatAnnouncementBlockChildrenBatchDelete(chat_id, block_id) => {
+                format!(
+                    "/open-apis/docx/v1/chats/{chat_id}/announcement/blocks/{block_id}/children/batch_delete"
+                )
+            }
+
+            // 文档相关API (12个)
+            DocxApiV1::DocumentCreate => "/open-apis/docx/v1/documents".to_string(),
+            DocxApiV1::DocumentGet(document_id) => {
+                format!("/open-apis/docx/v1/documents/{document_id}")
+            }
+            DocxApiV1::DocumentRawContent(document_id) => {
+                format!("/open-apis/docx/v1/documents/{document_id}/raw_content")
+            }
+            DocxApiV1::DocumentBlockList(document_id) => {
+                format!("/open-apis/docx/v1/documents/{document_id}/blocks")
+            }
+            DocxApiV1::DocumentBlockChildrenCreate(document_id, block_id) => {
+                format!("/open-apis/docx/v1/documents/{document_id}/blocks/{block_id}/children")
+            }
+            DocxApiV1::DocumentBlockDescendantCreate(document_id, block_id) => {
+                format!("/open-apis/docx/v1/documents/{document_id}/blocks/{block_id}/descendant")
+            }
+            DocxApiV1::DocumentBlockPatch(document_id, block_id) => {
+                format!("/open-apis/docx/v1/documents/{document_id}/blocks/{block_id}")
+            }
+            DocxApiV1::DocumentBlockGet(document_id, block_id) => {
+                format!("/open-apis/docx/v1/documents/{document_id}/blocks/{block_id}")
+            }
+            DocxApiV1::DocumentBlockBatchUpdate(document_id) => {
+                format!("/open-apis/docx/v1/documents/{document_id}/blocks/batch_update")
+            }
+            DocxApiV1::DocumentBlockChildrenGet(document_id, block_id) => {
+                format!("/open-apis/docx/v1/documents/{document_id}/blocks/{block_id}/children")
+            }
+            DocxApiV1::DocumentBlockChildrenBatchDelete(document_id, block_id) => {
+                format!(
+                    "/open-apis/docx/v1/documents/{document_id}/blocks/{block_id}/children/batch_delete"
+                )
+            }
+            // 注意：该接口虽然归类在 docx-v1 文档下，但实际 HTTP URL 不包含 /v1
+            DocxApiV1::DocumentConvert => "/open-apis/docx/documents/blocks/convert".to_string(),
+        }
+    }
+
+    /// 返回配置了稳定请求语义的请求。
+    pub fn to_request<R>(&self) -> ApiRequest<R> {
+        <Self as CatalogEndpoint>::to_request(self)
+    }
+
+    /// 返回端点的 HTTP 方法。
+    pub fn method(&self) -> HttpMethod {
+        match self {
+            Self::ChatAnnouncementGet(_)
+            | Self::ChatAnnouncementBlockList(_)
+            | Self::ChatAnnouncementBlockGet(_, _)
+            | Self::ChatAnnouncementBlockChildrenGet(_, _)
+            | Self::DocumentGet(_)
+            | Self::DocumentRawContent(_)
+            | Self::DocumentBlockList(_)
+            | Self::DocumentBlockGet(_, _)
+            | Self::DocumentBlockChildrenGet(_, _) => HttpMethod::Get,
+            Self::ChatAnnouncementBlockChildrenCreate(_, _)
+            | Self::DocumentCreate
+            | Self::DocumentBlockChildrenCreate(_, _)
+            | Self::DocumentBlockDescendantCreate(_, _)
+            | Self::DocumentConvert => HttpMethod::Post,
+            Self::ChatAnnouncementBlockBatchUpdate(_)
+            | Self::DocumentBlockPatch(_, _)
+            | Self::DocumentBlockBatchUpdate(_) => HttpMethod::Patch,
+            Self::ChatAnnouncementBlockChildrenBatchDelete(_, _)
+            | Self::DocumentBlockChildrenBatchDelete(_, _) => HttpMethod::Delete,
+        }
+    }
+}
+
+impl CatalogEndpoint for DocxApiV1 {
+    fn to_url(&self) -> String {
+        DocxApiV1::to_url(self)
+    }
+
+    fn method(&self) -> HttpMethod {
+        DocxApiV1::method(self)
+    }
+
+    fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
+        Some(vec![AccessTokenType::User, AccessTokenType::Tenant])
+    }
+}


### PR DESCRIPTION
## Summary

- centralize Docs and Docx endpoint path, method, and token semantics
- migrate scoped request builders to endpoint-catalog request construction
- split Docs and Docx catalogs into focused modules while preserving existing re-exports
- strengthen PATCH, DELETE, and GET request-level assertions

## Verification

- cargo test -p openlark-docs --all-features --lib
- cargo clippy -p openlark-docs --all-targets --all-features -- -Dwarnings
- cargo clippy -p openlark-docs --all-targets --no-default-features -- -Dwarnings

Closes #441