### PR TITLE
refactor(docs): migrate Base and Bitable endpoint semantics

### DIFF
--- a/crates/openlark-docs/src/base/base/v2/app/role/create.rs
+++ b/crates/openlark-docs/src/base/base/v2/app/role/create.rs
@@ -147,15 +147,17 @@ mod tests {
     use super::*;
     use serde_json::json;
     use wiremock::MockServer;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, ResponseTemplate};
 
     /// 端到端：POST /open-apis/base/v2/apps/{app_token}/roles → CreateResp。
+    /// 同时断言 method、path、auth（catalog 提供）和响应（#438）。
     #[tokio::test]
     async fn test_create_role_returns_data_on_success() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/open-apis/base/v2/apps/app001/roles"))
+            .and(header("Authorization", "Bearer test-tenant-token"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0, "msg": "success", "data": {}
             })))
@@ -167,19 +169,30 @@ mod tests {
             .base_url(server.uri())
             .enable_token_cache(false)
             .build();
+        let option = openlark_core::req_option::RequestOption::builder()
+            .tenant_access_token("test-tenant-token")
+            .build();
         let resp = Create::new(config)
             .app_token("app001")
             .role_name("角色")
             .table_roles(vec![json!({})])
-            .execute()
+            .execute_with_options(option)
             .await
             .expect("创建角色应成功");
         assert!(resp.role.is_none());
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
+        assert_eq!(received[0].method, "POST");
         assert_eq!(
             received[0].url.path(),
             "/open-apis/base/v2/apps/app001/roles"
+        );
+        assert_eq!(
+            received[0]
+                .headers
+                .get("authorization")
+                .and_then(|h| h.to_str().ok()),
+            Some("Bearer test-tenant-token")
         );
     }
 
@@ -188,5 +201,13 @@ mod tests {
         let ep = BaseApiV2::RoleCreate("app".into());
         let req: openlark_core::api::ApiRequest<CreateResp> = ep.to_request();
         assert_eq!(req.method(), &openlark_core::api::HttpMethod::Post);
+        // 同时验证 catalog 提供的认证要求
+        assert_eq!(
+            req.supported_access_token_types(),
+            vec![
+                openlark_core::constants::AccessTokenType::User,
+                openlark_core::constants::AccessTokenType::Tenant
+            ]
+        );
     }
 }

--- a/crates/openlark-docs/src/base/base/v2/app/role/delete.rs
+++ b/crates/openlark-docs/src/base/base/v2/app/role/delete.rs
@@ -82,15 +82,17 @@ mod tests {
     use super::*;
     use serde_json::json;
     use wiremock::MockServer;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, ResponseTemplate};
 
     /// 端到端：DELETE .../roles/{role_id} → DeleteResp。
+    /// 同时断言 method、path、auth（catalog 提供）和响应（#438）。
     #[tokio::test]
     async fn test_delete_role_returns_data_on_success() {
         let server = MockServer::start().await;
         Mock::given(method("DELETE"))
             .and(path("/open-apis/base/v2/apps/app001/roles/role001"))
+            .and(header("Authorization", "Bearer test-tenant-token"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0, "msg": "success", "data": {}
             })))
@@ -102,17 +104,28 @@ mod tests {
             .base_url(server.uri())
             .enable_token_cache(false)
             .build();
+        let option = openlark_core::req_option::RequestOption::builder()
+            .tenant_access_token("test-tenant-token")
+            .build();
         Delete::new(config)
             .app_token("app001")
             .role_id("role001")
-            .execute()
+            .execute_with_options(option)
             .await
             .expect("删除角色应成功");
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
+        assert_eq!(received[0].method, "DELETE");
         assert_eq!(
             received[0].url.path(),
             "/open-apis/base/v2/apps/app001/roles/role001"
+        );
+        assert_eq!(
+            received[0]
+                .headers
+                .get("authorization")
+                .and_then(|h| h.to_str().ok()),
+            Some("Bearer test-tenant-token")
         );
     }
 
@@ -121,5 +134,12 @@ mod tests {
         let ep = BaseApiV2::RoleDelete("app".into(), "role001".into());
         let req: openlark_core::api::ApiRequest<DeleteResp> = ep.to_request();
         assert_eq!(req.method(), &openlark_core::api::HttpMethod::Delete);
+        assert_eq!(
+            req.supported_access_token_types(),
+            vec![
+                openlark_core::constants::AccessTokenType::User,
+                openlark_core::constants::AccessTokenType::Tenant
+            ]
+        );
     }
 }

--- a/crates/openlark-docs/src/base/base/v2/app/role/list.rs
+++ b/crates/openlark-docs/src/base/base/v2/app/role/list.rs
@@ -125,15 +125,17 @@ mod tests {
     use super::*;
     use serde_json::json;
     use wiremock::MockServer;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, ResponseTemplate};
 
     /// 端到端：GET .../roles → ListResp。
+    /// 同时断言 method、path、auth（catalog 提供）和响应（#438）。
     #[tokio::test]
     async fn test_list_roles_returns_data_on_success() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/open-apis/base/v2/apps/app001/roles"))
+            .and(header("Authorization", "Bearer test-tenant-token"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0, "msg": "success", "data": { "items": [], "has_more": false }
             })))
@@ -145,17 +147,28 @@ mod tests {
             .base_url(server.uri())
             .enable_token_cache(false)
             .build();
+        let option = openlark_core::req_option::RequestOption::builder()
+            .tenant_access_token("test-tenant-token")
+            .build();
         let resp = List::new(config)
             .app_token("app001")
-            .execute()
+            .execute_with_options(option)
             .await
             .expect("列出角色应成功");
         assert!(resp.items.is_empty());
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
+        assert_eq!(received[0].method, "GET");
         assert_eq!(
             received[0].url.path(),
             "/open-apis/base/v2/apps/app001/roles"
+        );
+        assert_eq!(
+            received[0]
+                .headers
+                .get("authorization")
+                .and_then(|h| h.to_str().ok()),
+            Some("Bearer test-tenant-token")
         );
     }
 
@@ -164,5 +177,12 @@ mod tests {
         let ep = BaseApiV2::RoleList("app".into());
         let req: openlark_core::api::ApiRequest<ListResp> = ep.to_request();
         assert_eq!(req.method(), &openlark_core::api::HttpMethod::Get);
+        assert_eq!(
+            req.supported_access_token_types(),
+            vec![
+                openlark_core::constants::AccessTokenType::User,
+                openlark_core::constants::AccessTokenType::Tenant
+            ]
+        );
     }
 }

--- a/crates/openlark-docs/src/base/base/v2/app/role/update.rs
+++ b/crates/openlark-docs/src/base/base/v2/app/role/update.rs
@@ -152,15 +152,17 @@ mod tests {
     use super::*;
     use serde_json::json;
     use wiremock::MockServer;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, ResponseTemplate};
 
     /// 端到端：PUT .../roles/{role_id} → UpdateResp。
+    /// 同时断言 method、path、auth（catalog 提供）和响应（#438）。
     #[tokio::test]
     async fn test_update_role_returns_data_on_success() {
         let server = MockServer::start().await;
         Mock::given(method("PUT"))
             .and(path("/open-apis/base/v2/apps/app001/roles/role001"))
+            .and(header("Authorization", "Bearer test-tenant-token"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0, "msg": "success", "data": {}
             })))
@@ -172,19 +174,30 @@ mod tests {
             .base_url(server.uri())
             .enable_token_cache(false)
             .build();
+        let option = openlark_core::req_option::RequestOption::builder()
+            .tenant_access_token("test-tenant-token")
+            .build();
         let resp = Update::new(config)
             .app_token("app001")
             .role_id("role001")
             .role_name("新角色名")
-            .execute()
+            .execute_with_options(option)
             .await
             .expect("更新角色应成功");
         assert!(resp.role.is_none());
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
+        assert_eq!(received[0].method, "PUT");
         assert_eq!(
             received[0].url.path(),
             "/open-apis/base/v2/apps/app001/roles/role001"
+        );
+        assert_eq!(
+            received[0]
+                .headers
+                .get("authorization")
+                .and_then(|h| h.to_str().ok()),
+            Some("Bearer test-tenant-token")
         );
     }
 
@@ -193,5 +206,12 @@ mod tests {
         let ep = BaseApiV2::RoleUpdate("app".into(), "role001".into());
         let req: openlark_core::api::ApiRequest<UpdateResp> = ep.to_request();
         assert_eq!(req.method(), &openlark_core::api::HttpMethod::Put);
+        assert_eq!(
+            req.supported_access_token_types(),
+            vec![
+                openlark_core::constants::AccessTokenType::User,
+                openlark_core::constants::AccessTokenType::Tenant
+            ]
+        );
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/block_workflow/list.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/block_workflow/list.rs
@@ -73,8 +73,8 @@ impl ListBlockWorkflowRequest {
         validate_required!(self.app_token.trim(), "app_token 不能为空");
 
         let api_endpoint = BitableApiV1::BlockWorkflowList(self.app_token);
-        let api_request: ApiRequest<ListBlockWorkflowResponse> =
-            ApiRequest::get(&api_endpoint.to_url());
+        // #439: method 来自 catalog
+        let api_request: ApiRequest<ListBlockWorkflowResponse> = api_endpoint.to_request();
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         response

--- a/crates/openlark-docs/src/base/bitable/v1/app/copy.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/copy.rs
@@ -111,11 +111,11 @@ impl CopyAppRequest {
             time_zone: self.time_zone.clone(),
         };
 
-        // 创建API请求 - 使用类型安全的URL生成
-        let api_request: ApiRequest<CopyAppResponse> = ApiRequest::post(&api_endpoint.to_url())
-            .body(openlark_core::api::RequestData::Binary(serde_json::to_vec(
-                &request_body,
-            )?));
+        // #439: method 来自 catalog
+        let api_request: ApiRequest<CopyAppResponse> =
+            api_endpoint.to_request::<CopyAppResponse>().body(
+                openlark_core::api::RequestData::Binary(serde_json::to_vec(&request_body)?),
+            );
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;

--- a/crates/openlark-docs/src/base/bitable/v1/app/create.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/create.rs
@@ -96,11 +96,11 @@ impl CreateAppRequest {
             app_settings: None,
         };
 
-        // 创建API请求 - 使用类型安全的URL生成
-        let api_request: ApiRequest<CreateAppResponse> = ApiRequest::post(&api_endpoint.to_url())
-            .body(openlark_core::api::RequestData::Binary(serde_json::to_vec(
-                &request_body,
-            )?));
+        // #439: method 来自 catalog；叶子不再重复声明稳定请求语义
+        let api_request: ApiRequest<CreateAppResponse> =
+            api_endpoint.to_request::<CreateAppResponse>().body(
+                openlark_core::api::RequestData::Binary(serde_json::to_vec(&request_body)?),
+            );
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
@@ -142,32 +142,50 @@ mod tests {
     use super::*;
     use serde_json::json;
     use wiremock::MockServer;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, ResponseTemplate};
 
     /// 端到端：POST /open-apis/bitable/v1/apps → CreateAppResponse。
+    /// 完整断言 method、path、auth（来自 catalog #439）和响应。
     #[tokio::test]
     async fn test_create_app_returns_data_on_success() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/open-apis/bitable/v1/apps"))
+            .and(header("Authorization", "Bearer test-tenant-token"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0, "msg": "success", "data": { "app": { "app_token": "app001", "name": "测试应用" } }
             })))
-            .mount(&server).await;
+            .mount(&server)
+            .await;
         let config = Config::builder()
             .app_id("ci_app_id")
             .app_secret("ci_app_secret")
             .base_url(server.uri())
             .enable_token_cache(false)
             .build();
-        CreateAppRequest::new(config)
+        let option = openlark_core::req_option::RequestOption::builder()
+            .tenant_access_token("test-tenant-token")
+            .build();
+        let resp = CreateAppRequest::new(config)
             .name("测试应用")
-            .execute()
+            .execute_with_options(option)
             .await
             .expect("创建多维表格应成功");
