### PR TITLE
refactor(mail): migrate all leaf extraction to Transport::request_typed (#482)

### DIFF
--- a/crates/openlark-core/src/http.rs
+++ b/crates/openlark-core/src/http.rs
@@ -116,7 +116,9 @@ impl<T: ApiResponseTrait + std::fmt::Debug + for<'de> serde::Deserialize<'de>> T
     /// + 响应携带的 `request_id`，便于排障与飞书服务端对账。
     ///
     /// 与既有 `Transport::request` + `extract_response_data` 两步 idiom **行为等价**，
-    /// 仅把两步收成一次调用，供 leaf 默认走 canonical 路径（additive，不迁移任何 leaf）。
+    /// 仅把两步收成一次调用。入口本身 additive（无破坏性公开 API 变更）；leaf 正按
+    /// crate 增量迁入（#482 mail 已迁，#483-#485 其余），旧 helper
+    /// `extract_response_data` 在零剩余 caller 后由 #486 删除。
     /// 无 `data` 载荷的删除类 API 继续用 `Transport::request` + `ensure_success`，
     /// 不经本入口。
     pub async fn request_typed<R: Send>(

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/alias/create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/alias/create.rs
@@ -80,9 +80,7 @@ impl CreateMailGroupAliasRequest {
         let req: ApiRequest<CreateMailGroupAliasResponse> =
             ApiRequest::post(&path).body(serialize_params(&self.body, "创建邮件组别名")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("创建邮件组别名", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "创建邮件组别名").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/alias/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/alias/delete.rs
@@ -1,7 +1,6 @@
 //! 删除邮件组别名
 //! docPath: <https://open.feishu.cn/document/server-docs/mail-v1/mail-group/mailgroup/delete>
 
-use crate::common::api_utils::extract_response_data;
 use openlark_core::{
     SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
 };
@@ -59,8 +58,7 @@ impl DeleteMailGroupAliasRequest {
         );
         let req: ApiRequest<DeleteMailGroupAliasResponse> = ApiRequest::delete(&path);
 
-        let response = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(response, "删除邮件组别名")
+        Transport::request_typed(req, &self.config, Some(option), "删除邮件组别名").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/alias/list.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/alias/list.rs
@@ -72,10 +72,7 @@ impl ListMailGroupAliasRequest {
         );
         let req: ApiRequest<ListMailGroupAliasResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取邮件组所有别名", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取邮件组所有别名").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/create.rs
@@ -80,9 +80,13 @@ impl CreateMailGroupRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "创建邮件组")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "创建邮件组")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "创建邮件组",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/delete.rs
@@ -1,7 +1,7 @@
 //! 删除邮件组
 //! docPath: <https://open.feishu.cn/document/server-docs/mail-v1/mail-group/mailgroup/delete>
 
-use crate::common::{api_endpoints::MailApiV1, api_utils::*};
+use crate::common::api_endpoints::MailApiV1;
 use crate::mail::mail::v1::mailgroup::models::DeleteMailGroupResponse;
 use openlark_core::{
     SDKResult,
@@ -43,9 +43,13 @@ impl DeleteMailGroupRequest {
         let api_endpoint = MailApiV1::MailGroupDelete(self.mail_group_id.clone());
         let request = ApiRequest::<DeleteMailGroupResponse>::delete(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "删除邮件组")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "删除邮件组",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/get.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/get.rs
@@ -1,7 +1,7 @@
 //! 获取邮件组详情
 //! docPath: <https://open.feishu.cn/document/server-docs/mail-v1/mail-group/mailgroup/get>
 
-use crate::common::{api_endpoints::MailApiV1, api_utils::*};
+use crate::common::api_endpoints::MailApiV1;
 use crate::mail::mail::v1::mailgroup::models::GetMailGroupResponse;
 use openlark_core::{
     SDKResult,
@@ -43,9 +43,13 @@ impl GetMailGroupRequest {
         let api_endpoint = MailApiV1::MailGroupGet(self.mail_group_id.clone());
         let request = ApiRequest::<GetMailGroupResponse>::get(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取邮件组")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取邮件组",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/list.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/list.rs
@@ -1,7 +1,7 @@
 //! 获取邮件组列表
 //! docPath: <https://open.feishu.cn/document/server-docs/mail-v1/mail-group/mailgroup/list>
 
-use crate::common::{api_endpoints::MailApiV1, api_utils::*};
+use crate::common::api_endpoints::MailApiV1;
 use crate::mail::mail::v1::mailgroup::models::MailGroupListResponse;
 use openlark_core::{
     SDKResult,
@@ -62,9 +62,13 @@ impl MailGroupListRequest {
             request = request.query("page_token", page_token);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取邮件组列表")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取邮件组列表",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/batch_create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/batch_create.rs
@@ -1,6 +1,6 @@
 //! 批量创建邮件组管理员
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use openlark_core::{
     SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
@@ -80,8 +80,7 @@ impl BatchCreateMailGroupManagerRequest {
         let req: ApiRequest<BatchCreateMailGroupManagerResponse> =
             ApiRequest::post(&path).body(serialize_params(&self.body, "批量创建邮件组管理员")?);
 
-        let response = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(response, "批量创建邮件组管理员")
+        Transport::request_typed(req, &self.config, Some(option), "批量创建邮件组管理员").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/batch_delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/batch_delete.rs
@@ -1,6 +1,6 @@
 //! 批量删除邮件组管理员
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use openlark_core::{
     SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
@@ -80,8 +80,7 @@ impl BatchDeleteMailGroupManagerRequest {
         let req: ApiRequest<BatchDeleteMailGroupManagerResponse> =
             ApiRequest::post(&path).body(serialize_params(&self.body, "批量删除邮件组管理员")?);
 
-        let response = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(response, "批量删除邮件组管理员")
+        Transport::request_typed(req, &self.config, Some(option), "批量删除邮件组管理员").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/list.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/list.rs
@@ -72,10 +72,7 @@ impl ListMailGroupManagerRequest {
         );
         let req: ApiRequest<ListMailGroupManagerResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("批量获取邮件组管理员", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "批量获取邮件组管理员").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/mod.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/manager/mod.rs
@@ -132,9 +132,13 @@ impl BatchCreateMailGroupManagerRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "批量创建邮件组管理员")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "批量创建邮件组管理员")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "批量创建邮件组管理员",
+        )
+        .await
     }
 }
 
@@ -186,9 +190,13 @@ impl BatchDeleteMailGroupManagerRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "批量删除邮件组管理员")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "批量删除邮件组管理员")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "批量删除邮件组管理员",
+        )
+        .await
     }
 }
 
@@ -251,9 +259,13 @@ impl MailGroupManagerListRequest {
             request = request.query("page_size", page_size.to_string());
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取邮件组管理员列表")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取邮件组管理员列表",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/batch_create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/batch_create.rs
@@ -99,10 +99,7 @@ impl BatchCreateMailGroupMemberRequest {
         let req: ApiRequest<BatchCreateMailGroupMemberResponse> =
             ApiRequest::post(&path).body(serialize_params(&self.body, "批量创建邮件组成员")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("批量创建邮件组成员", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "批量创建邮件组成员").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/batch_delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/batch_delete.rs
@@ -55,10 +55,7 @@ impl BatchDeleteMailGroupMemberRequest {
         );
         let req: ApiRequest<BatchDeleteMailGroupMemberResponse> = ApiRequest::delete(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("批量删除邮件组成员", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "批量删除邮件组成员").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/create.rs
@@ -89,9 +89,7 @@ impl CreateMailGroupMemberRequest {
         let req: ApiRequest<CreateMailGroupMemberResponse> =
             ApiRequest::post(&path).body(serialize_params(&self.body, "创建邮件组成员")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("创建邮件组成员", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "创建邮件组成员").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/delete.rs
@@ -1,7 +1,6 @@
 //! 删除邮件组成员
 //! docPath: <https://open.feishu.cn/document/server-docs/mail-v1/mail-group/mailgroup/delete>
 
-use crate::common::api_utils::extract_response_data;
 use openlark_core::{
     SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
 };
@@ -53,8 +52,7 @@ impl DeleteMailGroupMemberRequest {
         );
         let req: ApiRequest<DeleteMailGroupMemberResponse> = ApiRequest::delete(&path);
 
-        let response = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(response, "删除邮件组成员")
+        Transport::request_typed(req, &self.config, Some(option), "删除邮件组成员").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/get.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/get.rs
@@ -62,10 +62,7 @@ impl GetMailGroupMemberRequest {
         );
         let req: ApiRequest<GetMailGroupMemberResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("查询指定邮件组成员", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "查询指定邮件组成员").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/list.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/member/list.rs
@@ -56,10 +56,7 @@ impl ListMailGroupMemberRequest {
         );
         let req: ApiRequest<ListMailGroupMemberResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取所有邮件组成员", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取所有邮件组成员").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/patch.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/patch.rs
@@ -1,7 +1,7 @@
 //! 修改邮件组部分信息
 //! docPath: <https://open.feishu.cn/document/server-docs/mail-v1/mail-group/mailgroup/patch>
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use openlark_core::{
     SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
 };
@@ -70,8 +70,7 @@ impl PatchMailGroupRequest {
         let req: ApiRequest<PatchMailGroupResponse> =
             ApiRequest::patch(&path).body(serialize_params(&self.body, "请求")?);
 
-        let response = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(response, "修改邮件组部分信息")
+        Transport::request_typed(req, &self.config, Some(option), "修改邮件组部分信息").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/batch_create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/batch_create.rs
@@ -99,10 +99,7 @@ impl BatchCreateMailGroupPermissionMemberRequest {
         let req: ApiRequest<BatchCreateMailGroupPermissionMemberResponse> =
             ApiRequest::post(&path).body(serialize_params(&self.body, "请求")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("批量创建邮件组权限成员", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "批量创建邮件组权限成员").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/batch_delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/batch_delete.rs
@@ -1,6 +1,6 @@
 //! 批量删除邮件组权限成员
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use openlark_core::{
     SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
@@ -80,8 +80,7 @@ impl BatchDeleteMailGroupPermissionMemberRequest {
         let req: ApiRequest<BatchDeleteMailGroupPermissionMemberResponse> =
             ApiRequest::delete(&path).body(serialize_params(&self.body, "批量删除邮件组权限成员")?);
 
-        let response = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(response, "批量删除邮件组权限成员")
+        Transport::request_typed(req, &self.config, Some(option), "批量删除邮件组权限成员").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/create.rs
@@ -83,10 +83,7 @@ impl CreateMailGroupPermissionMemberRequest {
         let req: ApiRequest<CreateMailGroupPermissionMemberResponse> =
             ApiRequest::post(&path).body(serialize_params(&self.body, "请求")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("创建邮件组权限成员", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "创建邮件组权限成员").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/delete.rs
@@ -1,7 +1,6 @@
 //! 删除邮件组权限成员
 //! docPath: <https://open.feishu.cn/document/server-docs/mail-v1/mail-group/mailgroup/delete>
 
-use crate::common::api_utils::extract_response_data;
 use openlark_core::{
     SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
 };
@@ -53,8 +52,7 @@ impl DeleteMailGroupPermissionMemberRequest {
         );
         let req: ApiRequest<DeleteMailGroupPermissionMemberResponse> = ApiRequest::delete(&path);
 
-        let response = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(response, "删除邮件组权限成员")
+        Transport::request_typed(req, &self.config, Some(option), "删除邮件组权限成员").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/get.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/get.rs
@@ -73,10 +73,7 @@ impl GetMailGroupPermissionMemberRequest {
         );
         let req: ApiRequest<GetMailGroupPermissionMemberResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取邮件组权限成员", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取邮件组权限成员").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/list.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/permission_member/list.rs
@@ -56,10 +56,7 @@ impl ListMailGroupPermissionMemberRequest {
         );
         let req: ApiRequest<ListMailGroupPermissionMemberResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("批量获取邮件组权限成员", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "批量获取邮件组权限成员").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/mailgroup/update.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/mailgroup/update.rs
@@ -60,9 +60,13 @@ impl UpdateMailGroupRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "更新邮件组")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "更新邮件组")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "更新邮件组",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/multi_entity/search.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/multi_entity/search.rs
@@ -110,9 +110,7 @@ impl MultiEntitySearchRequest {
         })?;
         let req = req.body(body);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("多实体搜索", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "多实体搜索").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/alias/create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/alias/create.rs
@@ -57,9 +57,13 @@ impl CreatePublicMailboxAliasRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "创建公共邮箱别名")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "创建公共邮箱别名")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "创建公共邮箱别名",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/alias/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/alias/delete.rs
@@ -1,7 +1,7 @@
 //! 删除公共邮箱别名
 //! docPath: <https://open.feishu.cn/document/server-docs/mail-v1/public-mailbox/public_mailbox/delete>
 
-use crate::common::{api_endpoints::MailApiV1, api_utils::*};
+use crate::common::api_endpoints::MailApiV1;
 use crate::mail::mail::v1::public_mailbox::alias::models::DeletePublicMailboxAliasResponse;
 use openlark_core::{
     SDKResult,
@@ -47,9 +47,13 @@ impl DeletePublicMailboxAliasRequest {
             MailApiV1::PublicMailboxAliasDelete(self.mailbox_id.clone(), self.alias_id.clone());
         let request = ApiRequest::<DeletePublicMailboxAliasResponse>::delete(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "删除公共邮箱别名")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "删除公共邮箱别名",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/alias/list.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/alias/list.rs
@@ -1,7 +1,7 @@
 //! 获取公共邮箱别名列表
 //! docPath: <https://open.feishu.cn/document/server-docs/mail-v1/public-mailbox/public_mailbox/list>
 
-use crate::common::{api_endpoints::MailApiV1, api_utils::*};
+use crate::common::api_endpoints::MailApiV1;
 use crate::mail::mail::v1::public_mailbox::alias::models::PublicMailboxAliasListResponse;
 use openlark_core::{
     SDKResult,
@@ -65,9 +65,13 @@ impl PublicMailboxAliasListRequest {
             request = request.query("page_size", page_size.to_string());
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取公共邮箱别名列表")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取公共邮箱别名列表",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/create.rs
@@ -70,9 +70,13 @@ impl CreatePublicMailboxRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "创建公共邮箱")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "创建公共邮箱")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "创建公共邮箱",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/delete.rs
@@ -1,7 +1,7 @@
 //! 删除公共邮箱
 //! docPath: <https://open.feishu.cn/document/server-docs/mail-v1/public-mailbox/public_mailbox/delete>
 
-use crate::common::{api_endpoints::MailApiV1, api_utils::*};
+use crate::common::api_endpoints::MailApiV1;
 use crate::mail::mail::v1::public_mailbox::models::DeletePublicMailboxResponse;
 use openlark_core::{
     SDKResult,
@@ -40,9 +40,13 @@ impl DeletePublicMailboxRequest {
         let api_endpoint = MailApiV1::PublicMailboxDelete(self.mailbox_id.clone());
         let request = ApiRequest::<DeletePublicMailboxResponse>::delete(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "删除公共邮箱")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "删除公共邮箱",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/get.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/get.rs
@@ -1,7 +1,7 @@
 //! 获取公共邮箱详情
 //! docPath: <https://open.feishu.cn/document/server-docs/mail-v1/public-mailbox/public_mailbox/get>
 
-use crate::common::{api_endpoints::MailApiV1, api_utils::*};
+use crate::common::api_endpoints::MailApiV1;
 use crate::mail::mail::v1::public_mailbox::models::GetPublicMailboxResponse;
 use openlark_core::{
     SDKResult,
@@ -40,9 +40,13 @@ impl GetPublicMailboxRequest {
         let api_endpoint = MailApiV1::PublicMailboxGet(self.mailbox_id.clone());
         let request = ApiRequest::<GetPublicMailboxResponse>::get(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取公共邮箱")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取公共邮箱",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/list.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/list.rs
@@ -1,7 +1,7 @@
 //! 获取公共邮箱列表
 //! docPath: <https://open.feishu.cn/document/server-docs/mail-v1/public-mailbox/public_mailbox/list>
 
-use crate::common::{api_endpoints::MailApiV1, api_utils::*};
+use crate::common::api_endpoints::MailApiV1;
 use crate::mail::mail::v1::public_mailbox::models::PublicMailboxListResponse;
 use openlark_core::{
     SDKResult,
@@ -63,9 +63,13 @@ impl PublicMailboxListRequest {
             request = request.query("page_size", page_size.to_string());
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取公共邮箱列表")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取公共邮箱列表",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/batch_create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/batch_create.rs
@@ -55,10 +55,7 @@ impl BatchCreatePublicMailboxMemberRequest {
         );
         let req: ApiRequest<BatchCreatePublicMailboxMemberResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("批量添加公共邮箱成员", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "批量添加公共邮箱成员").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/batch_delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/batch_delete.rs
@@ -55,10 +55,7 @@ impl BatchDeletePublicMailboxMemberRequest {
         );
         let req: ApiRequest<BatchDeletePublicMailboxMemberResponse> = ApiRequest::delete(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("批量删除公共邮箱成员", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "批量删除公共邮箱成员").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/clear.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/clear.rs
@@ -55,10 +55,7 @@ impl ClearPublicMailboxMemberRequest {
         );
         let req: ApiRequest<ClearPublicMailboxMemberResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("清空公共邮箱成员", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "清空公共邮箱成员").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/create.rs
@@ -63,9 +63,13 @@ impl CreatePublicMailboxMemberRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "创建公共邮箱成员")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "创建公共邮箱成员")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "创建公共邮箱成员",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/delete.rs
@@ -1,7 +1,7 @@
 //! 删除公共邮箱成员
 //! docPath: <https://open.feishu.cn/document/server-docs/mail-v1/public-mailbox/public_mailbox/delete>
 
-use crate::common::{api_endpoints::MailApiV1, api_utils::*};
+use crate::common::api_endpoints::MailApiV1;
 use crate::mail::mail::v1::public_mailbox::member::models::DeletePublicMailboxMemberResponse;
 use openlark_core::{
     SDKResult,
@@ -48,9 +48,13 @@ impl DeletePublicMailboxMemberRequest {
         let request =
             ApiRequest::<DeletePublicMailboxMemberResponse>::delete(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "删除公共邮箱成员")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "删除公共邮箱成员",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/get.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/get.rs
@@ -1,7 +1,7 @@
 //! 获取公共邮箱成员详情
 //! docPath: <https://open.feishu.cn/document/server-docs/mail-v1/public-mailbox/public_mailbox/get>
 
-use crate::common::{api_endpoints::MailApiV1, api_utils::*};
+use crate::common::api_endpoints::MailApiV1;
 use crate::mail::mail::v1::public_mailbox::member::models::GetPublicMailboxMemberResponse;
 use openlark_core::{
     SDKResult,
@@ -47,9 +47,13 @@ impl GetPublicMailboxMemberRequest {
             MailApiV1::PublicMailboxMemberGet(self.mailbox_id.clone(), self.member_id.clone());
         let request = ApiRequest::<GetPublicMailboxMemberResponse>::get(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取公共邮箱成员")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取公共邮箱成员",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/list.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/member/list.rs
@@ -1,7 +1,7 @@
 //! 获取公共邮箱成员列表
 //! docPath: <https://open.feishu.cn/document/server-docs/mail-v1/public-mailbox/public_mailbox/list>
 
-use crate::common::{api_endpoints::MailApiV1, api_utils::*};
+use crate::common::api_endpoints::MailApiV1;
 use crate::mail::mail::v1::public_mailbox::member::models::PublicMailboxMemberListResponse;
 use openlark_core::{
     SDKResult,
@@ -65,9 +65,13 @@ impl PublicMailboxMemberListRequest {
             request = request.query("page_size", page_size.to_string());
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取公共邮箱成员列表")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取公共邮箱成员列表",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/patch.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/patch.rs
@@ -59,9 +59,13 @@ impl PatchPublicMailboxRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "部分更新公共邮箱")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "部分更新公共邮箱")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "部分更新公共邮箱",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/remove_to_recycle_bin.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/remove_to_recycle_bin.rs
@@ -56,10 +56,7 @@ impl RemovePublicMailboxToRecycleBinRequest {
         );
         let req: ApiRequest<RemovePublicMailboxToRecycleBinResponse> = ApiRequest::delete(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("将公共邮箱移至回收站", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "将公共邮箱移至回收站").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/public_mailbox/update.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/public_mailbox/update.rs
@@ -65,9 +65,13 @@ impl UpdatePublicMailboxRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "更新公共邮箱")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "更新公共邮箱")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "更新公共邮箱",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user/query.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user/query.rs
@@ -49,10 +49,7 @@ impl QueryMailUserRequest {
         let path = "/open-apis/mail/v1/users/query".to_string();
         let req: ApiRequest<QueryMailUserResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("查询邮箱地址状态", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "查询邮箱地址状态").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/accessible_mailboxes.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/accessible_mailboxes.rs
@@ -43,10 +43,7 @@ impl UserMailboxAccessibleMailboxesRequest {
             self.user_mailbox_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::get(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("列出可访问的邮箱", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "列出可访问的邮箱").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/alias/create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/alias/create.rs
@@ -55,10 +55,7 @@ impl CreateMailboxAliasRequest {
         );
         let req: ApiRequest<CreateMailboxAliasResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("创建用户邮箱别名", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "创建用户邮箱别名").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/alias/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/alias/delete.rs
@@ -62,10 +62,7 @@ impl DeleteMailboxAliasRequest {
         );
         let req: ApiRequest<DeleteMailboxAliasResponse> = ApiRequest::delete(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("删除用户邮箱别名", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "删除用户邮箱别名").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/alias/list.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/alias/list.rs
@@ -55,10 +55,7 @@ impl ListMailboxAliasRequest {
         );
         let req: ApiRequest<ListMailboxAliasResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("列出用户邮箱别名", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "列出用户邮箱别名").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/delete.rs
@@ -53,10 +53,7 @@ impl DeleteUserMailboxRequest {
         let path = format!("/open-apis/mail/v1/user_mailboxes/{}", self.user_mailbox_id);
         let req: ApiRequest<DeleteUserMailboxResponse> = ApiRequest::delete(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("从回收站删除用户邮箱地址", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "从回收站删除用户邮箱地址").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/draft/cancel_scheduled_send.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/draft/cancel_scheduled_send.rs
@@ -70,9 +70,7 @@ impl CancelScheduledSendRequest {
             self.mailbox_id, self.message_id
         );
         let req: ApiRequest<CancelScheduledSendResponse> = ApiRequest::post(&path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("取消定时发送", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "取消定时发送").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/draft/create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/draft/create.rs
@@ -48,9 +48,7 @@ impl UserMailboxDraftCreateRequest {
             self.user_mailbox_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("创建草稿", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "创建草稿").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/draft/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/draft/delete.rs
@@ -52,9 +52,7 @@ impl UserMailboxDraftDeleteRequest {
             self.user_mailbox_id, self.draft_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::delete(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("删除草稿", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "删除草稿").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/draft/get.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/draft/get.rs
@@ -52,9 +52,7 @@ impl UserMailboxDraftGetRequest {
             self.user_mailbox_id, self.draft_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::get(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("获取草稿内容", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "获取草稿内容").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/draft/list.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/draft/list.rs
@@ -43,9 +43,7 @@ impl UserMailboxDraftListRequest {
             self.user_mailbox_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::get(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("列出草稿列表", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "列出草稿列表").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/draft/send.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/draft/send.rs
@@ -57,9 +57,7 @@ impl UserMailboxDraftSendRequest {
             self.user_mailbox_id, self.draft_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("发送草稿", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "发送草稿").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/draft/update.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/draft/update.rs
@@ -57,9 +57,7 @@ impl UserMailboxDraftUpdateRequest {
             self.user_mailbox_id, self.draft_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::put(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("更新草稿", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "更新草稿").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/event/subscribe.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/event/subscribe.rs
@@ -55,9 +55,7 @@ impl SubscribeMailboxEventRequest {
         );
         let req: ApiRequest<SubscribeMailboxEventResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("订阅邮箱事件", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "订阅邮箱事件").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/event/subscription.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/event/subscription.rs
@@ -55,9 +55,7 @@ impl GetMailboxEventSubscriptionRequest {
         );
         let req: ApiRequest<GetMailboxEventSubscriptionResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("获取订阅状态", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "获取订阅状态").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/event/unsubscribe.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/event/unsubscribe.rs
@@ -55,9 +55,7 @@ impl UnsubscribeMailboxEventRequest {
         );
         let req: ApiRequest<UnsubscribeMailboxEventResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("取消订阅", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "取消订阅").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/folder/create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/folder/create.rs
@@ -55,9 +55,7 @@ impl CreateMailboxFolderRequest {
         );
         let req: ApiRequest<CreateMailboxFolderResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("创建邮箱文件夹", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "创建邮箱文件夹").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/folder/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/folder/delete.rs
@@ -62,9 +62,7 @@ impl DeleteMailboxFolderRequest {
         );
         let req: ApiRequest<DeleteMailboxFolderResponse> = ApiRequest::delete(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("删除邮箱文件夹", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "删除邮箱文件夹").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/folder/get.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/folder/get.rs
@@ -52,10 +52,7 @@ impl UserMailboxFolderGetRequest {
             self.user_mailbox_id, self.folder_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::get(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取邮箱文件信息", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取邮箱文件信息").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/folder/list.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/folder/list.rs
@@ -55,9 +55,7 @@ impl ListMailboxFolderRequest {
         );
         let req: ApiRequest<ListMailboxFolderResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("列出邮箱文件夹", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "列出邮箱文件夹").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/folder/patch.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/folder/patch.rs
@@ -61,9 +61,7 @@ impl PatchMailboxFolderRequest {
         );
         let req: ApiRequest<PatchMailboxFolderResponse> = ApiRequest::patch(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("修改邮箱文件夹", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "修改邮箱文件夹").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/label/create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/label/create.rs
@@ -48,9 +48,7 @@ impl UserMailboxLabelCreateRequest {
             self.user_mailbox_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("创建标签", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "创建标签").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/label/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/label/delete.rs
@@ -52,9 +52,7 @@ impl UserMailboxLabelDeleteRequest {
             self.user_mailbox_id, self.label_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::delete(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("删除标签", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "删除标签").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/label/get.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/label/get.rs
@@ -52,9 +52,7 @@ impl UserMailboxLabelGetRequest {
             self.user_mailbox_id, self.label_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::get(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("获取标签信息", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "获取标签信息").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/label/list.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/label/list.rs
@@ -43,9 +43,7 @@ impl UserMailboxLabelListRequest {
             self.user_mailbox_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::get(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("列出标签", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "列出标签").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/label/patch.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/label/patch.rs
@@ -57,9 +57,7 @@ impl UserMailboxLabelPatchRequest {
             self.user_mailbox_id, self.label_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::patch(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("更新标签", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "更新标签").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/mail_contact/create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/mail_contact/create.rs
@@ -55,9 +55,7 @@ impl CreateMailContactRequest {
         );
         let req: ApiRequest<CreateMailContactResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("创建邮箱联系人", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "创建邮箱联系人").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/mail_contact/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/mail_contact/delete.rs
@@ -62,9 +62,7 @@ impl DeleteMailContactRequest {
         );
         let req: ApiRequest<DeleteMailContactResponse> = ApiRequest::delete(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("删除邮箱联系人", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "删除邮箱联系人").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/mail_contact/list.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/mail_contact/list.rs
@@ -55,9 +55,7 @@ impl ListMailContactRequest {
         );
         let req: ApiRequest<ListMailContactResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("列出邮箱联系人", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "列出邮箱联系人").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/mail_contact/patch.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/mail_contact/patch.rs
@@ -61,9 +61,7 @@ impl PatchMailContactRequest {
         );
         let req: ApiRequest<PatchMailContactResponse> = ApiRequest::patch(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("修改邮箱联系人", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "修改邮箱联系人").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/attachment/download_url.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/attachment/download_url.rs
@@ -75,10 +75,7 @@ impl GetAttachmentDownloadUrlRequest {
         let req: ApiRequest<GetAttachmentDownloadUrlResponse> =
             ApiRequest::get(&path).query("attachment_id", self.attachment_id);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取附件下载链接", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取附件下载链接").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/batch_get.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/batch_get.rs
@@ -48,10 +48,7 @@ impl UserMailboxMessageBatchGetRequest {
             self.user_mailbox_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("批量获取邮件详情", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "批量获取邮件详情").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/batch_modify.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/batch_modify.rs
@@ -48,9 +48,7 @@ impl UserMailboxMessageBatchModifyRequest {
             self.user_mailbox_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("批量修改邮件", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "批量修改邮件").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/batch_trash.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/batch_trash.rs
@@ -48,9 +48,7 @@ impl UserMailboxMessageBatchTrashRequest {
             self.user_mailbox_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("批量删除邮件", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "批量删除邮件").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/get.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/get.rs
@@ -73,9 +73,7 @@ impl GetMailboxMessageRequest {
         );
         let req: ApiRequest<GetMailboxMessageResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("获取邮件详情", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "获取邮件详情").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/get_by_card.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/get_by_card.rs
@@ -55,10 +55,7 @@ impl GetMailboxMessageByCardRequest {
         );
         let req: ApiRequest<GetMailboxMessageByCardResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取邮件卡片的邮件列表", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取邮件卡片的邮件列表").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/list.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/list.rs
@@ -55,9 +55,7 @@ impl ListMailboxMessageRequest {
         );
         let req: ApiRequest<ListMailboxMessageResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("列出邮件", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "列出邮件").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/list_thread_message.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/list_thread_message.rs
@@ -52,10 +52,7 @@ impl UserMailboxMessageListThreadMessageRequest {
             self.user_mailbox_id, self.thread_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::get(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("查询会话下邮件信息", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "查询会话下邮件信息").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/modify.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/modify.rs
@@ -57,9 +57,7 @@ impl UserMailboxMessageModifyRequest {
             self.user_mailbox_id, self.message_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::put(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("修改邮件", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "修改邮件").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/recall/get_recall_detail.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/recall/get_recall_detail.rs
@@ -109,10 +109,7 @@ impl GetRecallDetailRequest {
             self.mailbox_id, self.message_id
         );
         let req: ApiRequest<GetRecallDetailResponse> = ApiRequest::get(&path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取邮件撤回进度", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取邮件撤回进度").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/recall/recall.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/recall/recall.rs
@@ -80,9 +80,7 @@ impl RecallMessageRequest {
             self.mailbox_id, self.message_id
         );
         let req: ApiRequest<RecallMessageResponse> = ApiRequest::post(&path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("撤回邮件", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "撤回邮件").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/send.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/send.rs
@@ -55,9 +55,7 @@ impl SendMailboxMessageRequest {
         );
         let req: ApiRequest<SendMailboxMessageResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("发送邮件", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "发送邮件").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/send_status.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/send_status.rs
@@ -99,10 +99,7 @@ impl GetMailSendStatusRequest {
             self.mailbox_id, self.message_id
         );
         let req: ApiRequest<GetMailSendStatusResponse> = ApiRequest::get(&path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("查询邮件发送状态", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "查询邮件发送状态").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/trash.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/message/trash.rs
@@ -57,9 +57,7 @@ impl UserMailboxMessageTrashRequest {
             self.user_mailbox_id, self.message_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("删除邮件", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "删除邮件").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/profile.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/profile.rs
@@ -71,10 +71,7 @@ impl GetUserMailboxProfileRequest {
             self.user_mailbox_id
         );
         let req: ApiRequest<GetUserMailboxProfileResponse> = ApiRequest::get(&path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取用户邮箱信息", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取用户邮箱信息").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/create.rs
@@ -55,9 +55,7 @@ impl CreateMailboxRuleRequest {
         );
         let req: ApiRequest<CreateMailboxRuleResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("创建收信规则", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "创建收信规则").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/delete.rs
@@ -62,9 +62,7 @@ impl DeleteMailboxRuleRequest {
         );
         let req: ApiRequest<DeleteMailboxRuleResponse> = ApiRequest::delete(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("删除收信规则", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "删除收信规则").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/list.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/list.rs
@@ -55,9 +55,7 @@ impl ListMailboxRuleRequest {
         );
         let req: ApiRequest<ListMailboxRuleResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("列出收信规则", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "列出收信规则").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/reorder.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/reorder.rs
@@ -55,10 +55,7 @@ impl ReorderMailboxRuleRequest {
         );
         let req: ApiRequest<ReorderMailboxRuleResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("对收信规则进行排序", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "对收信规则进行排序").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/update.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/rule/update.rs
@@ -61,9 +61,7 @@ impl UpdateMailboxRuleRequest {
         );
         let req: ApiRequest<UpdateMailboxRuleResponse> = ApiRequest::put(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("更新收信规则", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "更新收信规则").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/search.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/search.rs
@@ -175,9 +175,7 @@ impl SearchMailRequest {
         })?;
         let req = req.body(body);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("搜索邮件", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "搜索邮件").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/setting/get_signatures.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/setting/get_signatures.rs
@@ -123,9 +123,7 @@ impl GetSignaturesRequest {
             self.mailbox_id
         );
         let req: ApiRequest<GetSignaturesResponse> = ApiRequest::get(&path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("获取签名列表", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "获取签名列表").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/setting/send_as.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/setting/send_as.rs
@@ -43,9 +43,7 @@ impl UserMailboxSettingSendAsRequest {
             self.user_mailbox_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::get(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("列出可发信邮箱", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "列出可发信邮箱").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/template/attachment/download_url.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/template/attachment/download_url.rs
@@ -52,10 +52,7 @@ impl UserMailboxTemplateAttachmentDownloadUrlRequest {
             self.user_mailbox_id, self.template_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::get(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取模板附件下载链接", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取模板附件下载链接").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/template/create.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/template/create.rs
@@ -48,9 +48,7 @@ impl UserMailboxTemplateCreateRequest {
             self.user_mailbox_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("创建邮件模板", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "创建邮件模板").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/template/delete.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/template/delete.rs
@@ -52,9 +52,7 @@ impl UserMailboxTemplateDeleteRequest {
             self.user_mailbox_id, self.template_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::delete(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("删除邮件模板", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "删除邮件模板").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/template/get.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/template/get.rs
@@ -52,9 +52,7 @@ impl UserMailboxTemplateGetRequest {
             self.user_mailbox_id, self.template_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::get(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("获取邮件模板", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "获取邮件模板").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/template/list.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/template/list.rs
@@ -43,9 +43,7 @@ impl UserMailboxTemplateListRequest {
             self.user_mailbox_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::get(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("列出邮件模板", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "列出邮件模板").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/template/update.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/template/update.rs
@@ -57,9 +57,7 @@ impl UserMailboxTemplateUpdateRequest {
             self.user_mailbox_id, self.template_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::put(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("更新邮件模板", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "更新邮件模板").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/thread/batch_modify.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/thread/batch_modify.rs
@@ -48,10 +48,7 @@ impl UserMailboxThreadBatchModifyRequest {
             self.user_mailbox_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("批量修改邮件会话", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "批量修改邮件会话").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/thread/batch_trash.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/thread/batch_trash.rs
@@ -48,10 +48,7 @@ impl UserMailboxThreadBatchTrashRequest {
             self.user_mailbox_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("批量删除邮件会话", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "批量删除邮件会话").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/thread/get.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/thread/get.rs
@@ -52,10 +52,7 @@ impl UserMailboxThreadGetRequest {
             self.user_mailbox_id, self.thread_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::get(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取邮件会话详情", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取邮件会话详情").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/thread/list.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/thread/list.rs
@@ -43,9 +43,7 @@ impl UserMailboxThreadListRequest {
             self.user_mailbox_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::get(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("列出邮件会话", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "列出邮件会话").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/thread/modify.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/thread/modify.rs
@@ -57,9 +57,7 @@ impl UserMailboxThreadModifyRequest {
             self.user_mailbox_id, self.thread_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("修改邮件会话", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "修改邮件会话").await
     }
 }
 

--- a/crates/openlark-mail/src/mail/mail/v1/user_mailbox/thread/trash.rs
+++ b/crates/openlark-mail/src/mail/mail/v1/user_mailbox/thread/trash.rs
@@ -57,9 +57,7 @@ impl UserMailboxThreadTrashRequest {
             self.user_mailbox_id, self.thread_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("删除邮件会话", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "删除邮件会话").await
     }
 }
 


### PR DESCRIPTION
Closes #482 · Parent #470（楔子 step 2 · mail 试点迁移）

## What

把 openlark-mail 全部 leaf execute 的 response 抽取迁到 #479 的 canonical 入口 `Transport::request_typed`。迁移后 mail 的 `Transport::request(` 非 test 调用为 **0**，全部走 canonical 入口。

## 迁移覆盖（110 个抽取点，grep 零残留）

| 旧 idiom | 数量 | 新写法 | 行为变化 |
|---|---|---|---|
| 手写 `.data.ok_or_else` 块式 `{ ... }` | 33 | `request_typed(...,"CTX")` | **有**：补回 operation/resource/request_id |
| 手写 `.data.ok_or_else` 换行单表达式 | 49 | 同上 | 同上 |
| canonical 两步 `extract_response_data` | 28 | `request_typed(...,"CTX")` | **无**（request_typed = request + extract_response_data） |

82 个手写点此前把 operation 字符串误塞进 `validation_error(field, msg)` 的 `field` 位，既无 `map_context` 也无 `request_id`——父 #470 所述「43% 丢 context 是真 correctness bug」。迁后经 canonical helper 的 `map_context` 正确附着 `operation`(=extract_response_data) + `resource`(=caller context) + `request_id`。

## Why

mail 作中小 crate 试点，验证迁移模式 + 确认错误上下文补回。模式跑通后扇出 #483-#485（HR / communication+meeting+docs / 其余）。`extract_response_data` helper 在全 crate 零 caller 后由 #486 删除。

## 一个值得 review 的发现

初次 grep `.data.ok_or_else`（要求同行）只见 33 个，漏了 49 个**换行变体**（`resp.data\n    .ok_or_else(|| validation_error(...))`）。naive grep 严重低估手写抽取量——正确统计须 grep `ok_or_else`（不带前缀）。脚本 `/tmp/migrate_mail_482.py` 处理全部三式。此 gotcha 已记给 #483-485。

## Acceptance criteria

- [x] mail leaf execute 零手写抽取（grep `ok_or_else` 非 test = 0；`.into_result()` = 0；`.unwrap_or_default()` 抽取 = 0，仅 test `received_requests` 残留）
- [x] 全部走 canonical 入口（`Transport::request(` 非 test = 0；`request_typed` = 110）
- [x] mail 既有 leaf 测试绿（147 passed / 0 failed）
- [x] 失败路径现带 operation / resource / request_id（由构造保证：request_typed → extract_response_data → map_context；入口层 context 附着已由 #479 的 `request_typed_failure_attaches...` 契约测试证明）

## 验证

- `cargo test -p openlark-mail --all-features`：120 + 26 + 1 = 147 passed / 0 failed
- `cargo clippy -p openlark-mail --all-targets --all-features -- -Dwarnings`：clean
- `cargo clippy -p openlark-mail --all-targets --no-default-features -- -Dwarnings`：clean
- `cargo fmt --check`（workspace）：clean
- code-review（Standards + Spec 双轴）：0 硬违规 / 0 spec 缺失；1 个非阻塞 doc 自相矛盾已在本 PR 修（commit 2）

## 附带

- commit 2 刷新 `request_typed` doc（#479 写的「不迁移任何 leaf」在本 PR 迁移 mail 后自相矛盾，改为准确的增量迁移状态）。
- 各 crate `common/api_utils.rs` 的 `extract_response_data` re-export 仍存（pub API，留给 #486 删 core helper 时一并清）。