### PR TITLE
feat(core): add Transport::request_typed canonical typed-request entry (#479)

### DIFF
--- a/crates/openlark-core/src/http.rs
+++ b/crates/openlark-core/src/http.rs
@@ -109,6 +109,26 @@ impl<T: ApiResponseTrait + std::fmt::Debug + for<'de> serde::Deserialize<'de>> T
         .await
     }
 
+    /// Canonical typed-request 入口（#479）：焊合 [`Transport::request`] + 抽取 typed `T`。
+    ///
+    /// 成功时直接返回 typed `T`；抽取失败时错误经 canonical helper 的 `map_context`
+    /// 机制携带 `operation`（= `extract_response_data`）+ `resource`（= `context`）
+    /// + 响应携带的 `request_id`，便于排障与飞书服务端对账。
+    ///
+    /// 与既有 `Transport::request` + `extract_response_data` 两步 idiom **行为等价**，
+    /// 仅把两步收成一次调用，供 leaf 默认走 canonical 路径（additive，不迁移任何 leaf）。
+    /// 无 `data` 载荷的删除类 API 继续用 `Transport::request` + `ensure_success`，
+    /// 不经本入口。
+    pub async fn request_typed<R: Send>(
+        req: ApiRequest<R>,
+        config: &Config,
+        option: Option<RequestOption>,
+        context: &str,
+    ) -> Result<T, CoreError> {
+        let response = Self::request(req, config, option).await?;
+        crate::api::extract_response_data(response, context)
+    }
+
     async fn do_request<R: Send>(
         mut http_req: ApiRequest<R>,
         access_token_type: AccessTokenType,

--- a/crates/openlark-core/tests/transport_request_contract.rs
+++ b/crates/openlark-core/tests/transport_request_contract.rs
@@ -924,3 +924,170 @@ async fn transport_text_invalid_utf8_returns_error() {
         "got: {err}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Typed-request entry: Transport::request_typed (#479 / parent #470)
+// ---------------------------------------------------------------------------
+//
+// Canonical 入口焊合 `Transport::request` + `extract_response_data`：成功直接返回
+// typed `T`，失败经 `map_context` 附着 operation / resource / request_id。
+// 下列测试复用上方 5 种 ResponseFormat fixture，断言每种格式下入口均返回 typed 结果，
+// 外加一条业务错误失败路径断言 context 附着。
+
+#[tokio::test]
+async fn request_typed_data_success_returns_typed() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/open-apis/contract/typed/data"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_envelope(
+            serde_json::json!({"id": 11, "name": "typed-data"}),
+        )))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let config = contract_config(&server.uri());
+    let req = get_req("/open-apis/contract/typed/data");
+    let data =
+        Transport::<ContractData>::request_typed(req, &config, Some(no_auth_option()), "测试-Data")
+            .await
+            .expect("Data format should decode to typed T");
+    assert_eq!(data.id, 11);
+    assert_eq!(data.name, "typed-data");
+}
+
+#[tokio::test]
+async fn request_typed_flatten_success_returns_typed() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/open-apis/contract/typed/flatten"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "code": 0,
+            "msg": "ok",
+            "app_access_token": "tok-typed",
+            "expire": 7200
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let config = contract_config(&server.uri());
+    let req = get_req("/open-apis/contract/typed/flatten");
+    let data = Transport::<FlattenToken>::request_typed(
+        req,
+        &config,
+        Some(no_auth_option()),
+        "测试-Flatten",
+    )
+    .await
+    .expect("Flatten format should decode to typed T");
+    assert_eq!(data.app_access_token, "tok-typed");
+    assert_eq!(data.expires_in, 7200);
+}
+
+#[tokio::test]
+async fn request_typed_text_success_returns_typed() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/open-apis/contract/typed/text"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("typed-text-body"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let config = contract_config(&server.uri());
+    let req = get_req("/open-apis/contract/typed/text");
+    let data =
+        Transport::<TextBody>::request_typed(req, &config, Some(no_auth_option()), "测试-Text")
+            .await
+            .expect("Text format should decode to typed T");
+    assert_eq!(data.0, "typed-text-body");
+}
+
+#[tokio::test]
+async fn request_typed_binary_success_returns_typed() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/open-apis/contract/typed/binary"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-disposition", "attachment; filename=\"typed.bin\"")
+                .set_body_bytes(b"TYPED-BIN".as_slice()),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let config = contract_config(&server.uri());
+    let req = get_req("/open-apis/contract/typed/binary");
+    let data =
+        Transport::<BinaryFile>::request_typed(req, &config, Some(no_auth_option()), "测试-Binary")
+            .await
+            .expect("Binary format should decode to typed T");
+    assert_eq!(data.file_name, "typed.bin");
+    assert_eq!(data.content, b"TYPED-BIN");
+}
+
+#[tokio::test]
+async fn request_typed_custom_success_returns_typed() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/open-apis/contract/typed/custom"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(b"typed-custom-bytes".as_slice()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let config = contract_config(&server.uri());
+    let req = get_req("/open-apis/contract/typed/custom");
+    let data =
+        Transport::<CustomRaw>::request_typed(req, &config, Some(no_auth_option()), "测试-Custom")
+            .await
+            .expect("Custom format should decode to typed T");
+    assert_eq!(data.0, b"typed-custom-bytes");
+}
+
+/// 失败路径：业务错误 envelope（code≠0，data=null）→ `Transport::request` 仍返回
+/// `Ok(Response{data:None})`，`request_typed` 经 `extract_response_data` 抽取失败，
+/// 错误须附着 `operation` + `resource`(=context) + `request_id`（来自 envelope）。
+#[tokio::test]
+async fn request_typed_failure_attaches_operation_resource_request_id() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/open-apis/contract/typed/fail"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "code": 99991663,
+            "msg": "permission denied",
+            "request_id": "rid-typed-fail",
+            "data": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let config = contract_config(&server.uri());
+    let req = get_req("/open-apis/contract/typed/fail");
+
+    let err =
+        Transport::<ContractData>::request_typed(req, &config, Some(no_auth_option()), "文本翻译")
+            .await
+            .expect_err("business error envelope must surface as extraction failure");
+
+    // 经 canonical helper 的 map_context 附着的三件诊断上下文
+    let ctx = err.ctx();
+    assert_eq!(
+        ctx.operation(),
+        Some("extract_response_data"),
+        "operation should identify the canonical extraction step"
+    );
+    assert_eq!(
+        ctx.get_context("resource"),
+        Some("文本翻译"),
+        "resource should carry caller-provided context"
+    );
+    assert_eq!(
+        ctx.request_id(),
+        Some("rid-typed-fail"),
+        "request_id from envelope must be attached for server-side reconciliation"
+    );
+}