+        assert_eq!(resp.app.app_token, "app001");
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
+        assert_eq!(received[0].method, "POST");
         assert_eq!(received[0].url.path(), "/open-apis/bitable/v1/apps");
+        let body: serde_json::Value =
+            serde_json::from_slice(&received[0].body).expect("请求体应为 JSON");
+        assert_eq!(body["name"], "测试应用");
+        assert_eq!(
+            received[0]
+                .headers
+                .get("authorization")
+                .and_then(|h| h.to_str().ok()),
+            Some("Bearer test-tenant-token")
+        );
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/dashboard/copy.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/dashboard/copy.rs
@@ -66,10 +66,13 @@ impl CopyDashboardRequest {
         validate_required!(self.name, "name 不能为空");
 
         let api_endpoint = BitableApiV1::DashboardCopy(self.app_token, self.block_id);
+        // #439: method 来自 catalog
         let api_request: ApiRequest<CopyDashboardResponse> =
-            ApiRequest::post(&api_endpoint.to_url()).body(serde_json::to_vec(
-                &CopyDashboardRequestBody { name: self.name },
-            )?);
+            api_endpoint
+                .to_request()
+                .body(serde_json::to_vec(&CopyDashboardRequestBody {
+                    name: self.name,
+                })?);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         response

--- a/crates/openlark-docs/src/base/bitable/v1/app/dashboard/list.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/dashboard/list.rs
@@ -72,8 +72,8 @@ impl ListDashboardsRequest {
         }
 
         let api_endpoint = BitableApiV1::DashboardList(self.app_token);
-        let mut api_request: ApiRequest<ListDashboardsResponse> =
-            ApiRequest::get(&api_endpoint.to_url());
+        // #439: method 来自 catalog
+        let mut api_request: ApiRequest<ListDashboardsResponse> = api_endpoint.to_request();
 
         api_request = api_request.query_opt("page_size", self.page_size.map(|v| v.to_string()));
         api_request = api_request.query_opt("page_token", self.page_token);

--- a/crates/openlark-docs/src/base/bitable/v1/app/get.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/get.rs
@@ -72,8 +72,8 @@ impl GetAppRequest {
         use crate::common::api_endpoints::BitableApiV1;
         let api_endpoint = BitableApiV1::AppGet(self.app_token.clone());
 
-        // 创建API请求 - 使用类型安全的URL生成
-        let api_request: ApiRequest<GetAppResponse> = ApiRequest::get(&api_endpoint.to_url());
+        // #439: method 来自 catalog
+        let api_request: ApiRequest<GetAppResponse> = api_endpoint.to_request::<GetAppResponse>();
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
@@ -100,32 +100,52 @@ mod tests {
     use super::*;
     use serde_json::json;
     use wiremock::MockServer;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, ResponseTemplate};
 
-    /// 端到端：GET .../apps/{app_token} → GetAppResponse。
+    /// 端到端：GET /open-apis/bitable/v1/apps/{app_token} → GetAppResponse。
+    /// 完整断言 method、path、auth（来自 catalog #439）和响应。
     #[tokio::test]
     async fn test_get_app_returns_data_on_success() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .and(path("/open-apis/bitable/v1/apps/app001"))
+            .and(path("/open-apis/bitable/v1/apps/app%20token"))
+            .and(header("Authorization", "Bearer test-tenant-token"))
+            .and(header("X-Test-Option", "preserved"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "code": 0, "msg": "success", "data": { "app": { "app_token": "app001", "name": "测试" } }
+                "code": 0, "msg": "success", "data": { "app": { "app_token": "app token", "name": "测试" } }
             })))
-            .mount(&server).await;
+            .mount(&server)
+            .await;
         let config = Config::builder()
             .app_id("ci_app_id")
             .app_secret("ci_app_secret")
             .base_url(server.uri())
             .enable_token_cache(false)
             .build();
-        GetAppRequest::new(config)
-            .app_token("app001")
-            .execute()
+        let option = openlark_core::req_option::RequestOption::builder()
+            .tenant_access_token("test-tenant-token")
+            .add_header("X-Test-Option", "preserved")
+            .build();
+        let resp = GetAppRequest::new(config)
+            .app_token("app token")
+            .execute_with_options(option)
             .await
             .expect("获取多维表格应成功");
