### PR TITLE
refactor(docs): contract path-only leaf declarations and verify catalog (#443)

### DIFF
--- a/crates/openlark-docs/src/baike/baike/v1/classification/list.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/classification/list.rs
@@ -88,8 +88,9 @@ impl ListClassificationRequest {
         }
 
         // ===== 构建请求 =====
+        // 使用 catalog 提供 method + path + auth（#443 contract path-only）
         let mut api_request: ApiRequest<ListClassificationResponse> =
-            ApiRequest::get(&BaikeApiV1::ClassificationList.to_url());
+            BaikeApiV1::ClassificationList.to_request();
         if let Some(page_size) = self.page_size {
             api_request = api_request.query("page_size", page_size.to_string());
         }

--- a/crates/openlark-docs/src/baike/baike/v1/draft/create.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/draft/create.rs
@@ -133,8 +133,9 @@ impl CreateDraftRequest {
         }
 
         // ===== 构建请求 =====
+        // 使用 catalog 提供 method + path + auth（#443）
         let mut api_request: ApiRequest<CreateDraftResp> =
-            ApiRequest::post(&BaikeApiV1::DraftCreate.to_url())
+            BaikeApiV1::DraftCreate.to_request()
                 .body(serde_json::to_value(&self.req)?);
         if let Some(user_id_type) = &self.user_id_type {
             api_request = api_request.query("user_id_type", user_id_type.as_str());

--- a/crates/openlark-docs/src/baike/baike/v1/draft/create.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/draft/create.rs
@@ -134,9 +134,9 @@ impl CreateDraftRequest {
 
         // ===== 构建请求 =====
         // 使用 catalog 提供 method + path + auth（#443）
-        let mut api_request: ApiRequest<CreateDraftResp> =
-            BaikeApiV1::DraftCreate.to_request()
-                .body(serde_json::to_value(&self.req)?);
+        let mut api_request: ApiRequest<CreateDraftResp> = BaikeApiV1::DraftCreate
+            .to_request()
+            .body(serde_json::to_value(&self.req)?);
         if let Some(user_id_type) = &self.user_id_type {
             api_request = api_request.query("user_id_type", user_id_type.as_str());
         }

--- a/crates/openlark-docs/src/baike/baike/v1/draft/update.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/draft/update.rs
@@ -126,8 +126,10 @@ impl UpdateDraftRequest {
         }
 
         // ===== 构建请求 =====
+        // 使用 catalog 提供 method + path + auth（#443）
         let mut api_request: ApiRequest<UpdateDraftResp> =
-            ApiRequest::put(&BaikeApiV1::DraftUpdate(self.draft_id).to_url())
+            BaikeApiV1::DraftUpdate(self.draft_id)
+                .to_request()
                 .body(serde_json::to_value(&self.req)?);
         if let Some(user_id_type) = &self.user_id_type {
             api_request = api_request.query("user_id_type", user_id_type.as_str());

--- a/crates/openlark-docs/src/baike/baike/v1/draft/update.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/draft/update.rs
@@ -127,10 +127,9 @@ impl UpdateDraftRequest {
 
         // ===== 构建请求 =====
         // 使用 catalog 提供 method + path + auth（#443）
-        let mut api_request: ApiRequest<UpdateDraftResp> =
-            BaikeApiV1::DraftUpdate(self.draft_id)
-                .to_request()
-                .body(serde_json::to_value(&self.req)?);
+        let mut api_request: ApiRequest<UpdateDraftResp> = BaikeApiV1::DraftUpdate(self.draft_id)
+            .to_request()
+            .body(serde_json::to_value(&self.req)?);
         if let Some(user_id_type) = &self.user_id_type {
             api_request = api_request.query("user_id_type", user_id_type.as_str());
         }

--- a/crates/openlark-docs/src/baike/baike/v1/entity/create.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/entity/create.rs
@@ -121,9 +121,9 @@ impl CreateEntityRequest {
         }
 
         // ===== 构建请求 =====
-
+        // 使用 catalog 提供 method + path + auth（#443 contract path-only）
         let mut api_request: ApiRequest<CreateEntityResp> =
-            ApiRequest::post(&BaikeApiV1::EntityCreate.to_url())
+            BaikeApiV1::EntityCreate.to_request()
                 .body(serde_json::to_value(&self.req)?);
         if let Some(user_id_type) = &self.user_id_type {
             api_request = api_request.query("user_id_type", user_id_type.as_str());

--- a/crates/openlark-docs/src/baike/baike/v1/entity/create.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/entity/create.rs
@@ -122,9 +122,9 @@ impl CreateEntityRequest {
 
         // ===== 构建请求 =====
         // 使用 catalog 提供 method + path + auth（#443 contract path-only）
-        let mut api_request: ApiRequest<CreateEntityResp> =
-            BaikeApiV1::EntityCreate.to_request()
-                .body(serde_json::to_value(&self.req)?);
+        let mut api_request: ApiRequest<CreateEntityResp> = BaikeApiV1::EntityCreate
+            .to_request()
+            .body(serde_json::to_value(&self.req)?);
         if let Some(user_id_type) = &self.user_id_type {
             api_request = api_request.query("user_id_type", user_id_type.as_str());
         }

--- a/crates/openlark-docs/src/baike/baike/v1/entity/extract.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/entity/extract.rs
@@ -79,9 +79,9 @@ impl ExtractEntityRequest {
 
         // ===== 构建请求 =====
         // 使用 catalog 提供 method + path + auth（#443）
-        let api_request: ApiRequest<ExtractEntityResponse> =
-            BaikeApiV1::EntityExtract.to_request()
-                .body(serde_json::to_value(&self.req)?);
+        let api_request: ApiRequest<ExtractEntityResponse> = BaikeApiV1::EntityExtract
+            .to_request()
+            .body(serde_json::to_value(&self.req)?);
 
         // ===== 发送请求 =====
         let response: Response<ExtractEntityResponse> =

--- a/crates/openlark-docs/src/baike/baike/v1/entity/extract.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/entity/extract.rs
@@ -78,8 +78,9 @@ impl ExtractEntityRequest {
         }
 
         // ===== 构建请求 =====
+        // 使用 catalog 提供 method + path + auth（#443）
         let api_request: ApiRequest<ExtractEntityResponse> =
-            ApiRequest::post(&BaikeApiV1::EntityExtract.to_url())
+            BaikeApiV1::EntityExtract.to_request()
                 .body(serde_json::to_value(&self.req)?);
 
         // ===== 发送请求 =====

--- a/crates/openlark-docs/src/baike/baike/v1/entity/get.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/entity/get.rs
@@ -113,8 +113,9 @@ impl GetEntityRequest {
         }
 
         // ===== 构建请求 =====
+        // 使用 catalog 提供 method + path + auth（#443）
         let mut api_request: ApiRequest<GetEntityResp> =
-            ApiRequest::get(&BaikeApiV1::EntityGet(self.entity_id).to_url());
+            BaikeApiV1::EntityGet(self.entity_id).to_request();
         if let Some(provider) = &self.provider {
             api_request = api_request.query("provider", provider);
         }

--- a/crates/openlark-docs/src/baike/baike/v1/entity/highlight.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/entity/highlight.rs
@@ -90,8 +90,9 @@ impl HighlightEntityRequest {
         }
 
         // ===== 构建请求 =====
+        // 使用 catalog 提供 method + path + auth（#443）
         let api_request: ApiRequest<HighlightEntityResponse> =
-            ApiRequest::post(&BaikeApiV1::EntityHighlight.to_url())
+            BaikeApiV1::EntityHighlight.to_request()
                 .body(serde_json::to_value(&self.req)?);
 
         // ===== 发送请求 =====

--- a/crates/openlark-docs/src/baike/baike/v1/entity/highlight.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/entity/highlight.rs
@@ -91,9 +91,9 @@ impl HighlightEntityRequest {
 
         // ===== 构建请求 =====
         // 使用 catalog 提供 method + path + auth（#443）
-        let api_request: ApiRequest<HighlightEntityResponse> =
-            BaikeApiV1::EntityHighlight.to_request()
-                .body(serde_json::to_value(&self.req)?);
+        let api_request: ApiRequest<HighlightEntityResponse> = BaikeApiV1::EntityHighlight
+            .to_request()
+            .body(serde_json::to_value(&self.req)?);
 
         // ===== 发送请求 =====
         let response: Response<HighlightEntityResponse> =

--- a/crates/openlark-docs/src/baike/baike/v1/entity/list.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/entity/list.rs
@@ -104,8 +104,7 @@ impl ListEntityRequest {
 
         // ===== 构建请求 =====
         // 使用 catalog 提供 method + path + auth（#443）
-        let mut api_request: ApiRequest<ListEntityResp> =
-            BaikeApiV1::EntityList.to_request();
+        let mut api_request: ApiRequest<ListEntityResp> = BaikeApiV1::EntityList.to_request();
         if let Some(page_size) = self.page_size {
             api_request = api_request.query("page_size", page_size.to_string());
         }

--- a/crates/openlark-docs/src/baike/baike/v1/entity/list.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/entity/list.rs
@@ -103,8 +103,9 @@ impl ListEntityRequest {
         }
 
         // ===== 构建请求 =====
+        // 使用 catalog 提供 method + path + auth（#443）
         let mut api_request: ApiRequest<ListEntityResp> =
-            ApiRequest::get(&BaikeApiV1::EntityList.to_url());
+            BaikeApiV1::EntityList.to_request();
         if let Some(page_size) = self.page_size {
             api_request = api_request.query("page_size", page_size.to_string());
         }

--- a/crates/openlark-docs/src/baike/baike/v1/entity/match.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/entity/match.rs
@@ -80,8 +80,9 @@ impl MatchEntityRequest {
             ));
         }
 
+        // 使用 catalog 提供 method + path + auth（#443）
         let api_request: ApiRequest<MatchEntityResp> =
-            ApiRequest::post(&BaikeApiV1::EntityMatch.to_url())
+            BaikeApiV1::EntityMatch.to_request()
                 .body(serde_json::to_value(&self.req)?);
 
         let response: Response<MatchEntityResp> =

--- a/crates/openlark-docs/src/baike/baike/v1/entity/match.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/entity/match.rs
@@ -81,9 +81,9 @@ impl MatchEntityRequest {
         }
 
         // 使用 catalog 提供 method + path + auth（#443）
-        let api_request: ApiRequest<MatchEntityResp> =
-            BaikeApiV1::EntityMatch.to_request()
-                .body(serde_json::to_value(&self.req)?);
+        let api_request: ApiRequest<MatchEntityResp> = BaikeApiV1::EntityMatch
+            .to_request()
+            .body(serde_json::to_value(&self.req)?);
 
         let response: Response<MatchEntityResp> =
             Transport::request(api_request, &self.config, Some(option)).await?;

--- a/crates/openlark-docs/src/baike/baike/v1/entity/search.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/entity/search.rs
@@ -175,8 +175,9 @@ impl SearchEntityRequest {
         }
 
         // ===== 构建请求 =====
+        // 使用 catalog 提供 method + path + auth（#443）
         let mut api_request: ApiRequest<SearchEntityResponse> =
-            ApiRequest::post(&BaikeApiV1::EntitySearch.to_url())
+            BaikeApiV1::EntitySearch.to_request()
                 .body(serde_json::to_value(&self.req)?);
 
         if let Some(page_size) = self.page_size {

--- a/crates/openlark-docs/src/baike/baike/v1/entity/search.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/entity/search.rs
@@ -176,9 +176,9 @@ impl SearchEntityRequest {
 
         // ===== 构建请求 =====
         // 使用 catalog 提供 method + path + auth（#443）
-        let mut api_request: ApiRequest<SearchEntityResponse> =
-            BaikeApiV1::EntitySearch.to_request()
-                .body(serde_json::to_value(&self.req)?);
+        let mut api_request: ApiRequest<SearchEntityResponse> = BaikeApiV1::EntitySearch
+            .to_request()
+            .body(serde_json::to_value(&self.req)?);
 
         if let Some(page_size) = self.page_size {
             api_request = api_request.query("page_size", page_size.to_string());

--- a/crates/openlark-docs/src/baike/baike/v1/entity/update.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/entity/update.rs
@@ -124,8 +124,10 @@ impl UpdateEntityRequest {
         }
 
         // ===== 构建请求 =====
+        // 使用 catalog 提供 method + path + auth（#443）
         let mut api_request: ApiRequest<UpdateEntityResp> =
-            ApiRequest::put(&BaikeApiV1::EntityUpdate(self.entity_id).to_url())
+            BaikeApiV1::EntityUpdate(self.entity_id)
+                .to_request()
                 .body(serde_json::to_value(&self.req)?);
         if let Some(user_id_type) = &self.user_id_type {
             api_request = api_request.query("user_id_type", user_id_type.as_str());

--- a/crates/openlark-docs/src/baike/baike/v1/file/download.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/file/download.rs
@@ -38,8 +38,9 @@ impl DownloadFileRequest {
     pub async fn execute_with_options(self, option: RequestOption) -> SDKResult<Response<Vec<u8>>> {
         validate_required!(self.file_token, "file_token 不能为空");
 
+        // 使用 catalog 提供 method + path + auth（#443）
         let api_request: ApiRequest<Vec<u8>> =
-            ApiRequest::get(&BaikeApiV1::FileDownload(self.file_token).to_url());
+            BaikeApiV1::FileDownload(self.file_token).to_request();
         Transport::request(api_request, &self.config, Some(option)).await
     }
 }

--- a/crates/openlark-docs/src/baike/baike/v1/file/upload.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/file/upload.rs
@@ -106,10 +106,10 @@ impl UploadFileRequest {
 
         // ===== 构建请求并发送 =====
         // 使用 catalog 提供 method + path + auth（#443）
-        let api_request: ApiRequest<UploadFileResponse> =
-            BaikeApiV1::FileUpload.to_request()
-                .body(body)
-                .file_content(self.file);
+        let api_request: ApiRequest<UploadFileResponse> = BaikeApiV1::FileUpload
+            .to_request()
+            .body(body)
+            .file_content(self.file);
 
         let response: Response<UploadFileResponse> =
             Transport::request(api_request, &self.config, Some(option)).await?;

--- a/crates/openlark-docs/src/baike/baike/v1/file/upload.rs
+++ b/crates/openlark-docs/src/baike/baike/v1/file/upload.rs
@@ -105,8 +105,9 @@ impl UploadFileRequest {
         });
 
         // ===== 构建请求并发送 =====
+        // 使用 catalog 提供 method + path + auth（#443）
         let api_request: ApiRequest<UploadFileResponse> =
-            ApiRequest::post(&BaikeApiV1::FileUpload.to_url())
+            BaikeApiV1::FileUpload.to_request()
                 .body(body)
                 .file_content(self.file);
 

--- a/crates/openlark-docs/src/common/api_endpoints.rs
+++ b/crates/openlark-docs/src/common/api_endpoints.rs
@@ -62,7 +62,9 @@ pub trait CatalogEndpoint {
             HttpMethod::Put => ApiRequest::put(url),
             HttpMethod::Delete => ApiRequest::delete(url),
             HttpMethod::Patch => ApiRequest::patch(url),
-            _ => unreachable!("CatalogEndpoint encountered unknown HttpMethod variant — this should never happen"),
+            _ => unreachable!(
+                "CatalogEndpoint encountered unknown HttpMethod variant — this should never happen"
+            ),
         };
         if let Some(tokens) = self.supported_access_token_types() {
             req = req.with_supported_access_token_types(tokens);

--- a/crates/openlark-docs/src/common/api_endpoints.rs
+++ b/crates/openlark-docs/src/common/api_endpoints.rs
@@ -127,16 +127,6 @@ impl CcmDocApiOld {
     pub fn to_request<R>(&self) -> ApiRequest<R> {
         <Self as CatalogEndpoint>::to_request(self)
     }
-
-    /// 返回端点的 HTTP 方法。
-    pub fn method(&self) -> HttpMethod {
-        match self {
-            Self::Create | Self::BatchUpdate(_) => HttpMethod::Post,
-            Self::Meta(_) | Self::SheetMeta(_) | Self::RawContent(_) | Self::Content(_) => {
-                HttpMethod::Get
-            }
-        }
-    }
 }
 
 impl CatalogEndpoint for CcmDocApiOld {
@@ -145,7 +135,12 @@ impl CatalogEndpoint for CcmDocApiOld {
     }
 
     fn method(&self) -> HttpMethod {
-        CcmDocApiOld::method(self)
+        match self {
+            Self::Create | Self::BatchUpdate(_) => HttpMethod::Post,
+            Self::Meta(_) | Self::SheetMeta(_) | Self::RawContent(_) | Self::Content(_) => {
+                HttpMethod::Get
+            }
+        }
     }
 
     fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
@@ -176,14 +171,6 @@ impl CcmDocsApiOld {
     pub fn to_request<R>(&self) -> ApiRequest<R> {
         <Self as CatalogEndpoint>::to_request(self)
     }
-
-    /// 返回端点的 HTTP 方法。
-    pub fn method(&self) -> HttpMethod {
-        match self {
-            Self::SearchObject => HttpMethod::Post,
-            Self::Meta => HttpMethod::Get,
-        }
-    }
 }
 
 impl CatalogEndpoint for CcmDocsApiOld {
@@ -192,7 +179,10 @@ impl CatalogEndpoint for CcmDocsApiOld {
     }
 
     fn method(&self) -> HttpMethod {
-        CcmDocsApiOld::method(self)
+        match self {
+            Self::SearchObject => HttpMethod::Post,
+            Self::Meta => HttpMethod::Get,
+        }
     }
 
     fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {

--- a/crates/openlark-docs/src/common/api_endpoints.rs
+++ b/crates/openlark-docs/src/common/api_endpoints.rs
@@ -42,9 +42,10 @@ pub trait CatalogEndpoint {
     /// 返回 HTTP 方法。
     fn method(&self) -> HttpMethod;
 
-    /// 稳定的访问令牌要求（默认 None）。
+    /// 稳定的访问令牌要求。
+    /// Docs 域的绝大多数端点都同时接受 User 和 Tenant token（#424 系列）。
     fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
-        None
+        Some(vec![AccessTokenType::User, AccessTokenType::Tenant])
     }
 
     /// 构建带正确方法的请求。
@@ -61,7 +62,7 @@ pub trait CatalogEndpoint {
             HttpMethod::Put => ApiRequest::put(url),
             HttpMethod::Delete => ApiRequest::delete(url),
             HttpMethod::Patch => ApiRequest::patch(url),
-            _ => ApiRequest::get(self.to_url()),
+            _ => unreachable!("CatalogEndpoint encountered unknown HttpMethod variant — this should never happen"),
         };
         if let Some(tokens) = self.supported_access_token_types() {
             req = req.with_supported_access_token_types(tokens);

--- a/crates/openlark-docs/src/common/api_endpoints/bitable.rs
+++ b/crates/openlark-docs/src/common/api_endpoints/bitable.rs
@@ -330,9 +330,15 @@ impl BitableApiV1 {
     pub fn to_request<R>(&self) -> ApiRequest<R> {
         <Self as CatalogEndpoint>::to_request(self)
     }
+}
 
-    /// 该端点的 HTTP 方法。稳定语义，method 与 path 必须在同一处变更。
-    pub fn method(&self) -> HttpMethod {
+impl CatalogEndpoint for BitableApiV1 {
+    fn to_url(&self) -> String {
+        // delegate to inherent for backward compat
+        BitableApiV1::to_url(self)
+    }
+
+    fn method(&self) -> HttpMethod {
         match self {
             // App 管理
             BitableApiV1::AppCreate => HttpMethod::Post,
@@ -400,17 +406,6 @@ impl BitableApiV1 {
             BitableApiV1::RoleMemberBatchDelete(_, _) => HttpMethod::Post,
             BitableApiV1::RoleMemberList(_, _) => HttpMethod::Get,
         }
-    }
-}
-
-impl CatalogEndpoint for BitableApiV1 {
-    fn to_url(&self) -> String {
-        // delegate to inherent for backward compat
-        BitableApiV1::to_url(self)
-    }
-
-    fn method(&self) -> HttpMethod {
-        BitableApiV1::method(self)
     }
 
     /// Bitable 端点的稳定认证要求（#439 迁移）。

--- a/crates/openlark-docs/src/common/api_endpoints/docs.rs
+++ b/crates/openlark-docs/src/common/api_endpoints/docs.rs
@@ -2,7 +2,6 @@
 
 use super::CatalogEndpoint;
 use openlark_core::api::{ApiRequest, HttpMethod};
-use openlark_core::constants::AccessTokenType;
 
 /// Docs API V1 端点枚举
 #[derive(Debug, Clone, PartialEq)]
@@ -34,7 +33,5 @@ impl CatalogEndpoint for DocsApiV1 {
         HttpMethod::Get
     }
 
-    fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
-        Some(vec![AccessTokenType::User, AccessTokenType::Tenant])
-    }
+    // supported_access_token_types 使用 trait 默认实现（User + Tenant）
 }

--- a/crates/openlark-docs/src/common/api_endpoints/docs.rs
+++ b/crates/openlark-docs/src/common/api_endpoints/docs.rs
@@ -23,11 +23,6 @@ impl DocsApiV1 {
     pub fn to_request<R>(&self) -> ApiRequest<R> {
         <Self as CatalogEndpoint>::to_request(self)
     }
-
-    /// 返回端点的 HTTP 方法。
-    pub fn method(&self) -> HttpMethod {
-        HttpMethod::Get
-    }
 }
 
 impl CatalogEndpoint for DocsApiV1 {
@@ -36,7 +31,7 @@ impl CatalogEndpoint for DocsApiV1 {
     }
 
     fn method(&self) -> HttpMethod {
-        DocsApiV1::method(self)
+        HttpMethod::Get
     }
 
     fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {

--- a/crates/openlark-docs/src/common/api_endpoints/docx.rs
+++ b/crates/openlark-docs/src/common/api_endpoints/docx.rs
@@ -126,9 +126,14 @@ impl DocxApiV1 {
     pub fn to_request<R>(&self) -> ApiRequest<R> {
         <Self as CatalogEndpoint>::to_request(self)
     }
+}
 
-    /// 返回端点的 HTTP 方法。
-    pub fn method(&self) -> HttpMethod {
+impl CatalogEndpoint for DocxApiV1 {
+    fn to_url(&self) -> String {
+        DocxApiV1::to_url(self)
+    }
+
+    fn method(&self) -> HttpMethod {
         match self {
             Self::ChatAnnouncementGet(_)
             | Self::ChatAnnouncementBlockList(_)
@@ -150,16 +155,6 @@ impl DocxApiV1 {
             Self::ChatAnnouncementBlockChildrenBatchDelete(_, _)
             | Self::DocumentBlockChildrenBatchDelete(_, _) => HttpMethod::Delete,
         }
-    }
-}
-
-impl CatalogEndpoint for DocxApiV1 {
-    fn to_url(&self) -> String {
-        DocxApiV1::to_url(self)
-    }
-
-    fn method(&self) -> HttpMethod {
-        DocxApiV1::method(self)
     }
 
     fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {

--- a/crates/openlark-docs/src/common/api_endpoints/drive.rs
+++ b/crates/openlark-docs/src/common/api_endpoints/drive.rs
@@ -61,15 +61,6 @@ impl CcmDriveExplorerApiOld {
     pub fn to_request<R>(&self) -> ApiRequest<R> {
         <Self as CatalogEndpoint>::to_request(self)
     }
-
-    /// 返回端点的 HTTP 方法。
-    pub fn method(&self) -> HttpMethod {
-        match self {
-            Self::RootFolderMeta | Self::FolderMeta(_) | Self::FolderChildren(_) => HttpMethod::Get,
-            Self::File(_) | Self::FileCopy(_) | Self::Folder(_) => HttpMethod::Post,
-            Self::FileSpreadsheets(_) | Self::FileDocs(_) => HttpMethod::Delete,
-        }
-    }
 }
 
 impl CatalogEndpoint for CcmDriveExplorerApiOld {
@@ -78,7 +69,11 @@ impl CatalogEndpoint for CcmDriveExplorerApiOld {
     }
 
     fn method(&self) -> HttpMethod {
-        CcmDriveExplorerApiOld::method(self)
+        match self {
+            Self::RootFolderMeta | Self::FolderMeta(_) | Self::FolderChildren(_) => HttpMethod::Get,
+            Self::File(_) | Self::FileCopy(_) | Self::Folder(_) => HttpMethod::Post,
+            Self::FileSpreadsheets(_) | Self::FileDocs(_) => HttpMethod::Delete,
+        }
     }
 
     fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
@@ -157,9 +152,14 @@ impl CcmDriveExplorerApi {
     pub fn to_request<R>(&self) -> ApiRequest<R> {
         <Self as CatalogEndpoint>::to_request(self)
     }
+}
 
-    /// 返回端点的 HTTP 方法。
-    pub fn method(&self) -> HttpMethod {
+impl CatalogEndpoint for CcmDriveExplorerApi {
+    fn to_url(&self) -> String {
+        CcmDriveExplorerApi::to_url(self)
+    }
+
+    fn method(&self) -> HttpMethod {
         match self {
             Self::RootFolderMeta
             | Self::FolderMeta(_)
@@ -169,16 +169,6 @@ impl CcmDriveExplorerApi {
             | Self::FolderChildren(_) => HttpMethod::Get,
             Self::FileCopy(_) | Self::Folder => HttpMethod::Post,
         }
-    }
-}
-
-impl CatalogEndpoint for CcmDriveExplorerApi {
-    fn to_url(&self) -> String {
-        CcmDriveExplorerApi::to_url(self)
-    }
-
-    fn method(&self) -> HttpMethod {
-        CcmDriveExplorerApi::method(self)
     }
 
     fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
@@ -227,11 +217,6 @@ impl PermissionApi {
     pub fn to_request<R>(&self) -> ApiRequest<R> {
         <Self as CatalogEndpoint>::to_request(self)
     }
-
-    /// 返回端点的 HTTP 方法。
-    pub fn method(&self) -> HttpMethod {
-        HttpMethod::Post
-    }
 }
 
 impl CatalogEndpoint for PermissionApi {
@@ -240,7 +225,7 @@ impl CatalogEndpoint for PermissionApi {
     }
 
     fn method(&self) -> HttpMethod {
-        PermissionApi::method(self)
+        HttpMethod::Post
     }
 
     fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
@@ -278,11 +263,6 @@ impl PermissionApiOld {
     pub fn to_request<R>(&self) -> ApiRequest<R> {
         <Self as CatalogEndpoint>::to_request(self)
     }
-
-    /// 返回端点的 HTTP 方法。
-    pub fn method(&self) -> HttpMethod {
-        HttpMethod::Post
-    }
 }
 
 impl CatalogEndpoint for PermissionApiOld {
@@ -291,7 +271,7 @@ impl CatalogEndpoint for PermissionApiOld {
     }
 
     fn method(&self) -> HttpMethod {
-        PermissionApiOld::method(self)
+        HttpMethod::Post
     }
 
     fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
@@ -656,9 +636,14 @@ impl DriveApi {
     pub fn to_request_with_url<R>(&self, url: impl Into<String>) -> ApiRequest<R> {
         <Self as CatalogEndpoint>::to_request_with_url(self, url)
     }
+}
 
-    /// 返回该端点的 HTTP 方法。
-    pub fn method(&self) -> HttpMethod {
+impl CatalogEndpoint for DriveApi {
+    fn to_url(&self) -> String {
+        DriveApi::to_url(self)
+    }
+
+    fn method(&self) -> HttpMethod {
         match self {
             Self::ListFiles
             | Self::TaskCheck
@@ -729,16 +714,6 @@ impl DriveApi {
             | Self::DeleteCommentReply(_, _, _) => HttpMethod::Delete,
             Self::UserRemoveSubscription => HttpMethod::Delete,
         }
-    }
-}
-
-impl CatalogEndpoint for DriveApi {
-    fn to_url(&self) -> String {
-        DriveApi::to_url(self)
-    }
-
-    fn method(&self) -> HttpMethod {
-        DriveApi::method(self)
     }
 
     fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {

--- a/crates/openlark-docs/src/common/api_endpoints/lingo.rs
+++ b/crates/openlark-docs/src/common/api_endpoints/lingo.rs
@@ -108,9 +108,14 @@ impl LingoApiV1 {
     pub fn to_request<R>(&self) -> ApiRequest<R> {
         <Self as CatalogEndpoint>::to_request(self)
     }
+}
 
-    /// 返回端点的 HTTP 方法。
-    pub fn method(&self) -> HttpMethod {
+impl CatalogEndpoint for LingoApiV1 {
+    fn to_url(&self) -> String {
+        LingoApiV1::to_url(self)
+    }
+
+    fn method(&self) -> HttpMethod {
         match self {
             Self::EntityGet(_)
             | Self::EntityList
@@ -135,16 +140,6 @@ impl LingoApiV1 {
             | Self::TranslateText => HttpMethod::Post,
             Self::EntityExtract => HttpMethod::Post,
         }
-    }
-}
-
-impl CatalogEndpoint for LingoApiV1 {
-    fn to_url(&self) -> String {
-        LingoApiV1::to_url(self)
-    }
-
-    fn method(&self) -> HttpMethod {
-        LingoApiV1::method(self)
     }
 
     fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {

--- a/crates/openlark-docs/src/common/api_endpoints/lingo.rs
+++ b/crates/openlark-docs/src/common/api_endpoints/lingo.rs
@@ -2,7 +2,6 @@
 
 use super::CatalogEndpoint;
 use openlark_core::api::{ApiRequest, HttpMethod};
-use openlark_core::constants::AccessTokenType;
 
 /// Lingo语言服务 API v1 端点
 #[derive(Debug, Clone, PartialEq)]
@@ -142,7 +141,5 @@ impl CatalogEndpoint for LingoApiV1 {
         }
     }
 
-    fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
-        Some(vec![AccessTokenType::User, AccessTokenType::Tenant])
-    }
+    // supported_access_token_types 使用 trait 默认实现（User + Tenant）
 }

--- a/crates/openlark-docs/src/common/api_endpoints/minutes.rs
+++ b/crates/openlark-docs/src/common/api_endpoints/minutes.rs
@@ -2,7 +2,6 @@
 
 use super::CatalogEndpoint;
 use openlark_core::api::{ApiRequest, HttpMethod};
-use openlark_core::constants::AccessTokenType;
 
 /// Minutes API V1 端点枚举
 #[derive(Debug, Clone, PartialEq)]
@@ -64,9 +63,7 @@ impl CatalogEndpoint for MinutesApiV1 {
         }
     }
 
-    fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
-        Some(vec![AccessTokenType::User, AccessTokenType::Tenant])
-    }
+    // supported_access_token_types 使用 trait 默认实现（User + Tenant）
 }
 
 /// 不扩展公开 `MinutesApiV1` 的补充端点，避免破坏下游穷举匹配。
@@ -105,7 +102,5 @@ impl CatalogEndpoint for MinutesExtraApiV1 {
         }
     }
 
-    fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
-        Some(vec![AccessTokenType::User, AccessTokenType::Tenant])
-    }
+    // supported_access_token_types 使用 trait 默认实现（User + Tenant）
 }

--- a/crates/openlark-docs/src/common/api_endpoints/minutes.rs
+++ b/crates/openlark-docs/src/common/api_endpoints/minutes.rs
@@ -48,16 +48,6 @@ impl MinutesApiV1 {
     pub fn to_request<R>(&self) -> ApiRequest<R> {
         <Self as CatalogEndpoint>::to_request(self)
     }
-
-    /// 返回端点的 HTTP 方法。
-    pub fn method(&self) -> HttpMethod {
-        match self {
-            Self::Get(_) | Self::MediaGet(_) | Self::TranscriptGet(_) | Self::StatisticsGet(_) => {
-                HttpMethod::Get
-            }
-            Self::Subscription | Self::Unsubscription => HttpMethod::Post,
-        }
-    }
 }
 
 impl CatalogEndpoint for MinutesApiV1 {
@@ -66,7 +56,12 @@ impl CatalogEndpoint for MinutesApiV1 {
     }
 
     fn method(&self) -> HttpMethod {
-        MinutesApiV1::method(self)
+        match self {
+            Self::Get(_) | Self::MediaGet(_) | Self::TranscriptGet(_) | Self::StatisticsGet(_) => {
+                HttpMethod::Get
+            }
+            Self::Subscription | Self::Unsubscription => HttpMethod::Post,
+        }
     }
 
     fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {

--- a/crates/openlark-docs/src/common/api_endpoints/sheets.rs
+++ b/crates/openlark-docs/src/common/api_endpoints/sheets.rs
@@ -432,9 +432,15 @@ impl CcmSheetApiOld {
     pub fn to_request<R>(&self) -> ApiRequest<R> {
         <Self as CatalogEndpoint>::to_request(self)
     }
+}
+
+impl CatalogEndpoint for CcmSheetApiOld {
+    fn to_url(&self) -> String {
+        CcmSheetApiOld::to_url(self)
+    }
 
     /// 返回端点的 HTTP 方法，并保持旧版 leaf 的现有请求语义。
-    pub fn method(&self) -> HttpMethod {
+    fn method(&self) -> HttpMethod {
         match self {
             Self::ValuesRange(_, _)
             | Self::ValuesBatchGet(_)
@@ -506,20 +512,6 @@ impl CcmSheetApiOld {
             | Self::ReplaceRange(_)
             | Self::FindReplace(_) => HttpMethod::Post,
         }
-    }
-}
-
-impl CatalogEndpoint for CcmSheetApiOld {
-    fn to_url(&self) -> String {
-        CcmSheetApiOld::to_url(self)
-    }
-
-    fn method(&self) -> HttpMethod {
-        CcmSheetApiOld::method(self)
-    }
-
-    fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
-        Some(vec![AccessTokenType::User, AccessTokenType::Tenant])
     }
 }
 
@@ -706,9 +698,14 @@ impl SheetsApiV3 {
     pub fn to_request<R>(&self) -> ApiRequest<R> {
         <Self as CatalogEndpoint>::to_request(self)
     }
+}
 
-    /// 返回端点的 HTTP 方法。
-    pub fn method(&self) -> HttpMethod {
+impl CatalogEndpoint for SheetsApiV3 {
+    fn to_url(&self) -> String {
+        SheetsApiV3::to_url(self)
+    }
+
+    fn method(&self) -> HttpMethod {
         match self {
             Self::GetSpreadsheet(_)
             | Self::QuerySheets(_)
@@ -721,32 +718,23 @@ impl SheetsApiV3 {
             | Self::QueryFloatImages(_, _)
             | Self::GetFloatImage(_, _, _) => HttpMethod::Get,
             Self::CreateSpreadsheet
-            | Self::MoveDimension(_, _)
-            | Self::FindCells(_, _)
-            | Self::ReplaceCells(_, _)
             | Self::CreateFilter(_, _)
             | Self::CreateFilterView(_, _)
             | Self::CreateFilterCondition(_, _, _)
             | Self::CreateFloatImage(_, _) => HttpMethod::Post,
-            Self::UpdateFilter(_, _) | Self::UpdateFilterCondition(_, _, _, _) => HttpMethod::Put,
+            Self::MoveDimension(_, _)
+            | Self::FindCells(_, _)
+            | Self::ReplaceCells(_, _) => HttpMethod::Post,
             Self::PatchSpreadsheet(_)
             | Self::PatchFilterView(_, _, _)
             | Self::PatchFloatImage(_, _, _) => HttpMethod::Patch,
+            Self::UpdateFilter(_, _)
+            | Self::UpdateFilterCondition(_, _, _, _) => HttpMethod::Put,
             Self::DeleteFilter(_, _)
             | Self::DeleteFilterView(_, _, _)
             | Self::DeleteFilterCondition(_, _, _, _)
             | Self::DeleteFloatImage(_, _, _) => HttpMethod::Delete,
         }
-    }
-}
-
-impl CatalogEndpoint for SheetsApiV3 {
-    fn to_url(&self) -> String {
-        SheetsApiV3::to_url(self)
-    }
-
-    fn method(&self) -> HttpMethod {
-        SheetsApiV3::method(self)
     }
 
     fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {

--- a/crates/openlark-docs/src/common/api_endpoints/sheets.rs
+++ b/crates/openlark-docs/src/common/api_endpoints/sheets.rs
@@ -722,14 +722,13 @@ impl CatalogEndpoint for SheetsApiV3 {
             | Self::CreateFilterView(_, _)
             | Self::CreateFilterCondition(_, _, _)
             | Self::CreateFloatImage(_, _) => HttpMethod::Post,
-            Self::MoveDimension(_, _)
-            | Self::FindCells(_, _)
-            | Self::ReplaceCells(_, _) => HttpMethod::Post,
+            Self::MoveDimension(_, _) | Self::FindCells(_, _) | Self::ReplaceCells(_, _) => {
+                HttpMethod::Post
+            }
             Self::PatchSpreadsheet(_)
             | Self::PatchFilterView(_, _, _)
             | Self::PatchFloatImage(_, _, _) => HttpMethod::Patch,
-            Self::UpdateFilter(_, _)
-            | Self::UpdateFilterCondition(_, _, _, _) => HttpMethod::Put,
+            Self::UpdateFilter(_, _) | Self::UpdateFilterCondition(_, _, _, _) => HttpMethod::Put,
             Self::DeleteFilter(_, _)
             | Self::DeleteFilterView(_, _, _)
             | Self::DeleteFilterCondition(_, _, _, _)

--- a/crates/openlark-docs/src/common/api_endpoints/wiki.rs
+++ b/crates/openlark-docs/src/common/api_endpoints/wiki.rs
@@ -2,7 +2,6 @@
 
 use super::CatalogEndpoint;
 use openlark_core::api::{ApiRequest, HttpMethod};
-use openlark_core::constants::AccessTokenType;
 
 /// Wiki API V1 端点枚举
 #[derive(Debug, Clone, PartialEq)]
@@ -34,9 +33,7 @@ impl CatalogEndpoint for WikiApiV1 {
         HttpMethod::Post
     }
 
-    fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
-        Some(vec![AccessTokenType::User, AccessTokenType::Tenant])
-    }
+    // supported_access_token_types 使用 trait 默认实现（User + Tenant）
 }
 
 /// Wiki API V2 端点枚举
@@ -151,9 +148,7 @@ impl CatalogEndpoint for WikiApiV2 {
         }
     }
 
-    fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
-        Some(vec![AccessTokenType::User, AccessTokenType::Tenant])
-    }
+    // supported_access_token_types 使用 trait 默认实现（User + Tenant）
 }
 
 /// Wiki API 端点枚举
@@ -290,7 +285,5 @@ impl CatalogEndpoint for WikiApi {
         }
     }
 
-    fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
-        Some(vec![AccessTokenType::User, AccessTokenType::Tenant])
-    }
+    // supported_access_token_types 使用 trait 默认实现（User + Tenant）
 }

--- a/crates/openlark-docs/src/common/api_endpoints/wiki.rs
+++ b/crates/openlark-docs/src/common/api_endpoints/wiki.rs
@@ -23,11 +23,6 @@ impl WikiApiV1 {
     pub fn to_request<R>(&self) -> ApiRequest<R> {
         <Self as CatalogEndpoint>::to_request(self)
     }
-
-    /// 返回端点的 HTTP 方法。
-    pub fn method(&self) -> HttpMethod {
-        HttpMethod::Post
-    }
 }
 
 impl CatalogEndpoint for WikiApiV1 {
@@ -36,7 +31,7 @@ impl CatalogEndpoint for WikiApiV1 {
     }
 
     fn method(&self) -> HttpMethod {
-        WikiApiV1::method(self)
+        HttpMethod::Post
     }
 
     fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
@@ -129,9 +124,14 @@ impl WikiApiV2 {
     pub fn to_request<R>(&self) -> ApiRequest<R> {
         <Self as CatalogEndpoint>::to_request(self)
     }
+}
 
-    /// 返回端点的 HTTP 方法。
-    pub fn method(&self) -> HttpMethod {
+impl CatalogEndpoint for WikiApiV2 {
+    fn to_url(&self) -> String {
+        WikiApiV2::to_url(self)
+    }
+
+    fn method(&self) -> HttpMethod {
         match self {
             Self::SpaceList
             | Self::SpaceGet(_)
@@ -149,16 +149,6 @@ impl WikiApiV2 {
             Self::SpaceSettingUpdate(_) => HttpMethod::Put,
             Self::SpaceMemberDelete(_, _) => HttpMethod::Delete,
         }
-    }
-}
-
-impl CatalogEndpoint for WikiApiV2 {
-    fn to_url(&self) -> String {
-        WikiApiV2::to_url(self)
-    }
-
-    fn method(&self) -> HttpMethod {
-        WikiApiV2::method(self)
     }
 
     fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {
@@ -272,9 +262,14 @@ impl WikiApi {
     pub fn to_request<R>(&self) -> ApiRequest<R> {
         <Self as CatalogEndpoint>::to_request(self)
     }
+}
 
-    /// 返回端点的 HTTP 方法。
-    pub fn method(&self) -> HttpMethod {
+impl CatalogEndpoint for WikiApi {
+    fn to_url(&self) -> String {
+        WikiApi::to_url(self)
+    }
+
+    fn method(&self) -> HttpMethod {
         match self {
             Self::ListSpaces
             | Self::GetSpace
@@ -293,16 +288,6 @@ impl WikiApi {
             Self::UpdateSpaceSetting(_) => HttpMethod::Put,
             Self::DeleteSpaceMember(_, _) => HttpMethod::Delete,
         }
-    }
-}
-
-impl CatalogEndpoint for WikiApi {
-    fn to_url(&self) -> String {
-        WikiApi::to_url(self)
-    }
-
-    fn method(&self) -> HttpMethod {
-        WikiApi::method(self)
     }
 
     fn supported_access_token_types(&self) -> Option<Vec<AccessTokenType>> {


### PR DESCRIPTION
Implements #443 (part of the #424 docs catalog semantic deepening series).

## Summary

- Contracted the remaining path-only leaf declarations in `baike/baike/v1/*` to use the endpoint catalog (`BaikeApiV1::*.to_request()`).
- Standardized all catalog modules (including Bitable in review follow-up) so that stable `method()` + `supported_access_token_types()` live **only** in `impl CatalogEndpoint` (no more inherent duplication).
- Updated `CatalogEndpoint` trait default for auth tokens to reduce repetition across families.
- Made the `to_request_with_url` fallback use `unreachable!` for future safety.
- All changes preserve public builder API and do not affect ADR-0001 navigation shells.

## Review Fixes Applied

Addressed feedback from strict code review:
- BitableApiV1 fully standardized (was the only remaining duplication).
- Reduced duplication of `supported_access_token_types` via trait default.
- Safer handling in catalog request construction.

## Verification

- `cargo check -p openlark-docs --all-features`
- `cargo clippy -p openlark-docs --all-features -- -D warnings`
- `cargo test -p openlark-docs --all-features` (935+ tests)
- `cargo doc -p openlark-docs --all-features --no-deps`

## Scope

Only touches `openlark-docs`. No breaking changes for downstream users of the builders.