### PR DESCRIPTION
Closes #479 · Parent #470（楔子 step 1）

## What

在 `Transport<T>` 上加 canonical typed-request 入口 `request_typed`，焊合既有 `Transport::request`（不动）+ `extract_response_data` 成一条路径，让 leaf 默认从 Transport 上就能发现 canonical 路径。

```rust
pub async fn request_typed<R: Send>(
    req: ApiRequest<R>,
    config: &Config,
    option: Option<RequestOption>,
    context: &str,
) -> Result<T, CoreError>
// body: Self::request(...).await? 然后 crate::api::extract_response_data(response, context)
```

decode 失败时错误经 canonical helper 既有的 `map_context` 机制附着 `operation`(=extract_response_data) + `resource`(=caller context) + `request_id`（来自响应），便于排障与飞书服务端对账。

## Why

架构审查 Top #1 楔子：1717 个 leaf 的 response 抽取碎成 4 种写法，canonical helper 仅 18% 采用，43% 手写 `.data.ok_or_else` 丢掉 operation/resource/request_id 上下文（真 correctness bug，不只风格）。本票是 "core 先落入口"，后续 per-crate 迁移由 #482-#485 消费，#486 删旧 helper + 加 CI guard 收尾。

## 设计取舍

- **Additive、零 caller、不迁任何 leaf**（AC #5）。零 caller 过渡态有界、已立项（#482-485/#486），非 speculative generality。
- **复用 `extract_response_data`**（spec 明文 "走 canonical helper 已用的 map_context 机制"），刻意不引入新抽象、不改 `ApiResponseTrait`、不改 `Transport::request`。
- **删除类无 `data` 载荷的 API** 仍走 `Transport::request` + `ensure_success`，不经本入口。

## Acceptance criteria

- [x] `Transport` 上新 typed-request 入口存在
- [x] 单测覆盖全部 5 种 ResponseFormat（Data/Flatten/Text/Binary/Custom）成功路径
- [x] 单测覆盖失败路径，断言 operation + resource + request_id 附着
- [x] 不改 Transport::request、不新增 trait 方法、不改 ApiResponseTrait
- [x] 无 leaf 被迁移（与旧 idiom 共存）

## 验证

- `cargo test -p openlark-core --all-features`：516 passed / 0 failed（含 6 新测试，无回归）
- `cargo clippy -p openlark-core --all-targets --all-features -- -Dwarnings`：clean
- `cargo clippy -p openlark-core --all-targets --no-default-features -- -Dwarnings`：clean
- `cargo fmt --check`：clean
- `cargo doc -p openlark-core --all-features`：intra-doc 链通过

## 失败路径测试关键点

测 canonical 抽取失败（断言 context 附着）须用 **code≠0 业务错误 envelope**：code=0 缺 data 会让 `Transport::request` 自己在 `ResponseDecoder` 报错，到不了 `extract_response_data`。详见 `request_typed_failure_attaches_operation_resource_request_id`。