+        assert_eq!(resp.app.app_token, "app token");
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
-        assert_eq!(received[0].url.path(), "/open-apis/bitable/v1/apps/app001");
+        assert_eq!(received[0].method, "GET");
+        assert_eq!(
+            received[0].url.path(),
+            "/open-apis/bitable/v1/apps/app%20token"
+        );
+        assert_eq!(
+            received[0]
+                .headers
+                .get("authorization")
+                .and_then(|h| h.to_str().ok()),
+            Some("Bearer test-tenant-token")
+        );
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/role/create.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/role/create.rs
@@ -94,9 +94,10 @@ impl CreateAppRoleRequest {
 
         use crate::common::api_endpoints::BitableApiV1;
         let api_endpoint = BitableApiV1::RoleCreate(self.app_token.clone());
+        // #439: method 来自 catalog
 
         let api_request: ApiRequest<CreateAppRoleResponse> =
-            ApiRequest::post(&api_endpoint.to_url()).body(serialize_params(
+            api_endpoint.to_request().body(serialize_params(
                 &CreateAppRoleRequestBody {
                     role_name: self.role_name,
                     table_roles: self.table_roles,

--- a/crates/openlark-docs/src/base/bitable/v1/app/role/delete.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/role/delete.rs
@@ -58,9 +58,9 @@ impl DeleteAppRoleRequest {
 
         use crate::common::api_endpoints::BitableApiV1;
         let api_endpoint = BitableApiV1::RoleDelete(self.app_token, self.role_id);
+        // #439: method 来自 catalog
 
-        let api_request: ApiRequest<DeleteAppRoleResponse> =
-            ApiRequest::delete(&api_endpoint.to_url());
+        let api_request: ApiRequest<DeleteAppRoleResponse> = api_endpoint.to_request();
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         response

--- a/crates/openlark-docs/src/base/bitable/v1/app/role/list.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/role/list.rs
@@ -77,9 +77,9 @@ impl ListAppRoleRequest {
 
         use crate::common::api_endpoints::BitableApiV1;
         let api_endpoint = BitableApiV1::RoleList(self.app_token.clone());
+        // #439: method 来自 catalog
 
-        let mut api_request: ApiRequest<ListAppRoleResponse> =
-            ApiRequest::get(&api_endpoint.to_url());
+        let mut api_request: ApiRequest<ListAppRoleResponse> = api_endpoint.to_request();
         api_request = api_request.query_opt("page_token", self.page_token);
         api_request = api_request.query_opt("page_size", self.page_size.map(|v| v.to_string()));
 

--- a/crates/openlark-docs/src/base/bitable/v1/app/role/member/batch_create.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/role/member/batch_create.rs
@@ -90,12 +90,12 @@ impl BatchCreateRoleMemberRequest {
         let api_endpoint =
             BitableApiV1::RoleMemberBatchCreate(self.app_token.clone(), self.role_id.clone());
 
-        let api_request: ApiRequest<BatchCreateRoleMemberResponse> = ApiRequest::post(
-            &api_endpoint.to_url(),
-        )
-        .body(serde_json::to_vec(&BatchCreateRoleMemberRequestBody {
-            member_list: self.member_list,
-        })?);
+        // #439: method 来自 catalog
+        let api_request: ApiRequest<BatchCreateRoleMemberResponse> = api_endpoint
+            .to_request::<BatchCreateRoleMemberResponse>()
+            .body(serde_json::to_vec(&BatchCreateRoleMemberRequestBody {
+                member_list: self.member_list,
+            })?);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         response

--- a/crates/openlark-docs/src/base/bitable/v1/app/role/member/batch_delete.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/role/member/batch_delete.rs
@@ -90,12 +90,12 @@ impl BatchDeleteRoleMemberRequest {
         let api_endpoint =
             BitableApiV1::RoleMemberBatchDelete(self.app_token.clone(), self.role_id.clone());
 
-        let api_request: ApiRequest<BatchDeleteRoleMemberResponse> = ApiRequest::post(
-            &api_endpoint.to_url(),
-        )
-        .body(serde_json::to_vec(&BatchDeleteRoleMemberRequestBody {
-            member_list: self.member_list,
-        })?);
+        // #439: method 来自 catalog
+        let api_request: ApiRequest<BatchDeleteRoleMemberResponse> = api_endpoint
+            .to_request::<BatchDeleteRoleMemberResponse>()
+            .body(serde_json::to_vec(&BatchDeleteRoleMemberRequestBody {
+                member_list: self.member_list,
+            })?);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         response

--- a/crates/openlark-docs/src/base/bitable/v1/app/role/member/create.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/role/member/create.rs
@@ -81,12 +81,12 @@ impl CreateRoleMemberRequest {
         let api_endpoint =
             BitableApiV1::RoleMemberCreate(self.app_token.clone(), self.role_id.clone());
 
-        let mut api_request: ApiRequest<CreateRoleMemberResponse> = ApiRequest::post(
-            &api_endpoint.to_url(),
-        )
-        .body(serde_json::to_vec(&CreateRoleMemberRequestBody {
-            member_id: self.member_id,
-        })?);
+        // #439: method 来自 catalog
+        let mut api_request: ApiRequest<CreateRoleMemberResponse> = api_endpoint
+            .to_request::<CreateRoleMemberResponse>()
+            .body(serde_json::to_vec(&CreateRoleMemberRequestBody {
+                member_id: self.member_id,
+            })?);
 
         // query 参数需要字符串值（open_id / user_id / ...），这里用枚举做一次映射。
         if let Some(member_id_type) = self.member_id_type {

--- a/crates/openlark-docs/src/base/bitable/v1/app/role/member/delete.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/role/member/delete.rs
@@ -83,8 +83,7 @@ impl DeleteRoleMemberRequest {
             self.member_id.clone(),
         );
 
-        let mut api_request: ApiRequest<DeleteRoleMemberResponse> =
-            ApiRequest::delete(&api_endpoint.to_url());
+        let mut api_request: ApiRequest<DeleteRoleMemberResponse> = api_endpoint.to_request();
 
         if let Some(member_id_type) = self.member_id_type {
             let member_id_type = match member_id_type {

--- a/crates/openlark-docs/src/base/bitable/v1/app/role/member/list.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/role/member/list.rs
@@ -88,8 +88,7 @@ impl ListRoleMembersRequest {
         let api_endpoint =
             BitableApiV1::RoleMemberList(self.app_token.clone(), self.role_id.clone());
 
-        let mut api_request: ApiRequest<ListRoleMembersResponse> =
-            ApiRequest::get(&api_endpoint.to_url());
+        let mut api_request: ApiRequest<ListRoleMembersResponse> = api_endpoint.to_request();
 
         if let Some(page_size) = self.page_size {
             api_request = api_request.query("page_size", &page_size.to_string());

--- a/crates/openlark-docs/src/base/bitable/v1/app/role/update.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/role/update.rs
@@ -100,14 +100,14 @@ impl UpdateAppRoleRequest {
         use crate::common::api_endpoints::BitableApiV1;
         let api_endpoint = BitableApiV1::RoleUpdate(self.app_token.clone(), self.role_id);
 
-        let api_request: ApiRequest<UpdateAppRoleResponse> = ApiRequest::put(
-            &api_endpoint.to_url(),
-        )
-        .body(serde_json::to_vec(&UpdateAppRoleRequestBody {
-            role_name: self.role_name,
-            table_roles: self.table_roles,
-            block_roles: self.block_roles,
-        })?);
+        // #439: method 来自 catalog
+        let api_request: ApiRequest<UpdateAppRoleResponse> = api_endpoint
+            .to_request::<UpdateAppRoleResponse>()
+            .body(serde_json::to_vec(&UpdateAppRoleRequestBody {
+                role_name: self.role_name,
+                table_roles: self.table_roles,
+                block_roles: self.block_roles,
+            })?);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         response

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/batch_create.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/batch_create.rs
@@ -87,12 +87,12 @@ impl BatchCreateTableRequest {
         }
 
         let api_endpoint = BitableApiV1::TableBatchCreate(self.app_token);
-        let mut api_request: ApiRequest<BatchCreateTableResponse> = ApiRequest::post(
-            &api_endpoint.to_url(),
-        )
-        .body(serde_json::to_vec(&BatchCreateTableRequestBody {
-            tables: self.tables,
-        })?);
+        // #439: method 来自 catalog
+        let mut api_request: ApiRequest<BatchCreateTableResponse> = api_endpoint
+            .to_request::<BatchCreateTableResponse>()
+            .body(serde_json::to_vec(&BatchCreateTableRequestBody {
+                tables: self.tables,
+            })?);
 
         api_request = api_request.query_opt("user_id_type", self.user_id_type);
         api_request = api_request.query_opt("client_token", self.client_token);

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/batch_delete.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/batch_delete.rs
@@ -85,12 +85,12 @@ impl BatchDeleteTableRequest {
         }
 
         let api_endpoint = BitableApiV1::TableBatchDelete(self.app_token);
-        let mut api_request: ApiRequest<BatchDeleteTableResponse> = ApiRequest::post(
-            &api_endpoint.to_url(),
-        )
-        .body(serde_json::to_vec(&BatchDeleteTableRequestBody {
-            table_ids: self.table_ids,
-        })?);
+        // #439: method 来自 catalog
+        let mut api_request: ApiRequest<BatchDeleteTableResponse> = api_endpoint
+            .to_request::<BatchDeleteTableResponse>()
+            .body(serde_json::to_vec(&BatchDeleteTableRequestBody {
+                table_ids: self.table_ids,
+            })?);
 
         api_request = api_request.query_opt("user_id_type", self.user_id_type);
         api_request = api_request.query_opt("client_token", self.client_token);
@@ -123,10 +123,11 @@ mod tests {
     use super::*;
     use serde_json::json;
     use wiremock::MockServer;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, ResponseTemplate};
 
     /// 端到端：POST .../tables/batch_delete → BatchDeleteTableResponse。
+    /// 完整断言 method、path、auth（来自 catalog #439）和响应。
     #[tokio::test]
     async fn test_batch_delete_table_returns_data_on_success() {
         let server = MockServer::start().await;
@@ -134,6 +135,7 @@ mod tests {
             .and(path(
                 "/open-apis/bitable/v1/apps/app001/tables/batch_delete",
             ))
+            .and(header("Authorization", "Bearer test-tenant-token"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0, "msg": "success", "data": {}
             })))
@@ -145,17 +147,47 @@ mod tests {
             .base_url(server.uri())
             .enable_token_cache(false)
             .build();
-        BatchDeleteTableRequest::new(config)
+        let option = openlark_core::req_option::RequestOption::builder()
+            .tenant_access_token("test-tenant-token")
+            .build();
+        let resp = BatchDeleteTableRequest::new(config)
             .app_token("app001")
+            .user_id_type("open_id")
+            .client_token("client_001")
             .table_ids(vec!["tbl001".into()])
-            .execute()
+            .execute_with_options(option)
             .await
             .expect("批量删除数据表应成功");
+        let _response = resp;
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
+        assert_eq!(received[0].method, "POST");
         assert_eq!(
             received[0].url.path(),
             "/open-apis/bitable/v1/apps/app001/tables/batch_delete"
+        );
+        let body: serde_json::Value =
+            serde_json::from_slice(&received[0].body).expect("请求体应为 JSON");
+        assert_eq!(body["table_ids"], json!(["tbl001"]));
+        let query: std::collections::HashMap<_, _> = received[0]
+            .url
+            .query_pairs()
+            .map(|(key, value)| (key.into_owned(), value.into_owned()))
+            .collect();
+        assert_eq!(
+            query.get("user_id_type").map(String::as_str),
+            Some("open_id")
+        );
+        assert_eq!(
+            query.get("client_token").map(String::as_str),
+            Some("client_001")
+        );
+        assert_eq!(
+            received[0]
+                .headers
+                .get("authorization")
+                .and_then(|h| h.to_str().ok()),
+            Some("Bearer test-tenant-token")
         );
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/create.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/create.rs
@@ -158,8 +158,9 @@ impl CreateTableRequest {
         let request_body = CreateTableRequestBody { table: self.table };
 
         // 创建API请求 - 使用类型安全的URL生成
-        let api_request: ApiRequest<CreateTableResponse> =
-            ApiRequest::post(&api_endpoint.to_url()).body(serde_json::to_vec(&request_body)?);
+        let api_request: ApiRequest<CreateTableResponse> = api_endpoint
+            .to_request()
+            .body(serde_json::to_vec(&request_body)?);
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/delete.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/delete.rs
@@ -72,10 +72,8 @@ impl DeleteTableRequest {
         // 替代传统的字符串拼接方式，提供类型安全和IDE自动补全
         use crate::common::api_endpoints::BitableApiV1;
         let api_endpoint = BitableApiV1::TableDelete(self.app_token.clone(), self.table_id.clone());
-
-        // 创建API请求 - 使用类型安全的URL生成
-        let api_request: ApiRequest<DeleteTableResponse> =
-            ApiRequest::delete(&api_endpoint.to_url());
+        // #439: method 来自 catalog
+        let api_request: ApiRequest<DeleteTableResponse> = api_endpoint.to_request();
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/field/create.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/field/create.rs
@@ -210,7 +210,7 @@ impl CreateFieldRequest {
 
         // 创建API请求 - 使用类型安全的URL生成
         let mut api_request: ApiRequest<CreateFieldResponse> =
-            ApiRequest::post(&api_endpoint.to_url()).body(serde_json::to_vec(&body)?);
+            api_endpoint.to_request().body(serde_json::to_vec(&body)?);
 
         // 构建查询参数
         api_request = api_request.query_opt("client_token", self.client_token);

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/field/delete.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/field/delete.rs
@@ -81,8 +81,7 @@ impl DeleteFieldRequest {
         );
 
         // 创建API请求 - 使用类型安全的URL生成
-        let api_request: ApiRequest<DeleteFieldResponse> =
-            ApiRequest::delete(&api_endpoint.to_url());
+        let api_request: ApiRequest<DeleteFieldResponse> = api_endpoint.to_request();
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/field/list.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/field/list.rs
@@ -113,10 +113,8 @@ impl ListFieldRequest {
         // 替代传统的字符串拼接方式，提供类型安全和IDE自动补全
         use crate::common::api_endpoints::BitableApiV1;
         let api_endpoint = BitableApiV1::FieldList(self.app_token.clone(), self.table_id.clone());
-
-        // 创建API请求 - 使用类型安全的URL生成
-        let mut api_request: ApiRequest<ListFieldResponse> =
-            ApiRequest::get(&api_endpoint.to_url());
+        // #439: method 来自 catalog
+        let mut api_request: ApiRequest<ListFieldResponse> = api_endpoint.to_request();
 
         // 构建查询参数
         if let Some(ref view_id) = self.view_id {

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/field/update.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/field/update.rs
@@ -170,7 +170,7 @@ impl UpdateFieldRequest {
 
         // 创建API请求 - 使用类型安全的URL生成
         let api_request: ApiRequest<UpdateFieldResponse> =
-            ApiRequest::put(&api_endpoint.to_url()).body(serde_json::to_vec(&body)?);
+            api_endpoint.to_request().body(serde_json::to_vec(&body)?);
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/field_group/create.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/field_group/create.rs
@@ -121,7 +121,7 @@ impl CreateFieldGroupRequest {
             field_groups: self.field_groups,
         };
         let api_request: ApiRequest<CreateFieldGroupResponse> =
-            ApiRequest::post(&api_endpoint.to_url()).body(serde_json::to_vec(&body)?);
+            api_endpoint.to_request().body(serde_json::to_vec(&body)?);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         response

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/form/field/list.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/form/field/list.rs
@@ -116,8 +116,7 @@ impl ListFormFieldQuestionRequest {
             self.form_id.clone(),
         );
 
-        let mut api_request: ApiRequest<ListFormFieldQuestionResponse> =
-            ApiRequest::get(&api_endpoint.to_url());
+        let mut api_request: ApiRequest<ListFormFieldQuestionResponse> = api_endpoint.to_request();
 
         if let Some(page_size) = self.page_size {
             api_request = api_request.query("page_size", &page_size.to_string());

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/form/field/patch.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/form/field/patch.rs
@@ -118,8 +118,9 @@ impl PatchFormFieldQuestionRequest {
             self.field_id,
         );
 
-        let api_request: ApiRequest<PatchFormFieldQuestionResponse> =
-            ApiRequest::patch(&api_endpoint.to_url()).body(serde_json::to_vec(&self.body)?);
+        let api_request: ApiRequest<PatchFormFieldQuestionResponse> = api_endpoint
+            .to_request()
+            .body(serde_json::to_vec(&self.body)?);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         response

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/form/get.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/form/get.rs
@@ -68,8 +68,9 @@ impl GetFormRequest {
 
         use crate::common::api_endpoints::BitableApiV1;
         let api_endpoint = BitableApiV1::FormGet(self.app_token, self.table_id, self.form_id);
+        // #439: method 来自 catalog
 
-        let api_request: ApiRequest<GetFormResponse> = ApiRequest::get(&api_endpoint.to_url());
+        let api_request: ApiRequest<GetFormResponse> = api_endpoint.to_request();
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         response
             .data

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/form/patch.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/form/patch.rs
@@ -122,14 +122,16 @@ impl PatchFormRequest {
         use crate::common::api_endpoints::BitableApiV1;
         let api_endpoint = BitableApiV1::FormPatch(self.app_token, self.table_id, self.form_id);
 
-        let api_request: ApiRequest<PatchFormResponse> = ApiRequest::patch(&api_endpoint.to_url())
-            .body(serde_json::to_vec(&PatchFormRequestBody {
-                name: self.name,
-                description: self.description,
-                shared: self.shared,
-                shared_limit: self.shared_limit,
-                submit_limit_once: self.submit_limit_once,
-            })?);
+        let api_request: ApiRequest<PatchFormResponse> =
+            api_endpoint
+                .to_request()
+                .body(serde_json::to_vec(&PatchFormRequestBody {
+                    name: self.name,
+                    description: self.description,
+                    shared: self.shared,
+                    shared_limit: self.shared_limit,
+                    submit_limit_once: self.submit_limit_once,
+                })?);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         response

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/form/upgrade.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/form/upgrade.rs
@@ -132,7 +132,7 @@ impl UpgradeFormRequest {
             display_mode,
         };
         let api_request: ApiRequest<UpgradeFormResponse> =
-            ApiRequest::post(&api_endpoint.to_url()).body(serde_json::to_vec(&body)?);
+            api_endpoint.to_request().body(serde_json::to_vec(&body)?);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         response

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/list.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/list.rs
@@ -81,10 +81,8 @@ impl ListTablesRequest {
         // 替代传统的字符串拼接方式，提供类型安全和IDE自动补全
         use crate::common::api_endpoints::BitableApiV1;
         let api_endpoint = BitableApiV1::TableList(self.app_token.clone());
-
-        // 创建API请求 - 使用类型安全的URL生成
-        let mut api_request: ApiRequest<ListTablesResponse> =
-            ApiRequest::get(&api_endpoint.to_url());
+        // #439: method 来自 catalog
+        let mut api_request: ApiRequest<ListTablesResponse> = api_endpoint.to_request();
 
         // 构建查询参数
         if let Some(page_size) = self.page_size {

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/patch.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/patch.rs
@@ -137,8 +137,9 @@ impl PatchTableRequest {
         let request_body = PatchTableRequestBody { name };
 
         // 创建API请求 - 使用类型安全的URL生成
-        let api_request: ApiRequest<PatchTableResponse> =
-            ApiRequest::patch(&api_endpoint.to_url()).body(serde_json::to_vec(&request_body)?);
+        let api_request: ApiRequest<PatchTableResponse> = api_endpoint
+            .to_request()
+            .body(serde_json::to_vec(&request_body)?);
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/view/create.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/view/create.rs
@@ -133,10 +133,10 @@ impl CreateViewRequest {
         // 替代传统的字符串拼接方式，提供类型安全和IDE自动补全
         use crate::common::api_endpoints::BitableApiV1;
         let api_endpoint = BitableApiV1::ViewCreate(self.app_token.clone(), self.table_id.clone());
-
-        // 创建API请求 - 使用类型安全的URL生成
-        let api_request: ApiRequest<CreateViewResponse> =
-            ApiRequest::post(&api_endpoint.to_url()).body(serde_json::to_vec(&self.view)?);
+        // #439: method 来自 catalog
+        let api_request: ApiRequest<CreateViewResponse> = api_endpoint
+            .to_request()
+            .body(serde_json::to_vec(&self.view)?);
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/view/delete.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/view/delete.rs
@@ -102,8 +102,7 @@ impl DeleteViewRequest {
         );
 
         // 创建API请求 - 使用类型安全的URL生成
-        let api_request: ApiRequest<DeleteViewResponse> =
-            ApiRequest::delete(&api_endpoint.to_url());
+        let api_request: ApiRequest<DeleteViewResponse> = api_endpoint.to_request();
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/view/get.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/view/get.rs
@@ -102,7 +102,7 @@ impl GetViewRequest {
         );
 
         // 创建API请求 - 使用类型安全的URL生成
-        let api_request: ApiRequest<GetViewResponse> = ApiRequest::get(&api_endpoint.to_url());
+        let api_request: ApiRequest<GetViewResponse> = api_endpoint.to_request();
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/view/list.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/view/list.rs
@@ -125,10 +125,8 @@ impl ListViewsRequest {
         // 替代传统的字符串拼接方式，提供类型安全和IDE自动补全
         use crate::common::api_endpoints::BitableApiV1;
         let api_endpoint = BitableApiV1::ViewList(self.app_token.clone(), self.table_id.clone());
-
-        // 创建API请求 - 使用类型安全的URL生成
-        let mut api_request: ApiRequest<ListViewsResponse> =
-            ApiRequest::get(&api_endpoint.to_url());
+        // #439: method 来自 catalog
+        let mut api_request: ApiRequest<ListViewsResponse> = api_endpoint.to_request();
 
         // 构建查询参数
         if let Some(ref user_id_type) = self.user_id_type {

--- a/crates/openlark-docs/src/base/bitable/v1/app/table/view/patch.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/table/view/patch.rs
@@ -166,8 +166,10 @@ impl PatchViewRequest {
         }
 
         let api_endpoint = BitableApiV1::ViewPatch(self.app_token, self.table_id, self.view_id);
-        let api_request: ApiRequest<PatchViewResponse> =
-            ApiRequest::patch(&api_endpoint.to_url()).body(serde_json::to_vec(&self.payload)?);
+        // #439: method 来自 catalog
+        let api_request: ApiRequest<PatchViewResponse> = api_endpoint
+            .to_request()
+            .body(serde_json::to_vec(&self.payload)?);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         response

--- a/crates/openlark-docs/src/base/bitable/v1/app/update.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/update.rs
@@ -104,11 +104,11 @@ impl UpdateAppRequest {
             app_settings: self.app_settings.clone(),
         };
 
-        // 创建API请求 - 使用类型安全的URL生成
-        let api_request: ApiRequest<UpdateAppResponse> = ApiRequest::put(&api_endpoint.to_url())
-            .body(openlark_core::api::RequestData::Binary(serde_json::to_vec(
-                &request_body,
-            )?));
+        // #439: method 来自 catalog
+        let api_request: ApiRequest<UpdateAppResponse> =
+            api_endpoint.to_request::<UpdateAppResponse>().body(
+                openlark_core::api::RequestData::Binary(serde_json::to_vec(&request_body)?),
+            );
 
         // 发送请求
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
@@ -155,7 +155,7 @@ mod tests {
     use super::*;
     use serde_json::json;
     use wiremock::MockServer;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, ResponseTemplate};
 
     /// 端到端：PUT .../apps/{app_token} → UpdateAppResponse。
@@ -164,24 +164,41 @@ mod tests {
         let server = MockServer::start().await;
         Mock::given(method("PUT"))
             .and(path("/open-apis/bitable/v1/apps/app001"))
+            .and(header("Authorization", "Bearer test-tenant-token"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0, "msg": "success", "data": { "app": { "app_token": "app001", "name": "新名称" } }
             })))
-            .mount(&server).await;
+            .mount(&server)
+            .await;
         let config = Config::builder()
             .app_id("ci_app_id")
             .app_secret("ci_app_secret")
             .base_url(server.uri())
             .enable_token_cache(false)
             .build();
-        UpdateAppRequest::new(config)
+        let option = openlark_core::req_option::RequestOption::builder()
+            .tenant_access_token("test-tenant-token")
+            .build();
+        let response = UpdateAppRequest::new(config)
             .app_token("app001")
             .name("新名称")
-            .execute()
+            .execute_with_options(option)
             .await
             .expect("更新多维表格应成功");
+        assert_eq!(response.app.name, "新名称");
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
+        assert_eq!(received[0].method, "PUT");
         assert_eq!(received[0].url.path(), "/open-apis/bitable/v1/apps/app001");
+        let body: serde_json::Value =
+            serde_json::from_slice(&received[0].body).expect("请求体应为 JSON");
+        assert_eq!(body["name"], "新名称");
+        assert_eq!(
+            received[0]
+                .headers
+                .get("authorization")
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer test-tenant-token")
+        );
     }
 }

--- a/crates/openlark-docs/src/base/bitable/v1/app/workflow/list.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/workflow/list.rs
@@ -92,8 +92,8 @@ impl ListWorkflowRequest {
         validate_required!(self.app_token, "app_token 不能为空");
 
         let api_endpoint = BitableApiV1::WorkflowList(self.app_token);
-        let mut api_request: ApiRequest<ListWorkflowResponse> =
-            ApiRequest::get(&api_endpoint.to_url());
+        // #439: method 来自 catalog
+        let mut api_request: ApiRequest<ListWorkflowResponse> = api_endpoint.to_request();
         api_request = api_request.query_opt("page_token", self.page_token);
         api_request = api_request.query_opt("page_size", self.page_size.map(|v| v.to_string()));
 

--- a/crates/openlark-docs/src/base/bitable/v1/app/workflow/update.rs
+++ b/crates/openlark-docs/src/base/bitable/v1/app/workflow/update.rs
@@ -101,8 +101,7 @@ impl UpdateWorkflowRequest {
             openlark_core::error::serialization_error("序列化更新自动化流程请求体失败", Some(e))
         })?;
 
-        let api_request: ApiRequest<UpdateWorkflowResponse> =
-            ApiRequest::put(&api_endpoint.to_url()).body(body);
+        let api_request: ApiRequest<UpdateWorkflowResponse> = api_endpoint.to_request().body(body);
 
         let response = Transport::request(api_request, &self.config, Some(option)).await?;
         response

--- a/crates/openlark-docs/src/common/api_endpoints.rs
+++ b/crates/openlark-docs/src/common/api_endpoints.rs
@@ -67,416 +67,8 @@ pub trait CatalogEndpoint {
 pub mod base;
 pub use base::BaseApiV2;
 
-/// Bitable API V1 端点枚举（#424 深化了请求语义：method + path + auth 在此集中）。
-///
-/// 注意：此文件已 > 2700 行。Bitable 相关定义未来应迁移到独立子模块以避免进一步膨胀。
-#[derive(Debug, Clone, PartialEq)]
-pub enum BitableApiV1 {
-    /// App管理相关
-    AppCreate,
-    /// 复制多维表格应用（参数：app_token）
-    AppCopy(String),
-    /// 获取多维表格应用信息（参数：app_token）
-    AppGet(String),
-    /// 更新多维表格应用信息（参数：app_token）
-    AppUpdate(String),
-    /// 列出多维表格仪表盘（参数：app_token）
-    DashboardList(String),
-    /// 复制仪表盘（参数：app_token, block_id）
-    DashboardCopy(String, String),
-    /// 自动化流程
-    BlockWorkflowList(String),
-    /// 列出自动化工作流（参数：app_token）
-    WorkflowList(String),
-    /// 更新自动化工作流（参数：app_token, workflow_id）
-    WorkflowUpdate(String, String),
-
-    /// 表格管理相关
-    TableCreate(String),
-    /// 批量创建数据表（参数：app_token）
-    TableBatchCreate(String),
-    /// 更新数据表（参数：app_token, table_id）
-    TableUpdate(String, String),
-    /// 删除数据表（参数：app_token, table_id）
-    TableDelete(String, String),
-    /// 批量删除数据表（参数：app_token）
-    TableBatchDelete(String),
-    /// 获取数据表信息（参数：app_token, table_id）
-    TableGet(String, String),
-    /// 列出数据表（参数：app_token）
-    TableList(String),
-    /// 增量更新数据表（参数：app_token, table_id）
-    TablePatch(String, String),
-
-    /// 字段管理相关
-    FieldCreate(String, String),
-    /// 创建字段分组（参数：app_token, table_id）
-    FieldGroupCreate(String, String),
-    /// 更新字段（参数：app_token, table_id, field_id）
-    FieldUpdate(String, String, String),
-    /// 删除字段（参数：app_token, table_id, field_id）
-    FieldDelete(String, String, String),
-    /// 列出字段（参数：app_token, table_id）
-    FieldList(String, String),
-
-    /// 视图管理相关
-    ViewCreate(String, String),
-    /// 更新视图（参数：app_token, table_id, view_id）
-    ViewUpdate(String, String, String),
-    /// 删除视图（参数：app_token, table_id, view_id）
-    ViewDelete(String, String, String),
-    /// 获取视图（参数：app_token, table_id, view_id）
-    ViewGet(String, String, String),
-    /// 列出视图（参数：app_token, table_id）
-    ViewList(String, String),
-    /// 增量更新视图（参数：app_token, table_id, view_id）
-    ViewPatch(String, String, String),
-
-    /// 记录管理相关
-    RecordCreate(String, String),
-    /// 批量创建记录（参数：app_token, table_id）
-    RecordBatchCreate(String, String),
-    /// 获取记录（参数：app_token, table_id, record_id）
-    RecordGet(String, String, String),
-    /// 批量获取记录（参数：app_token, table_id）
-    RecordBatchGet(String, String),
-    /// 更新记录（参数：app_token, table_id, record_id）
-    RecordUpdate(String, String, String),
-    /// 批量更新记录（参数：app_token, table_id）
-    RecordBatchUpdate(String, String),
-    /// 删除记录（参数：app_token, table_id, record_id）
-    RecordDelete(String, String, String),
-    /// 批量删除记录（参数：app_token, table_id）
-    RecordBatchDelete(String, String),
-    /// 列出记录（参数：app_token, table_id）
-    RecordList(String, String),
-    /// 查询记录（参数：app_token, table_id）
-    RecordSearch(String, String),
-
-    /// 表单管理相关
-    FormGet(String, String, String),
-    /// 更新表单（参数：app_token, table_id, form_id）
-    FormPatch(String, String, String),
-    /// 升级表单（参数：app_token, table_id, form_id）
-    FormUpgrade(String, String, String),
-    /// 列出表单字段（参数：app_token, table_id, form_id）
-    FormFieldList(String, String, String),
-    /// 更新表单字段（参数：app_token, table_id, form_id, field_id）
-    FormFieldPatch(String, String, String, String),
-
-    /// 权限管理相关
-    RoleCreate(String),
-    /// 更新自定义角色（参数：app_token, role_id）
-    RoleUpdate(String, String),
-    /// 删除自定义角色（参数：app_token, role_id）
-    RoleDelete(String, String),
-    /// 列出自定义角色（参数：app_token）
-    RoleList(String),
-    /// 新增角色成员（参数：app_token, role_id）
-    RoleMemberCreate(String, String),
-    /// 批量新增角色成员（参数：app_token, role_id）
-    RoleMemberBatchCreate(String, String),
-    /// 删除角色成员（参数：app_token, role_id, member_id）
-    RoleMemberDelete(String, String, String),
-    /// 批量删除角色成员（参数：app_token, role_id）
-    RoleMemberBatchDelete(String, String),
-    /// 列出角色成员（参数：app_token, role_id）
-    RoleMemberList(String, String),
-}
-
-impl BitableApiV1 {
-    /// 生成对应的 URL
-    pub fn to_url(&self) -> String {
-        match self {
-            // App管理
-            BitableApiV1::AppCreate => "/open-apis/bitable/v1/apps".to_string(),
-            BitableApiV1::AppCopy(app_token) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/copy")
-            }
-            BitableApiV1::AppGet(app_token) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}")
-            }
-            BitableApiV1::AppUpdate(app_token) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}")
-            }
-            BitableApiV1::DashboardList(app_token) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/dashboards")
-            }
-            BitableApiV1::DashboardCopy(app_token, block_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/dashboards/{block_id}/copy")
-            }
-            BitableApiV1::BlockWorkflowList(app_token) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/block_workflows")
-            }
-            BitableApiV1::WorkflowList(app_token) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/workflows")
-            }
-            BitableApiV1::WorkflowUpdate(app_token, workflow_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/workflows/{workflow_id}")
-            }
-
-            // 表格管理
-            BitableApiV1::TableCreate(app_token) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables")
-            }
-            BitableApiV1::TableBatchCreate(app_token) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables/batch_create")
-            }
-            BitableApiV1::TableUpdate(app_token, table_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}")
-            }
-            BitableApiV1::TableDelete(app_token, table_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}")
-            }
-            BitableApiV1::TableBatchDelete(app_token) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables/batch_delete")
-            }
-            BitableApiV1::TableGet(app_token, table_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}")
-            }
-            BitableApiV1::TableList(app_token) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables")
-            }
-            BitableApiV1::TablePatch(app_token, table_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}")
-            }
-
-            // 字段管理
-            BitableApiV1::FieldCreate(app_token, table_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/fields")
-            }
-            BitableApiV1::FieldGroupCreate(app_token, table_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/field_groups")
-            }
-            BitableApiV1::FieldUpdate(app_token, table_id, field_id) => {
-                format!(
-                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/fields/{field_id}"
-                )
-            }
-            BitableApiV1::FieldDelete(app_token, table_id, field_id) => {
-                format!(
-                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/fields/{field_id}"
-                )
-            }
-            BitableApiV1::FieldList(app_token, table_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/fields")
-            }
-
-            // 视图管理
-            BitableApiV1::ViewCreate(app_token, table_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/views")
-            }
-            BitableApiV1::ViewUpdate(app_token, table_id, view_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/views/{view_id}")
-            }
-            BitableApiV1::ViewDelete(app_token, table_id, view_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/views/{view_id}")
-            }
-            BitableApiV1::ViewGet(app_token, table_id, view_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/views/{view_id}")
-            }
-            BitableApiV1::ViewList(app_token, table_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/views")
-            }
-            BitableApiV1::ViewPatch(app_token, table_id, view_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/views/{view_id}")
-            }
-
-            // 记录管理
-            BitableApiV1::RecordCreate(app_token, table_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records")
-            }
-            BitableApiV1::RecordBatchCreate(app_token, table_id) => {
-                format!(
-                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/batch_create"
-                )
-            }
-            BitableApiV1::RecordGet(app_token, table_id, record_id) => {
-                format!(
-                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/{record_id}"
-                )
-            }
-            BitableApiV1::RecordBatchGet(app_token, table_id) => {
-                format!(
-                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/batch_get"
-                )
-            }
-            BitableApiV1::RecordUpdate(app_token, table_id, record_id) => {
-                format!(
-                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/{record_id}"
-                )
-            }
-            BitableApiV1::RecordBatchUpdate(app_token, table_id) => {
-                format!(
-                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/batch_update"
-                )
-            }
-            BitableApiV1::RecordDelete(app_token, table_id, record_id) => {
-                format!(
-                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/{record_id}"
-                )
-            }
-            BitableApiV1::RecordBatchDelete(app_token, table_id) => {
-                format!(
-                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/batch_delete"
-                )
-            }
-            BitableApiV1::RecordList(app_token, table_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records")
-            }
-            BitableApiV1::RecordSearch(app_token, table_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/search")
-            }
-
-            // 表单管理
-            BitableApiV1::FormGet(app_token, table_id, form_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/forms/{form_id}")
-            }
-            BitableApiV1::FormPatch(app_token, table_id, form_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/forms/{form_id}")
-            }
-            BitableApiV1::FormUpgrade(app_token, table_id, form_id) => {
-                format!(
-                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/forms/{form_id}/upgrade"
-                )
-            }
-            BitableApiV1::FormFieldList(app_token, table_id, form_id) => {
-                format!(
-                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/forms/{form_id}/fields"
-                )
-            }
-            BitableApiV1::FormFieldPatch(app_token, table_id, form_id, field_id) => {
-                format!(
-                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/forms/{form_id}/fields/{field_id}"
-                )
-            }
-
-            // 权限管理
-            BitableApiV1::RoleCreate(app_token) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/roles")
-            }
-            BitableApiV1::RoleUpdate(app_token, role_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/roles/{role_id}")
-            }
-            BitableApiV1::RoleDelete(app_token, role_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/roles/{role_id}")
-            }
-            BitableApiV1::RoleList(app_token) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/roles")
-            }
-            BitableApiV1::RoleMemberCreate(app_token, role_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/roles/{role_id}/members")
-            }
-            BitableApiV1::RoleMemberBatchCreate(app_token, role_id) => {
-                format!(
-                    "/open-apis/bitable/v1/apps/{app_token}/roles/{role_id}/members/batch_create"
-                )
-            }
-            BitableApiV1::RoleMemberDelete(app_token, role_id, member_id) => {
-                format!(
-                    "/open-apis/bitable/v1/apps/{app_token}/roles/{role_id}/members/{member_id}"
-                )
-            }
-            BitableApiV1::RoleMemberBatchDelete(app_token, role_id) => {
-                format!(
-                    "/open-apis/bitable/v1/apps/{app_token}/roles/{role_id}/members/batch_delete"
-                )
-            }
-            BitableApiV1::RoleMemberList(app_token, role_id) => {
-                format!("/open-apis/bitable/v1/apps/{app_token}/roles/{role_id}/members")
-            }
-        }
-    }
-
-    /// 返回配置了正确 HTTP 方法的 ApiRequest（委托到 CatalogEndpoint trait）。
-    pub fn to_request<R>(&self) -> ApiRequest<R> {
-        <Self as CatalogEndpoint>::to_request(self)
-    }
-
-    /// 该端点的 HTTP 方法。稳定语义，method 与 path 必须在同一处变更。
-    pub fn method(&self) -> HttpMethod {
-        match self {
-            // App 管理
-            BitableApiV1::AppCreate => HttpMethod::Post,
-            BitableApiV1::AppCopy(_) => HttpMethod::Post,
-            BitableApiV1::AppGet(_) => HttpMethod::Get,
-            BitableApiV1::AppUpdate(_) => HttpMethod::Put,
-            BitableApiV1::DashboardList(_) => HttpMethod::Get,
-            BitableApiV1::DashboardCopy(_, _) => HttpMethod::Post,
-            BitableApiV1::BlockWorkflowList(_) => HttpMethod::Get,
-            BitableApiV1::WorkflowList(_) => HttpMethod::Get,
-            BitableApiV1::WorkflowUpdate(_, _) => HttpMethod::Put,
-
-            // 表格管理
-            BitableApiV1::TableCreate(_) => HttpMethod::Post,
-            BitableApiV1::TableBatchCreate(_) => HttpMethod::Post,
-            BitableApiV1::TableUpdate(_, _) => HttpMethod::Put,
-            BitableApiV1::TableDelete(_, _) => HttpMethod::Delete,
-            BitableApiV1::TableBatchDelete(_) => HttpMethod::Post,
-            BitableApiV1::TableGet(_, _) => HttpMethod::Get,
-            BitableApiV1::TableList(_) => HttpMethod::Get,
-            BitableApiV1::TablePatch(_, _) => HttpMethod::Patch,
-
-            // 字段管理
-            BitableApiV1::FieldCreate(_, _) => HttpMethod::Post,
-            BitableApiV1::FieldGroupCreate(_, _) => HttpMethod::Post,
-            BitableApiV1::FieldUpdate(_, _, _) => HttpMethod::Put,
-            BitableApiV1::FieldDelete(_, _, _) => HttpMethod::Delete,
-            BitableApiV1::FieldList(_, _) => HttpMethod::Get,
-
-            // 视图管理
-            BitableApiV1::ViewCreate(_, _) => HttpMethod::Post,
-            BitableApiV1::ViewUpdate(_, _, _) => HttpMethod::Put,
-            BitableApiV1::ViewDelete(_, _, _) => HttpMethod::Delete,
-            BitableApiV1::ViewGet(_, _, _) => HttpMethod::Get,
-            BitableApiV1::ViewList(_, _) => HttpMethod::Get,
-            BitableApiV1::ViewPatch(_, _, _) => HttpMethod::Patch,
-
-            // 记录管理（tracer bullet #424）
-            BitableApiV1::RecordCreate(_, _) => HttpMethod::Post,
-            BitableApiV1::RecordBatchCreate(_, _) => HttpMethod::Post,
-            BitableApiV1::RecordGet(_, _, _) => HttpMethod::Get,
-            BitableApiV1::RecordBatchGet(_, _) => HttpMethod::Post,
-            BitableApiV1::RecordUpdate(_, _, _) => HttpMethod::Put,
-            BitableApiV1::RecordBatchUpdate(_, _) => HttpMethod::Post,
-            BitableApiV1::RecordDelete(_, _, _) => HttpMethod::Delete,
-            BitableApiV1::RecordBatchDelete(_, _) => HttpMethod::Post,
-            BitableApiV1::RecordList(_, _) => HttpMethod::Get,
-            BitableApiV1::RecordSearch(_, _) => HttpMethod::Post,
-
-            // 表单管理
-            BitableApiV1::FormGet(_, _, _) => HttpMethod::Get,
-            BitableApiV1::FormPatch(_, _, _) => HttpMethod::Patch,
-            BitableApiV1::FormUpgrade(_, _, _) => HttpMethod::Post,
-            BitableApiV1::FormFieldList(_, _, _) => HttpMethod::Get,
-            BitableApiV1::FormFieldPatch(_, _, _, _) => HttpMethod::Patch,
-
-            // 权限/角色管理
-            BitableApiV1::RoleCreate(_) => HttpMethod::Post,
-            BitableApiV1::RoleUpdate(_, _) => HttpMethod::Put,
-            BitableApiV1::RoleDelete(_, _) => HttpMethod::Delete,
-            BitableApiV1::RoleList(_) => HttpMethod::Get,
-            BitableApiV1::RoleMemberCreate(_, _) => HttpMethod::Post,
-            BitableApiV1::RoleMemberBatchCreate(_, _) => HttpMethod::Post,
-            BitableApiV1::RoleMemberDelete(_, _, _) => HttpMethod::Delete,
-            BitableApiV1::RoleMemberBatchDelete(_, _) => HttpMethod::Post,
-            BitableApiV1::RoleMemberList(_, _) => HttpMethod::Get,
-        }
-    }
-}
-
-impl CatalogEndpoint for BitableApiV1 {
-    fn to_url(&self) -> String {
-        // delegate to inherent for backward compat
-        BitableApiV1::to_url(self)
-    }
-
-    fn method(&self) -> HttpMethod {
-        BitableApiV1::method(self)
-    }
-
-    // supported and to_request use trait defaults
-}
+pub mod bitable;
+pub use bitable::BitableApiV1;
 
 /// Minutes API V1 端点枚举
 #[derive(Debug, Clone, PartialEq)]
@@ -2225,6 +1817,7 @@ pub const LINGO_API_V1: &str = "/open-apis/lingo/v1";
 mod tests {
     use super::*;
     use openlark_core::api::{ApiRequest, HttpMethod};
+    use openlark_core::constants::AccessTokenType;
 
     // ========== BaseApiV2 Tests ==========
     #[test]
@@ -2237,7 +1830,15 @@ mod tests {
         assert_eq!(endpoint.method(), HttpMethod::Post);
         let req: ApiRequest<()> = endpoint.to_request();
         assert_eq!(req.method(), &HttpMethod::Post);
-        assert!(endpoint.supported_access_token_types().is_none());
+        // #438: catalog 拥有认证要求
+        assert_eq!(
+            endpoint.supported_access_token_types(),
+            Some(vec![AccessTokenType::User, AccessTokenType::Tenant])
+        );
+        assert_eq!(
+            req.supported_access_token_types(),
+            vec![AccessTokenType::User, AccessTokenType::Tenant]
+        );
     }
 
     #[test]
@@ -2251,6 +1852,14 @@ mod tests {
         assert_eq!(endpoint.method(), HttpMethod::Put);
         let req: ApiRequest<()> = endpoint.to_request();
         assert_eq!(req.method(), &HttpMethod::Put);
+        assert_eq!(
+            endpoint.supported_access_token_types(),
+            Some(vec![AccessTokenType::User, AccessTokenType::Tenant])
+        );
+        assert_eq!(
+            req.supported_access_token_types(),
+            vec![AccessTokenType::User, AccessTokenType::Tenant]
+        );
     }
 
     #[test]
@@ -2263,6 +1872,14 @@ mod tests {
         assert_eq!(endpoint.method(), HttpMethod::Get);
         let req: ApiRequest<()> = endpoint.to_request();
         assert_eq!(req.method(), &HttpMethod::Get);
+        assert_eq!(
+            endpoint.supported_access_token_types(),
+            Some(vec![AccessTokenType::User, AccessTokenType::Tenant])
+        );
+        assert_eq!(
+            req.supported_access_token_types(),
+            vec![AccessTokenType::User, AccessTokenType::Tenant]
+        );
     }
 
     #[test]
@@ -2276,185 +1893,20 @@ mod tests {
         assert_eq!(endpoint.method(), HttpMethod::Delete);
         let req: ApiRequest<()> = endpoint.to_request();
         assert_eq!(req.method(), &HttpMethod::Delete);
+        assert_eq!(
+            endpoint.supported_access_token_types(),
+            Some(vec![AccessTokenType::User, AccessTokenType::Tenant])
+        );
+        assert_eq!(
+            req.supported_access_token_types(),
+            vec![AccessTokenType::User, AccessTokenType::Tenant]
+        );
     }
 
     #[test]
     fn test_base_api_v2_with_special_chars() {
         let endpoint = BaseApiV2::RoleCreate("app-token_123".to_string());
         assert!(endpoint.to_url().contains("app-token_123"));
-    }
-
-    // ========== BitableApiV1 Tests ==========
-    #[test]
-    fn test_bitable_api_v1_app_create() {
-        let endpoint = BitableApiV1::AppCreate;
-        assert_eq!(endpoint.to_url(), "/open-apis/bitable/v1/apps");
-    }
-
-    #[test]
-    fn test_bitable_api_v1_app_copy() {
-        let endpoint = BitableApiV1::AppCopy("app_token_123".to_string());
-        assert_eq!(
-            endpoint.to_url(),
-            "/open-apis/bitable/v1/apps/app_token_123/copy"
-        );
-    }
-
-    #[test]
-    fn test_bitable_api_v1_table_create() {
-        let endpoint = BitableApiV1::TableCreate("app_token_123".to_string());
-        assert_eq!(
-            endpoint.to_url(),
-            "/open-apis/bitable/v1/apps/app_token_123/tables"
-        );
-    }
-
-    #[test]
-    fn test_bitable_api_v1_record_create() {
-        let endpoint =
-            BitableApiV1::RecordCreate("app_token_123".to_string(), "table_id_456".to_string());
-        assert_eq!(
-            endpoint.to_url(),
-            "/open-apis/bitable/v1/apps/app_token_123/tables/table_id_456/records"
-        );
-    }
-
-    #[test]
-    fn test_bitable_api_v1_field_create() {
-        let endpoint =
-            BitableApiV1::FieldCreate("app_token_123".to_string(), "table_id_456".to_string());
-        assert_eq!(
-            endpoint.to_url(),
-            "/open-apis/bitable/v1/apps/app_token_123/tables/table_id_456/fields"
-        );
-    }
-
-    #[test]
-    fn test_bitable_api_v1_block_workflow_list() {
-        let endpoint = BitableApiV1::BlockWorkflowList("app_token_123".to_string());
-        assert_eq!(
-            endpoint.to_url(),
-            "/open-apis/bitable/v1/apps/app_token_123/block_workflows"
-        );
-    }
-
-    #[test]
-    fn test_bitable_api_v1_field_group_create() {
-        let endpoint =
-            BitableApiV1::FieldGroupCreate("app_token_123".to_string(), "table_id_456".to_string());
-        assert_eq!(
-            endpoint.to_url(),
-            "/open-apis/bitable/v1/apps/app_token_123/tables/table_id_456/field_groups"
-        );
-    }
-
-    #[test]
-    fn test_bitable_api_v1_form_upgrade() {
-        let endpoint = BitableApiV1::FormUpgrade(
-            "app_token_123".to_string(),
-            "table_id_456".to_string(),
-            "form_id_789".to_string(),
-        );
-        assert_eq!(
-            endpoint.to_url(),
-            "/open-apis/bitable/v1/apps/app_token_123/tables/table_id_456/forms/form_id_789/upgrade"
-        );
-    }
-
-    #[test]
-    fn test_bitable_api_v1_view_create() {
-        let endpoint =
-            BitableApiV1::ViewCreate("app_token_123".to_string(), "table_id_456".to_string());
-        assert_eq!(
-            endpoint.to_url(),
-            "/open-apis/bitable/v1/apps/app_token_123/tables/table_id_456/views"
-        );
-    }
-
-    #[test]
-    fn test_bitable_api_v1_form_get() {
-        let endpoint = BitableApiV1::FormGet(
-            "app_token_123".to_string(),
-            "table_id_456".to_string(),
-            "form_id_789".to_string(),
-        );
-        assert_eq!(
-            endpoint.to_url(),
-            "/open-apis/bitable/v1/apps/app_token_123/tables/table_id_456/forms/form_id_789"
-        );
-    }
-
-    #[test]
-    fn test_bitable_api_v1_role_member_create() {
-        let endpoint =
-            BitableApiV1::RoleMemberCreate("app_token_123".to_string(), "role_id_456".to_string());
-        assert_eq!(
-            endpoint.to_url(),
-            "/open-apis/bitable/v1/apps/app_token_123/roles/role_id_456/members"
-        );
-    }
-
-    #[test]
-    fn test_bitable_api_v1_batch_operations() {
-        let endpoint = BitableApiV1::TableBatchCreate("app_token_123".to_string());
-        assert!(endpoint.to_url().contains("batch_create"));
-
-        let endpoint = BitableApiV1::RecordBatchDelete(
-            "app_token_123".to_string(),
-            "table_id_456".to_string(),
-        );
-        assert!(endpoint.to_url().contains("batch_delete"));
-    }
-
-    // ========== #424: 端点目录语义测试（method + path + auth） ==========
-    // tracer: record 族，确保 method/path 组合由 catalog 拥有，防止叶子漂移。
-    #[test]
-    fn test_bitable_record_endpoints_semantics_424() {
-        use openlark_core::api::HttpMethod;
-
-        // Create / BatchCreate -> POST
-        let ep = BitableApiV1::RecordCreate("app".into(), "tbl".into());
-        assert_eq!(ep.method(), HttpMethod::Post);
-        assert!(ep.to_url().contains("/records"));
-        let req: ApiRequest<()> = ep.to_request();
-        assert_eq!(req.method(), &HttpMethod::Post);
-
-        let ep = BitableApiV1::RecordBatchCreate("app".into(), "tbl".into());
-        assert_eq!(ep.method(), HttpMethod::Post);
-
-        // Get / List -> GET
-        let ep = BitableApiV1::RecordGet("app".into(), "tbl".into(), "rec".into());
-        assert_eq!(ep.method(), HttpMethod::Get);
-        let req: ApiRequest<()> = ep.to_request();
-        assert_eq!(req.method(), &HttpMethod::Get);
-
-        let ep = BitableApiV1::RecordList("app".into(), "tbl".into());
-        assert_eq!(ep.method(), HttpMethod::Get);
-
-        // Update -> PUT , BatchUpdate -> POST
-        let ep = BitableApiV1::RecordUpdate("app".into(), "tbl".into(), "rec".into());
-        assert_eq!(ep.method(), HttpMethod::Put);
-
-        let ep = BitableApiV1::RecordBatchUpdate("app".into(), "tbl".into());
-        assert_eq!(ep.method(), HttpMethod::Post);
-
-        // Delete -> DELETE , BatchDelete -> POST
-        let ep = BitableApiV1::RecordDelete("app".into(), "tbl".into(), "rec".into());
-        assert_eq!(ep.method(), HttpMethod::Delete);
-        let req: ApiRequest<()> = ep.to_request();
-        assert_eq!(req.method(), &HttpMethod::Delete);
-
-        let ep = BitableApiV1::RecordBatchDelete("app".into(), "tbl".into());
-        assert_eq!(ep.method(), HttpMethod::Post);
-
-        // Search -> POST (body query)
-        let ep = BitableApiV1::RecordSearch("app".into(), "tbl".into());
-        assert_eq!(ep.method(), HttpMethod::Post);
-        assert!(ep.to_url().contains("/search"));
-
-        // auth: 默认 None -> User+Tenant （由 ApiRequest 默认提供）
-        let ep = BitableApiV1::RecordCreate("a".into(), "t".into());
-        assert!(ep.supported_access_token_types().is_none());
     }
 
     // ========== MinutesApiV1 Tests ==========

--- a/crates/openlark-docs/src/common/api_endpoints/base.rs
+++ b/crates/openlark-docs/src/common/api_endpoints/base.rs
@@ -4,6 +4,7 @@
 
 use super::CatalogEndpoint;
 use openlark_core::api::HttpMethod;
+use openlark_core::constants::AccessTokenType;
 
 /// Base API V2 端点枚举
 #[derive(Debug, Clone, PartialEq)]
@@ -53,5 +54,10 @@ impl CatalogEndpoint for BaseApiV2 {
         }
     }
 
-    // supported_access_token_types and to_request use trait defaults
+    fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
+        // 证明 catalog 统一拥有认证要求（#438 tracer）；与 core 默认一致，但显式声明
+        Some(vec![AccessTokenType::User, AccessTokenType::Tenant])
+    }
+
+    // to_request 使用 trait 默认实现，会应用 supported token types
 }

--- a/crates/openlark-docs/src/common/api_endpoints/bitable.rs
+++ b/crates/openlark-docs/src/common/api_endpoints/bitable.rs
@@ -1,0 +1,602 @@
+//! Bitable API V1 端点枚举
+//!
+//! 提供 Bitable v1 的端点定义，支持 method、path 和认证要求的统一管理（#439 迁移）。
+//! 从 api_endpoints.rs 提取为独立子模块，避免主文件持续膨胀。
+
+use super::CatalogEndpoint;
+use openlark_core::api::{ApiRequest, HttpMethod};
+use openlark_core::constants::AccessTokenType;
+
+/// Bitable API V1 端点枚举（#424 深化了请求语义：method + path + auth 在此集中）。
+#[derive(Debug, Clone, PartialEq)]
+pub enum BitableApiV1 {
+    /// App管理相关
+    AppCreate,
+    /// 复制多维表格应用（参数：app_token）
+    AppCopy(String),
+    /// 获取多维表格应用信息（参数：app_token）
+    AppGet(String),
+    /// 更新多维表格应用信息（参数：app_token）
+    AppUpdate(String),
+    /// 列出多维表格仪表盘（参数：app_token）
+    DashboardList(String),
+    /// 复制仪表盘（参数：app_token, block_id）
+    DashboardCopy(String, String),
+    /// 自动化流程
+    BlockWorkflowList(String),
+    /// 列出自动化工作流（参数：app_token）
+    WorkflowList(String),
+    /// 更新自动化工作流（参数：app_token, workflow_id）
+    WorkflowUpdate(String, String),
+
+    /// 表格管理相关
+    TableCreate(String),
+    /// 批量创建数据表（参数：app_token）
+    TableBatchCreate(String),
+    /// 更新数据表（参数：app_token, table_id）
+    TableUpdate(String, String),
+    /// 删除数据表（参数：app_token, table_id）
+    TableDelete(String, String),
+    /// 批量删除数据表（参数：app_token）
+    TableBatchDelete(String),
+    /// 获取数据表信息（参数：app_token, table_id）
+    TableGet(String, String),
+    /// 列出数据表（参数：app_token）
+    TableList(String),
+    /// 增量更新数据表（参数：app_token, table_id）
+    TablePatch(String, String),
+
+    /// 字段管理相关
+    FieldCreate(String, String),
+    /// 创建字段分组（参数：app_token, table_id）
+    FieldGroupCreate(String, String),
+    /// 更新字段（参数：app_token, table_id, field_id）
+    FieldUpdate(String, String, String),
+    /// 删除字段（参数：app_token, table_id, field_id）
+    FieldDelete(String, String, String),
+    /// 列出字段（参数：app_token, table_id）
+    FieldList(String, String),
+
+    /// 视图管理相关
+    ViewCreate(String, String),
+    /// 更新视图（参数：app_token, table_id, view_id）
+    ViewUpdate(String, String, String),
+    /// 删除视图（参数：app_token, table_id, view_id）
+    ViewDelete(String, String, String),
+    /// 获取视图（参数：app_token, table_id, view_id）
+    ViewGet(String, String, String),
+    /// 列出视图（参数：app_token, table_id）
+    ViewList(String, String),
+    /// 增量更新视图（参数：app_token, table_id, view_id）
+    ViewPatch(String, String, String),
+
+    /// 记录管理相关
+    RecordCreate(String, String),
+    /// 批量创建记录（参数：app_token, table_id）
+    RecordBatchCreate(String, String),
+    /// 获取记录（参数：app_token, table_id, record_id）
+    RecordGet(String, String, String),
+    /// 批量获取记录（参数：app_token, table_id）
+    RecordBatchGet(String, String),
+    /// 更新记录（参数：app_token, table_id, record_id）
+    RecordUpdate(String, String, String),
+    /// 批量更新记录（参数：app_token, table_id）
+    RecordBatchUpdate(String, String),
+    /// 删除记录（参数：app_token, table_id, record_id）
+    RecordDelete(String, String, String),
+    /// 批量删除记录（参数：app_token, table_id）
+    RecordBatchDelete(String, String),
+    /// 列出记录（参数：app_token, table_id）
+    RecordList(String, String),
+    /// 查询记录（参数：app_token, table_id）
+    RecordSearch(String, String),
+
+    /// 表单管理相关
+    FormGet(String, String, String),
+    /// 更新表单（参数：app_token, table_id, form_id）
+    FormPatch(String, String, String),
+    /// 升级表单（参数：app_token, table_id, form_id）
+    FormUpgrade(String, String, String),
+    /// 列出表单字段（参数：app_token, table_id, form_id）
+    FormFieldList(String, String, String),
+    /// 更新表单字段（参数：app_token, table_id, form_id, field_id）
+    FormFieldPatch(String, String, String, String),
+
+    /// 权限管理相关
+    RoleCreate(String),
+    /// 更新自定义角色（参数：app_token, role_id）
+    RoleUpdate(String, String),
+    /// 删除自定义角色（参数：app_token, role_id）
+    RoleDelete(String, String),
+    /// 列出自定义角色（参数：app_token）
+    RoleList(String),
+    /// 新增角色成员（参数：app_token, role_id）
+    RoleMemberCreate(String, String),
+    /// 批量新增角色成员（参数：app_token, role_id）
+    RoleMemberBatchCreate(String, String),
+    /// 删除角色成员（参数：app_token, role_id, member_id）
+    RoleMemberDelete(String, String, String),
+    /// 批量删除角色成员（参数：app_token, role_id）
+    RoleMemberBatchDelete(String, String),
+    /// 列出角色成员（参数：app_token, role_id）
+    RoleMemberList(String, String),
+}
+
+impl BitableApiV1 {
+    /// 生成对应的 URL
+    pub fn to_url(&self) -> String {
+        match self {
+            // App管理
+            BitableApiV1::AppCreate => "/open-apis/bitable/v1/apps".to_string(),
+            BitableApiV1::AppCopy(app_token) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/copy")
+            }
+            BitableApiV1::AppGet(app_token) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}")
+            }
+            BitableApiV1::AppUpdate(app_token) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}")
+            }
+            BitableApiV1::DashboardList(app_token) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/dashboards")
+            }
+            BitableApiV1::DashboardCopy(app_token, block_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/dashboards/{block_id}/copy")
+            }
+            BitableApiV1::BlockWorkflowList(app_token) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/block_workflows")
+            }
+            BitableApiV1::WorkflowList(app_token) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/workflows")
+            }
+            BitableApiV1::WorkflowUpdate(app_token, workflow_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/workflows/{workflow_id}")
+            }
+
+            // 表格管理
+            BitableApiV1::TableCreate(app_token) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables")
+            }
+            BitableApiV1::TableBatchCreate(app_token) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables/batch_create")
+            }
+            BitableApiV1::TableUpdate(app_token, table_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}")
+            }
+            BitableApiV1::TableDelete(app_token, table_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}")
+            }
+            BitableApiV1::TableBatchDelete(app_token) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables/batch_delete")
+            }
+            BitableApiV1::TableGet(app_token, table_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}")
+            }
+            BitableApiV1::TableList(app_token) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables")
+            }
+            BitableApiV1::TablePatch(app_token, table_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}")
+            }
+
+            // 字段管理
+            BitableApiV1::FieldCreate(app_token, table_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/fields")
+            }
+            BitableApiV1::FieldGroupCreate(app_token, table_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/field_groups")
+            }
+            BitableApiV1::FieldUpdate(app_token, table_id, field_id) => {
+                format!(
+                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/fields/{field_id}"
+                )
+            }
+            BitableApiV1::FieldDelete(app_token, table_id, field_id) => {
+                format!(
+                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/fields/{field_id}"
+                )
+            }
+            BitableApiV1::FieldList(app_token, table_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/fields")
+            }
+
+            // 视图管理
+            BitableApiV1::ViewCreate(app_token, table_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/views")
+            }
+            BitableApiV1::ViewUpdate(app_token, table_id, view_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/views/{view_id}")
+            }
+            BitableApiV1::ViewDelete(app_token, table_id, view_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/views/{view_id}")
+            }
+            BitableApiV1::ViewGet(app_token, table_id, view_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/views/{view_id}")
+            }
+            BitableApiV1::ViewList(app_token, table_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/views")
+            }
+            BitableApiV1::ViewPatch(app_token, table_id, view_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/views/{view_id}")
+            }
+
+            // 记录管理
+            BitableApiV1::RecordCreate(app_token, table_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records")
+            }
+            BitableApiV1::RecordBatchCreate(app_token, table_id) => {
+                format!(
+                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/batch_create"
+                )
+            }
+            BitableApiV1::RecordGet(app_token, table_id, record_id) => {
+                format!(
+                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/{record_id}"
+                )
+            }
+            BitableApiV1::RecordBatchGet(app_token, table_id) => {
+                format!(
+                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/batch_get"
+                )
+            }
+            BitableApiV1::RecordUpdate(app_token, table_id, record_id) => {
+                format!(
+                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/{record_id}"
+                )
+            }
+            BitableApiV1::RecordBatchUpdate(app_token, table_id) => {
+                format!(
+                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/batch_update"
+                )
+            }
+            BitableApiV1::RecordDelete(app_token, table_id, record_id) => {
+                format!(
+                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/{record_id}"
+                )
+            }
+            BitableApiV1::RecordBatchDelete(app_token, table_id) => {
+                format!(
+                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/batch_delete"
+                )
+            }
+            BitableApiV1::RecordList(app_token, table_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records")
+            }
+            BitableApiV1::RecordSearch(app_token, table_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/search")
+            }
+
+            // 表单管理
+            BitableApiV1::FormGet(app_token, table_id, form_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/forms/{form_id}")
+            }
+            BitableApiV1::FormPatch(app_token, table_id, form_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/forms/{form_id}")
+            }
+            BitableApiV1::FormUpgrade(app_token, table_id, form_id) => {
+                format!(
+                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/forms/{form_id}/upgrade"
+                )
+            }
+            BitableApiV1::FormFieldList(app_token, table_id, form_id) => {
+                format!(
+                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/forms/{form_id}/fields"
+                )
+            }
+            BitableApiV1::FormFieldPatch(app_token, table_id, form_id, field_id) => {
+                format!(
+                    "/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/forms/{form_id}/fields/{field_id}"
+                )
+            }
+
+            // 权限管理
+            BitableApiV1::RoleCreate(app_token) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/roles")
+            }
+            BitableApiV1::RoleUpdate(app_token, role_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/roles/{role_id}")
+            }
+            BitableApiV1::RoleDelete(app_token, role_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/roles/{role_id}")
+            }
+            BitableApiV1::RoleList(app_token) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/roles")
+            }
+            BitableApiV1::RoleMemberCreate(app_token, role_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/roles/{role_id}/members")
+            }
+            BitableApiV1::RoleMemberBatchCreate(app_token, role_id) => {
+                format!(
+                    "/open-apis/bitable/v1/apps/{app_token}/roles/{role_id}/members/batch_create"
+                )
+            }
+            BitableApiV1::RoleMemberDelete(app_token, role_id, member_id) => {
+                format!(
+                    "/open-apis/bitable/v1/apps/{app_token}/roles/{role_id}/members/{member_id}"
+                )
+            }
+            BitableApiV1::RoleMemberBatchDelete(app_token, role_id) => {
+                format!(
+                    "/open-apis/bitable/v1/apps/{app_token}/roles/{role_id}/members/batch_delete"
+                )
+            }
+            BitableApiV1::RoleMemberList(app_token, role_id) => {
+                format!("/open-apis/bitable/v1/apps/{app_token}/roles/{role_id}/members")
+            }
+        }
+    }
+
+    /// 返回配置了正确 HTTP 方法的 ApiRequest（委托到 CatalogEndpoint trait）。
+    pub fn to_request<R>(&self) -> ApiRequest<R> {
+        <Self as CatalogEndpoint>::to_request(self)
+    }
+
+    /// 该端点的 HTTP 方法。稳定语义，method 与 path 必须在同一处变更。
+    pub fn method(&self) -> HttpMethod {
+        match self {
+            // App 管理
+            BitableApiV1::AppCreate => HttpMethod::Post,
+            BitableApiV1::AppCopy(_) => HttpMethod::Post,
+            BitableApiV1::AppGet(_) => HttpMethod::Get,
+            BitableApiV1::AppUpdate(_) => HttpMethod::Put,
+            BitableApiV1::DashboardList(_) => HttpMethod::Get,
+            BitableApiV1::DashboardCopy(_, _) => HttpMethod::Post,
+            BitableApiV1::BlockWorkflowList(_) => HttpMethod::Get,
+            BitableApiV1::WorkflowList(_) => HttpMethod::Get,
+            BitableApiV1::WorkflowUpdate(_, _) => HttpMethod::Put,
+
+            // 表格管理
+            BitableApiV1::TableCreate(_) => HttpMethod::Post,
+            BitableApiV1::TableBatchCreate(_) => HttpMethod::Post,
+            BitableApiV1::TableUpdate(_, _) => HttpMethod::Put,
+            BitableApiV1::TableDelete(_, _) => HttpMethod::Delete,
+            BitableApiV1::TableBatchDelete(_) => HttpMethod::Post,
+            BitableApiV1::TableGet(_, _) => HttpMethod::Get,
+            BitableApiV1::TableList(_) => HttpMethod::Get,
+            BitableApiV1::TablePatch(_, _) => HttpMethod::Patch,
+
+            // 字段管理
+            BitableApiV1::FieldCreate(_, _) => HttpMethod::Post,
+            BitableApiV1::FieldGroupCreate(_, _) => HttpMethod::Post,
+            BitableApiV1::FieldUpdate(_, _, _) => HttpMethod::Put,
+            BitableApiV1::FieldDelete(_, _, _) => HttpMethod::Delete,
+            BitableApiV1::FieldList(_, _) => HttpMethod::Get,
+
+            // 视图管理
+            BitableApiV1::ViewCreate(_, _) => HttpMethod::Post,
+            BitableApiV1::ViewUpdate(_, _, _) => HttpMethod::Put,
+            BitableApiV1::ViewDelete(_, _, _) => HttpMethod::Delete,
+            BitableApiV1::ViewGet(_, _, _) => HttpMethod::Get,
+            BitableApiV1::ViewList(_, _) => HttpMethod::Get,
+            BitableApiV1::ViewPatch(_, _, _) => HttpMethod::Patch,
+
+            // 记录管理
+            BitableApiV1::RecordCreate(_, _) => HttpMethod::Post,
+            BitableApiV1::RecordBatchCreate(_, _) => HttpMethod::Post,
+            BitableApiV1::RecordGet(_, _, _) => HttpMethod::Get,
+            BitableApiV1::RecordBatchGet(_, _) => HttpMethod::Post,
+            BitableApiV1::RecordUpdate(_, _, _) => HttpMethod::Put,
+            BitableApiV1::RecordBatchUpdate(_, _) => HttpMethod::Post,
+            BitableApiV1::RecordDelete(_, _, _) => HttpMethod::Delete,
+            BitableApiV1::RecordBatchDelete(_, _) => HttpMethod::Post,
+            BitableApiV1::RecordList(_, _) => HttpMethod::Get,
+            BitableApiV1::RecordSearch(_, _) => HttpMethod::Post,
+
+            // 表单管理
+            BitableApiV1::FormGet(_, _, _) => HttpMethod::Get,
+            BitableApiV1::FormPatch(_, _, _) => HttpMethod::Patch,
+            BitableApiV1::FormUpgrade(_, _, _) => HttpMethod::Post,
+            BitableApiV1::FormFieldList(_, _, _) => HttpMethod::Get,
+            BitableApiV1::FormFieldPatch(_, _, _, _) => HttpMethod::Patch,
+
+            // 权限/角色管理
+            BitableApiV1::RoleCreate(_) => HttpMethod::Post,
+            BitableApiV1::RoleUpdate(_, _) => HttpMethod::Put,
+            BitableApiV1::RoleDelete(_, _) => HttpMethod::Delete,
+            BitableApiV1::RoleList(_) => HttpMethod::Get,
+            BitableApiV1::RoleMemberCreate(_, _) => HttpMethod::Post,
+            BitableApiV1::RoleMemberBatchCreate(_, _) => HttpMethod::Post,
+            BitableApiV1::RoleMemberDelete(_, _, _) => HttpMethod::Delete,
+            BitableApiV1::RoleMemberBatchDelete(_, _) => HttpMethod::Post,
+            BitableApiV1::RoleMemberList(_, _) => HttpMethod::Get,
+        }
+    }
+}
+
+impl CatalogEndpoint for BitableApiV1 {
+    fn to_url(&self) -> String {
+        // delegate to inherent for backward compat
+        BitableApiV1::to_url(self)
+    }
+
+    fn method(&self) -> HttpMethod {
+        BitableApiV1::method(self)
+    }
+
+    /// Bitable 端点的稳定认证要求（#439 迁移）。
+    /// 与 Base 一致，显式声明以便语义目录统一拥有认证要求。
+    fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
+        Some(vec![AccessTokenType::User, AccessTokenType::Tenant])
+    }
+
+    // to_request 使用 trait 默认实现
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openlark_core::api::{ApiRequest, HttpMethod};
+    use openlark_core::constants::AccessTokenType;
+
+    #[test]
+    fn test_bitable_api_v1_app_create() {
+        let endpoint = BitableApiV1::AppCreate;
+        assert_eq!(endpoint.to_url(), "/open-apis/bitable/v1/apps");
+    }
+
+    #[test]
+    fn test_bitable_api_v1_app_copy() {
+        let endpoint = BitableApiV1::AppCopy("app_token_123".to_string());
+        assert_eq!(
+            endpoint.to_url(),
+            "/open-apis/bitable/v1/apps/app_token_123/copy"
+        );
+    }
+
+    #[test]
+    fn test_bitable_api_v1_table_create() {
+        let endpoint = BitableApiV1::TableCreate("app_token_123".to_string());
+        assert_eq!(
+            endpoint.to_url(),
+            "/open-apis/bitable/v1/apps/app_token_123/tables"
+        );
+    }
+
+    #[test]
+    fn test_bitable_api_v1_record_create() {
+        let endpoint =
+            BitableApiV1::RecordCreate("app_token_123".to_string(), "table_id_456".to_string());
+        assert_eq!(
+            endpoint.to_url(),
+            "/open-apis/bitable/v1/apps/app_token_123/tables/table_id_456/records"
+        );
+    }
+
+    #[test]
+    fn test_bitable_api_v1_field_create() {
+        let endpoint =
+            BitableApiV1::FieldCreate("app_token_123".to_string(), "table_id_456".to_string());
+        assert_eq!(
+            endpoint.to_url(),
+            "/open-apis/bitable/v1/apps/app_token_123/tables/table_id_456/fields"
+        );
+    }
+
+    #[test]
+    fn test_bitable_api_v1_block_workflow_list() {
+        let endpoint = BitableApiV1::BlockWorkflowList("app_token_123".to_string());
+        assert_eq!(
+            endpoint.to_url(),
+            "/open-apis/bitable/v1/apps/app_token_123/block_workflows"
+        );
+    }
+
+    #[test]
+    fn test_bitable_api_v1_field_group_create() {
+        let endpoint =
+            BitableApiV1::FieldGroupCreate("app_token_123".to_string(), "table_id_456".to_string());
+        assert_eq!(
+            endpoint.to_url(),
+            "/open-apis/bitable/v1/apps/app_token_123/tables/table_id_456/field_groups"
+        );
+    }
+
+    #[test]
+    fn test_bitable_api_v1_form_upgrade() {
+        let endpoint = BitableApiV1::FormUpgrade(
+            "app_token_123".to_string(),
+            "table_id_456".to_string(),
+            "form_id_789".to_string(),
+        );
+        assert_eq!(
+            endpoint.to_url(),
+            "/open-apis/bitable/v1/apps/app_token_123/tables/table_id_456/forms/form_id_789/upgrade"
+        );
+    }
+
+    #[test]
+    fn test_bitable_api_v1_view_create() {
+        let endpoint =
+            BitableApiV1::ViewCreate("app_token_123".to_string(), "table_id_456".to_string());
+        assert_eq!(
+            endpoint.to_url(),
+            "/open-apis/bitable/v1/apps/app_token_123/tables/table_id_456/views"
+        );
+    }
+
+    #[test]
+    fn test_bitable_api_v1_form_get() {
+        let endpoint = BitableApiV1::FormGet(
+            "app_token_123".to_string(),
+            "table_id_456".to_string(),
+            "form_id_789".to_string(),
+        );
+        assert_eq!(
+            endpoint.to_url(),
+            "/open-apis/bitable/v1/apps/app_token_123/tables/table_id_456/forms/form_id_789"
+        );
+    }
+
+    #[test]
+    fn test_bitable_api_v1_role_member_create() {
+        let endpoint =
+            BitableApiV1::RoleMemberCreate("app_token_123".to_string(), "role_id_456".to_string());
+        assert_eq!(
+            endpoint.to_url(),
+            "/open-apis/bitable/v1/apps/app_token_123/roles/role_id_456/members"
+        );
+    }
+
+    #[test]
+    fn test_bitable_api_v1_batch_operations() {
+        let endpoint = BitableApiV1::TableBatchCreate("app_token_123".to_string());
+        assert!(endpoint.to_url().contains("batch_create"));
+
+        let endpoint = BitableApiV1::RecordBatchDelete(
+            "app_token_123".to_string(),
+            "table_id_456".to_string(),
+        );
+        assert!(endpoint.to_url().contains("batch_delete"));
+    }
+
+    // ========== #424 / #439: 端点目录语义测试（method + path + auth） ==========
+    #[test]
+    fn test_bitable_record_endpoints_semantics_424() {
+        // Create / BatchCreate -> POST
+        let ep = BitableApiV1::RecordCreate("app".into(), "tbl".into());
+        assert_eq!(ep.method(), HttpMethod::Post);
+        assert!(ep.to_url().contains("/records"));
+        let req: ApiRequest<()> = ep.to_request();
+        assert_eq!(req.method(), &HttpMethod::Post);
+
+        let ep = BitableApiV1::RecordBatchCreate("app".into(), "tbl".into());
+        assert_eq!(ep.method(), HttpMethod::Post);
+
+        // Get / List -> GET
+        let ep = BitableApiV1::RecordGet("app".into(), "tbl".into(), "rec".into());
+        assert_eq!(ep.method(), HttpMethod::Get);
+        let req: ApiRequest<()> = ep.to_request();
+        assert_eq!(req.method(), &HttpMethod::Get);
+
+        let ep = BitableApiV1::RecordList("app".into(), "tbl".into());
+        assert_eq!(ep.method(), HttpMethod::Get);
+
+        // Update -> PUT , BatchUpdate -> POST
+        let ep = BitableApiV1::RecordUpdate("app".into(), "tbl".into(), "rec".into());
+        assert_eq!(ep.method(), HttpMethod::Put);
+
+        let ep = BitableApiV1::RecordBatchUpdate("app".into(), "tbl".into());
+        assert_eq!(ep.method(), HttpMethod::Post);
+
+        // Delete -> DELETE , BatchDelete -> POST
+        let ep = BitableApiV1::RecordDelete("app".into(), "tbl".into(), "rec".into());
+        assert_eq!(ep.method(), HttpMethod::Delete);
+        let req: ApiRequest<()> = ep.to_request();
+        assert_eq!(req.method(), &HttpMethod::Delete);
+
+        let ep = BitableApiV1::RecordBatchDelete("app".into(), "tbl".into());
+        assert_eq!(ep.method(), HttpMethod::Post);
+
+        // Search -> POST (body query)
+        let ep = BitableApiV1::RecordSearch("app".into(), "tbl".into());
+        assert_eq!(ep.method(), HttpMethod::Post);
+        assert!(ep.to_url().contains("/search"));
+
+        // auth: 显式声明在 catalog 中（#439）
+        let ep = BitableApiV1::RecordCreate("a".into(), "t".into());
+        assert_eq!(
+            ep.supported_access_token_types(),
+            Some(vec![AccessTokenType::User, AccessTokenType::Tenant])
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- centralize Base and Bitable endpoint path, HTTP method, and token semantics in the endpoint catalog
- migrate request builders to construct requests through catalog endpoints
- add request-level coverage for encoded paths, query/body forwarding, auth, and RequestOption behavior

## Verification

- cargo test -p openlark-docs --all-features --lib
- cargo clippy -p openlark-docs --all-targets --all-features -- -Dwarnings
- cargo clippy -p openlark-docs --all-targets --no-default-features -- -Dwarnings

Closes #439