### PR TITLE
chore(security): drop dead deps masked by cargo-machete ignored list

### DIFF
--- a/.github/msrv/Cargo.lock
+++ b/.github/msrv/Cargo.lock
@@ -1824,27 +1824,15 @@ dependencies = [
 name = "openlark-security"
 version = "0.18.0"
 dependencies = [
- "anyhow",
- "async-trait",
- "base64",
  "chrono",
- "hmac",
- "log",
  "mockall",
  "openlark-core",
- "rand 0.8.6",
  "rstest",
  "serde",
  "serde_json",
- "serde_repr",
- "sha2",
  "tempfile",
- "thiserror",
  "tokio",
  "tokio-test",
- "tracing",
- "url",
- "urlencoding",
  "uuid",
  "wiremock",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,27 +1824,15 @@ dependencies = [
 name = "openlark-security"
 version = "0.18.0"
 dependencies = [
- "anyhow",
- "async-trait",
- "base64",
  "chrono",
- "hmac",
- "log",
  "mockall",
  "openlark-core",
- "rand 0.8.6",
  "rstest",
  "serde",
  "serde_json",
- "serde_repr",
- "sha2",
  "tempfile",
- "thiserror",
  "tokio",
  "tokio-test",
- "tracing",
- "url",
- "urlencoding",
  "uuid",
  "wiremock",
 ]

--- a/crates/openlark-security/Cargo.toml
+++ b/crates/openlark-security/Cargo.toml
@@ -51,21 +51,9 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
-async-trait = { workspace = true }
-anyhow = { workspace = true }
-thiserror = { workspace = true }
 
 # 工具依赖
 uuid = { workspace = true }
-url = { workspace = true }
-urlencoding = { workspace = true }
-hmac = { workspace = true }
-sha2 = { workspace = true }
-base64 = { workspace = true }
-rand = { workspace = true }
-serde_repr = { workspace = true }
-log = { workspace = true }
-tracing = { workspace = true }
 
 
 [dev-dependencies]
@@ -74,6 +62,3 @@ wiremock = { workspace = true }
 rstest = { workspace = true }
 tempfile = { workspace = true }
 mockall = { workspace = true }
-
-[package.metadata.cargo-machete]
-ignored = ["anyhow", "async-trait", "base64", "hmac", "log", "rand", "serde_repr", "sha2", "thiserror", "tracing", "url", "urlencoding"]


### PR DESCRIPTION
## Context

Follow-up to the **#425** umbrella review (*security: retain canonical core Config*). A 4-agent code review of #444/#445/#446/#447 surfaced that `openlark-security` carried **12 unused dependencies** hidden behind `[package.metadata.cargo-machete] ignored`.

## What

- Drop from `[dependencies]`: `anyhow`, `async-trait`, `base64`, `hmac`, `log`, `rand`, `serde_repr`, `sha2`, `thiserror`, `tracing`, `url`, `urlencoding`
- Remove the now-empty `[package.metadata.cargo-machete]` section
- Sync `Cargo.lock` + `.github/msrv/Cargo.lock` (`openlark-security`: 24→11 deps)

`hmac`/`sha2`/`base64` became orphans after `openlark-auth` was dropped in #425; the rest were pre-existing dead deps. Each verified unused via `grep` — note the 36 `url` hits are all wiremock `req.url` field accesses, **not** the `url` crate.

## Why the ignored list is a blind spot

`cargo machete` skips entries in `[package.metadata.cargo-machete] ignored`, so CI's `unused-deps` job cannot catch dead deps hidden there. Effective check: temporarily delete the `ignored` section before running `cargo machete`.

## Verification

| check | result |
|-------|--------|
| `cargo build -p openlark-security --all-features` | ✅ |
| `cargo machete crates/openlark-security` | ✅ 0 unused |
| `cargo test -p openlark-security --all-features` | ✅ 84 passed |
| `clippy --all-features --all-targets -Dwarnings` | ✅ |
| `clippy --no-default-features --all-targets -Dwarnings` | ✅ |
| `cargo doc --no-deps` | ✅ |
| cross-crate `build -p openlark-client --features security` | ✅ |
| msrv `--locked` (msrv lockfile) | ✅ rc=0 |

## Issues

#444/#445/#446/#447 closed (terminal state shipped via #465). This PR is an independent cleanup, **not** part of any of those acceptance criteria.
