### PR TITLE
refactor: migrate remaining 12 crates' leaf extraction to Transport::request_typed (#485)

### DIFF
--- a/crates/openlark-ai/src/ai/document_ai/v1/bank_card/recognize.rs
+++ b/crates/openlark-ai/src/ai/document_ai/v1/bank_card/recognize.rs
@@ -10,7 +10,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::DOCUMENT_AI_BANK_CARD_RECOGNIZE;
 
 /// 银行卡识别请求体
@@ -103,8 +103,7 @@ impl BankCardRecognizeRequest {
                 .body(serialize_params(&body, "银行卡识别")?)
                 .file_content(body.file.clone());
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "银行卡识别")
+        Transport::request_typed(req, &self.config, Some(option), "银行卡识别").await
     }
 }
 
@@ -183,8 +182,7 @@ pub async fn bank_card_recognize_with_options(
             .body(serialize_params(&body, "银行卡识别")?)
             .file_content(body.file.clone());
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "银行卡识别")
+    Transport::request_typed(req, config, Some(option), "银行卡识别").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/document_ai/v1/business_card/recognize.rs
+++ b/crates/openlark-ai/src/ai/document_ai/v1/business_card/recognize.rs
@@ -10,7 +10,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::DOCUMENT_AI_BUSINESS_CARD_RECOGNIZE;
 
 /// 名片识别请求体
@@ -100,8 +100,7 @@ impl BusinessCardRecognizeRequest {
             ApiRequest::post(DOCUMENT_AI_BUSINESS_CARD_RECOGNIZE)
                 .body(serialize_params(&body, "名片识别")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "名片识别")
+        Transport::request_typed(req, &self.config, Some(option), "名片识别").await
     }
 }
 
@@ -181,8 +180,7 @@ pub async fn business_card_recognize_with_options(
         ApiRequest::post(DOCUMENT_AI_BUSINESS_CARD_RECOGNIZE)
             .body(serialize_params(&body, "名片识别")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "名片识别")
+    Transport::request_typed(req, config, Some(option), "名片识别").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/document_ai/v1/business_license/recognize.rs
+++ b/crates/openlark-ai/src/ai/document_ai/v1/business_license/recognize.rs
@@ -10,7 +10,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::DOCUMENT_AI_BUSINESS_LICENSE_RECOGNIZE;
 
 /// 营业执照识别请求体
@@ -120,8 +120,7 @@ impl BusinessLicenseRecognizeRequest {
             ApiRequest::post(DOCUMENT_AI_BUSINESS_LICENSE_RECOGNIZE)
                 .body(serialize_params(&body, "营业执照识别")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "营业执照识别")
+        Transport::request_typed(req, &self.config, Some(option), "营业执照识别").await
     }
 }
 
@@ -199,8 +198,7 @@ pub async fn business_license_recognize_with_options(
         ApiRequest::post(DOCUMENT_AI_BUSINESS_LICENSE_RECOGNIZE)
             .body(serialize_params(&body, "营业执照识别")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "营业执照识别")
+    Transport::request_typed(req, config, Some(option), "营业执照识别").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/document_ai/v1/chinese_passport/recognize.rs
+++ b/crates/openlark-ai/src/ai/document_ai/v1/chinese_passport/recognize.rs
@@ -10,7 +10,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::DOCUMENT_AI_CHINESE_PASSPORT_RECOGNIZE;
 
 /// 中国护照识别请求体
@@ -106,8 +106,7 @@ impl ChinesePassportRecognizeRequest {
             ApiRequest::post(DOCUMENT_AI_CHINESE_PASSPORT_RECOGNIZE)
                 .body(serialize_params(&body, "中国护照识别")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "中国护照识别")
+        Transport::request_typed(req, &self.config, Some(option), "中国护照识别").await
     }
 }
 
@@ -187,8 +186,7 @@ pub async fn chinese_passport_recognize_with_options(
         ApiRequest::post(DOCUMENT_AI_CHINESE_PASSPORT_RECOGNIZE)
             .body(serialize_params(&body, "中国护照识别")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "中国护照识别")
+    Transport::request_typed(req, config, Some(option), "中国护照识别").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/document_ai/v1/contract/field_extraction.rs
+++ b/crates/openlark-ai/src/ai/document_ai/v1/contract/field_extraction.rs
@@ -10,7 +10,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::DOCUMENT_AI_CONTRACT_FIELD_EXTRACTION;
 
 /// 合同字段提取请求体
@@ -117,8 +117,7 @@ impl ContractFieldExtractionRequest {
             ApiRequest::post(DOCUMENT_AI_CONTRACT_FIELD_EXTRACTION)
                 .body(serialize_params(&body, "合同字段提取")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "合同字段提取")
+        Transport::request_typed(req, &self.config, Some(option), "合同字段提取").await
     }
 }
 
@@ -198,8 +197,7 @@ pub async fn contract_field_extraction_with_options(
         ApiRequest::post(DOCUMENT_AI_CONTRACT_FIELD_EXTRACTION)
             .body(serialize_params(&body, "合同字段提取")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "合同字段提取")
+    Transport::request_typed(req, config, Some(option), "合同字段提取").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/document_ai/v1/driving_license/recognize.rs
+++ b/crates/openlark-ai/src/ai/document_ai/v1/driving_license/recognize.rs
@@ -10,7 +10,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::DOCUMENT_AI_DRIVING_LICENSE_RECOGNIZE;
 
 /// 驾驶证识别请求体
@@ -109,8 +109,7 @@ impl DrivingLicenseRecognizeRequest {
             ApiRequest::post(DOCUMENT_AI_DRIVING_LICENSE_RECOGNIZE)
                 .body(serialize_params(&body, "驾驶证识别")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "驾驶证识别")
+        Transport::request_typed(req, &self.config, Some(option), "驾驶证识别").await
     }
 }
 
@@ -190,8 +189,7 @@ pub async fn driving_license_recognize_with_options(
         ApiRequest::post(DOCUMENT_AI_DRIVING_LICENSE_RECOGNIZE)
             .body(serialize_params(&body, "驾驶证识别")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "驾驶证识别")
+    Transport::request_typed(req, config, Some(option), "驾驶证识别").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/document_ai/v1/food_manage_license/recognize.rs
+++ b/crates/openlark-ai/src/ai/document_ai/v1/food_manage_license/recognize.rs
@@ -10,7 +10,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::DOCUMENT_AI_FOOD_MANAGE_LICENSE_RECOGNIZE;
 
 /// 食品经营许可证识别请求体
@@ -100,8 +100,7 @@ impl FoodManageLicenseRecognizeRequest {
             ApiRequest::post(DOCUMENT_AI_FOOD_MANAGE_LICENSE_RECOGNIZE)
                 .body(serialize_params(&body, "食品经营许可证识别")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "食品经营许可证识别")
+        Transport::request_typed(req, &self.config, Some(option), "食品经营许可证识别").await
     }
 }
 
@@ -181,8 +180,7 @@ pub async fn food_manage_license_recognize_with_options(
         ApiRequest::post(DOCUMENT_AI_FOOD_MANAGE_LICENSE_RECOGNIZE)
             .body(serialize_params(&body, "食品经营许可证识别")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "食品经营许可证识别")
+    Transport::request_typed(req, config, Some(option), "食品经营许可证识别").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/document_ai/v1/food_produce_license/recognize.rs
+++ b/crates/openlark-ai/src/ai/document_ai/v1/food_produce_license/recognize.rs
@@ -10,7 +10,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::DOCUMENT_AI_FOOD_PRODUCE_LICENSE_RECOGNIZE;
 
 /// 食品生产许可证识别请求体
@@ -100,8 +100,7 @@ impl FoodProduceLicenseRecognizeRequest {
             ApiRequest::post(DOCUMENT_AI_FOOD_PRODUCE_LICENSE_RECOGNIZE)
                 .body(serialize_params(&body, "食品生产许可证识别")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "食品生产许可证识别")
+        Transport::request_typed(req, &self.config, Some(option), "食品生产许可证识别").await
     }
 }
 
@@ -181,8 +180,7 @@ pub async fn food_produce_license_recognize_with_options(
         ApiRequest::post(DOCUMENT_AI_FOOD_PRODUCE_LICENSE_RECOGNIZE)
             .body(serialize_params(&body, "食品生产许可证识别")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "食品生产许可证识别")
+    Transport::request_typed(req, config, Some(option), "食品生产许可证识别").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/document_ai/v1/health_certificate/recognize.rs
+++ b/crates/openlark-ai/src/ai/document_ai/v1/health_certificate/recognize.rs
@@ -10,7 +10,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::DOCUMENT_AI_HEALTH_CERTIFICATE_RECOGNIZE;
 
 /// 健康证识别请求体
@@ -97,8 +97,7 @@ impl HealthCertificateRecognizeRequest {
             ApiRequest::post(DOCUMENT_AI_HEALTH_CERTIFICATE_RECOGNIZE)
                 .body(serialize_params(&body, "健康证识别")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "健康证识别")
+        Transport::request_typed(req, &self.config, Some(option), "健康证识别").await
     }
 }
 
@@ -178,8 +177,7 @@ pub async fn health_certificate_recognize_with_options(
         ApiRequest::post(DOCUMENT_AI_HEALTH_CERTIFICATE_RECOGNIZE)
             .body(serialize_params(&body, "健康证识别")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "健康证识别")
+    Transport::request_typed(req, config, Some(option), "健康证识别").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/document_ai/v1/hkm_mainland_travel_permit/recognize.rs
+++ b/crates/openlark-ai/src/ai/document_ai/v1/hkm_mainland_travel_permit/recognize.rs
@@ -10,7 +10,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::DOCUMENT_AI_HKM_MAINLAND_TRAVEL_PERMIT_RECOGNIZE;
 
 /// 港澳通行证识别请求体
@@ -97,8 +97,7 @@ impl HkmMainlandTravelPermitRecognizeRequest {
             ApiRequest::post(DOCUMENT_AI_HKM_MAINLAND_TRAVEL_PERMIT_RECOGNIZE)
                 .body(serialize_params(&body, "港澳通行证识别")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "港澳通行证识别")
+        Transport::request_typed(req, &self.config, Some(option), "港澳通行证识别").await
     }
 }
 
@@ -178,8 +177,7 @@ pub async fn hkm_mainland_travel_permit_recognize_with_options(
         ApiRequest::post(DOCUMENT_AI_HKM_MAINLAND_TRAVEL_PERMIT_RECOGNIZE)
             .body(serialize_params(&body, "港澳通行证识别")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "港澳通行证识别")
+    Transport::request_typed(req, config, Some(option), "港澳通行证识别").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/document_ai/v1/id_card/recognize.rs
+++ b/crates/openlark-ai/src/ai/document_ai/v1/id_card/recognize.rs
@@ -10,7 +10,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::DOCUMENT_AI_ID_CARD_RECOGNIZE;
 
 /// 身份证识别请求体
@@ -114,8 +114,7 @@ impl IdCardRecognizeRequest {
             ApiRequest::post(DOCUMENT_AI_ID_CARD_RECOGNIZE)
                 .body(serialize_params(&body, "身份证识别")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "身份证识别")
+        Transport::request_typed(req, &self.config, Some(option), "身份证识别").await
     }
 }
 
@@ -192,8 +191,7 @@ pub async fn id_card_recognize_with_options(
     let req: ApiRequest<IdCardRecognizeResponse> = ApiRequest::post(DOCUMENT_AI_ID_CARD_RECOGNIZE)
         .body(serialize_params(&body, "身份证识别")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "身份证识别")
+    Transport::request_typed(req, config, Some(option), "身份证识别").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/document_ai/v1/resume/parse.rs
+++ b/crates/openlark-ai/src/ai/document_ai/v1/resume/parse.rs
@@ -10,7 +10,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::DOCUMENT_AI_RESUME_PARSE;
 
 /// 简历解析请求体
@@ -191,8 +191,7 @@ impl ResumeParseRequest {
         let req: ApiRequest<ResumeParseResponse> =
             ApiRequest::post(DOCUMENT_AI_RESUME_PARSE).body(serialize_params(&body, "简历解析")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "简历解析")
+        Transport::request_typed(req, &self.config, Some(option), "简历解析").await
     }
 }
 
@@ -271,8 +270,7 @@ pub async fn resume_parse_with_options(
     let req: ApiRequest<ResumeParseResponse> =
         ApiRequest::post(DOCUMENT_AI_RESUME_PARSE).body(serialize_params(&body, "简历解析")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "简历解析")
+    Transport::request_typed(req, config, Some(option), "简历解析").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/document_ai/v1/taxi_invoice/recognize.rs
+++ b/crates/openlark-ai/src/ai/document_ai/v1/taxi_invoice/recognize.rs
@@ -10,7 +10,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::DOCUMENT_AI_TAXI_INVOICE_RECOGNIZE;
 
 /// 出租车发票识别请求体
@@ -103,8 +103,7 @@ impl TaxiInvoiceRecognizeRequest {
             ApiRequest::post(DOCUMENT_AI_TAXI_INVOICE_RECOGNIZE)
                 .body(serialize_params(&body, "出租车发票识别")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "出租车发票识别")
+        Transport::request_typed(req, &self.config, Some(option), "出租车发票识别").await
     }
 }
 
@@ -184,8 +183,7 @@ pub async fn taxi_invoice_recognize_with_options(
         ApiRequest::post(DOCUMENT_AI_TAXI_INVOICE_RECOGNIZE)
             .body(serialize_params(&body, "出租车发票识别")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "出租车发票识别")
+    Transport::request_typed(req, config, Some(option), "出租车发票识别").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/document_ai/v1/train_invoice/recognize.rs
+++ b/crates/openlark-ai/src/ai/document_ai/v1/train_invoice/recognize.rs
@@ -10,7 +10,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::DOCUMENT_AI_TRAIN_INVOICE_RECOGNIZE;
 
 /// 火车票识别请求体
@@ -103,8 +103,7 @@ impl TrainInvoiceRecognizeRequest {
             ApiRequest::post(DOCUMENT_AI_TRAIN_INVOICE_RECOGNIZE)
                 .body(serialize_params(&body, "火车票识别")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "火车票识别")
+        Transport::request_typed(req, &self.config, Some(option), "火车票识别").await
     }
 }
 
@@ -184,8 +183,7 @@ pub async fn train_invoice_recognize_with_options(
         ApiRequest::post(DOCUMENT_AI_TRAIN_INVOICE_RECOGNIZE)
             .body(serialize_params(&body, "火车票识别")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "火车票识别")
+    Transport::request_typed(req, config, Some(option), "火车票识别").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/document_ai/v1/tw_mainland_travel_permit/recognize.rs
+++ b/crates/openlark-ai/src/ai/document_ai/v1/tw_mainland_travel_permit/recognize.rs
@@ -10,7 +10,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::DOCUMENT_AI_TW_MAINLAND_TRAVEL_PERMIT_RECOGNIZE;
 
 /// 台湾通行证识别请求体
@@ -97,8 +97,7 @@ impl TwMainlandTravelPermitRecognizeRequest {
             ApiRequest::post(DOCUMENT_AI_TW_MAINLAND_TRAVEL_PERMIT_RECOGNIZE)
                 .body(serialize_params(&body, "台湾通行证识别")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "台湾通行证识别")
+        Transport::request_typed(req, &self.config, Some(option), "台湾通行证识别").await
     }
 }
 
@@ -178,8 +177,7 @@ pub async fn tw_mainland_travel_permit_recognize_with_options(
         ApiRequest::post(DOCUMENT_AI_TW_MAINLAND_TRAVEL_PERMIT_RECOGNIZE)
             .body(serialize_params(&body, "台湾通行证识别")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "台湾通行证识别")
+    Transport::request_typed(req, config, Some(option), "台湾通行证识别").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/document_ai/v1/vat_invoice/recognize.rs
+++ b/crates/openlark-ai/src/ai/document_ai/v1/vat_invoice/recognize.rs
@@ -10,7 +10,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::DOCUMENT_AI_VAT_INVOICE_RECOGNIZE;
 
 /// 增值税发票识别请求体
@@ -120,8 +120,7 @@ impl VatInvoiceRecognizeRequest {
             ApiRequest::post(DOCUMENT_AI_VAT_INVOICE_RECOGNIZE)
                 .body(serialize_params(&body, "增值税发票识别")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "增值税发票识别")
+        Transport::request_typed(req, &self.config, Some(option), "增值税发票识别").await
     }
 }
 
@@ -199,8 +198,7 @@ pub async fn vat_invoice_recognize_with_options(
         ApiRequest::post(DOCUMENT_AI_VAT_INVOICE_RECOGNIZE)
             .body(serialize_params(&body, "增值税发票识别")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "增值税发票识别")
+    Transport::request_typed(req, config, Some(option), "增值税发票识别").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/document_ai/v1/vehicle_invoice/recognize.rs
+++ b/crates/openlark-ai/src/ai/document_ai/v1/vehicle_invoice/recognize.rs
@@ -10,7 +10,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::DOCUMENT_AI_VEHICLE_INVOICE_RECOGNIZE;
 
 /// 机动车发票识别请求体
@@ -109,8 +109,7 @@ impl VehicleInvoiceRecognizeRequest {
             ApiRequest::post(DOCUMENT_AI_VEHICLE_INVOICE_RECOGNIZE)
                 .body(serialize_params(&body, "机动车发票识别")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "机动车发票识别")
+        Transport::request_typed(req, &self.config, Some(option), "机动车发票识别").await
     }
 }
 
@@ -190,8 +189,7 @@ pub async fn vehicle_invoice_recognize_with_options(
         ApiRequest::post(DOCUMENT_AI_VEHICLE_INVOICE_RECOGNIZE)
             .body(serialize_params(&body, "机动车发票识别")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "机动车发票识别")
+    Transport::request_typed(req, config, Some(option), "机动车发票识别").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/document_ai/v1/vehicle_license/recognize.rs
+++ b/crates/openlark-ai/src/ai/document_ai/v1/vehicle_license/recognize.rs
@@ -10,7 +10,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::DOCUMENT_AI_VEHICLE_LICENSE_RECOGNIZE;
 
 /// 行驶证识别请求体
@@ -109,8 +109,7 @@ impl VehicleLicenseRecognizeRequest {
             ApiRequest::post(DOCUMENT_AI_VEHICLE_LICENSE_RECOGNIZE)
                 .body(serialize_params(&body, "行驶证识别")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "行驶证识别")
+        Transport::request_typed(req, &self.config, Some(option), "行驶证识别").await
     }
 }
 
@@ -190,8 +189,7 @@ pub async fn vehicle_license_recognize_with_options(
         ApiRequest::post(DOCUMENT_AI_VEHICLE_LICENSE_RECOGNIZE)
             .body(serialize_params(&body, "行驶证识别")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "行驶证识别")
+    Transport::request_typed(req, config, Some(option), "行驶证识别").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/optical_char_recognition/v1/image/basic_recognize.rs
+++ b/crates/openlark-ai/src/ai/optical_char_recognition/v1/image/basic_recognize.rs
@@ -10,7 +10,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::OPTICAL_CHAR_RECOGNITION_V1_IMAGE_BASIC_RECOGNIZE;
 
 /// OCR 基础识别请求体
@@ -123,8 +123,7 @@ impl BasicRecognizeRequest {
             ApiRequest::post(OPTICAL_CHAR_RECOGNITION_V1_IMAGE_BASIC_RECOGNIZE)
                 .body(serialize_params(&body, "OCR 基础识别")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "OCR 基础识别")
+        Transport::request_typed(req, &self.config, Some(option), "OCR 基础识别").await
     }
 }
 
@@ -204,8 +203,7 @@ pub async fn basic_recognize_with_options(
         ApiRequest::post(OPTICAL_CHAR_RECOGNITION_V1_IMAGE_BASIC_RECOGNIZE)
             .body(serialize_params(&body, "OCR 基础识别")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "OCR 基础识别")
+    Transport::request_typed(req, config, Some(option), "OCR 基础识别").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/speech_to_text/v1/speech/file_recognize.rs
+++ b/crates/openlark-ai/src/ai/speech_to_text/v1/speech/file_recognize.rs
@@ -11,7 +11,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::SPEECH_TO_TEXT_V1_SPEECH_FILE_RECOGNIZE;
 
 /// 语音文件识别请求体
@@ -92,8 +92,7 @@ impl FileRecognizeRequest {
             ApiRequest::post(SPEECH_TO_TEXT_V1_SPEECH_FILE_RECOGNIZE)
                 .body(serialize_params(&body, "语音文件识别")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "语音文件识别")
+        Transport::request_typed(req, &self.config, Some(option), "语音文件识别").await
     }
 }
 
@@ -191,8 +190,7 @@ pub async fn file_recognize_with_options(
         ApiRequest::post(SPEECH_TO_TEXT_V1_SPEECH_FILE_RECOGNIZE)
             .body(serialize_params(&body, "语音文件识别")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "语音文件识别")
+    Transport::request_typed(req, config, Some(option), "语音文件识别").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/speech_to_text/v1/speech/stream_recognize.rs
+++ b/crates/openlark-ai/src/ai/speech_to_text/v1/speech/stream_recognize.rs
@@ -11,7 +11,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::SPEECH_TO_TEXT_V1_SPEECH_STREAM_RECOGNIZE;
 
 /// 流式语音识别请求体
@@ -104,8 +104,7 @@ impl StreamRecognizeRequest {
             ApiRequest::post(SPEECH_TO_TEXT_V1_SPEECH_STREAM_RECOGNIZE)
                 .body(serialize_params(&body, "流式语音识别")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "流式语音识别")
+        Transport::request_typed(req, &self.config, Some(option), "流式语音识别").await
     }
 }
 
@@ -221,8 +220,7 @@ pub async fn stream_recognize_with_options(
         ApiRequest::post(SPEECH_TO_TEXT_V1_SPEECH_STREAM_RECOGNIZE)
             .body(serialize_params(&body, "流式语音识别")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "流式语音识别")
+    Transport::request_typed(req, config, Some(option), "流式语音识别").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/translation/v1/text/detect.rs
+++ b/crates/openlark-ai/src/ai/translation/v1/text/detect.rs
@@ -10,7 +10,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::TRANSLATION_V1_TEXT_DETECT;
 
 /// 文本语言检测请求体
@@ -78,8 +78,7 @@ impl TextDetectRequest {
         let req: ApiRequest<TextDetectResponse> = ApiRequest::post(TRANSLATION_V1_TEXT_DETECT)
             .body(serialize_params(&body, "文本语言检测")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "文本语言检测")
+        Transport::request_typed(req, &self.config, Some(option), "文本语言检测").await
     }
 }
 
@@ -146,8 +145,7 @@ pub async fn text_detect_with_options(
     let req: ApiRequest<TextDetectResponse> =
         ApiRequest::post(TRANSLATION_V1_TEXT_DETECT).body(serialize_params(&body, "文本语言检测")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "文本语言检测")
+    Transport::request_typed(req, config, Some(option), "文本语言检测").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/ai/translation/v1/text/translate.rs
+++ b/crates/openlark-ai/src/ai/translation/v1/text/translate.rs
@@ -10,7 +10,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 use crate::endpoints::TRANSLATION_V1_TEXT_TRANSLATE;
 
 /// 文本翻译请求体
@@ -96,8 +96,7 @@ impl TextTranslateRequest {
             ApiRequest::post(TRANSLATION_V1_TEXT_TRANSLATE)
                 .body(serialize_params(&body, "文本翻译")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "文本翻译")
+        Transport::request_typed(req, &self.config, Some(option), "文本翻译").await
     }
 }
 
@@ -191,8 +190,7 @@ pub async fn text_translate_with_options(
     let req: ApiRequest<TextTranslateResponse> =
         ApiRequest::post(TRANSLATION_V1_TEXT_TRANSLATE).body(serialize_params(&body, "文本翻译")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "文本翻译")
+    Transport::request_typed(req, config, Some(option), "文本翻译").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-ai/src/common/api_utils.rs
+++ b/crates/openlark-ai/src/common/api_utils.rs
@@ -1,6 +1,6 @@
 //! API 工具函数（re-export core canonical）。
 //!
-//! serialize_params / extract_response_data 已下沉到 `openlark_core::api`（#330）。
-//! ai 当前不用 ensure_success，故仅 re-export 用到的两项。
+//! serialize_params 已下沉到 `openlark::api`（#330）。extract_response_data 原 re-export
+//! 在 #485 迁移到 Transport::request_typed 后零 caller，移除（core helper 删除留给 #486）。
 
-pub use openlark_core::api::{extract_response_data, serialize_params};
+pub use openlark_core::api::serialize_params;

--- a/crates/openlark-analytics/src/report/report/v1/rule/query.rs
+++ b/crates/openlark-analytics/src/report/report/v1/rule/query.rs
@@ -49,9 +49,7 @@ impl QueryReportRuleRequest {
         let path = "/open-apis/report/v1/rules/query".to_string();
         let req: ApiRequest<QueryReportRuleResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("查询规则", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "查询规则").await
     }
 }
 

--- a/crates/openlark-analytics/src/report/report/v1/rule/view/remove.rs
+++ b/crates/openlark-analytics/src/report/report/v1/rule/view/remove.rs
@@ -55,9 +55,7 @@ impl RemoveReportRuleViewRequest {
         let path = format!("/open-apis/report/v1/rules/{}/views/remove", self.rule_id);
         let req: ApiRequest<RemoveReportRuleViewResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("移除规则看板", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "移除规则看板").await
     }
 }
 

--- a/crates/openlark-analytics/src/report/report/v1/task/query.rs
+++ b/crates/openlark-analytics/src/report/report/v1/task/query.rs
@@ -49,9 +49,7 @@ impl QueryReportTaskRequest {
         let path = "/open-apis/report/v1/tasks/query".to_string();
         let req: ApiRequest<QueryReportTaskResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("查询任务", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "查询任务").await
     }
 }
 

--- a/crates/openlark-analytics/src/search/search/v2/app/create.rs
+++ b/crates/openlark-analytics/src/search/search/v2/app/create.rs
@@ -46,9 +46,7 @@ impl SearchAppRequest {
         let path = "/open-apis/search/v2/app".to_string();
         let req: ApiRequest<SearchAppResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("搜索应用", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "搜索应用").await
     }
 }
 

--- a/crates/openlark-analytics/src/search/search/v2/data_source/create.rs
+++ b/crates/openlark-analytics/src/search/search/v2/data_source/create.rs
@@ -49,9 +49,7 @@ impl CreateDataSourceRequest {
         let path = "/open-apis/search/v2/data_sources".to_string();
         let req: ApiRequest<CreateDataSourceResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("创建数据源", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "创建数据源").await
     }
 }
 

--- a/crates/openlark-analytics/src/search/search/v2/data_source/delete.rs
+++ b/crates/openlark-analytics/src/search/search/v2/data_source/delete.rs
@@ -55,9 +55,7 @@ impl DeleteDataSourceRequest {
         let path = format!("/open-apis/search/v2/data_sources/{}", self.data_source_id);
         let req: ApiRequest<DeleteDataSourceResponse> = ApiRequest::delete(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("删除数据源", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "删除数据源").await
     }
 }
 

--- a/crates/openlark-analytics/src/search/search/v2/data_source/get.rs
+++ b/crates/openlark-analytics/src/search/search/v2/data_source/get.rs
@@ -64,9 +64,7 @@ impl GetDataSourceRequest {
         let path = format!("/open-apis/search/v2/data_sources/{}", self.data_source_id);
         let req: ApiRequest<GetDataSourceResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("获取数据源", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "获取数据源").await
     }
 }
 

--- a/crates/openlark-analytics/src/search/search/v2/data_source/item/create.rs
+++ b/crates/openlark-analytics/src/search/search/v2/data_source/item/create.rs
@@ -58,10 +58,7 @@ impl CreateDataSourceItemRequest {
         );
         let req: ApiRequest<CreateDataSourceItemResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("为指定数据项创建索引", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "为指定数据项创建索引").await
     }
 }
 

--- a/crates/openlark-analytics/src/search/search/v2/data_source/item/delete.rs
+++ b/crates/openlark-analytics/src/search/search/v2/data_source/item/delete.rs
@@ -65,9 +65,7 @@ impl DeleteDataSourceItemRequest {
         );
         let req: ApiRequest<DeleteDataSourceItemResponse> = ApiRequest::delete(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("删除数据项", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "删除数据项").await
     }
 }
 

--- a/crates/openlark-analytics/src/search/search/v2/data_source/item/get.rs
+++ b/crates/openlark-analytics/src/search/search/v2/data_source/item/get.rs
@@ -71,9 +71,7 @@ impl GetDataSourceItemRequest {
         );
         let req: ApiRequest<GetDataSourceItemResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("查询指定数据项", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "查询指定数据项").await
     }
 }
 

--- a/crates/openlark-analytics/src/search/search/v2/data_source/list.rs
+++ b/crates/openlark-analytics/src/search/search/v2/data_source/list.rs
@@ -49,9 +49,7 @@ impl ListDataSourceRequest {
         let path = "/open-apis/search/v2/data_sources".to_string();
         let req: ApiRequest<ListDataSourceResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("批量获取数据源", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "批量获取数据源").await
     }
 }
 

--- a/crates/openlark-analytics/src/search/search/v2/data_source/patch.rs
+++ b/crates/openlark-analytics/src/search/search/v2/data_source/patch.rs
@@ -55,9 +55,7 @@ impl PatchDataSourceRequest {
         let path = format!("/open-apis/search/v2/data_sources/{}", self.data_source_id);
         let req: ApiRequest<PatchDataSourceResponse> = ApiRequest::patch(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("修改数据源", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "修改数据源").await
     }
 }
 

--- a/crates/openlark-analytics/src/search/search/v2/doc_wiki/search.rs
+++ b/crates/openlark-analytics/src/search/search/v2/doc_wiki/search.rs
@@ -49,9 +49,7 @@ impl SearchDocWikiRequest {
         let path = "/open-apis/search/v2/doc_wiki/search".to_string();
         let req: ApiRequest<SearchDocWikiResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("搜索文档", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "搜索文档").await
     }
 }
 

--- a/crates/openlark-analytics/src/search/search/v2/message/create.rs
+++ b/crates/openlark-analytics/src/search/search/v2/message/create.rs
@@ -49,9 +49,7 @@ impl SearchMessageRequest {
         let path = "/open-apis/search/v2/message".to_string();
         let req: ApiRequest<SearchMessageResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("搜索消息", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "搜索消息").await
     }
 }
 

--- a/crates/openlark-analytics/src/search/search/v2/schema/create.rs
+++ b/crates/openlark-analytics/src/search/search/v2/schema/create.rs
@@ -49,9 +49,7 @@ impl CreateSchemaRequest {
         let path = "/open-apis/search/v2/schemas".to_string();
         let req: ApiRequest<CreateSchemaResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("创建数据范式", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "创建数据范式").await
     }
 }
 

--- a/crates/openlark-analytics/src/search/search/v2/schema/delete.rs
+++ b/crates/openlark-analytics/src/search/search/v2/schema/delete.rs
@@ -55,9 +55,7 @@ impl DeleteSchemaRequest {
         let path = format!("/open-apis/search/v2/schemas/{}", self.schema_id);
         let req: ApiRequest<DeleteSchemaResponse> = ApiRequest::delete(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("删除数据范式", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "删除数据范式").await
     }
 }
 

--- a/crates/openlark-analytics/src/search/search/v2/schema/get.rs
+++ b/crates/openlark-analytics/src/search/search/v2/schema/get.rs
@@ -70,9 +70,7 @@ impl GetSchemaRequest {
         let path = format!("/open-apis/search/v2/schemas/{}", self.schema_id);
         let req: ApiRequest<GetSchemaResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("获取数据范式", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "获取数据范式").await
     }
 }
 

--- a/crates/openlark-analytics/src/search/search/v2/schema/patch.rs
+++ b/crates/openlark-analytics/src/search/search/v2/schema/patch.rs
@@ -55,9 +55,7 @@ impl PatchSchemaRequest {
         let path = format!("/open-apis/search/v2/schemas/{}", self.schema_id);
         let req: ApiRequest<PatchSchemaResponse> = ApiRequest::patch(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("修改数据范式", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "修改数据范式").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v1/app_badge/set.rs
+++ b/crates/openlark-application/src/application/application/v1/app_badge/set.rs
@@ -37,6 +37,11 @@ impl ApiResponseTrait for SetAppBadgeResponse {
     fn data_format() -> ResponseFormat {
         ResponseFormat::Data
     }
+
+    /// 成功但无 `data` 字段时的空成功（set 类 API，与旧 `unwrap_or` 默认值一致）。
+    fn empty_success() -> Option<Self> {
+        Some(Self { data: None })
+    }
 }
 
 impl SetAppBadgeRequest {
@@ -73,8 +78,7 @@ impl SetAppBadgeRequest {
         let path = "/open-apis/application/v6/app_badge/set";
         let body = serde_json::to_value(&self.body)?;
         let req: ApiRequest<SetAppBadgeResponse> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        Ok(resp.data.unwrap_or(SetAppBadgeResponse { data: None }))
+        Transport::request_typed(req, &self.config, Some(option), "更新应用红点").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v1/application/contacts_range_configuration.rs
+++ b/crates/openlark-application/src/application/application/v1/application/contacts_range_configuration.rs
@@ -66,10 +66,13 @@ impl GetApplicationContactsRangeConfigurationRequest {
         let req: ApiRequest<GetApplicationContactsRangeConfigurationResponse> =
             ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取应用通讯录权限范围配置", "响应数据为空")
-        })
+        Transport::request_typed(
+            req,
+            &self.config,
+            Some(option),
+            "获取应用通讯录权限范围配置",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v5/application/favourite.rs
+++ b/crates/openlark-application/src/application/application/v5/application/favourite.rs
@@ -49,9 +49,7 @@ impl GetFavouriteAppsRequest {
         let req: ApiRequest<GetFavouriteAppsResponse> =
             ApiRequest::get("/open-apis/application/v5/applications/favourite");
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("获取收藏应用", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "获取收藏应用").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v5/application/recommend.rs
+++ b/crates/openlark-application/src/application/application/v5/application/recommend.rs
@@ -49,9 +49,7 @@ impl GetRecommendedAppsRequest {
         let req: ApiRequest<GetRecommendedAppsResponse> =
             ApiRequest::get("/open-apis/application/v5/applications/recommend");
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("获取推荐应用", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "获取推荐应用").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/app_badge/set.rs
+++ b/crates/openlark-application/src/application/application/v6/app_badge/set.rs
@@ -38,6 +38,11 @@ impl ApiResponseTrait for SetAppBadgeResponse {
     fn data_format() -> ResponseFormat {
         ResponseFormat::Data
     }
+
+    /// 成功但无 `data` 字段时的空成功（set 类 API，与旧 `unwrap_or` 默认值一致）。
+    fn empty_success() -> Option<Self> {
+        Some(Self { data: None })
+    }
 }
 
 impl SetAppBadgeRequest {
@@ -74,8 +79,7 @@ impl SetAppBadgeRequest {
         let path = "/open-apis/application/v6/app_badge/set";
         let body = serde_json::to_value(&self.body)?;
         let req: ApiRequest<SetAppBadgeResponse> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        Ok(resp.data.unwrap_or(SetAppBadgeResponse { data: None }))
+        Transport::request_typed(req, &self.config, Some(option), "更新应用红点").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/app_recommend_rule/list.rs
+++ b/crates/openlark-application/src/application/application/v6/app_recommend_rule/list.rs
@@ -49,10 +49,7 @@ impl ListAppRecommendRuleRequest {
         let req: ApiRequest<ListAppRecommendRuleResponse> =
             ApiRequest::get("/open-apis/application/v6/app_recommend_rules");
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取推荐规则列表", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取推荐规则列表").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/app_usage/department_overview.rs
+++ b/crates/openlark-application/src/application/application/v6/application/app_usage/department_overview.rs
@@ -56,10 +56,7 @@ impl GetApplicationUsageDepartmentOverviewRequest {
         let req: ApiRequest<GetApplicationUsageDepartmentOverviewResponse> =
             ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取多部门应用使用概览", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取多部门应用使用概览").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/app_usage/message_push_overview.rs
+++ b/crates/openlark-application/src/application/application/v6/application/app_usage/message_push_overview.rs
@@ -55,10 +55,7 @@ impl GetMessagePushOverviewRequest {
         );
         let req: ApiRequest<GetMessagePushOverviewResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取消息推送概览", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取消息推送概览").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/app_usage/overview.rs
+++ b/crates/openlark-application/src/application/application/v6/application/app_usage/overview.rs
@@ -55,10 +55,7 @@ impl GetApplicationUsageOverviewRequest {
         );
         let req: ApiRequest<GetApplicationUsageOverviewResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取应用使用概览", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取应用使用概览").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/app_version/contacts_range_suggest.rs
+++ b/crates/openlark-application/src/application/application/v6/application/app_version/contacts_range_suggest.rs
@@ -61,13 +61,13 @@ impl GetAppVersionContactsRangeSuggestRequest {
         );
         let req: ApiRequest<GetAppVersionContactsRangeSuggestResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error(
-                "获取应用版本中开发者申请的通讯录权限范围",
-                "响应数据为空",
-            )
-        })
+        Transport::request_typed(
+            req,
+            &self.config,
+            Some(option),
+            "获取应用版本中开发者申请的通讯录权限范围",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/app_version/get.rs
+++ b/crates/openlark-application/src/application/application/v6/application/app_version/get.rs
@@ -62,10 +62,7 @@ impl GetApplicationVersionRequest {
         );
         let req: ApiRequest<GetApplicationVersionResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取应用版本信息", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取应用版本信息").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/app_version/list.rs
+++ b/crates/openlark-application/src/application/application/v6/application/app_version/list.rs
@@ -56,10 +56,7 @@ impl ListApplicationVersionsRequest {
         );
         let req: ApiRequest<ListApplicationVersionsResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取应用版本列表", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取应用版本列表").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/app_version/patch.rs
+++ b/crates/openlark-application/src/application/application/v6/application/app_version/patch.rs
@@ -62,10 +62,7 @@ impl PatchApplicationAppVersionRequest {
         );
         let req: ApiRequest<PatchApplicationAppVersionResponse> = ApiRequest::patch(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("更新应用审核状态", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "更新应用审核状态").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/collaborators/get.rs
+++ b/crates/openlark-application/src/application/application/v6/application/collaborators/get.rs
@@ -56,10 +56,7 @@ impl GetApplicationCollaboratorsRequest {
         );
         let req: ApiRequest<GetApplicationCollaboratorsResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取应用协作者列表", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取应用协作者列表").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/collaborators/list.rs
+++ b/crates/openlark-application/src/application/application/v6/application/collaborators/list.rs
@@ -56,10 +56,7 @@ impl ListApplicationCollaboratorsRequest {
         );
         let req: ApiRequest<ListApplicationCollaboratorsResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取应用协作者列表", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取应用协作者列表").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/collaborators/update.rs
+++ b/crates/openlark-application/src/application/application/v6/application/collaborators/update.rs
@@ -55,9 +55,7 @@ impl UpdateApplicationCollaboratorsRequest {
         );
         let req: ApiRequest<UpdateApplicationCollaboratorsResponse> = ApiRequest::put(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("更新应用协作者", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "更新应用协作者").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/contacts_range/patch.rs
+++ b/crates/openlark-application/src/application/application/v6/application/contacts_range/patch.rs
@@ -56,10 +56,13 @@ impl PatchApplicationContactsRangeRequest {
         );
         let req: ApiRequest<PatchApplicationContactsRangeResponse> = ApiRequest::patch(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("更新应用通讯录权限范围配置", "响应数据为空")
-        })
+        Transport::request_typed(
+            req,
+            &self.config,
+            Some(option),
+            "更新应用通讯录权限范围配置",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/contacts_range_configuration.rs
+++ b/crates/openlark-application/src/application/application/v6/application/contacts_range_configuration.rs
@@ -57,10 +57,13 @@ impl GetApplicationContactsRangeConfigurationRequest {
         let req: ApiRequest<GetApplicationContactsRangeConfigurationResponse> =
             ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取应用通讯录权限范围配置", "响应数据为空")
-        })
+        Transport::request_typed(
+            req,
+            &self.config,
+            Some(option),
+            "获取应用通讯录权限范围配置",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/feedback/list.rs
+++ b/crates/openlark-application/src/application/application/v6/application/feedback/list.rs
@@ -56,10 +56,7 @@ impl ListApplicationFeedbackRequest {
         );
         let req: ApiRequest<ListApplicationFeedbackResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取应用反馈列表", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取应用反馈列表").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/feedback/patch.rs
+++ b/crates/openlark-application/src/application/application/v6/application/feedback/patch.rs
@@ -62,9 +62,7 @@ impl PatchApplicationFeedbackRequest {
         );
         let req: ApiRequest<PatchApplicationFeedbackResponse> = ApiRequest::patch(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("更新应用反馈", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "更新应用反馈").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/get.rs
+++ b/crates/openlark-application/src/application/application/v6/application/get.rs
@@ -53,9 +53,7 @@ impl GetApplicationRequest {
         let path = format!("/open-apis/application/v6/applications/{}", self.app_id);
         let req: ApiRequest<GetApplicationResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("获取应用信息", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "获取应用信息").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/list.rs
+++ b/crates/openlark-application/src/application/application/v6/application/list.rs
@@ -49,10 +49,7 @@ impl ListApplicationsRequest {
         let path = "/open-apis/application/v6/applications";
         let req: ApiRequest<ListApplicationsResponse> = ApiRequest::get(path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取企业安装的应用", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取企业安装的应用").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/management/update.rs
+++ b/crates/openlark-application/src/application/application/v6/application/management/update.rs
@@ -55,9 +55,7 @@ impl UpdateApplicationManagementRequest {
         );
         let req: ApiRequest<UpdateApplicationManagementResponse> = ApiRequest::put(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("启停用应用", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "启停用应用").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/owner/update.rs
+++ b/crates/openlark-application/src/application/application/v6/application/owner/update.rs
@@ -55,9 +55,7 @@ impl UpdateAppOwnerRequest {
         );
         let req: ApiRequest<UpdateAppOwnerResponse> = ApiRequest::put(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("转移应用所有者", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "转移应用所有者").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/patch.rs
+++ b/crates/openlark-application/src/application/application/v6/application/patch.rs
@@ -53,10 +53,7 @@ impl PatchApplicationRequest {
         let path = format!("/open-apis/application/v6/applications/{}", self.app_id);
         let req: ApiRequest<PatchApplicationResponse> = ApiRequest::patch(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("更新应用分组信息", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "更新应用分组信息").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/underauditlist.rs
+++ b/crates/openlark-application/src/application/application/v6/application/underauditlist.rs
@@ -49,10 +49,7 @@ impl GetApplicationUnderauditlistRequest {
         let path = "/open-apis/application/v6/applications/underauditlist";
         let req: ApiRequest<GetApplicationUnderauditlistResponse> = ApiRequest::get(path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("查看待审核的应用列表", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "查看待审核的应用列表").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/visibility/check_white_black_list.rs
+++ b/crates/openlark-application/src/application/application/v6/application/visibility/check_white_black_list.rs
@@ -56,13 +56,13 @@ impl CheckApplicationVisibilityWhiteBlackListRequest {
         let req: ApiRequest<CheckApplicationVisibilityWhiteBlackListResponse> =
             ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error(
-                "查询用户或部门是否在应用的可用或禁用名单",
-                "响应数据为空",
-            )
-        })
+        Transport::request_typed(
+            req,
+            &self.config,
+            Some(option),
+            "查询用户或部门是否在应用的可用或禁用名单",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/application/visibility/patch.rs
+++ b/crates/openlark-application/src/application/application/v6/application/visibility/patch.rs
@@ -56,10 +56,7 @@ impl PatchApplicationVisibilityRequest {
         );
         let req: ApiRequest<PatchApplicationVisibilityResponse> = ApiRequest::patch(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("更新应用可用范围", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "更新应用可用范围").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/scope/apply.rs
+++ b/crates/openlark-application/src/application/application/v6/scope/apply.rs
@@ -38,6 +38,11 @@ impl ApiResponseTrait for ApplyScopeResponse {
     fn data_format() -> ResponseFormat {
         ResponseFormat::Data
     }
+
+    /// 成功但无 `data` 字段时的空成功（apply 类 API，与旧 `unwrap_or` 默认值一致）。
+    fn empty_success() -> Option<Self> {
+        Some(Self { data: None })
+    }
 }
 
 impl ApplyScopeRequest {
@@ -62,8 +67,7 @@ impl ApplyScopeRequest {
         let path = "/open-apis/application/v6/scopes/apply";
         let body = serde_json::to_value(&self.body)?;
         let req: ApiRequest<ApplyScopeResponse> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        Ok(resp.data.unwrap_or(ApplyScopeResponse { data: None }))
+        Transport::request_typed(req, &self.config, Some(option), "向管理员申请授权").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v6/scope/list.rs
+++ b/crates/openlark-application/src/application/application/v6/scope/list.rs
@@ -49,10 +49,7 @@ impl ListApplicationScopeRequest {
         let path = "/open-apis/application/v6/scopes";
         let req: ApiRequest<ListApplicationScopeResponse> = ApiRequest::get(path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("查询租户授权状态", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "查询租户授权状态").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v7/app_avatar/upload/create.rs
+++ b/crates/openlark-application/src/application/application/v7/app_avatar/upload/create.rs
@@ -33,9 +33,7 @@ impl AppAvatarUploadCreateRequest {
     ) -> SDKResult<serde_json::Value> {
         let path = "/open-apis/application/v7/app_avatar/upload".to_string();
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("上传应用图标", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "上传应用图标").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v7/application/ability/patch.rs
+++ b/crates/openlark-application/src/application/application/v7/application/ability/patch.rs
@@ -48,10 +48,7 @@ impl ApplicationAbilityPatchRequest {
             self.app_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::patch(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("更新应用能力配置", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "更新应用能力配置").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v7/application/base/patch.rs
+++ b/crates/openlark-application/src/application/application/v7/application/base/patch.rs
@@ -48,10 +48,7 @@ impl ApplicationBasePatchRequest {
             self.app_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::patch(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("更新应用基础信息配置", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "更新应用基础信息配置").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v7/application/config/patch.rs
+++ b/crates/openlark-application/src/application/application/v7/application/config/patch.rs
@@ -48,10 +48,7 @@ impl ApplicationConfigPatchRequest {
             self.app_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::patch(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("更新应用开发配置", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "更新应用开发配置").await
     }
 }
 

--- a/crates/openlark-application/src/application/application/v7/application/publish/create.rs
+++ b/crates/openlark-application/src/application/application/v7/application/publish/create.rs
@@ -48,10 +48,7 @@ impl ApplicationPublishCreateRequest {
             self.app_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("提交发布自建应用", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "提交发布自建应用").await
     }
 }
 

--- a/crates/openlark-application/src/workplace/workplace/v1/custom_workplace_access_data/search.rs
+++ b/crates/openlark-application/src/workplace/workplace/v1/custom_workplace_access_data/search.rs
@@ -61,9 +61,7 @@ impl AccessDataSearchCustomRequestBuilder {
 
         let req: ApiRequest<AccessDataSearchCustomResponse> =
             ApiRequest::post(url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-application/src/workplace/workplace/v1/workplace_access_data/search.rs
+++ b/crates/openlark-application/src/workplace/workplace/v1/workplace_access_data/search.rs
@@ -61,9 +61,7 @@ impl AccessDataSearchWorkplaceRequestBuilder {
 
         let req: ApiRequest<AccessDataSearchWorkplaceResponse> =
             ApiRequest::post(url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-application/src/workplace/workplace/v1/workplace_block_access_data/search.rs
+++ b/crates/openlark-application/src/workplace/workplace/v1/workplace_block_access_data/search.rs
@@ -61,9 +61,7 @@ impl AccessDataSearchBlockRequestBuilder {
 
         let req: ApiRequest<AccessDataSearchBlockResponse> =
             ApiRequest::post(url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-auth/src/auth/auth/v3/auth/app_access_token.rs
+++ b/crates/openlark-auth/src/auth/auth/v3/auth/app_access_token.rs
@@ -109,10 +109,13 @@ impl AppAccessTokenRequestBuilder {
                 .with_supported_access_token_types(vec![AccessTokenType::None]);
 
         // 发送请求
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取商店应用 access_token", "响应数据为空")
-        })
+        Transport::request_typed(
+            api_request,
+            &self.config,
+            Some(option),
+            "获取商店应用 access_token",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-auth/src/auth/auth/v3/auth/app_access_token_internal.rs
+++ b/crates/openlark-auth/src/auth/auth/v3/auth/app_access_token_internal.rs
@@ -89,10 +89,13 @@ impl AppAccessTokenInternalRequestBuilder {
                 .with_supported_access_token_types(vec![AccessTokenType::None]);
 
         // 发送请求
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取自建应用 access_token", "响应数据为空")
-        })
+        Transport::request_typed(
+            api_request,
+            &self.config,
+            Some(option),
+            "获取自建应用 access_token",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-auth/src/auth/auth/v3/auth/app_ticket_resend.rs
+++ b/crates/openlark-auth/src/auth/auth/v3/auth/app_ticket_resend.rs
@@ -92,10 +92,13 @@ impl AppTicketResendRequestBuilder {
                 .with_supported_access_token_types(vec![AccessTokenType::None]);
 
         // 发送请求
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("重新获取 app_ticket", "响应数据为空")
-        })
+        Transport::request_typed(
+            api_request,
+            &self.config,
+            Some(option),
+            "重新获取 app_ticket",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-auth/src/auth/auth/v3/auth/tenant_access_token.rs
+++ b/crates/openlark-auth/src/auth/auth/v3/auth/tenant_access_token.rs
@@ -97,13 +97,13 @@ impl TenantAccessTokenRequestBuilder {
                 .with_supported_access_token_types(vec![AccessTokenType::None]);
 
         // 发送请求
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error(
-                "获取商店应用 tenant_access_token",
-                "响应数据为空",
-            )
-        })
+        Transport::request_typed(
+            api_request,
+            &self.config,
+            Some(option),
+            "获取商店应用 tenant_access_token",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-auth/src/auth/auth/v3/auth/tenant_access_token_internal.rs
+++ b/crates/openlark-auth/src/auth/auth/v3/auth/tenant_access_token_internal.rs
@@ -89,13 +89,13 @@ impl TenantAccessTokenInternalRequestBuilder {
                 .with_supported_access_token_types(vec![AccessTokenType::None]);
 
         // 发送请求
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error(
-                "获取自建应用 tenant_access_token",
-                "响应数据为空",
-            )
-        })
+        Transport::request_typed(
+            api_request,
+            &self.config,
+            Some(option),
+            "获取自建应用 tenant_access_token",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-auth/src/auth/authen/v1/access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/access_token/create.rs
@@ -113,10 +113,13 @@ impl UserAccessTokenV1RequestBuilder {
                 .with_supported_access_token_types(vec![AccessTokenType::App]);
 
         // 发送请求
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取 user_access_token v1", "响应数据为空")
-        })
+        Transport::request_typed(
+            api_request,
+            &self.config,
+            Some(option),
+            "获取 user_access_token v1",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-auth/src/auth/authen/v1/oidc/access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/oidc/access_token/create.rs
@@ -126,10 +126,13 @@ impl OidcAccessTokenRequestBuilder {
                 .with_supported_access_token_types(vec![AccessTokenType::App]);
 
         // 发送请求
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取 OIDC user_access_token", "响应数据为空")
-        })
+        Transport::request_typed(
+            api_request,
+            &self.config,
+            Some(option),
+            "获取 OIDC user_access_token",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-auth/src/auth/authen/v1/oidc/refresh_access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/oidc/refresh_access_token/create.rs
@@ -108,10 +108,13 @@ impl OidcRefreshAccessTokenRequestBuilder {
                 .with_supported_access_token_types(vec![AccessTokenType::App]);
 
         // 发送请求
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("刷新 OIDC user_access_token", "响应数据为空")
-        })
+        Transport::request_typed(
+            api_request,
+            &self.config,
+            Some(option),
+            "刷新 OIDC user_access_token",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-auth/src/auth/authen/v1/refresh_access_token/create.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/refresh_access_token/create.rs
@@ -109,10 +109,13 @@ impl RefreshUserAccessTokenV1RequestBuilder {
                 .with_supported_access_token_types(vec![AccessTokenType::App]);
 
         // 发送请求
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("刷新 user_access_token v1", "响应数据为空")
-        })
+        Transport::request_typed(
+            api_request,
+            &self.config,
+            Some(option),
+            "刷新 user_access_token v1",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-auth/src/auth/authen/v1/user_info/get.rs
+++ b/crates/openlark-auth/src/auth/authen/v1/user_info/get.rs
@@ -92,10 +92,7 @@ impl UserInfoRequestBuilder {
         }
 
         // 发送请求
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response
-            .data
-            .ok_or_else(|| openlark_core::error::validation_error("获取用户信息", "响应数据为空"))
+        Transport::request_typed(api_request, &self.config, Some(option), "获取用户信息").await
     }
 }
 

--- a/crates/openlark-auth/src/human_authentication/human_authentication/v1/identity/create.rs
+++ b/crates/openlark-auth/src/human_authentication/human_authentication/v1/identity/create.rs
@@ -170,9 +170,7 @@ impl IdentityCreateRequestBuilder {
             req = req.query("user_id_type", user_id_type.as_str());
         }
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("录入身份信息", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "录入身份信息").await
     }
 }
 

--- a/crates/openlark-auth/src/passport/passport/v1/session/logout.rs
+++ b/crates/openlark-auth/src/passport/passport/v1/session/logout.rs
@@ -45,10 +45,7 @@ impl LogoutRequest {
     pub async fn execute_with_options(self, option: RequestOption) -> SDKResult<LogoutResponse> {
         let req: ApiRequest<LogoutResponse> = ApiRequest::post(PassportApiV1::SessionLogout.path());
 
-        let response = Transport::request(req, &self.config, Some(option)).await?;
-        response
-            .data
-            .ok_or_else(|| openlark_core::error::validation_error("logout", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "logout").await
     }
 }
 

--- a/crates/openlark-auth/src/passport/passport/v1/session/query.rs
+++ b/crates/openlark-auth/src/passport/passport/v1/session/query.rs
@@ -59,10 +59,7 @@ impl QuerySessionRequest {
         let req: ApiRequest<QuerySessionResponse> =
             ApiRequest::post(PassportApiV1::SessionQuery.path()).body(serde_json::to_value(&body)?);
 
-        let response = Transport::request(req, &self.config, Some(option)).await?;
-        response
-            .data
-            .ok_or_else(|| openlark_core::error::validation_error("query_session", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "query_session").await
     }
 }
 

--- a/crates/openlark-auth/src/verification_information/verification/v1/verification/get.rs
+++ b/crates/openlark-auth/src/verification_information/verification/v1/verification/get.rs
@@ -36,9 +36,7 @@ impl VerificationGetRequestBuilder {
     ) -> SDKResult<VerificationGetResponse> {
         let req: ApiRequest<VerificationGetResponse> =
             ApiRequest::get("/open-apis/verification/v1/verification");
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-bot/src/bot/bot/v4/bot/search.rs
+++ b/crates/openlark-bot/src/bot/bot/v4/bot/search.rs
@@ -165,9 +165,7 @@ impl SearchBotRequest {
         })?;
         req = req.body(body);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("搜索机器人", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "搜索机器人").await
     }
 }
 

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/batch_update.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/batch_update.rs
@@ -8,10 +8,7 @@ use openlark_core::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    common::{
-        api_utils::{extract_response_data, serialize_params},
-        validation::validate_card_id,
-    },
+    common::{api_utils::serialize_params, validation::validate_card_id},
     endpoints::cardkit_v1_card_batch_update,
 };
 
@@ -92,8 +89,7 @@ impl BatchUpdateCardRequest {
         let req: ApiRequest<BatchUpdateCardResponse> =
             ApiRequest::post(url).body(serialize_params(&body, "局部更新卡片实体")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "局部更新卡片实体")
+        Transport::request_typed(req, &self.config, Some(option), "局部更新卡片实体").await
     }
 }
 

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/create.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/create.rs
@@ -7,10 +7,7 @@ use openlark_core::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    common::api_utils::{extract_response_data, serialize_params},
-    endpoints::CARDKIT_V1_CARDS,
-};
+use crate::{common::api_utils::serialize_params, endpoints::CARDKIT_V1_CARDS};
 
 /// 创建卡片实体请求体
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -108,8 +105,7 @@ impl CreateCardRequest {
         let req: ApiRequest<CreateCardResponse> =
             ApiRequest::post(CARDKIT_V1_CARDS).body(serialize_params(&body, "创建卡片实体")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "创建卡片实体")
+        Transport::request_typed(req, &self.config, Some(option), "创建卡片实体").await
     }
 }
 
@@ -196,8 +192,7 @@ pub async fn create_with_options(
     let req: ApiRequest<CreateCardResponse> =
         ApiRequest::post(CARDKIT_V1_CARDS).body(serialize_params(&body, "创建卡片实体")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "创建卡片实体")
+    Transport::request_typed(req, config, Some(option), "创建卡片实体").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/content.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/content.rs
@@ -8,7 +8,7 @@ use openlark_core::{
 
 use super::models::UpdateCardElementContentResponse;
 use crate::common::{
-    api_utils::{extract_response_data, serialize_params},
+    api_utils::serialize_params,
     validation::{validate_card_id, validate_element_id},
 };
 use crate::endpoints::cardkit_v1_card_element_content;
@@ -83,8 +83,7 @@ impl UpdateCardElementContentRequest {
         )
         .body(serialize_params(&body, "流式更新文本")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "流式更新文本")
+        Transport::request_typed(req, &self.config, Some(option), "流式更新文本").await
     }
 }
 

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/create.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/create.rs
@@ -7,10 +7,7 @@ use openlark_core::{
 };
 
 use super::models::CreateCardElementResponse;
-use crate::common::{
-    api_utils::{extract_response_data, serialize_params},
-    validation::validate_card_id,
-};
+use crate::common::{api_utils::serialize_params, validation::validate_card_id};
 use crate::endpoints::cardkit_v1_card_elements;
 
 /// 新增组件请求体（结构以官方文档为准）
@@ -69,8 +66,7 @@ impl CreateCardElementRequest {
             ApiRequest::post(cardkit_v1_card_elements(&body.card_id))
                 .body(serialize_params(&body, "新增组件")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "新增组件")
+        Transport::request_typed(req, &self.config, Some(option), "新增组件").await
     }
 }
 
@@ -138,8 +134,7 @@ pub async fn create_with_options(
         ApiRequest::post(cardkit_v1_card_elements(&body.card_id))
             .body(serialize_params(&body, "新增组件")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "新增组件")
+    Transport::request_typed(req, config, Some(option), "新增组件").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/delete.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/delete.rs
@@ -7,10 +7,7 @@ use openlark_core::{
 };
 
 use super::models::DeleteCardElementResponse;
-use crate::common::{
-    api_utils::extract_response_data,
-    validation::{validate_card_id, validate_element_id},
-};
+use crate::common::validation::{validate_card_id, validate_element_id};
 use crate::endpoints::cardkit_v1_card_element;
 
 /// 删除组件请求体
@@ -74,8 +71,7 @@ impl DeleteCardElementRequest {
         let req: ApiRequest<DeleteCardElementResponse> =
             ApiRequest::delete(cardkit_v1_card_element(&body.card_id, &body.element_id));
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "删除组件")
+        Transport::request_typed(req, &self.config, Some(option), "删除组件").await
     }
 }
 

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/patch.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/patch.rs
@@ -8,7 +8,7 @@ use openlark_core::{
 
 use super::models::PatchCardElementResponse;
 use crate::common::{
-    api_utils::{extract_response_data, serialize_params},
+    api_utils::serialize_params,
     validation::{validate_card_id, validate_element_id},
 };
 use crate::endpoints::cardkit_v1_card_element;
@@ -79,8 +79,7 @@ impl PatchCardElementRequest {
             ApiRequest::patch(cardkit_v1_card_element(&body.card_id, &body.element_id))
                 .body(serialize_params(&body, "更新组件属性")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "更新组件属性")
+        Transport::request_typed(req, &self.config, Some(option), "更新组件属性").await
     }
 }
 

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/update.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/element/update.rs
@@ -8,7 +8,7 @@ use openlark_core::{
 
 use super::models::UpdateCardElementResponse;
 use crate::common::{
-    api_utils::{extract_response_data, serialize_params},
+    api_utils::serialize_params,
     validation::{validate_card_id, validate_element_id},
 };
 use crate::endpoints::cardkit_v1_card_element;
@@ -82,8 +82,7 @@ impl UpdateCardElementRequest {
             ApiRequest::put(cardkit_v1_card_element(&body.card_id, &body.element_id))
                 .body(serialize_params(&body, "更新组件属性")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "更新组件属性")
+        Transport::request_typed(req, &self.config, Some(option), "更新组件属性").await
     }
 }
 

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/id_convert.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/id_convert.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use super::models::ConvertCardIdResponse;
 use crate::common::{
-    api_utils::{extract_response_data, serialize_params},
+    api_utils::serialize_params,
     validation::{validate_id_list, validate_id_type},
 };
 use crate::endpoints::CARDKIT_V1_CARD_ID_CONVERT;
@@ -80,8 +80,7 @@ impl ConvertCardIdRequest {
         let req: ApiRequest<ConvertCardIdResponse> =
             ApiRequest::post(CARDKIT_V1_CARD_ID_CONVERT).body(serialize_params(&body, "转换 ID")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "转换 ID")
+        Transport::request_typed(req, &self.config, Some(option), "转换 ID").await
     }
 }
 
@@ -157,8 +156,7 @@ pub async fn convert_with_options(
     let req: ApiRequest<ConvertCardIdResponse> =
         ApiRequest::post(CARDKIT_V1_CARD_ID_CONVERT).body(serialize_params(&body, "转换 ID")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "转换 ID")
+    Transport::request_typed(req, config, Some(option), "转换 ID").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/settings.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/settings.rs
@@ -8,10 +8,7 @@ use openlark_core::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    common::{
-        api_utils::{extract_response_data, serialize_params},
-        validation::validate_card_id,
-    },
+    common::{api_utils::serialize_params, validation::validate_card_id},
     endpoints::cardkit_v1_card_settings,
 };
 
@@ -89,8 +86,7 @@ impl UpdateCardSettingsRequest {
         let req: ApiRequest<UpdateCardSettingsResponse> =
             ApiRequest::patch(url).body(serialize_params(&body, "更新卡片实体配置")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "更新卡片实体配置")
+        Transport::request_typed(req, &self.config, Some(option), "更新卡片实体配置").await
     }
 }
 

--- a/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/update.rs
+++ b/crates/openlark-cardkit/src/cardkit/cardkit/v1/card/update.rs
@@ -8,10 +8,7 @@ use openlark_core::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    common::{
-        api_utils::{extract_response_data, serialize_params},
-        validation::validate_card_id,
-    },
+    common::{api_utils::serialize_params, validation::validate_card_id},
     endpoints::cardkit_v1_card,
 };
 
@@ -104,8 +101,7 @@ impl UpdateCardRequest {
         let req: ApiRequest<UpdateCardResponse> =
             ApiRequest::put(url).body(serialize_params(&body, "全量更新卡片实体")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "全量更新卡片实体")
+        Transport::request_typed(req, &self.config, Some(option), "全量更新卡片实体").await
     }
 }
 

--- a/crates/openlark-core/src/api/helpers.rs
+++ b/crates/openlark-core/src/api/helpers.rs
@@ -6,7 +6,7 @@
 
 use crate::SDKResult;
 use crate::api::Response;
-use crate::error::validation_error;
+use crate::error::{api_error, validation_error};
 
 /// 标准化参数序列化。
 ///
@@ -25,19 +25,31 @@ pub fn serialize_params<T: serde::Serialize>(
 
 /// 标准化响应数据提取。
 ///
-/// 响应 `data` 为空时返回 `validation_error`，附加 `operation=extract_response_data` +
+/// 响应 `data` 为空时，区分两种失败（#470 user story 12：业务错误不再被误报为空成功）：
+/// - 业务错误（`code != 0`）：返回 `api_error` 保留飞书 `code` / `msg`；
+/// - `code == 0` 但缺 `data`：返回 `validation_error`（真正抽取失败）。
+///
+/// 两种失败都经 `map_context` 附加 `operation=extract_response_data` +
 /// `resource=<context>` + 响应携带的 `request_id`。
 pub fn extract_response_data<T>(response: Response<T>, context: &str) -> SDKResult<T> {
-    let request_id = response.raw_response.request_id.clone();
-    response.data.ok_or_else(|| {
-        validation_error("response.data", "服务器没有返回有效的数据").map_context(|ctx| {
-            ctx.set_operation("extract_response_data")
-                .add_context("resource", context);
-            if let Some(req_id) = request_id.as_ref().filter(|r| !r.trim().is_empty()) {
-                ctx.set_request_id(req_id);
-            }
-        })
-    })
+    if let Some(data) = response.data {
+        return Ok(data);
+    }
+
+    let raw = response.raw_response;
+    let request_id = raw.request_id.clone();
+    let err = if raw.code != 0 {
+        api_error(raw.code as u16, "response", raw.msg, request_id.clone())
+    } else {
+        validation_error("response.data", "服务器没有返回有效的数据")
+    };
+    Err(err.map_context(|ctx| {
+        ctx.set_operation("extract_response_data")
+            .add_context("resource", context);
+        if let Some(req_id) = request_id.as_ref().filter(|r| !r.trim().is_empty()) {
+            ctx.set_request_id(req_id);
+        }
+    }))
 }
 
 /// 无 data 接口：仅用 `code==0` 判断成功。

--- a/crates/openlark-core/tests/transport_request_contract.rs
+++ b/crates/openlark-core/tests/transport_request_contract.rs
@@ -1090,4 +1090,17 @@ async fn request_typed_failure_attaches_operation_resource_request_id() {
         Some("rid-typed-fail"),
         "request_id from envelope must be attached for server-side reconciliation"
     );
+
+    // Option C (#485)：业务错误（code≠0）保留飞书 msg，返回 Api 错误（非 Validation）；
+    // 此前 canonical 路径把业务错误当"data 缺失"丢 msg。
+    match &err {
+        CoreError::Api(api) => {
+            assert!(
+                api.message.contains("permission denied"),
+                "business envelope msg must be preserved: {}",
+                api.message
+            );
+        }
+        other => panic!("expected CoreError::Api for business error, got: {other:?}"),
+    }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/agent_email.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/agent_email.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 获取客服邮箱请求
 #[derive(Debug, Clone)]
@@ -38,8 +37,7 @@ impl GetAgentEmailRequest {
         let req: ApiRequest<GetAgentEmailResponse> =
             ApiRequest::get(HelpdeskApiV1::AgentEmail.to_url());
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "获取客服邮箱")
+        Transport::request_typed(req, &self.config, Some(option), "获取客服邮箱").await
     }
 }
 
@@ -85,8 +83,7 @@ pub async fn get_agent_email_with_options(
     let req: ApiRequest<GetAgentEmailResponse> =
         ApiRequest::get(HelpdeskApiV1::AgentEmail.to_url());
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "获取客服邮箱")
+    Transport::request_typed(req, config, Some(option), "获取客服邮箱").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/patch.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 
 /// 更新客服信息请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -87,8 +87,7 @@ impl PatchAgentRequest {
             ApiRequest::patch(HelpdeskApiV1::AgentPatch(self.agent_id.clone()).to_url())
                 .body(serialize_params(&body, "更新客服信息")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "更新客服信息")
+        Transport::request_typed(req, &self.config, Some(option), "更新客服信息").await
     }
 }
 
@@ -163,8 +162,7 @@ pub async fn patch_agent_with_options(
         ApiRequest::patch(HelpdeskApiV1::AgentPatch(agent_id).to_url())
             .body(serialize_params(&body, "更新客服信息")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "更新客服信息")
+    Transport::request_typed(req, config, Some(option), "更新客服信息").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/schedules/delete.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/schedules/delete.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 删除客服工作日程响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -57,8 +56,7 @@ impl DeleteAgentScheduleRequest {
         let req: ApiRequest<DeleteAgentScheduleResponse> =
             ApiRequest::delete(HelpdeskApiV1::AgentScheduleDelete(self.agent_id.clone()).to_url());
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "删除客服工作日程")
+        Transport::request_typed(req, &self.config, Some(option), "删除客服工作日程").await
     }
 }
 
@@ -108,8 +106,7 @@ pub async fn delete_agent_schedule_with_options(
     let req: ApiRequest<DeleteAgentScheduleResponse> =
         ApiRequest::delete(HelpdeskApiV1::AgentScheduleDelete(agent_id).to_url());
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "删除客服工作日程")
+    Transport::request_typed(req, config, Some(option), "删除客服工作日程").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/schedules/get.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/schedules/get.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 获取指定客服工作日程查询参数
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -135,8 +134,7 @@ impl GetAgentScheduleRequest {
             request = request.query("page_token", page_token);
         }
 
-        let response = Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取指定客服工作日程")
+        Transport::request_typed(request, &self.config, Some(option), "获取指定客服工作日程").await
     }
 }
 
@@ -185,8 +183,7 @@ impl GetAgentScheduleRequestBuilder {
             request = request.query("page_token", page_token);
         }
 
-        let response = Transport::request(request, &self.config, None).await?;
-        extract_response_data(response, "获取指定客服工作日程")
+        Transport::request_typed(request, &self.config, None, "获取指定客服工作日程").await
     }
 }
 
@@ -198,8 +195,7 @@ pub async fn get_agent_schedule(
     let api_endpoint = HelpdeskApiV1::AgentScheduleGet(agent_id);
     let request = ApiRequest::<GetAgentScheduleResponse>::get(api_endpoint.to_url());
 
-    let response = Transport::request(request, config, None).await?;
-    extract_response_data(response, "获取指定客服工作日程")
+    Transport::request_typed(request, config, None, "获取指定客服工作日程").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/schedules/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/schedules/patch.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 
 /// 更新客服工作日程请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -108,8 +108,7 @@ impl PatchAgentScheduleRequest {
             ApiRequest::patch(HelpdeskApiV1::AgentSchedulePatch(self.agent_id.clone()).to_url())
                 .body(serialize_params(&body, "更新客服工作日程")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "更新客服工作日程")
+        Transport::request_typed(req, &self.config, Some(option), "更新客服工作日程").await
     }
 }
 
@@ -211,8 +210,7 @@ pub async fn patch_agent_schedule_with_options(
         ApiRequest::patch(HelpdeskApiV1::AgentSchedulePatch(agent_id).to_url())
             .body(serialize_params(&body, "更新客服工作日程")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "更新客服工作日程")
+    Transport::request_typed(req, config, Some(option), "更新客服工作日程").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/create.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 
 /// 创建客服工作日程请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -109,8 +109,7 @@ impl CreateAgentScheduleRequest {
             ApiRequest::post(HelpdeskApiV1::AgentScheduleCreate.to_url())
                 .body(serialize_params(&body, "创建客服工作日程")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "创建客服工作日程")
+        Transport::request_typed(req, &self.config, Some(option), "创建客服工作日程").await
     }
 }
 
@@ -214,8 +213,7 @@ pub async fn create_agent_schedule_with_options(
         ApiRequest::post(HelpdeskApiV1::AgentScheduleCreate.to_url())
             .body(serialize_params(&body, "创建客服工作日程")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "创建客服工作日程")
+    Transport::request_typed(req, config, Some(option), "创建客服工作日程").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/delete.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/delete.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 删除客服工作日程响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -57,8 +56,7 @@ impl DeleteAgentScheduleRequest {
         let req: ApiRequest<DeleteAgentScheduleResponse> =
             ApiRequest::delete(HelpdeskApiV1::AgentScheduleDelete(self.agent_id.clone()).to_url());
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "删除客服工作日程")
+        Transport::request_typed(req, &self.config, Some(option), "删除客服工作日程").await
     }
 }
 
@@ -108,8 +106,7 @@ pub async fn delete_agent_schedule_with_options(
     let req: ApiRequest<DeleteAgentScheduleResponse> =
         ApiRequest::delete(HelpdeskApiV1::AgentScheduleDelete(agent_id).to_url());
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "删除客服工作日程")
+    Transport::request_typed(req, config, Some(option), "删除客服工作日程").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/get.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/get.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 获取指定客服工作日程查询参数
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -135,8 +134,7 @@ impl GetAgentScheduleRequest {
             request = request.query("page_token", page_token);
         }
 
-        let response = Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取指定客服工作日程")
+        Transport::request_typed(request, &self.config, Some(option), "获取指定客服工作日程").await
     }
 }
 
@@ -185,8 +183,7 @@ impl GetAgentScheduleRequestBuilder {
             request = request.query("page_token", page_token);
         }
 
-        let response = Transport::request(request, &self.config, None).await?;
-        extract_response_data(response, "获取指定客服工作日程")
+        Transport::request_typed(request, &self.config, None, "获取指定客服工作日程").await
     }
 }
 
@@ -198,8 +195,7 @@ pub async fn get_agent_schedule(
     let api_endpoint = HelpdeskApiV1::AgentScheduleGet(agent_id);
     let request = ApiRequest::<GetAgentScheduleResponse>::get(api_endpoint.to_url());
 
-    let response = Transport::request(request, config, None).await?;
-    extract_response_data(response, "获取指定客服工作日程")
+    Transport::request_typed(request, config, None, "获取指定客服工作日程").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/list.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/list.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 获取客服工作日程列表查询参数
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -133,8 +132,7 @@ impl ListAgentScheduleRequest {
             request = request.query("page_token", page_token);
         }
 
-        let response = Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取客服工作日程列表")
+        Transport::request_typed(request, &self.config, Some(option), "获取客服工作日程列表").await
     }
 }
 
@@ -181,8 +179,7 @@ impl ListAgentScheduleRequestBuilder {
             request = request.query("page_token", page_token);
         }
 
-        let response = Transport::request(request, &self.config, None).await?;
-        extract_response_data(response, "获取客服工作日程列表")
+        Transport::request_typed(request, &self.config, None, "获取客服工作日程列表").await
     }
 }
 
@@ -191,8 +188,7 @@ pub async fn list_agent_schedules(config: &Config) -> SDKResult<ListAgentSchedul
     let api_endpoint = HelpdeskApiV1::AgentScheduleList;
     let request = ApiRequest::<ListAgentScheduleResponse>::get(api_endpoint.to_url());
 
-    let response = Transport::request(request, config, None).await?;
-    extract_response_data(response, "获取客服工作日程列表")
+    Transport::request_typed(request, config, None, "获取客服工作日程列表").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/patch.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 
 /// 更新客服工作日程请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -108,8 +108,7 @@ impl PatchAgentScheduleRequest {
             ApiRequest::patch(HelpdeskApiV1::AgentSchedulePatch(self.agent_id.clone()).to_url())
                 .body(serialize_params(&body, "更新客服工作日程")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "更新客服工作日程")
+        Transport::request_typed(req, &self.config, Some(option), "更新客服工作日程").await
     }
 }
 
@@ -211,8 +210,7 @@ pub async fn patch_agent_schedule_with_options(
         ApiRequest::patch(HelpdeskApiV1::AgentSchedulePatch(agent_id).to_url())
             .body(serialize_params(&body, "更新客服工作日程")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "更新客服工作日程")
+    Transport::request_typed(req, config, Some(option), "更新客服工作日程").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/create.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 
 /// 创建客服技能请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -92,8 +92,7 @@ impl CreateAgentSkillRequest {
             ApiRequest::post(HelpdeskApiV1::AgentSkillCreate.to_url())
                 .body(serialize_params(&body, "创建客服技能")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "创建客服技能")
+        Transport::request_typed(req, &self.config, Some(option), "创建客服技能").await
     }
 }
 
@@ -176,8 +175,7 @@ pub async fn create_agent_skill_with_options(
         ApiRequest::post(HelpdeskApiV1::AgentSkillCreate.to_url())
             .body(serialize_params(&body, "创建客服技能")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "创建客服技能")
+    Transport::request_typed(req, config, Some(option), "创建客服技能").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/delete.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/delete.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 删除客服技能响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -61,8 +60,7 @@ impl DeleteAgentSkillRequest {
             HelpdeskApiV1::AgentSkillDelete(self.agent_skill_id.clone()).to_url(),
         );
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "删除客服技能")
+        Transport::request_typed(req, &self.config, Some(option), "删除客服技能").await
     }
 }
 
@@ -117,8 +115,7 @@ pub async fn delete_agent_skill_with_options(
     let req: ApiRequest<DeleteAgentSkillResponse> =
         ApiRequest::delete(HelpdeskApiV1::AgentSkillDelete(agent_skill_id).to_url());
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "删除客服技能")
+    Transport::request_typed(req, config, Some(option), "删除客服技能").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/get.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/get.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 获取指定客服技能响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -77,8 +76,7 @@ impl GetAgentSkillRequest {
         let api_endpoint = HelpdeskApiV1::AgentSkillGet(self.agent_skill_id.clone());
         let request = ApiRequest::<GetAgentSkillResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取指定客服技能")
+        Transport::request_typed(request, &self.config, Some(option), "获取指定客服技能").await
     }
 }
 
@@ -103,8 +101,7 @@ impl GetAgentSkillRequestBuilder {
         let api_endpoint = HelpdeskApiV1::AgentSkillGet(self.agent_skill_id.clone());
         let request = ApiRequest::<GetAgentSkillResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, None).await?;
-        extract_response_data(response, "获取指定客服技能")
+        Transport::request_typed(request, &self.config, None, "获取指定客服技能").await
     }
 }
 
@@ -116,8 +113,7 @@ pub async fn get_agent_skill(
     let api_endpoint = HelpdeskApiV1::AgentSkillGet(agent_skill_id);
     let request = ApiRequest::<GetAgentSkillResponse>::get(api_endpoint.to_url());
 
-    let response = Transport::request(request, config, None).await?;
-    extract_response_data(response, "获取指定客服技能")
+    Transport::request_typed(request, config, None, "获取指定客服技能").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/list.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/list.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 获取客服技能列表响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -73,8 +72,7 @@ impl ListAgentSkillRequest {
         let api_endpoint = HelpdeskApiV1::AgentSkillList;
         let request = ApiRequest::<ListAgentSkillResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取客服技能列表")
+        Transport::request_typed(request, &self.config, Some(option), "获取客服技能列表").await
     }
 }
 
@@ -95,8 +93,7 @@ impl ListAgentSkillRequestBuilder {
         let api_endpoint = HelpdeskApiV1::AgentSkillList;
         let request = ApiRequest::<ListAgentSkillResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, None).await?;
-        extract_response_data(response, "获取客服技能列表")
+        Transport::request_typed(request, &self.config, None, "获取客服技能列表").await
     }
 }
 
@@ -105,8 +102,7 @@ pub async fn list_agent_skills(config: &Config) -> SDKResult<ListAgentSkillRespo
     let api_endpoint = HelpdeskApiV1::AgentSkillList;
     let request = ApiRequest::<ListAgentSkillResponse>::get(api_endpoint.to_url());
 
-    let response = Transport::request(request, config, None).await?;
-    extract_response_data(response, "获取客服技能列表")
+    Transport::request_typed(request, config, None, "获取客服技能列表").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/patch.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 
 /// 更新客服技能请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -102,8 +102,7 @@ impl PatchAgentSkillRequest {
             ApiRequest::patch(HelpdeskApiV1::AgentSkillPatch(self.agent_skill_id.clone()).to_url())
                 .body(serialize_params(&body, "更新客服技能")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "更新客服技能")
+        Transport::request_typed(req, &self.config, Some(option), "更新客服技能").await
     }
 }
 
@@ -196,8 +195,7 @@ pub async fn patch_agent_skill_with_options(
         ApiRequest::patch(HelpdeskApiV1::AgentSkillPatch(agent_skill_id).to_url())
             .body(serialize_params(&body, "更新客服技能")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "更新客服技能")
+    Transport::request_typed(req, config, Some(option), "更新客服技能").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill_rule/list.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill_rule/list.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 获取客服技能规则列表响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -73,8 +72,7 @@ impl ListAgentSkillRuleRequest {
         let api_endpoint = HelpdeskApiV1::AgentSkillRuleList;
         let request = ApiRequest::<ListAgentSkillRuleResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取客服技能规则列表")
+        Transport::request_typed(request, &self.config, Some(option), "获取客服技能规则列表").await
     }
 }
 
@@ -95,8 +93,7 @@ impl ListAgentSkillRuleRequestBuilder {
         let api_endpoint = HelpdeskApiV1::AgentSkillRuleList;
         let request = ApiRequest::<ListAgentSkillRuleResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, None).await?;
-        extract_response_data(response, "获取客服技能规则列表")
+        Transport::request_typed(request, &self.config, None, "获取客服技能规则列表").await
     }
 }
 
@@ -105,8 +102,7 @@ pub async fn list_agent_skill_rules(config: &Config) -> SDKResult<ListAgentSkill
     let api_endpoint = HelpdeskApiV1::AgentSkillRuleList;
     let request = ApiRequest::<ListAgentSkillRuleResponse>::get(api_endpoint.to_url());
 
-    let response = Transport::request(request, config, None).await?;
-    extract_response_data(response, "获取客服技能规则列表")
+    Transport::request_typed(request, config, None, "获取客服技能规则列表").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/bot/message/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/bot/message/create.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 
 /// 通过服务台机器人发送消息请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -97,8 +97,7 @@ impl CreateBotMessageRequest {
             ApiRequest::post(HelpdeskApiV1::BotMessageCreate.to_url())
                 .body(serialize_params(&body, "通过服务台机器人发送消息")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "通过服务台机器人发送消息")
+        Transport::request_typed(req, &self.config, Some(option), "通过服务台机器人发送消息").await
     }
 }
 
@@ -183,8 +182,7 @@ pub async fn create_bot_message_with_options(
         ApiRequest::post(HelpdeskApiV1::BotMessageCreate.to_url())
             .body(serialize_params(&body, "通过服务台机器人发送消息")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "通过服务台机器人发送消息")
+    Transport::request_typed(req, config, Some(option), "通过服务台机器人发送消息").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/create.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 
 /// 创建知识库分类请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -98,8 +98,7 @@ impl CreateCategoryRequest {
             ApiRequest::post(HelpdeskApiV1::CategoryCreate.to_url())
                 .body(serialize_params(&body, "创建知识库分类")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "创建知识库分类")
+        Transport::request_typed(req, &self.config, Some(option), "创建知识库分类").await
     }
 }
 
@@ -191,8 +190,7 @@ pub async fn create_category_with_options(
         ApiRequest::post(HelpdeskApiV1::CategoryCreate.to_url())
             .body(serialize_params(&body, "创建知识库分类")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "创建知识库分类")
+    Transport::request_typed(req, config, Some(option), "创建知识库分类").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/delete.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/delete.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 删除知识库分类响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -57,8 +56,7 @@ impl DeleteCategoryRequest {
         let req: ApiRequest<DeleteCategoryResponse> =
             ApiRequest::delete(HelpdeskApiV1::CategoryDelete(self.id.clone()).to_url());
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "删除知识库分类")
+        Transport::request_typed(req, &self.config, Some(option), "删除知识库分类").await
     }
 }
 
@@ -105,8 +103,7 @@ pub async fn delete_category_with_options(
     let req: ApiRequest<DeleteCategoryResponse> =
         ApiRequest::delete(HelpdeskApiV1::CategoryDelete(id).to_url());
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "删除知识库分类")
+    Transport::request_typed(req, config, Some(option), "删除知识库分类").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/get.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/get.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 获取指定知识库分类响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -77,8 +76,7 @@ impl GetCategoryRequest {
         let api_endpoint = HelpdeskApiV1::CategoryGet(self.id.clone());
         let request = ApiRequest::<GetCategoryResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取指定知识库分类")
+        Transport::request_typed(request, &self.config, Some(option), "获取指定知识库分类").await
     }
 }
 
@@ -100,8 +98,7 @@ impl GetCategoryRequestBuilder {
         let api_endpoint = HelpdeskApiV1::CategoryGet(self.id.clone());
         let request = ApiRequest::<GetCategoryResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, None).await?;
-        extract_response_data(response, "获取指定知识库分类")
+        Transport::request_typed(request, &self.config, None, "获取指定知识库分类").await
     }
 }
 
@@ -110,8 +107,7 @@ pub async fn get_category(config: &Config, id: String) -> SDKResult<GetCategoryR
     let api_endpoint = HelpdeskApiV1::CategoryGet(id);
     let request = ApiRequest::<GetCategoryResponse>::get(api_endpoint.to_url());
 
-    let response = Transport::request(request, config, None).await?;
-    extract_response_data(response, "获取指定知识库分类")
+    Transport::request_typed(request, config, None, "获取指定知识库分类").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/list.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/list.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 获取知识库分类列表响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -76,8 +75,7 @@ impl ListCategoryRequest {
         let api_endpoint = HelpdeskApiV1::CategoryList;
         let request = ApiRequest::<ListCategoryResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取知识库分类列表")
+        Transport::request_typed(request, &self.config, Some(option), "获取知识库分类列表").await
     }
 }
 
@@ -98,8 +96,7 @@ impl ListCategoryRequestBuilder {
         let api_endpoint = HelpdeskApiV1::CategoryList;
         let request = ApiRequest::<ListCategoryResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, None).await?;
-        extract_response_data(response, "获取知识库分类列表")
+        Transport::request_typed(request, &self.config, None, "获取知识库分类列表").await
     }
 }
 
@@ -108,8 +105,7 @@ pub async fn list_categories(config: &Config) -> SDKResult<ListCategoryResponse>
     let api_endpoint = HelpdeskApiV1::CategoryList;
     let request = ApiRequest::<ListCategoryResponse>::get(api_endpoint.to_url());
 
-    let response = Transport::request(request, config, None).await?;
-    extract_response_data(response, "获取知识库分类列表")
+    Transport::request_typed(request, config, None, "获取知识库分类列表").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/patch.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 
 /// 更新知识库分类请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -105,8 +105,7 @@ impl PatchCategoryRequest {
             ApiRequest::patch(HelpdeskApiV1::CategoryPatch(self.id.clone()).to_url())
                 .body(serialize_params(&body, "更新知识库分类")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "更新知识库分类")
+        Transport::request_typed(req, &self.config, Some(option), "更新知识库分类").await
     }
 }
 
@@ -208,8 +207,7 @@ pub async fn patch_category_with_options(
         ApiRequest::patch(HelpdeskApiV1::CategoryPatch(id).to_url())
             .body(serialize_params(&body, "更新知识库分类")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "更新知识库分类")
+    Transport::request_typed(req, config, Some(option), "更新知识库分类").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/event/subscribe.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/event/subscribe.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 订阅服务台事件响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -52,8 +51,7 @@ impl EventSubscribeRequest {
         let request =
             ApiRequest::<EventSubscribeResponse>::post(HelpdeskApiV1::EventSubscribe.to_url());
 
-        let response = Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "订阅服务台事件")
+        Transport::request_typed(request, &self.config, Some(option), "订阅服务台事件").await
     }
 }
 
@@ -74,8 +72,7 @@ impl EventSubscribeRequestBuilder {
         let request =
             ApiRequest::<EventSubscribeResponse>::post(HelpdeskApiV1::EventSubscribe.to_url());
 
-        let response = Transport::request(request, &self.config, None).await?;
-        extract_response_data(response, "订阅服务台事件")
+        Transport::request_typed(request, &self.config, None, "订阅服务台事件").await
     }
 }
 
@@ -84,8 +81,7 @@ pub async fn subscribe_event(config: &Config) -> SDKResult<EventSubscribeRespons
     let request =
         ApiRequest::<EventSubscribeResponse>::post(HelpdeskApiV1::EventSubscribe.to_url());
 
-    let response = Transport::request(request, config, None).await?;
-    extract_response_data(response, "订阅服务台事件")
+    Transport::request_typed(request, config, None, "订阅服务台事件").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/event/unsubscribe.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/event/unsubscribe.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 取消订阅服务台事件响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -52,8 +51,7 @@ impl EventUnsubscribeRequest {
         let request =
             ApiRequest::<EventUnsubscribeResponse>::post(HelpdeskApiV1::EventUnsubscribe.to_url());
 
-        let response = Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "取消订阅服务台事件")
+        Transport::request_typed(request, &self.config, Some(option), "取消订阅服务台事件").await
     }
 }
 
@@ -74,8 +72,7 @@ impl EventUnsubscribeRequestBuilder {
         let request =
             ApiRequest::<EventUnsubscribeResponse>::post(HelpdeskApiV1::EventUnsubscribe.to_url());
 
-        let response = Transport::request(request, &self.config, None).await?;
-        extract_response_data(response, "取消订阅服务台事件")
+        Transport::request_typed(request, &self.config, None, "取消订阅服务台事件").await
     }
 }
 
@@ -84,8 +81,7 @@ pub async fn unsubscribe_event(config: &Config) -> SDKResult<EventUnsubscribeRes
     let request =
         ApiRequest::<EventUnsubscribeResponse>::post(HelpdeskApiV1::EventUnsubscribe.to_url());
 
-    let response = Transport::request(request, config, None).await?;
-    extract_response_data(response, "取消订阅服务台事件")
+    Transport::request_typed(request, config, None, "取消订阅服务台事件").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/create.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 
 /// 创建知识库请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -95,8 +95,7 @@ impl CreateFaqRequest {
             ApiRequest::post(HelpdeskApiV1::FaqCreate.to_url())
                 .body(serialize_params(&body, "创建知识库")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "创建知识库")
+        Transport::request_typed(req, &self.config, Some(option), "创建知识库").await
     }
 }
 
@@ -176,8 +175,7 @@ pub async fn create_faq_with_options(
     let req: ApiRequest<CreateFaqResponse> = ApiRequest::post(HelpdeskApiV1::FaqCreate.to_url())
         .body(serialize_params(&body, "创建知识库")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "创建知识库")
+    Transport::request_typed(req, config, Some(option), "创建知识库").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/delete.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/delete.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 删除知识库响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -54,8 +53,7 @@ impl DeleteFaqRequest {
         let req: ApiRequest<DeleteFaqResponse> =
             ApiRequest::delete(HelpdeskApiV1::FaqDelete(self.id.clone()).to_url());
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "删除知识库")
+        Transport::request_typed(req, &self.config, Some(option), "删除知识库").await
     }
 }
 
@@ -102,8 +100,7 @@ pub async fn delete_faq_with_options(
     let req: ApiRequest<DeleteFaqResponse> =
         ApiRequest::delete(HelpdeskApiV1::FaqDelete(id).to_url());
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "删除知识库")
+    Transport::request_typed(req, config, Some(option), "删除知识库").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/get.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/get.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 获取指定知识库响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -80,8 +79,7 @@ impl GetFaqRequest {
         let api_endpoint = HelpdeskApiV1::FaqGet(self.id.clone());
         let request = ApiRequest::<GetFaqResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取指定知识库")
+        Transport::request_typed(request, &self.config, Some(option), "获取指定知识库").await
     }
 }
 
@@ -103,8 +101,7 @@ impl GetFaqRequestBuilder {
         let api_endpoint = HelpdeskApiV1::FaqGet(self.id.clone());
         let request = ApiRequest::<GetFaqResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, None).await?;
-        extract_response_data(response, "获取指定知识库")
+        Transport::request_typed(request, &self.config, None, "获取指定知识库").await
     }
 }
 
@@ -113,8 +110,7 @@ pub async fn get_faq(config: &Config, id: String) -> SDKResult<GetFaqResponse> {
     let api_endpoint = HelpdeskApiV1::FaqGet(id);
     let request = ApiRequest::<GetFaqResponse>::get(api_endpoint.to_url());
 
-    let response = Transport::request(request, config, None).await?;
-    extract_response_data(response, "获取指定知识库")
+    Transport::request_typed(request, config, None, "获取指定知识库").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/image.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/image.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 获取知识库图片响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -65,8 +64,7 @@ impl GetFaqImageRequest {
         let api_endpoint = HelpdeskApiV1::FaqImage(self.id.clone(), self.image_key.clone());
         let request = ApiRequest::<GetFaqImageResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取知识库图片")
+        Transport::request_typed(request, &self.config, Some(option), "获取知识库图片").await
     }
 }
 
@@ -93,8 +91,7 @@ impl GetFaqImageRequestBuilder {
         let api_endpoint = HelpdeskApiV1::FaqImage(self.id.clone(), self.image_key.clone());
         let request = ApiRequest::<GetFaqImageResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, None).await?;
-        extract_response_data(response, "获取知识库图片")
+        Transport::request_typed(request, &self.config, None, "获取知识库图片").await
     }
 }
 
@@ -107,8 +104,7 @@ pub async fn get_faq_image(
     let api_endpoint = HelpdeskApiV1::FaqImage(id, image_key);
     let request = ApiRequest::<GetFaqImageResponse>::get(api_endpoint.to_url());
 
-    let response = Transport::request(request, config, None).await?;
-    extract_response_data(response, "获取知识库图片")
+    Transport::request_typed(request, config, None, "获取知识库图片").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/list.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/list.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 获取知识库列表响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -79,8 +78,7 @@ impl ListFaqRequest {
         let api_endpoint = HelpdeskApiV1::FaqList;
         let request = ApiRequest::<ListFaqResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取知识库列表")
+        Transport::request_typed(request, &self.config, Some(option), "获取知识库列表").await
     }
 }
 
@@ -101,8 +99,7 @@ impl ListFaqRequestBuilder {
         let api_endpoint = HelpdeskApiV1::FaqList;
         let request = ApiRequest::<ListFaqResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, None).await?;
-        extract_response_data(response, "获取知识库列表")
+        Transport::request_typed(request, &self.config, None, "获取知识库列表").await
     }
 }
 
@@ -111,8 +108,7 @@ pub async fn list_faqs(config: &Config) -> SDKResult<ListFaqResponse> {
     let api_endpoint = HelpdeskApiV1::FaqList;
     let request = ApiRequest::<ListFaqResponse>::get(api_endpoint.to_url());
 
-    let response = Transport::request(request, config, None).await?;
-    extract_response_data(response, "获取知识库列表")
+    Transport::request_typed(request, config, None, "获取知识库列表").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/patch.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 
 /// 更新知识库请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -109,8 +109,7 @@ impl PatchFaqRequest {
             ApiRequest::patch(HelpdeskApiV1::FaqPatch(self.id.clone()).to_url())
                 .body(serialize_params(&body, "更新知识库")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "更新知识库")
+        Transport::request_typed(req, &self.config, Some(option), "更新知识库").await
     }
 }
 
@@ -199,8 +198,7 @@ pub async fn patch_faq_with_options(
     let req: ApiRequest<PatchFaqResponse> = ApiRequest::patch(HelpdeskApiV1::FaqPatch(id).to_url())
         .body(serialize_params(&body, "更新知识库")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "更新知识库")
+    Transport::request_typed(req, config, Some(option), "更新知识库").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/search.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/search.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 搜索知识库查询参数
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -131,8 +130,7 @@ impl SearchFaqRequest {
             request = request.query("page_token", page_token);
         }
 
-        let response = Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "搜索知识库")
+        Transport::request_typed(request, &self.config, Some(option), "搜索知识库").await
     }
 }
 
@@ -191,8 +189,7 @@ impl SearchFaqRequestBuilder {
             request = request.query("page_token", page_token);
         }
 
-        let response = Transport::request(request, &self.config, None).await?;
-        extract_response_data(response, "搜索知识库")
+        Transport::request_typed(request, &self.config, None, "搜索知识库").await
     }
 }
 
@@ -201,8 +198,7 @@ pub async fn search_faqs(config: &Config) -> SDKResult<SearchFaqResponse> {
     let api_endpoint = HelpdeskApiV1::FaqSearch;
     let request = ApiRequest::<SearchFaqResponse>::get(api_endpoint.to_url());
 
-    let response = Transport::request(request, config, None).await?;
-    extract_response_data(response, "搜索知识库")
+    Transport::request_typed(request, config, None, "搜索知识库").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/cancel_approve.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/cancel_approve.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 取消推送通知审核响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -61,8 +60,7 @@ impl CancelApproveNotificationRequest {
             HelpdeskApiV1::NotificationCancelApprove(self.notification_id.clone()).to_url(),
         );
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "取消推送通知审核")
+        Transport::request_typed(req, &self.config, Some(option), "取消推送通知审核").await
     }
 }
 
@@ -122,8 +120,7 @@ pub async fn cancel_approve_notification_with_options(
     let req: ApiRequest<CancelApproveNotificationResponse> =
         ApiRequest::post(HelpdeskApiV1::NotificationCancelApprove(notification_id).to_url());
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "取消推送通知审核")
+    Transport::request_typed(req, config, Some(option), "取消推送通知审核").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/cancel_send.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/cancel_send.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 取消推送通知发送响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -61,8 +60,7 @@ impl CancelSendNotificationRequest {
             HelpdeskApiV1::NotificationCancelSend(self.notification_id.clone()).to_url(),
         );
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "取消推送通知发送")
+        Transport::request_typed(req, &self.config, Some(option), "取消推送通知发送").await
     }
 }
 
@@ -117,8 +115,7 @@ pub async fn cancel_send_notification_with_options(
     let req: ApiRequest<CancelSendNotificationResponse> =
         ApiRequest::post(HelpdeskApiV1::NotificationCancelSend(notification_id).to_url());
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "取消推送通知发送")
+    Transport::request_typed(req, config, Some(option), "取消推送通知发送").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/create.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 
 /// 创建推送通知请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -89,8 +89,7 @@ impl CreateNotificationRequest {
             ApiRequest::post(HelpdeskApiV1::NotificationCreate.to_url())
                 .body(serialize_params(&body, "创建推送通知")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "创建推送通知")
+        Transport::request_typed(req, &self.config, Some(option), "创建推送通知").await
     }
 }
 
@@ -162,8 +161,7 @@ pub async fn create_notification_with_options(
         ApiRequest::post(HelpdeskApiV1::NotificationCreate.to_url())
             .body(serialize_params(&body, "创建推送通知")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "创建推送通知")
+    Transport::request_typed(req, config, Some(option), "创建推送通知").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/execute_send.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/execute_send.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 执行推送通知响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -61,8 +60,7 @@ impl ExecuteSendNotificationRequest {
             HelpdeskApiV1::NotificationExecuteSend(self.notification_id.clone()).to_url(),
         );
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "执行推送通知")
+        Transport::request_typed(req, &self.config, Some(option), "执行推送通知").await
     }
 }
 
@@ -117,8 +115,7 @@ pub async fn execute_send_notification_with_options(
     let req: ApiRequest<ExecuteSendNotificationResponse> =
         ApiRequest::post(HelpdeskApiV1::NotificationExecuteSend(notification_id).to_url());
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "执行推送通知")
+    Transport::request_typed(req, config, Some(option), "执行推送通知").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/get.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/get.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 获取指定推送通知响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -80,8 +79,7 @@ impl GetNotificationRequest {
         let api_endpoint = HelpdeskApiV1::NotificationGet(self.notification_id.clone());
         let request = ApiRequest::<GetNotificationResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取指定推送通知")
+        Transport::request_typed(request, &self.config, Some(option), "获取指定推送通知").await
     }
 }
 
@@ -106,8 +104,7 @@ impl GetNotificationRequestBuilder {
         let api_endpoint = HelpdeskApiV1::NotificationGet(self.notification_id.clone());
         let request = ApiRequest::<GetNotificationResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, None).await?;
-        extract_response_data(response, "获取指定推送通知")
+        Transport::request_typed(request, &self.config, None, "获取指定推送通知").await
     }
 }
 
@@ -119,8 +116,7 @@ pub async fn get_notification(
     let api_endpoint = HelpdeskApiV1::NotificationGet(notification_id);
     let request = ApiRequest::<GetNotificationResponse>::get(api_endpoint.to_url());
 
-    let response = Transport::request(request, config, None).await?;
-    extract_response_data(response, "获取指定推送通知")
+    Transport::request_typed(request, config, None, "获取指定推送通知").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/patch.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 
 /// 更新推送通知请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -107,8 +107,7 @@ impl PatchNotificationRequest {
         )
         .body(serialize_params(&body, "更新推送通知")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "更新推送通知")
+        Transport::request_typed(req, &self.config, Some(option), "更新推送通知").await
     }
 }
 
@@ -194,8 +193,7 @@ pub async fn patch_notification_with_options(
         ApiRequest::patch(HelpdeskApiV1::NotificationPatch(notification_id).to_url())
             .body(serialize_params(&body, "更新推送通知")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "更新推送通知")
+    Transport::request_typed(req, config, Some(option), "更新推送通知").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/preview.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/preview.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 预览推送通知响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -61,8 +60,7 @@ impl PreviewNotificationRequest {
             HelpdeskApiV1::NotificationPreview(self.notification_id.clone()).to_url(),
         );
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "预览推送通知")
+        Transport::request_typed(req, &self.config, Some(option), "预览推送通知").await
     }
 }
 
@@ -117,8 +115,7 @@ pub async fn preview_notification_with_options(
     let req: ApiRequest<PreviewNotificationResponse> =
         ApiRequest::post(HelpdeskApiV1::NotificationPreview(notification_id).to_url());
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "预览推送通知")
+    Transport::request_typed(req, config, Some(option), "预览推送通知").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/submit_approve.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/submit_approve.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 提交推送通知审核响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -61,8 +60,7 @@ impl SubmitApproveNotificationRequest {
             HelpdeskApiV1::NotificationSubmitApprove(self.notification_id.clone()).to_url(),
         );
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "提交推送通知审核")
+        Transport::request_typed(req, &self.config, Some(option), "提交推送通知审核").await
     }
 }
 
@@ -122,8 +120,7 @@ pub async fn submit_approve_notification_with_options(
     let req: ApiRequest<SubmitApproveNotificationResponse> =
         ApiRequest::post(HelpdeskApiV1::NotificationSubmitApprove(notification_id).to_url());
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "提交推送通知审核")
+    Transport::request_typed(req, config, Some(option), "提交推送通知审核").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/answer_user_query.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/answer_user_query.rs
@@ -100,10 +100,7 @@ impl AnswerUserQueryRequest {
         let req: ApiRequest<AnswerUserQueryResponse> =
             ApiRequest::post(&path).body(serialize_params(&self.body, "回复用户在工单里的提问")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("回复用户在工单里的提问", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "回复用户在工单里的提问").await
     }
 }
 

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/create.rs
@@ -63,9 +63,13 @@ impl CreateTicketRequest {
 
         request = request.body(serialize_params(&self.body, "创建工单")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "创建工单")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "创建工单",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/customized_fields.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/customized_fields.rs
@@ -68,10 +68,7 @@ impl GetCustomizedFieldsRequest {
         let path = HelpdeskApiV1::TicketCustomizedFields.to_url();
         let req: ApiRequest<GetCustomizedFieldsResponse> = ApiRequest::get(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取服务台自定义字段", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取服务台自定义字段").await
     }
 }
 

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/get.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/get.rs
@@ -1,7 +1,7 @@
 //! 获取工单详情
 //! docPath: <https://open.feishu.cn/document/server-docs/helpdesk-v1/ticket-management/ticket/get>
 
-use crate::common::{api_endpoints::HelpdeskApiV1, api_utils::*};
+use crate::common::api_endpoints::HelpdeskApiV1;
 use crate::helpdesk::helpdesk::v1::ticket::models::GetTicketResponse;
 use openlark_core::{
     SDKResult,
@@ -40,9 +40,13 @@ impl GetTicketRequest {
         let api_endpoint = HelpdeskApiV1::TicketGet(self.ticket_id.clone());
         let request = ApiRequest::<GetTicketResponse>::get(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取工单")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取工单",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/list.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/list.rs
@@ -1,7 +1,7 @@
 //! 获取工单列表
 //! docPath: <https://open.feishu.cn/document/server-docs/helpdesk-v1/ticket-management/ticket/list>
 
-use crate::common::{api_endpoints::HelpdeskApiV1, api_utils::*};
+use crate::common::api_endpoints::HelpdeskApiV1;
 use crate::helpdesk::helpdesk::v1::ticket::models::TicketListResponse;
 use openlark_core::{
     SDKResult,
@@ -62,9 +62,13 @@ impl TicketListRequest {
             request = request.query("page_token", page_token);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取工单列表")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取工单列表",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/message/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/message/create.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 
 /// 发送工单消息请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -84,8 +84,7 @@ impl CreateTicketMessageRequest {
             ApiRequest::post(HelpdeskApiV1::TicketMessageCreate(self.ticket_id.clone()).to_url())
                 .body(serialize_params(&body, "发送工单消息")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "发送工单消息")
+        Transport::request_typed(req, &self.config, Some(option), "发送工单消息").await
     }
 }
 
@@ -163,8 +162,7 @@ pub async fn create_ticket_message_with_options(
         ApiRequest::post(HelpdeskApiV1::TicketMessageCreate(ticket_id).to_url())
             .body(serialize_params(&body, "发送工单消息")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "发送工单消息")
+    Transport::request_typed(req, config, Some(option), "发送工单消息").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/message/list.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/message/list.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 获取工单消息列表响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -77,8 +76,7 @@ impl ListTicketMessageRequest {
         let api_endpoint = HelpdeskApiV1::TicketMessageList(self.ticket_id.clone());
         let request = ApiRequest::<ListTicketMessageResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取工单消息列表")
+        Transport::request_typed(request, &self.config, Some(option), "获取工单消息列表").await
     }
 }
 
@@ -100,8 +98,7 @@ impl ListTicketMessageRequestBuilder {
         let api_endpoint = HelpdeskApiV1::TicketMessageList(self.ticket_id.clone());
         let request = ApiRequest::<ListTicketMessageResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, None).await?;
-        extract_response_data(response, "获取工单消息列表")
+        Transport::request_typed(request, &self.config, None, "获取工单消息列表").await
     }
 }
 
@@ -113,8 +110,7 @@ pub async fn list_ticket_messages(
     let api_endpoint = HelpdeskApiV1::TicketMessageList(ticket_id);
     let request = ApiRequest::<ListTicketMessageResponse>::get(api_endpoint.to_url());
 
-    let response = Transport::request(request, config, None).await?;
-    extract_response_data(response, "获取工单消息列表")
+    Transport::request_typed(request, config, None, "获取工单消息列表").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/start_service.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/start_service.rs
@@ -111,9 +111,7 @@ impl StartServiceRequest {
             ApiRequest::post(HelpdeskApiV1::TicketStartService.to_url())
                 .body(serialize_params(&self.body, "创建服务台对话")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("创建服务台对话", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "创建服务台对话").await
     }
 }
 

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/ticket_image.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/ticket_image.rs
@@ -70,9 +70,7 @@ impl GetTicketImageRequest {
                 .query("ticket_id", self.ticket_id)
                 .query("image_key", self.image_key);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("获取工单内图像", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "获取工单内图像").await
     }
 }
 

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/update.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/update.rs
@@ -101,9 +101,13 @@ impl UpdateTicketRequest {
 
         request = request.body(serialize_params(&self.body, "更新工单")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "更新工单")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "更新工单",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/create.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 
 /// 创建工单自定义字段请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -89,8 +89,7 @@ impl CreateTicketCustomizedFieldRequest {
             ApiRequest::post(HelpdeskApiV1::TicketCustomizedFieldCreate.to_url())
                 .body(serialize_params(&body, "创建工单自定义字段")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "创建工单自定义字段")
+        Transport::request_typed(req, &self.config, Some(option), "创建工单自定义字段").await
     }
 }
 
@@ -174,8 +173,7 @@ pub async fn create_ticket_customized_field_with_options(
         ApiRequest::post(HelpdeskApiV1::TicketCustomizedFieldCreate.to_url())
             .body(serialize_params(&body, "创建工单自定义字段")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "创建工单自定义字段")
+    Transport::request_typed(req, config, Some(option), "创建工单自定义字段").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/delete.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/delete.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 删除工单自定义字段响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -58,8 +57,7 @@ impl DeleteTicketCustomizedFieldRequest {
             HelpdeskApiV1::TicketCustomizedFieldDelete(self.id.clone()).to_url(),
         );
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "删除工单自定义字段")
+        Transport::request_typed(req, &self.config, Some(option), "删除工单自定义字段").await
     }
 }
 
@@ -109,8 +107,7 @@ pub async fn delete_ticket_customized_field_with_options(
     let req: ApiRequest<DeleteTicketCustomizedFieldResponse> =
         ApiRequest::delete(HelpdeskApiV1::TicketCustomizedFieldDelete(id).to_url());
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "删除工单自定义字段")
+    Transport::request_typed(req, config, Some(option), "删除工单自定义字段").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/get.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/get.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 获取指定工单自定义字段响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -74,8 +73,13 @@ impl GetTicketCustomizedFieldRequest {
         let api_endpoint = HelpdeskApiV1::TicketCustomizedFieldGet(self.id.clone());
         let request = ApiRequest::<GetTicketCustomizedFieldResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取指定工单自定义字段")
+        Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取指定工单自定义字段",
+        )
+        .await
     }
 }
 
@@ -97,8 +101,7 @@ impl GetTicketCustomizedFieldRequestBuilder {
         let api_endpoint = HelpdeskApiV1::TicketCustomizedFieldGet(self.id.clone());
         let request = ApiRequest::<GetTicketCustomizedFieldResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, None).await?;
-        extract_response_data(response, "获取指定工单自定义字段")
+        Transport::request_typed(request, &self.config, None, "获取指定工单自定义字段").await
     }
 }
 
@@ -110,8 +113,7 @@ pub async fn get_ticket_customized_field(
     let api_endpoint = HelpdeskApiV1::TicketCustomizedFieldGet(id);
     let request = ApiRequest::<GetTicketCustomizedFieldResponse>::get(api_endpoint.to_url());
 
-    let response = Transport::request(request, config, None).await?;
-    extract_response_data(response, "获取指定工单自定义字段")
+    Transport::request_typed(request, config, None, "获取指定工单自定义字段").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/list.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/list.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::extract_response_data;
 
 /// 获取工单自定义字段列表响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -73,8 +72,13 @@ impl ListTicketCustomizedFieldRequest {
         let api_endpoint = HelpdeskApiV1::TicketCustomizedFieldList;
         let request = ApiRequest::<ListTicketCustomizedFieldResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取工单自定义字段列表")
+        Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取工单自定义字段列表",
+        )
+        .await
     }
 }
 
@@ -95,8 +99,7 @@ impl ListTicketCustomizedFieldRequestBuilder {
         let api_endpoint = HelpdeskApiV1::TicketCustomizedFieldList;
         let request = ApiRequest::<ListTicketCustomizedFieldResponse>::get(api_endpoint.to_url());
 
-        let response = Transport::request(request, &self.config, None).await?;
-        extract_response_data(response, "获取工单自定义字段列表")
+        Transport::request_typed(request, &self.config, None, "获取工单自定义字段列表").await
     }
 }
 
@@ -107,8 +110,7 @@ pub async fn list_ticket_customized_fields(
     let api_endpoint = HelpdeskApiV1::TicketCustomizedFieldList;
     let request = ApiRequest::<ListTicketCustomizedFieldResponse>::get(api_endpoint.to_url());
 
-    let response = Transport::request(request, config, None).await?;
-    extract_response_data(response, "获取工单自定义字段列表")
+    Transport::request_typed(request, config, None, "获取工单自定义字段列表").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/patch.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 
 /// 更新工单自定义字段请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -90,8 +90,7 @@ impl PatchTicketCustomizedFieldRequest {
             ApiRequest::patch(HelpdeskApiV1::TicketCustomizedFieldPatch(self.id.clone()).to_url())
                 .body(serialize_params(&body, "更新工单自定义字段")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "更新工单自定义字段")
+        Transport::request_typed(req, &self.config, Some(option), "更新工单自定义字段").await
     }
 }
 
@@ -175,8 +174,7 @@ pub async fn patch_ticket_customized_field_with_options(
         ApiRequest::patch(HelpdeskApiV1::TicketCustomizedFieldPatch(id).to_url())
             .body(serialize_params(&body, "更新工单自定义字段")?);
 
-    let resp = Transport::request(req, config, Some(option)).await?;
-    extract_response_data(resp, "更新工单自定义字段")
+    Transport::request_typed(req, config, Some(option), "更新工单自定义字段").await
 }
 
 #[cfg(test)]

--- a/crates/openlark-platform/src/admin/v1/admin_dept_stat/list.rs
+++ b/crates/openlark-platform/src/admin/v1/admin_dept_stat/list.rs
@@ -79,10 +79,7 @@ impl ListAdminDeptStatRequestBuilder {
 
         let api_request: ApiRequest<ListAdminDeptStatResponse> = ApiRequest::get(url);
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取部门统计数据", "响应数据为空")
-        })
+        Transport::request_typed(api_request, &self.config, Some(option), "获取部门统计数据").await
     }
 }
 

--- a/crates/openlark-platform/src/admin/v1/admin_user_stat/list.rs
+++ b/crates/openlark-platform/src/admin/v1/admin_user_stat/list.rs
@@ -79,10 +79,7 @@ impl ListAdminUserStatRequestBuilder {
 
         let api_request: ApiRequest<ListAdminUserStatResponse> = ApiRequest::get(url);
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取用户统计数据", "响应数据为空")
-        })
+        Transport::request_typed(api_request, &self.config, Some(option), "获取用户统计数据").await
     }
 }
 

--- a/crates/openlark-platform/src/admin/v1/audit_info/list.rs
+++ b/crates/openlark-platform/src/admin/v1/audit_info/list.rs
@@ -86,10 +86,7 @@ impl ListAuditInfoRequestBuilder {
 
         let api_request: ApiRequest<ListAuditInfoResponse> = ApiRequest::get(url);
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取审计日志列表", "响应数据为空")
-        })
+        Transport::request_typed(api_request, &self.config, Some(option), "获取审计日志列表").await
     }
 }
 

--- a/crates/openlark-platform/src/admin/v1/badge/create.rs
+++ b/crates/openlark-platform/src/admin/v1/badge/create.rs
@@ -73,10 +73,7 @@ impl CreateBadgeRequestBuilder {
             ApiRequest::post(AdminApiV1::CreateBadge.path())
                 .body(serde_json::to_value(&request_body)?);
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response
-            .data
-            .ok_or_else(|| openlark_core::error::validation_error("创建勋章", "响应数据为空"))
+        Transport::request_typed(api_request, &self.config, Some(option), "创建勋章").await
     }
 }
 

--- a/crates/openlark-platform/src/admin/v1/badge/get.rs
+++ b/crates/openlark-platform/src/admin/v1/badge/get.rs
@@ -43,10 +43,7 @@ impl GetBadgeRequestBuilder {
         let api_request: ApiRequest<GetBadgeResponse> =
             ApiRequest::get(format!("/open-apis/admin/v1/badges/{}", self.badge_id));
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response
-            .data
-            .ok_or_else(|| openlark_core::error::validation_error("获取勋章详情", "响应数据为空"))
+        Transport::request_typed(api_request, &self.config, Some(option), "获取勋章详情").await
     }
 }
 

--- a/crates/openlark-platform/src/admin/v1/badge/grant/create.rs
+++ b/crates/openlark-platform/src/admin/v1/badge/grant/create.rs
@@ -65,10 +65,7 @@ impl CreateBadgeGrantRequestBuilder {
         ))
         .body(serde_json::to_value(&request_body)?);
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("创建勋章授予名单", "响应数据为空")
-        })
+        Transport::request_typed(api_request, &self.config, Some(option), "创建勋章授予名单").await
     }
 }
 

--- a/crates/openlark-platform/src/admin/v1/badge/grant/delete.rs
+++ b/crates/openlark-platform/src/admin/v1/badge/grant/delete.rs
@@ -55,10 +55,7 @@ impl DeleteBadgeGrantRequestBuilder {
         );
         let api_request: ApiRequest<DeleteBadgeGrantResponse> = ApiRequest::delete(url);
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("删除勋章授予名单", "响应数据为空")
-        })
+        Transport::request_typed(api_request, &self.config, Some(option), "删除勋章授予名单").await
     }
 }
 

--- a/crates/openlark-platform/src/admin/v1/badge/grant/get.rs
+++ b/crates/openlark-platform/src/admin/v1/badge/grant/get.rs
@@ -55,10 +55,13 @@ impl GetBadgeGrantRequestBuilder {
         );
         let api_request: ApiRequest<GetBadgeGrantResponse> = ApiRequest::get(url);
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取勋章授予名单详情", "响应数据为空")
-        })
+        Transport::request_typed(
+            api_request,
+            &self.config,
+            Some(option),
+            "获取勋章授予名单详情",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-platform/src/admin/v1/badge/grant/list.rs
+++ b/crates/openlark-platform/src/admin/v1/badge/grant/list.rs
@@ -76,10 +76,13 @@ impl ListBadgeGrantRequestBuilder {
 
         let api_request: ApiRequest<ListBadgeGrantResponse> = ApiRequest::get(url);
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取勋章授予名单列表", "响应数据为空")
-        })
+        Transport::request_typed(
+            api_request,
+            &self.config,
+            Some(option),
+            "获取勋章授予名单列表",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-platform/src/admin/v1/badge/grant/update.rs
+++ b/crates/openlark-platform/src/admin/v1/badge/grant/update.rs
@@ -67,10 +67,7 @@ impl UpdateBadgeGrantRequestBuilder {
         let api_request: ApiRequest<UpdateBadgeGrantResponse> =
             ApiRequest::put(url).body(serde_json::to_value(&request_body)?);
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("修改勋章授予名单", "响应数据为空")
-        })
+        Transport::request_typed(api_request, &self.config, Some(option), "修改勋章授予名单").await
     }
 }
 

--- a/crates/openlark-platform/src/admin/v1/badge/list.rs
+++ b/crates/openlark-platform/src/admin/v1/badge/list.rs
@@ -66,10 +66,7 @@ impl ListBadgeRequestBuilder {
 
         let api_request: ApiRequest<ListBadgeResponse> = ApiRequest::get(url);
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response
-            .data
-            .ok_or_else(|| openlark_core::error::validation_error("获取勋章列表", "响应数据为空"))
+        Transport::request_typed(api_request, &self.config, Some(option), "获取勋章列表").await
     }
 }
 

--- a/crates/openlark-platform/src/admin/v1/badge/update.rs
+++ b/crates/openlark-platform/src/admin/v1/badge/update.rs
@@ -65,10 +65,7 @@ impl UpdateBadgeRequestBuilder {
         let api_request: ApiRequest<UpdateBadgeResponse> =
             ApiRequest::put(url).body(serde_json::to_value(&request_body)?);
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response
-            .data
-            .ok_or_else(|| openlark_core::error::validation_error("修改勋章信息", "响应数据为空"))
+        Transport::request_typed(api_request, &self.config, Some(option), "修改勋章信息").await
     }
 }
 

--- a/crates/openlark-platform/src/admin/v1/badge_image/create.rs
+++ b/crates/openlark-platform/src/admin/v1/badge_image/create.rs
@@ -49,10 +49,7 @@ impl CreateBadgeImageRequestBuilder {
             ApiRequest::post("/open-apis/admin/v1/badge_images")
                 .body(serde_json::to_value(&request_body)?);
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response
-            .data
-            .ok_or_else(|| openlark_core::error::validation_error("上传勋章图片", "响应数据为空"))
+        Transport::request_typed(api_request, &self.config, Some(option), "上传勋章图片").await
     }
 }
 

--- a/crates/openlark-platform/src/admin/v1/password/reset.rs
+++ b/crates/openlark-platform/src/admin/v1/password/reset.rs
@@ -62,10 +62,7 @@ impl ResetPasswordRequestBuilder {
             ApiRequest::post("/open-apis/admin/v1/password/reset")
                 .body(serde_json::to_value(&request_body)?);
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response
-            .data
-            .ok_or_else(|| openlark_core::error::validation_error("重置用户密码", "响应数据为空"))
+        Transport::request_typed(api_request, &self.config, Some(option), "重置用户密码").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/app/list.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/app/list.rs
@@ -66,10 +66,7 @@ impl ListAppRequestBuilder {
 
         let api_request: ApiRequest<ListAppResponse> = ApiRequest::get(url);
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("查看应用基本信息", "响应数据为空")
-        })
+        Transport::request_typed(api_request, &self.config, Some(option), "查看应用基本信息").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/audit_log/audit_log_list.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/audit_log/audit_log_list.rs
@@ -93,10 +93,7 @@ impl AuditLogListRequestBuilder {
         if let Some(page_size) = self.page_size {
             req = req.query("page_size", page_size.to_string());
         }
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("查询审计日志列表", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "查询审计日志列表").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/audit_log/data_change_log_detail.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/audit_log/data_change_log_detail.rs
@@ -49,10 +49,7 @@ impl DataChangeLogDetailRequestBuilder {
 
         let mut req: ApiRequest<DataChangeLogDetailResponse> = ApiRequest::get(&url);
         req = req.query("log_id", &self.log_id);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("查询数据变更日志详情", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "查询数据变更日志详情").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/audit_log/data_change_logs_list.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/audit_log/data_change_logs_list.rs
@@ -93,10 +93,7 @@ impl DataChangeLogsListRequestBuilder {
         if let Some(page_size) = self.page_size {
             req = req.query("page_size", page_size.to_string());
         }
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("查询数据变更日志列表", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "查询数据变更日志列表").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/audit_log/get.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/audit_log/get.rs
@@ -49,10 +49,7 @@ impl AuditLogGetRequestBuilder {
 
         let mut req: ApiRequest<AuditLogGetResponse> = ApiRequest::get(&url);
         req = req.query("log_id", &self.log_id);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("查询审计日志详情", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "查询审计日志详情").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/environment_variable/get.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/environment_variable/get.rs
@@ -52,9 +52,7 @@ impl EnvironmentVariableGetRequestBuilder {
         );
 
         let req: ApiRequest<EnvironmentVariableGetResponse> = ApiRequest::get(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/environment_variable/query.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/environment_variable/query.rs
@@ -69,9 +69,7 @@ impl EnvironmentVariableQueryRequestBuilder {
 
         let req: ApiRequest<EnvironmentVariableQueryResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/flow/execute.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/flow/execute.rs
@@ -62,9 +62,7 @@ impl FlowExecuteRequestBuilder {
 
         let req: ApiRequest<FlowExecuteResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/function/invoke.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/function/invoke.rs
@@ -66,9 +66,7 @@ impl FunctionInvokeRequestBuilder {
 
         let req: ApiRequest<FunctionInvokeResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/object/oql_query.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/object/oql_query.rs
@@ -66,9 +66,7 @@ impl OqlQueryRequestBuilder {
 
         let req: ApiRequest<OqlQueryResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/batch_create.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/batch_create.rs
@@ -75,9 +75,7 @@ impl RecordBatchCreateRequestBuilder {
 
         let req: ApiRequest<RecordBatchCreateResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/batch_delete.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/batch_delete.rs
@@ -73,9 +73,7 @@ impl RecordBatchDeleteRequestBuilder {
 
         let req: ApiRequest<RecordBatchDeleteResponse> =
             ApiRequest::delete(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/batch_query.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/batch_query.rs
@@ -89,9 +89,7 @@ impl RecordBatchQueryRequestBuilder {
 
         let req: ApiRequest<RecordBatchQueryResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/batch_update.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/batch_update.rs
@@ -78,9 +78,13 @@ impl RecordBatchUpdateRequestBuilder {
 
         let req: ApiRequest<RecordBatchUpdateResponse> =
             ApiRequest::patch(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(RequestOption::default())).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(
+            req,
+            &self.config,
+            Some(RequestOption::default()),
+            "Operation",
+        )
+        .await
     }
 
     /// 使用选项执行请求
@@ -99,9 +103,7 @@ impl RecordBatchUpdateRequestBuilder {
 
         let req: ApiRequest<RecordBatchUpdateResponse> =
             ApiRequest::patch(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/create.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/create.rs
@@ -64,9 +64,7 @@ impl RecordCreateRequestBuilder {
 
         let req: ApiRequest<RecordCreateResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/delete.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/delete.rs
@@ -56,9 +56,7 @@ impl RecordDeleteRequestBuilder {
         );
 
         let req: ApiRequest<RecordDeleteResponse> = ApiRequest::delete(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("删除记录", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "删除记录").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/patch.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/patch.rs
@@ -60,9 +60,13 @@ impl RecordPatchRequestBuilder {
 
         let req: ApiRequest<RecordPatchResponse> =
             ApiRequest::patch(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(RequestOption::default())).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(
+            req,
+            &self.config,
+            Some(RequestOption::default()),
+            "Operation",
+        )
+        .await
     }
 
     /// 使用选项执行请求
@@ -79,9 +83,7 @@ impl RecordPatchRequestBuilder {
 
         let req: ApiRequest<RecordPatchResponse> =
             ApiRequest::patch(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/query.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/object/record/query.rs
@@ -76,9 +76,7 @@ impl RecordQueryRequestBuilder {
 
         let req: ApiRequest<RecordQueryResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/object/search.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/object/search.rs
@@ -89,9 +89,7 @@ impl RecordSearchRequestBuilder {
 
         let req: ApiRequest<RecordSearchResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/record_permission/member/batch_create_authorization.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/record_permission/member/batch_create_authorization.rs
@@ -72,9 +72,7 @@ impl RecordPermissionBatchCreateAuthRequestBuilder {
 
         let req = ApiRequest::<RecordPermissionBatchCreateAuthResponse>::post(&url)
             .body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/record_permission/member/batch_remove_authorization.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/record_permission/member/batch_remove_authorization.rs
@@ -72,9 +72,7 @@ impl RecordPermissionBatchRemoveAuthRequestBuilder {
 
         let req = ApiRequest::<RecordPermissionBatchRemoveAuthResponse>::post(&url)
             .body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/role/member/batch_create_authorization.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/role/member/batch_create_authorization.rs
@@ -72,9 +72,7 @@ impl RoleMemberBatchCreateAuthRequestBuilder {
 
         let req = ApiRequest::<RoleMemberBatchCreateAuthResponse>::post(&url)
             .body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/role/member/batch_remove_authorization.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/role/member/batch_remove_authorization.rs
@@ -72,9 +72,7 @@ impl RoleMemberBatchRemoveAuthRequestBuilder {
 
         let req = ApiRequest::<RoleMemberBatchRemoveAuthResponse>::post(&url)
             .body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/application/role/member/get.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/application/role/member/get.rs
@@ -76,9 +76,7 @@ impl RoleMemberGetRequestBuilder {
         if let Some(page_size) = self.page_size {
             req = req.query("page_size", page_size.to_string());
         }
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/approval_instance/cancel.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/approval_instance/cancel.rs
@@ -50,10 +50,7 @@ impl CancelInstanceRequestBuilder {
         );
         let api_request: ApiRequest<CancelInstanceResponse> = ApiRequest::post(url);
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response
-            .data
-            .ok_or_else(|| openlark_core::error::validation_error("撤销人工任务", "响应数据为空"))
+        Transport::request_typed(api_request, &self.config, Some(option), "撤销人工任务").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/approval_instance/get.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/approval_instance/get.rs
@@ -49,10 +49,7 @@ impl GetInstanceRequestBuilder {
         );
         let api_request: ApiRequest<GetInstanceResponse> = ApiRequest::get(url);
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取人工任务详情", "响应数据为空")
-        })
+        Transport::request_typed(api_request, &self.config, Some(option), "获取人工任务详情").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/approval_instance/list.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/approval_instance/list.rs
@@ -76,10 +76,7 @@ impl ListInstanceRequestBuilder {
 
         let api_request: ApiRequest<ListInstanceResponse> = ApiRequest::get(url);
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取人工任务列表", "响应数据为空")
-        })
+        Transport::request_typed(api_request, &self.config, Some(option), "获取人工任务列表").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/approval_task/add_assignee.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/approval_task/add_assignee.rs
@@ -65,10 +65,7 @@ impl AddAssigneeRequestBuilder {
         let api_request: ApiRequest<AddAssigneeResponse> =
             ApiRequest::post(url).body(serde_json::to_value(&request_body)?);
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response
-            .data
-            .ok_or_else(|| openlark_core::error::validation_error("人工任务加签", "响应数据为空"))
+        Transport::request_typed(api_request, &self.config, Some(option), "人工任务加签").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/approval_task/agree.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/approval_task/agree.rs
@@ -47,10 +47,7 @@ impl AgreeTaskRequestBuilder {
         );
         let api_request: ApiRequest<AgreeTaskResponse> = ApiRequest::post(url);
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response
-            .data
-            .ok_or_else(|| openlark_core::error::validation_error("同意人工任务", "响应数据为空"))
+        Transport::request_typed(api_request, &self.config, Some(option), "同意人工任务").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/approval_task/cancel.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/approval_task/cancel.rs
@@ -49,10 +49,7 @@ impl CancelTaskRequestBuilder {
         );
         let api_request: ApiRequest<CancelTaskResponse> = ApiRequest::post(url);
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response
-            .data
-            .ok_or_else(|| openlark_core::error::validation_error("撤销人工任务", "响应数据为空"))
+        Transport::request_typed(api_request, &self.config, Some(option), "撤销人工任务").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/approval_task/reject.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/approval_task/reject.rs
@@ -62,10 +62,7 @@ impl RejectTaskRequestBuilder {
         let api_request: ApiRequest<RejectTaskResponse> =
             ApiRequest::post(url).body(serde_json::to_value(&request_body)?);
 
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-        response
-            .data
-            .ok_or_else(|| openlark_core::error::validation_error("拒绝人工任务", "响应数据为空"))
+        Transport::request_typed(api_request, &self.config, Some(option), "拒绝人工任务").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/approval_task/transfer.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/approval_task/transfer.rs
@@ -67,9 +67,7 @@ impl TransferApprovalTaskRequestBuilder {
 
         let req = ApiRequest::<TransferApprovalTaskResponse>::post(&url)
             .body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/seat_activity/list.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/seat_activity/list.rs
@@ -87,10 +87,7 @@ impl SeatActivityListRequestBuilder {
         if let Some(end_time) = self.end_time {
             req = req.query("end_time", end_time.to_string());
         }
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("查询席位活跃详情", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "查询席位活跃详情").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/seat_assignment/list.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/seat_assignment/list.rs
@@ -63,10 +63,7 @@ impl SeatAssignmentListRequestBuilder {
         if let Some(page_size) = self.page_size {
             req = req.query("page_size", page_size.to_string());
         }
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("查询席位分配详情", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "查询席位分配详情").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/tenant_app_metrics/query.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/tenant_app_metrics/query.rs
@@ -6,7 +6,7 @@ use openlark_core::{
     SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
 };
 
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 
 /// 应用运营数据查询端点。
 pub const TENANT_APP_METRICS_QUERY: &str = "/open-apis/apaas/v1/tenant_app_metrics/query";
@@ -45,8 +45,7 @@ impl TenantAppMetricsQueryRequest {
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(TENANT_APP_METRICS_QUERY)
             .body(serialize_params(&body, "获取应用运营数据")?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "获取应用运营数据")
+        Transport::request_typed(req, &self.config, Some(option), "获取应用运营数据").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/user_task/cc.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/user_task/cc.rs
@@ -69,9 +69,7 @@ impl CcTaskRequestBuilder {
 
         let req: ApiRequest<CcTaskResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/user_task/chat_group.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/user_task/chat_group.rs
@@ -86,9 +86,7 @@ impl ChatGroupRequestBuilder {
 
         let req: ApiRequest<ChatGroupResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/user_task/expediting.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/user_task/expediting.rs
@@ -62,9 +62,7 @@ impl ExpeditingRequestBuilder {
 
         let req: ApiRequest<ExpeditingResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/user_task/query.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/user_task/query.rs
@@ -115,9 +115,7 @@ impl UserTaskQueryRequestBuilder {
 
         let req: ApiRequest<UserTaskQueryResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/user_task/rollback.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/user_task/rollback.rs
@@ -60,9 +60,7 @@ impl RollbackTaskRequestBuilder {
 
         let req: ApiRequest<RollbackTaskResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/user_task/rollback_points.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/user_task/rollback_points.rs
@@ -45,9 +45,7 @@ impl RollbackPointsRequestBuilder {
         );
 
         let req: ApiRequest<RollbackPointsResponse> = ApiRequest::post(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/workspace/enum_mod/enum_get.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/workspace/enum_mod/enum_get.rs
@@ -51,9 +51,7 @@ impl EnumGetRequestBuilder {
         );
 
         let req: ApiRequest<EnumGetResponse> = ApiRequest::get(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/workspace/enum_mod/list.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/workspace/enum_mod/list.rs
@@ -41,9 +41,7 @@ impl EnumListRequestBuilder {
         let url = format!("/open-apis/apaas/v1/workspaces/{}/enums", self.workspace_id);
 
         let req: ApiRequest<EnumListResponse> = ApiRequest::get(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/workspace/sql_commands.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/workspace/sql_commands.rs
@@ -51,9 +51,7 @@ impl SqlCommandsRequestBuilder {
 
         let req: ApiRequest<SqlCommandsResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/list.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/list.rs
@@ -42,9 +42,7 @@ impl TableListRequestBuilder {
         );
 
         let req: ApiRequest<TableListResponse> = ApiRequest::get(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/records_batch_update.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/records_batch_update.rs
@@ -89,14 +89,7 @@ impl TableRecordsBatchUpdateRequestBuilder {
         let req: ApiRequest<TableRecordsBatchUpdateResponse> =
             ApiRequest::patch(url).body(serde_json::to_value(&request)?);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error(
-                "批量更新记录响应数据为空".to_string(),
-                "服务器没有返回有效的数据".to_string(),
-            )
-        })
+        Transport::request_typed(req, &self.config, Some(option), "批量更新记录响应数据为空").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/records_delete.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/records_delete.rs
@@ -76,9 +76,7 @@ impl TableRecordsDeleteRequestBuilder {
         let mut api_request = ApiRequest::<TableRecordsDeleteResponse>::delete(&url);
         api_request = api_request.body(request);
 
-        let resp = Transport::request(api_request, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("删除数据表记录", "响应数据为空"))
+        Transport::request_typed(api_request, &self.config, Some(option), "删除数据表记录").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/records_get.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/records_get.rs
@@ -100,9 +100,7 @@ impl TableRecordsGetRequestBuilder {
         if let Some(order_by) = self.order_by {
             req = req.query("order_by", &order_by);
         }
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("查询数据表记录", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "查询数据表记录").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/records_patch.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/records_patch.rs
@@ -63,9 +63,13 @@ impl TableRecordsPatchRequestBuilder {
 
         let req: ApiRequest<TableRecordsPatchResponse> =
             ApiRequest::patch(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(RequestOption::default())).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(
+            req,
+            &self.config,
+            Some(RequestOption::default()),
+            "Operation",
+        )
+        .await
     }
 
     /// 使用选项执行请求
@@ -85,9 +89,7 @@ impl TableRecordsPatchRequestBuilder {
 
         let req: ApiRequest<TableRecordsPatchResponse> =
             ApiRequest::patch(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/records_post.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/records_post.rs
@@ -75,9 +75,7 @@ impl TableRecordsPostRequestBuilder {
 
         let req: ApiRequest<TableRecordsPostResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/table_get.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/workspace/table/table_get.rs
@@ -49,9 +49,7 @@ impl TableGetRequestBuilder {
         );
 
         let req: ApiRequest<TableGetResponse> = ApiRequest::get(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/app_engine/apaas/v1/workspace/view/views_get.rs
+++ b/crates/openlark-platform/src/app_engine/apaas/v1/workspace/view/views_get.rs
@@ -85,9 +85,7 @@ impl ViewsGetRequestBuilder {
         if let Some(filter) = self.filter {
             req = req.query("filter", &filter);
         }
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("查询视图记录", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "查询视图记录").await
     }
 }
 

--- a/crates/openlark-platform/src/directory/v1/collaboration_rule/create.rs
+++ b/crates/openlark-platform/src/directory/v1/collaboration_rule/create.rs
@@ -78,9 +78,7 @@ impl CollaborationRuleCreateRequestBuilder {
 
         let req: ApiRequest<CollaborationRuleCreateResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/directory/v1/collaboration_rule/delete.rs
+++ b/crates/openlark-platform/src/directory/v1/collaboration_rule/delete.rs
@@ -45,10 +45,7 @@ impl CollaborationRuleDeleteRequestBuilder {
         );
 
         let req: ApiRequest<CollaborationRuleDeleteResponse> = ApiRequest::delete(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("删除可搜可见规则", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "删除可搜可见规则").await
     }
 }
 

--- a/crates/openlark-platform/src/directory/v1/collaboration_rule/list.rs
+++ b/crates/openlark-platform/src/directory/v1/collaboration_rule/list.rs
@@ -37,9 +37,7 @@ impl CollaborationRuleListRequestBuilder {
         let url = "/open-apis/directory/v1/collaboration_rules".to_string();
 
         let req: ApiRequest<CollaborationRuleListResponse> = ApiRequest::get(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/directory/v1/collaboration_rule/update.rs
+++ b/crates/openlark-platform/src/directory/v1/collaboration_rule/update.rs
@@ -93,10 +93,7 @@ impl CollaborationRuleUpdateRequestBuilder {
         let mut api_request = ApiRequest::<CollaborationRuleUpdateResponse>::put(&url);
         api_request = api_request.body(request);
 
-        let resp = Transport::request(api_request, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("更新可搜可见规则", "响应数据为空")
-        })
+        Transport::request_typed(api_request, &self.config, Some(option), "更新可搜可见规则").await
     }
 }
 

--- a/crates/openlark-platform/src/directory/v1/collaboration_share_entity/list.rs
+++ b/crates/openlark-platform/src/directory/v1/collaboration_share_entity/list.rs
@@ -51,9 +51,7 @@ impl CollaborationShareEntityListRequestBuilder {
         if let Some(tenant_id) = &self.tenant_id {
             req = req.query("tenant_id", tenant_id);
         }
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("获取共享成员", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "获取共享成员").await
     }
 }
 

--- a/crates/openlark-platform/src/directory/v1/collaboration_tenant/list.rs
+++ b/crates/openlark-platform/src/directory/v1/collaboration_tenant/list.rs
@@ -37,9 +37,7 @@ impl CollaborationTenantListRequestBuilder {
         let url = "/open-apis/directory/v1/collaboration_tenants".to_string();
 
         let req: ApiRequest<CollaborationTenantListResponse> = ApiRequest::get(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/directory/v1/department/create.rs
+++ b/crates/openlark-platform/src/directory/v1/department/create.rs
@@ -67,9 +67,7 @@ impl DepartmentCreateRequestBuilder {
 
         let req: ApiRequest<DepartmentCreateResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("创建部门", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "创建部门").await
     }
 }
 

--- a/crates/openlark-platform/src/directory/v1/department/delete.rs
+++ b/crates/openlark-platform/src/directory/v1/department/delete.rs
@@ -42,9 +42,7 @@ impl DepartmentDeleteRequestBuilder {
         let url = format!("/open-apis/directory/v1/departments/{}", self.department_id);
 
         let req: ApiRequest<DepartmentDeleteResponse> = ApiRequest::delete(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("删除部门", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "删除部门").await
     }
 }
 

--- a/crates/openlark-platform/src/directory/v1/department/filter.rs
+++ b/crates/openlark-platform/src/directory/v1/department/filter.rs
@@ -73,9 +73,7 @@ impl DepartmentFilterRequestBuilder {
 
         let req: ApiRequest<DepartmentFilterResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/directory/v1/department/mget.rs
+++ b/crates/openlark-platform/src/directory/v1/department/mget.rs
@@ -63,9 +63,7 @@ impl DepartmentMgetRequestBuilder {
 
         let req: ApiRequest<DepartmentMgetResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/directory/v1/department/patch.rs
+++ b/crates/openlark-platform/src/directory/v1/department/patch.rs
@@ -68,9 +68,13 @@ impl DepartmentPatchRequestBuilder {
 
         let req: ApiRequest<DepartmentPatchResponse> =
             ApiRequest::patch(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(RequestOption::default())).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(
+            req,
+            &self.config,
+            Some(RequestOption::default()),
+            "Operation",
+        )
+        .await
     }
 
     /// 使用选项执行请求
@@ -88,9 +92,7 @@ impl DepartmentPatchRequestBuilder {
 
         let req: ApiRequest<DepartmentPatchResponse> =
             ApiRequest::patch(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/directory/v1/department/search.rs
+++ b/crates/openlark-platform/src/directory/v1/department/search.rs
@@ -67,9 +67,7 @@ impl DepartmentSearchRequestBuilder {
 
         let req: ApiRequest<DepartmentSearchResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/directory/v1/employee/create.rs
+++ b/crates/openlark-platform/src/directory/v1/employee/create.rs
@@ -81,9 +81,7 @@ impl EmployeeCreateRequestBuilder {
 
         let req: ApiRequest<EmployeeCreateResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/directory/v1/employee/delete.rs
+++ b/crates/openlark-platform/src/directory/v1/employee/delete.rs
@@ -42,9 +42,7 @@ impl EmployeeDeleteRequestBuilder {
         let url = format!("/open-apis/directory/v1/employees/{}", self.employee_id);
 
         let req: ApiRequest<EmployeeDeleteResponse> = ApiRequest::delete(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("离职员工", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "离职员工").await
     }
 }
 

--- a/crates/openlark-platform/src/directory/v1/employee/filter.rs
+++ b/crates/openlark-platform/src/directory/v1/employee/filter.rs
@@ -83,9 +83,7 @@ impl EmployeeFilterRequestBuilder {
 
         let req: ApiRequest<EmployeeFilterResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/directory/v1/employee/mget.rs
+++ b/crates/openlark-platform/src/directory/v1/employee/mget.rs
@@ -63,9 +63,7 @@ impl EmployeeMgetRequestBuilder {
 
         let req: ApiRequest<EmployeeMgetResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/directory/v1/employee/patch.rs
+++ b/crates/openlark-platform/src/directory/v1/employee/patch.rs
@@ -78,9 +78,13 @@ impl EmployeePatchRequestBuilder {
 
         let req: ApiRequest<EmployeePatchResponse> =
             ApiRequest::patch(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(RequestOption::default())).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(
+            req,
+            &self.config,
+            Some(RequestOption::default()),
+            "Operation",
+        )
+        .await
     }
 
     /// 使用选项执行请求
@@ -98,9 +102,7 @@ impl EmployeePatchRequestBuilder {
 
         let req: ApiRequest<EmployeePatchResponse> =
             ApiRequest::patch(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/directory/v1/employee/regular.rs
+++ b/crates/openlark-platform/src/directory/v1/employee/regular.rs
@@ -45,10 +45,7 @@ impl EmployeeRegularRequestBuilder {
         );
 
         let req: ApiRequest<EmployeeRegularResponse> = ApiRequest::patch(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("更新待离职成员为在职", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "更新待离职成员为在职").await
     }
 }
 

--- a/crates/openlark-platform/src/directory/v1/employee/resurrect.rs
+++ b/crates/openlark-platform/src/directory/v1/employee/resurrect.rs
@@ -45,9 +45,7 @@ impl EmployeeResurrectRequestBuilder {
         );
 
         let req: ApiRequest<EmployeeResurrectResponse> = ApiRequest::post(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("恢复离职员工", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "恢复离职员工").await
     }
 }
 

--- a/crates/openlark-platform/src/directory/v1/employee/search.rs
+++ b/crates/openlark-platform/src/directory/v1/employee/search.rs
@@ -77,9 +77,7 @@ impl EmployeeSearchRequestBuilder {
 
         let req: ApiRequest<EmployeeSearchResponse> =
             ApiRequest::post(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/directory/v1/employee/to_be_resigned.rs
+++ b/crates/openlark-platform/src/directory/v1/employee/to_be_resigned.rs
@@ -51,9 +51,13 @@ impl EmployeeToBeResignedRequestBuilder {
 
         let req: ApiRequest<EmployeeToBeResignedResponse> =
             ApiRequest::patch(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(RequestOption::default())).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(
+            req,
+            &self.config,
+            Some(RequestOption::default()),
+            "Operation",
+        )
+        .await
     }
 
     /// 使用选项执行请求
@@ -72,9 +76,7 @@ impl EmployeeToBeResignedRequestBuilder {
 
         let req: ApiRequest<EmployeeToBeResignedResponse> =
             ApiRequest::patch(&url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/mdm/v1/user_auth_data_relation/bind.rs
+++ b/crates/openlark-platform/src/mdm/v1/user_auth_data_relation/bind.rs
@@ -67,9 +67,7 @@ impl UserAuthDataRelationBindRequestBuilder {
 
         let req: ApiRequest<UserAuthDataRelationBindResponse> =
             ApiRequest::post(url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/mdm/v1/user_auth_data_relation/unbind.rs
+++ b/crates/openlark-platform/src/mdm/v1/user_auth_data_relation/unbind.rs
@@ -67,9 +67,7 @@ impl UserAuthDataRelationUnbindRequestBuilder {
 
         let req: ApiRequest<UserAuthDataRelationUnbindResponse> =
             ApiRequest::post(url).body(serde_json::to_value(&request)?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/mdm/v3/batch_country_region/get.rs
+++ b/crates/openlark-platform/src/mdm/v3/batch_country_region/get.rs
@@ -57,9 +57,7 @@ impl CountryRegionBatchGetRequestBuilder {
         validate_required_list!(self.mdm_codes, 50, "mdm_codes 不能为空");
 
         let req: ApiRequest<CountryRegionBatchGetResponse> = ApiRequest::get(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/mdm/v3/country_region/list.rs
+++ b/crates/openlark-platform/src/mdm/v3/country_region/list.rs
@@ -68,9 +68,7 @@ impl CountryRegionListRequestBuilder {
         }
 
         let req: ApiRequest<CountryRegionListResponse> = ApiRequest::get(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/spark/v1/app/create.rs
+++ b/crates/openlark-platform/src/spark/v1/app/create.rs
@@ -32,8 +32,6 @@ impl CreateSparkAppRequest {
         option: RequestOption,
     ) -> SDKResult<serde_json::Value> {
         let req = ApiRequest::<serde_json::Value>::post("/open-apis/spark/v1/apps").body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("创建妙搭应用", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "创建妙搭应用").await
     }
 }

--- a/crates/openlark-platform/src/spark/v1/app/enum/get_enum_detail.rs
+++ b/crates/openlark-platform/src/spark/v1/app/enum/get_enum_detail.rs
@@ -52,10 +52,7 @@ impl AppEnumGetEnumDetailRequest {
             self.app_id, self.enum_name
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::get(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取自定义枚举详细信息", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取自定义枚举详细信息").await
     }
 }
 

--- a/crates/openlark-platform/src/spark/v1/app/enum/get_enum_list.rs
+++ b/crates/openlark-platform/src/spark/v1/app/enum/get_enum_list.rs
@@ -40,10 +40,7 @@ impl AppEnumGetEnumListRequest {
         validate_required!(self.app_id, "app_id 不能为空");
         let path = format!("/open-apis/spark/v1/apps/{}/enums", self.app_id);
         let req: ApiRequest<serde_json::Value> = ApiRequest::get(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取自定义枚举列表", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取自定义枚举列表").await
     }
 }
 

--- a/crates/openlark-platform/src/spark/v1/app/get_app_visibility.rs
+++ b/crates/openlark-platform/src/spark/v1/app/get_app_visibility.rs
@@ -34,9 +34,6 @@ impl GetSparkAppVisibilityRequest {
         validate_required!(self.app_id.trim(), "app_id 不能为空");
         let path = format!("/open-apis/spark/v1/apps/{}/access-scope", self.app_id);
         let req = ApiRequest::<serde_json::Value>::get(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取妙搭应用可用范围", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取妙搭应用可用范围").await
     }
 }

--- a/crates/openlark-platform/src/spark/v1/app/icon.rs
+++ b/crates/openlark-platform/src/spark/v1/app/icon.rs
@@ -32,9 +32,6 @@ impl UploadSparkAppIconRequest {
         option: RequestOption,
     ) -> SDKResult<serde_json::Value> {
         let req = ApiRequest::<serde_json::Value>::post("/open-apis/spark/v1/icon").body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("上传妙搭应用图标", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "上传妙搭应用图标").await
     }
 }

--- a/crates/openlark-platform/src/spark/v1/app/list.rs
+++ b/crates/openlark-platform/src/spark/v1/app/list.rs
@@ -40,9 +40,6 @@ impl ListSparkAppsRequest {
         for (key, value) in self.query {
             req = req.query(key, value);
         }
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("批量获取妙搭应用", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "批量获取妙搭应用").await
     }
 }

--- a/crates/openlark-platform/src/spark/v1/app/patch.rs
+++ b/crates/openlark-platform/src/spark/v1/app/patch.rs
@@ -39,9 +39,6 @@ impl PatchSparkAppRequest {
         validate_required!(self.app_id.trim(), "app_id 不能为空");
         let path = format!("/open-apis/spark/v1/apps/{}", self.app_id);
         let req = ApiRequest::<serde_json::Value>::patch(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("更新妙搭应用信息", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "更新妙搭应用信息").await
     }
 }

--- a/crates/openlark-platform/src/spark/v1/app/sql_commands.rs
+++ b/crates/openlark-platform/src/spark/v1/app/sql_commands.rs
@@ -45,9 +45,7 @@ impl AppSqlCommandsRequest {
         validate_required!(self.app_id, "app_id 不能为空");
         let path = format!("/open-apis/spark/v1/apps/{}/sql_commands", self.app_id);
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("执行 SQL", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "执行 SQL").await
     }
 }
 

--- a/crates/openlark-platform/src/spark/v1/app/storage/download.rs
+++ b/crates/openlark-platform/src/spark/v1/app/storage/download.rs
@@ -40,9 +40,7 @@ impl AppStorageDownloadRequest {
         validate_required!(self.app_id, "app_id 不能为空");
         let path = format!("/open-apis/spark/v1/apps/{}/storage", self.app_id);
         let req: ApiRequest<serde_json::Value> = ApiRequest::get(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("下载文件", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "下载文件").await
     }
 }
 

--- a/crates/openlark-platform/src/spark/v1/app/storage/upload.rs
+++ b/crates/openlark-platform/src/spark/v1/app/storage/upload.rs
@@ -45,9 +45,7 @@ impl AppStorageUploadRequest {
         validate_required!(self.app_id, "app_id 不能为空");
         let path = format!("/open-apis/spark/v1/apps/{}/storage/upload", self.app_id);
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("上传文件", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "上传文件").await
     }
 }
 

--- a/crates/openlark-platform/src/spark/v1/app/storage/upload_complete.rs
+++ b/crates/openlark-platform/src/spark/v1/app/storage/upload_complete.rs
@@ -48,10 +48,7 @@ impl AppStorageUploadCompleteRequest {
             self.app_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("分片上传文件 - 完成上传", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "分片上传文件 - 完成上传").await
     }
 }
 

--- a/crates/openlark-platform/src/spark/v1/app/storage/upload_initialize.rs
+++ b/crates/openlark-platform/src/spark/v1/app/storage/upload_initialize.rs
@@ -48,10 +48,13 @@ impl AppStorageUploadInitializeRequest {
             self.app_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("分片上传文件 - 创建上传请求", "响应数据为空")
-        })
+        Transport::request_typed(
+            req,
+            &self.config,
+            Some(option),
+            "分片上传文件 - 创建上传请求",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-platform/src/spark/v1/app/storage/upload_part.rs
+++ b/crates/openlark-platform/src/spark/v1/app/storage/upload_part.rs
@@ -48,10 +48,7 @@ impl AppStorageUploadPartRequest {
             self.app_id
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("分片上传文件 - 上传分片", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "分片上传文件 - 上传分片").await
     }
 }
 

--- a/crates/openlark-platform/src/spark/v1/app/table/batch_update_table_records.rs
+++ b/crates/openlark-platform/src/spark/v1/app/table/batch_update_table_records.rs
@@ -57,10 +57,7 @@ impl AppTableBatchUpdateTableRecordsRequest {
             self.app_id, self.table_name
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::patch(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("批量更新数据表中的记录", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "批量更新数据表中的记录").await
     }
 }
 

--- a/crates/openlark-platform/src/spark/v1/app/table/delete_table_records.rs
+++ b/crates/openlark-platform/src/spark/v1/app/table/delete_table_records.rs
@@ -52,10 +52,7 @@ impl AppTableDeleteTableRecordsRequest {
             self.app_id, self.table_name
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::delete(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("删除数据表中的记录", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "删除数据表中的记录").await
     }
 }
 

--- a/crates/openlark-platform/src/spark/v1/app/table/get_table_detail.rs
+++ b/crates/openlark-platform/src/spark/v1/app/table/get_table_detail.rs
@@ -52,10 +52,7 @@ impl AppTableGetTableDetailRequest {
             self.app_id, self.table_name
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::get(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("获取数据表详细信息", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "获取数据表详细信息").await
     }
 }
 

--- a/crates/openlark-platform/src/spark/v1/app/table/get_table_list.rs
+++ b/crates/openlark-platform/src/spark/v1/app/table/get_table_list.rs
@@ -40,9 +40,7 @@ impl AppTableGetTableListRequest {
         validate_required!(self.app_id, "app_id 不能为空");
         let path = format!("/open-apis/spark/v1/apps/{}/tables", self.app_id);
         let req: ApiRequest<serde_json::Value> = ApiRequest::get(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("获取数据表列表", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "获取数据表列表").await
     }
 }
 

--- a/crates/openlark-platform/src/spark/v1/app/table/get_table_record_list.rs
+++ b/crates/openlark-platform/src/spark/v1/app/table/get_table_record_list.rs
@@ -52,10 +52,7 @@ impl AppTableGetTableRecordListRequest {
             self.app_id, self.table_name
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::get(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("查询数据表数据记录", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "查询数据表数据记录").await
     }
 }
 

--- a/crates/openlark-platform/src/spark/v1/app/table/patch_table_records.rs
+++ b/crates/openlark-platform/src/spark/v1/app/table/patch_table_records.rs
@@ -57,10 +57,7 @@ impl AppTablePatchTableRecordsRequest {
             self.app_id, self.table_name
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::patch(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("按条件更新数据表中的记录", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "按条件更新数据表中的记录").await
     }
 }
 

--- a/crates/openlark-platform/src/spark/v1/app/table/post_table_records.rs
+++ b/crates/openlark-platform/src/spark/v1/app/table/post_table_records.rs
@@ -57,10 +57,7 @@ impl AppTablePostTableRecordsRequest {
             self.app_id, self.table_name
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("向数据表中添加或更新记录", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "向数据表中添加或更新记录").await
     }
 }
 

--- a/crates/openlark-platform/src/spark/v1/app/update_app_visibility.rs
+++ b/crates/openlark-platform/src/spark/v1/app/update_app_visibility.rs
@@ -39,9 +39,6 @@ impl UpdateSparkAppVisibilityRequest {
         validate_required!(self.app_id.trim(), "app_id 不能为空");
         let path = format!("/open-apis/spark/v1/apps/{}/access-scope", self.app_id);
         let req = ApiRequest::<serde_json::Value>::put(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("更新妙搭应用可用范围", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "更新妙搭应用可用范围").await
     }
 }

--- a/crates/openlark-platform/src/spark/v1/app/upload_html_code_and_release.rs
+++ b/crates/openlark-platform/src/spark/v1/app/upload_html_code_and_release.rs
@@ -42,10 +42,7 @@ impl UploadHtmlCodeAndReleaseRequest {
             self.app_id
         );
         let req = ApiRequest::<serde_json::Value>::post(path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("上传 HTML 代码并发布", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "上传 HTML 代码并发布").await
     }
 }
 

--- a/crates/openlark-platform/src/spark/v1/app/view/get_view_record_list.rs
+++ b/crates/openlark-platform/src/spark/v1/app/view/get_view_record_list.rs
@@ -52,10 +52,7 @@ impl AppViewGetViewRecordListRequest {
             self.app_id, self.view_name
         );
         let req: ApiRequest<serde_json::Value> = ApiRequest::get(path);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("查询视图数据记录", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "查询视图数据记录").await
     }
 }
 

--- a/crates/openlark-platform/src/spark/v1/directory/user/id_convert.rs
+++ b/crates/openlark-platform/src/spark/v1/directory/user/id_convert.rs
@@ -4,8 +4,7 @@
 //! docPath:
 
 use crate::common::{
-    api_utils::{extract_response_data, serialize_params},
-    constants::endpoints::SPARK_V1_DIRECTORY_USER_ID_CONVERT,
+    api_utils::serialize_params, constants::endpoints::SPARK_V1_DIRECTORY_USER_ID_CONVERT,
 };
 use openlark_core::{
     SDKResult,
@@ -85,8 +84,7 @@ impl DirectoryUserIdConvertRequestBuilder {
         let req: ApiRequest<DirectoryUserIdConvertResponse> =
             ApiRequest::post(SPARK_V1_DIRECTORY_USER_ID_CONVERT)
                 .body(serialize_params(&request, "转换妙搭和飞书用户 ID")?);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "转换妙搭和飞书用户 ID")
+        Transport::request_typed(req, &self.config, Some(option), "转换妙搭和飞书用户 ID").await
     }
 }
 

--- a/crates/openlark-platform/src/tenant/v2/tenant/product_assign_info/query.rs
+++ b/crates/openlark-platform/src/tenant/v2/tenant/product_assign_info/query.rs
@@ -68,9 +68,7 @@ impl AssignInfoListQueryRequestBuilder {
         }
 
         let req: ApiRequest<AssignInfoListQueryResponse> = ApiRequest::get(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/tenant/v2/tenant/query.rs
+++ b/crates/openlark-platform/src/tenant/v2/tenant/query.rs
@@ -37,9 +37,7 @@ impl TenantQueryRequestBuilder {
         let url = "/open-apis/tenant/v2/tenant/query";
 
         let req: ApiRequest<TenantQueryResponse> = ApiRequest::get(url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/trust_party/v1/collaboration_tenant/collaboration_department/get.rs
+++ b/crates/openlark-platform/src/trust_party/v1/collaboration_tenant/collaboration_department/get.rs
@@ -58,9 +58,7 @@ impl CollaborationDepartmentGetRequestBuilder {
         );
 
         let req: ApiRequest<CollaborationDepartmentGetResponse> = ApiRequest::get(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/trust_party/v1/collaboration_tenant/collaboration_user/get.rs
+++ b/crates/openlark-platform/src/trust_party/v1/collaboration_tenant/collaboration_user/get.rs
@@ -58,9 +58,7 @@ impl CollaborationUserGetRequestBuilder {
         );
 
         let req: ApiRequest<CollaborationUserGetResponse> = ApiRequest::get(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/trust_party/v1/collaboration_tenant/get.rs
+++ b/crates/openlark-platform/src/trust_party/v1/collaboration_tenant/get.rs
@@ -50,9 +50,7 @@ impl CollaborationTenantGetRequestBuilder {
         );
 
         let req: ApiRequest<CollaborationTenantGetResponse> = ApiRequest::get(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/trust_party/v1/collaboration_tenant/list.rs
+++ b/crates/openlark-platform/src/trust_party/v1/collaboration_tenant/list.rs
@@ -68,9 +68,7 @@ impl CollaborationTenantListRequestBuilder {
         }
 
         let req: ApiRequest<CollaborationTenantListResponse> = ApiRequest::get(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-platform/src/trust_party/v1/collaboration_tenant/visible_organization.rs
+++ b/crates/openlark-platform/src/trust_party/v1/collaboration_tenant/visible_organization.rs
@@ -50,9 +50,7 @@ impl VisibleOrganizationRequestBuilder {
         );
 
         let req: ApiRequest<VisibleOrganizationResponse> = ApiRequest::get(&url);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data
-            .ok_or_else(|| openlark_core::error::validation_error("Operation", "响应数据为空"))
+        Transport::request_typed(req, &self.config, Some(option), "Operation").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/access_record/access_photo/get.rs
+++ b/crates/openlark-security/src/acs/acs/v1/access_record/access_photo/get.rs
@@ -41,8 +41,7 @@ impl GetAccessPhotoRequest {
         let req: ApiRequest<serde_json::Value> =
             ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "下载开门时的人脸识别图片").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/access_record/list.rs
+++ b/crates/openlark-security/src/acs/acs/v1/access_record/list.rs
@@ -55,8 +55,7 @@ impl ListAccessRecordsRequest {
                 .query_opt("page_token", self.page_token.as_ref())
                 .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "获取门禁记录列表").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/client_device/get.rs
+++ b/crates/openlark-security/src/acs/acs/v1/client_device/get.rs
@@ -38,8 +38,7 @@ impl GetClientDeviceRequest {
         let req: ApiRequest<serde_json::Value> =
             ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "获取客户端设备认证信息").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/device/approve.rs
+++ b/crates/openlark-security/src/acs/acs/v1/device/approve.rs
@@ -53,8 +53,7 @@ impl ApproveDeviceRequest {
             req = req.body(body);
         }
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "审批设备申报").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/device/create.rs
+++ b/crates/openlark-security/src/acs/acs/v1/device/create.rs
@@ -46,8 +46,7 @@ impl CreateDeviceRequest {
             .body(body)
             .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "新增设备").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/device/delete.rs
+++ b/crates/openlark-security/src/acs/acs/v1/device/delete.rs
@@ -38,8 +38,7 @@ impl DeleteDeviceRequest {
         let req: ApiRequest<serde_json::Value> =
             ApiRequest::delete(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "删除设备").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/device/get.rs
+++ b/crates/openlark-security/src/acs/acs/v1/device/get.rs
@@ -38,8 +38,7 @@ impl GetDeviceRequest {
         let req: ApiRequest<serde_json::Value> =
             ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "获取单个设备信息").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/device/list.rs
+++ b/crates/openlark-security/src/acs/acs/v1/device/list.rs
@@ -64,8 +64,7 @@ impl ListDevicesRequest {
             .query_opt("device_type", self.device_type.as_ref())
             .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "获取门禁设备列表").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/device/query.rs
+++ b/crates/openlark-security/src/acs/acs/v1/device/query.rs
@@ -38,8 +38,7 @@ impl QueryDeviceRequest {
         let req: ApiRequest<serde_json::Value> =
             ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "查询设备信息").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/device/update.rs
+++ b/crates/openlark-security/src/acs/acs/v1/device/update.rs
@@ -53,8 +53,7 @@ impl UpdateDeviceRequest {
             req = req.body(body);
         }
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "更新设备").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/face/create.rs
+++ b/crates/openlark-security/src/acs/acs/v1/face/create.rs
@@ -46,8 +46,7 @@ impl FaceCreateRequest {
             .body(body)
             .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "创建人脸").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/face/delete.rs
+++ b/crates/openlark-security/src/acs/acs/v1/face/delete.rs
@@ -38,8 +38,7 @@ impl FaceDeleteRequest {
         let req: ApiRequest<serde_json::Value> =
             ApiRequest::delete(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "删除人脸").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/face/get.rs
+++ b/crates/openlark-security/src/acs/acs/v1/face/get.rs
@@ -38,8 +38,7 @@ impl FaceGetRequest {
         let req: ApiRequest<serde_json::Value> =
             ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "获取人脸信息").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/rule_external/create.rs
+++ b/crates/openlark-security/src/acs/acs/v1/rule_external/create.rs
@@ -71,8 +71,7 @@ impl CreateRuleExternalRequest {
                 .body(wrapped)
                 .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "创建或更新权限组").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/rule_external/delete.rs
+++ b/crates/openlark-security/src/acs/acs/v1/rule_external/delete.rs
@@ -42,8 +42,7 @@ impl DeleteRuleExternalRequest {
                 .query("rule_id", &self.rule_id)
                 .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "删除权限组").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/rule_external/device_bind.rs
+++ b/crates/openlark-security/src/acs/acs/v1/rule_external/device_bind.rs
@@ -78,8 +78,7 @@ impl BindDeviceToRuleRequest {
                 )
                 .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "设备绑定权限组").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/rule_external/get.rs
+++ b/crates/openlark-security/src/acs/acs/v1/rule_external/get.rs
@@ -51,8 +51,7 @@ impl GetRuleExternalRequest {
             .query_opt("user_id_type", self.user_id_type.as_ref())
             .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "获取权限组信息").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/user/create.rs
+++ b/crates/openlark-security/src/acs/acs/v1/user/create.rs
@@ -46,8 +46,7 @@ impl CreateUserRequest {
             .body(body)
             .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "创建用户").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/user/delete.rs
+++ b/crates/openlark-security/src/acs/acs/v1/user/delete.rs
@@ -38,8 +38,7 @@ impl DeleteUserRequest {
         let req: ApiRequest<serde_json::Value> =
             ApiRequest::delete(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "删除用户").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/user/face/get.rs
+++ b/crates/openlark-security/src/acs/acs/v1/user/face/get.rs
@@ -57,8 +57,7 @@ impl GetUserFaceRequest {
         let req: ApiRequest<FaceData> =
             ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "下载用户人脸图片").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/user/face/update.rs
+++ b/crates/openlark-security/src/acs/acs/v1/user/face/update.rs
@@ -54,8 +54,7 @@ impl UpdateUserFaceRequest {
             .body(body)
             .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "上传用户人脸图片").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/user/get.rs
+++ b/crates/openlark-security/src/acs/acs/v1/user/get.rs
@@ -40,8 +40,7 @@ impl GetUserRequest {
         let req: ApiRequest<serde_json::Value> =
             ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "获取单个用户信息").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/user/list.rs
+++ b/crates/openlark-security/src/acs/acs/v1/user/list.rs
@@ -38,6 +38,15 @@ impl openlark_core::api::ApiResponseTrait for ListUsersResponse {
     fn data_format() -> openlark_core::api::ResponseFormat {
         openlark_core::api::ResponseFormat::Data
     }
+
+    /// 成功但无 `data` 字段时的空列表（与旧 `unwrap_or` 默认值一致）。
+    fn empty_success() -> Option<Self> {
+        Some(Self {
+            has_more: false,
+            page_token: None,
+            items: None,
+        })
+    }
 }
 
 impl ListUsersRequest {
@@ -82,15 +91,7 @@ impl ListUsersRequest {
             .query_opt("department_id", self.department_id.as_ref())
             .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        if !resp.is_success() {
-            return resp.into_result();
-        }
-        Ok(resp.data.unwrap_or(ListUsersResponse {
-            has_more: false,
-            page_token: None,
-            items: None,
-        }))
+        Transport::request_typed(req, &self.config, Some(option), "获取用户列表").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/user/patch.rs
+++ b/crates/openlark-security/src/acs/acs/v1/user/patch.rs
@@ -53,8 +53,7 @@ impl PatchUserRequest {
             req = req.body(body);
         }
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "修改用户部分信息").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/visitor/create.rs
+++ b/crates/openlark-security/src/acs/acs/v1/visitor/create.rs
@@ -46,8 +46,7 @@ impl CreateVisitorRequest {
             .body(body)
             .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "添加访客").await
     }
 }
 

--- a/crates/openlark-security/src/acs/acs/v1/visitor/delete.rs
+++ b/crates/openlark-security/src/acs/acs/v1/visitor/delete.rs
@@ -38,8 +38,7 @@ impl DeleteVisitorRequest {
         let req: ApiRequest<serde_json::Value> =
             ApiRequest::delete(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "删除访客").await
     }
 }
 

--- a/crates/openlark-security/src/security/security_and_compliance/v1/multi_geo_entity/tenant/get.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/multi_geo_entity/tenant/get.rs
@@ -55,8 +55,7 @@ impl ListMultiGeoEntityTenantsRequest {
                 .query_opt("page_token", self.page_token.as_ref())
                 .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "获取地理位置列表").await
     }
 }
 

--- a/crates/openlark-security/src/security/security_and_compliance/v1/openapi_logs/list_data.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/openapi_logs/list_data.rs
@@ -72,8 +72,7 @@ impl ListOpenApiLogsRequest {
                 .body(self.body)
                 .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "获取 OpenAPI 审计日志数据").await
     }
 }
 

--- a/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/cancel.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/cancel.rs
@@ -38,8 +38,7 @@ impl CancelUserMigrationRequest {
                 .body(body)
                 .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "取消用户迁移").await
     }
 }
 

--- a/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/create.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/create.rs
@@ -47,8 +47,7 @@ impl CreateUserMigrationRequest {
                 .body(self.body)
                 .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "创建用户迁移").await
     }
 }
 

--- a/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/get.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/get.rs
@@ -38,8 +38,7 @@ impl GetUserMigrationRequest {
         ))
         .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "获取单个用户迁移状态").await
     }
 }
 

--- a/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/search.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/search.rs
@@ -47,8 +47,7 @@ impl SearchUserMigrationsRequest {
                 .body(self.body)
                 .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "批量获取用户迁移状态").await
     }
 }
 

--- a/crates/openlark-security/src/security/security_and_compliance/v2/device_apply_records/approve.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v2/device_apply_records/approve.rs
@@ -98,8 +98,7 @@ impl ApproveDeviceApplyRecordRequest {
             )
             .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "审批设备申报").await
     }
 }
 

--- a/crates/openlark-security/src/security/security_and_compliance/v2/device_records/create.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v2/device_records/create.rs
@@ -50,8 +50,7 @@ impl CreateDeviceRecordRequest {
                 .body(body)
                 .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "新增设备记录").await
     }
 }
 

--- a/crates/openlark-security/src/security/security_and_compliance/v2/device_records/delete.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v2/device_records/delete.rs
@@ -41,8 +41,7 @@ impl DeleteDeviceRecordRequest {
         let req: ApiRequest<serde_json::Value> =
             ApiRequest::delete(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "删除设备").await
     }
 }
 

--- a/crates/openlark-security/src/security/security_and_compliance/v2/device_records/get.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v2/device_records/get.rs
@@ -41,8 +41,7 @@ impl GetDeviceRecordRequest {
         let req: ApiRequest<serde_json::Value> =
             ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "获取单个设备信息").await
     }
 }
 

--- a/crates/openlark-security/src/security/security_and_compliance/v2/device_records/list.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v2/device_records/list.rs
@@ -108,8 +108,7 @@ impl ListDeviceRecordsRequest {
                 .query_opt("compliance_status", self.compliance_status.as_ref())
                 .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "查询设备信息列表").await
     }
 }
 

--- a/crates/openlark-security/src/security/security_and_compliance/v2/device_records/mine.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v2/device_records/mine.rs
@@ -65,8 +65,7 @@ impl GetMyDeviceRecordsRequest {
                 .query_opt("status", self.status.as_ref())
                 .with_supported_access_token_types(vec![AccessTokenType::App]);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "获取我的设备认证信息").await
     }
 }
 

--- a/crates/openlark-security/src/security/security_and_compliance/v2/device_records/update.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v2/device_records/update.rs
@@ -56,8 +56,7 @@ impl UpdateDeviceRecordRequest {
             req = req.body(body);
         }
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.into_result()
+        Transport::request_typed(req, &self.config, Some(option), "更新设备信息").await
     }
 }
 

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/batch_close.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/batch_close.rs
@@ -38,6 +38,11 @@ impl ApiResponseTrait for BatchCloseSystemStatusResponse {
     fn data_format() -> ResponseFormat {
         ResponseFormat::Data
     }
+
+    /// 成功但无 `data` 字段时的空成功（batch_close 类 API，与旧 `unwrap_or` 默认值一致）。
+    fn empty_success() -> Option<Self> {
+        Some(Self { data: None })
+    }
 }
 
 impl BatchCloseSystemStatusRequest {
@@ -79,10 +84,7 @@ impl BatchCloseSystemStatusRequest {
         );
         let body = serde_json::to_value(&self.body)?;
         let req: ApiRequest<BatchCloseSystemStatusResponse> = ApiRequest::post(&path).body(body);
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        Ok(resp
-            .data
-            .unwrap_or(BatchCloseSystemStatusResponse { data: None }))
+        Transport::request_typed(req, &self.config, Some(option), "批量关闭系统状态").await
     }
 }
 

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/batch_open.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/batch_open.rs
@@ -56,10 +56,7 @@ impl SystemStatusBatchOpenRequest {
         );
         let req: ApiRequest<SystemStatusBatchOpenResponse> = ApiRequest::post(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("system_status batch_open", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "system_status batch_open").await
     }
 }
 

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/create.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/create.rs
@@ -49,10 +49,7 @@ impl SystemStatusCreateRequest {
         let req: ApiRequest<SystemStatusCreateResponse> =
             ApiRequest::post("/open-apis/personal_settings/v1/system_statuses");
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("system_status create", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "system_status create").await
     }
 }
 

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/delete.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/delete.rs
@@ -64,10 +64,7 @@ impl SystemStatusDeleteRequest {
         );
         let req: ApiRequest<SystemStatusDeleteResponse> = ApiRequest::delete(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("system_status delete", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "system_status delete").await
     }
 }
 

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/list.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/list.rs
@@ -49,10 +49,7 @@ impl SystemStatusListRequest {
         let req: ApiRequest<SystemStatusListResponse> =
             ApiRequest::get("/open-apis/personal_settings/v1/system_statuses");
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("system_status list", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "system_status list").await
     }
 }
 

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/patch.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/patch.rs
@@ -64,10 +64,7 @@ impl SystemStatusPatchRequest {
         );
         let req: ApiRequest<SystemStatusPatchResponse> = ApiRequest::patch(&path);
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        resp.data.ok_or_else(|| {
-            openlark_core::error::validation_error("system_status patch", "响应数据为空")
-        })
+        Transport::request_typed(req, &self.config, Some(option), "system_status patch").await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/approval/create.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/approval/create.rs
@@ -78,11 +78,13 @@ impl CreateApprovalRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/approval/get.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/approval/get.rs
@@ -50,11 +50,13 @@ impl GetApprovalRequestV4 {
             crate::common::api_endpoints::ApprovalApiV4::ApprovalGet(self.approval_code.clone());
         let request = ApiRequest::<GetApprovalResponseV4>::get(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/approval/subscribe.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/approval/subscribe.rs
@@ -49,11 +49,13 @@ impl SubscribeApprovalRequestV4 {
         );
         let request = ApiRequest::<SubscribeApprovalResponseV4>::post(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/approval/unsubscribe.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/approval/unsubscribe.rs
@@ -49,11 +49,13 @@ impl UnsubscribeApprovalRequestV4 {
         );
         let request = ApiRequest::<UnsubscribeApprovalResponseV4>::post(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/district/list.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/district/list.rs
@@ -136,9 +136,6 @@ impl ListDistrictsRequest {
         if let Some(locale) = self.locale {
             request = request.query("locale", locale);
         }
-        let response = Transport::request(request, &self.config, Some(option)).await?;
-        response
-            .data
-            .ok_or_else(|| openlark_core::error::validation_error("查询地理库信息", "响应数据为空"))
+        Transport::request_typed(request, &self.config, Some(option), "查询地理库信息").await
     }
 }

--- a/crates/openlark-workflow/src/approval/approval/v4/district/search.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/district/search.rs
@@ -84,9 +84,6 @@ impl SearchDistrictsRequest {
             request = request.query("locale", locale);
         }
         request = request.body(serde_json::to_value(&self.body)?);
-        let response = Transport::request(request, &self.config, Some(option)).await?;
-        response
-            .data
-            .ok_or_else(|| openlark_core::error::validation_error("搜索地理库信息", "响应数据为空"))
+        Transport::request_typed(request, &self.config, Some(option), "搜索地理库信息").await
     }
 }

--- a/crates/openlark-workflow/src/approval/approval/v4/external_approval/create.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/external_approval/create.rs
@@ -113,11 +113,13 @@ impl CreateExternalApprovalRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/external_approval/get.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/external_approval/get.rs
@@ -78,11 +78,13 @@ impl GetExternalApprovalRequestV4 {
             crate::common::api_endpoints::ApprovalApiV4::ExternalApprovalGet(self.approval_code);
         let request = ApiRequest::<GetExternalApprovalResponseV4>::get(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/external_instance/check.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/external_instance/check.rs
@@ -78,11 +78,13 @@ impl CheckExternalInstanceRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/external_instance/create.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/external_instance/create.rs
@@ -119,11 +119,13 @@ impl CreateExternalInstanceRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/external_task/list.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/external_task/list.rs
@@ -93,11 +93,13 @@ impl ListExternalTaskRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/add_cc.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/add_cc.rs
@@ -11,7 +11,7 @@ use openlark_core::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-use crate::common::api_utils::{missing_response_data_error, request_serialization_error};
+use crate::common::api_utils::request_serialization_error;
 
 /// 抄送审批实例请求体（用户级，v4）
 #[derive(Debug, Clone, Serialize, Default)]
@@ -107,14 +107,13 @@ impl AddCcInstanceRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            missing_response_data_error(
-                "抄送审批实例（用户级）",
-                response.raw_response.request_id.clone(),
-            )
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "抄送审批实例（用户级）",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/add_sign.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/add_sign.rs
@@ -103,11 +103,13 @@ impl AddSignRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/cancel.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/cancel.rs
@@ -69,11 +69,13 @@ impl CancelInstanceRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/cc.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/cc.rs
@@ -82,11 +82,13 @@ impl CcInstanceRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/comment/create.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/comment/create.rs
@@ -84,11 +84,13 @@ impl CreateInstanceCommentRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/comment/delete.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/comment/delete.rs
@@ -57,11 +57,13 @@ impl DeleteInstanceCommentRequestV4 {
         );
         let request = ApiRequest::<DeleteInstanceCommentResponseV4>::delete(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/comment/list.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/comment/list.rs
@@ -101,11 +101,13 @@ impl ListInstanceCommentRequestV4 {
             request = request.query_param("page_token", page_token);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/comment/remove.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/comment/remove.rs
@@ -53,11 +53,13 @@ impl RemoveInstanceCommentRequestV4 {
         );
         let request = ApiRequest::<RemoveInstanceCommentResponseV4>::post(url);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/create.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/create.rs
@@ -89,11 +89,13 @@ impl CreateInstanceRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/detail.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/detail.rs
@@ -11,8 +11,6 @@ use openlark_core::{
 use serde::Deserialize;
 use std::sync::Arc;
 
-use crate::common::api_utils::missing_response_data_error;
-
 /// 审批实例任务项（用户级，v4）
 #[derive(Debug, Clone, Deserialize)]
 pub struct DetailInstanceTaskV4 {
@@ -123,14 +121,13 @@ impl DetailInstanceRequestV4 {
             request = request.query("locale", locale);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            missing_response_data_error(
-                "获取审批实例详情（用户级）",
-                response.raw_response.request_id.clone(),
-            )
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取审批实例详情（用户级）",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/get.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/get.rs
@@ -52,11 +52,13 @@ impl GetInstanceRequestV4 {
             crate::common::api_endpoints::ApprovalApiV4::InstanceGet(self.instance_id.clone());
         let request = ApiRequest::<GetInstanceResponseV4>::get(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/initiated.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/initiated.rs
@@ -10,8 +10,6 @@ use openlark_core::{
 use serde::Deserialize;
 use std::sync::Arc;
 
-use crate::common::api_utils::missing_response_data_error;
-
 /// 审批摘要项（v4）
 #[derive(Debug, Clone, Deserialize)]
 pub struct InstanceSummaryV4 {
@@ -145,14 +143,13 @@ impl InitiatedInstanceRequestV4 {
             request = request.query("page_token", page_token);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            missing_response_data_error(
-                "查询已发起审批列表（用户级）",
-                response.raw_response.request_id.clone(),
-            )
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "查询已发起审批列表（用户级）",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/list.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/list.rs
@@ -55,11 +55,13 @@ impl ListInstanceRequestV4 {
             crate::common::api_endpoints::ApprovalApiV4::InstanceList(self.approval_code.clone());
         let request = ApiRequest::<ListInstanceResponseV4>::get(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/preview.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/preview.rs
@@ -104,11 +104,13 @@ impl PreviewInstanceRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/query.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/query.rs
@@ -56,11 +56,13 @@ impl QueryInstanceRequestV4 {
         let api_endpoint = crate::common::api_endpoints::ApprovalApiV4::InstanceQuery;
         let request = ApiRequest::<QueryInstanceResponseV4>::post(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/recall.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/recall.rs
@@ -11,7 +11,7 @@ use openlark_core::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-use crate::common::api_utils::{missing_response_data_error, request_serialization_error};
+use crate::common::api_utils::request_serialization_error;
 
 /// 撤回审批实例请求体（用户级，v4）
 #[derive(Debug, Clone, Serialize, Default)]
@@ -79,14 +79,13 @@ impl RecallInstanceRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            missing_response_data_error(
-                "撤回审批实例（用户级）",
-                response.raw_response.request_id.clone(),
-            )
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "撤回审批实例（用户级）",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/remind.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/remind.rs
@@ -11,7 +11,7 @@ use openlark_core::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-use crate::common::api_utils::{missing_response_data_error, request_serialization_error};
+use crate::common::api_utils::request_serialization_error;
 
 /// 单据催办请求体（用户级，v4）
 #[derive(Debug, Clone, Serialize, Default)]
@@ -103,14 +103,13 @@ impl RemindInstanceRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            missing_response_data_error(
-                "单据催办（用户级）",
-                response.raw_response.request_id.clone(),
-            )
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "单据催办（用户级）",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/search_cc.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/search_cc.rs
@@ -56,11 +56,13 @@ impl SearchCcRequestV4 {
         let api_endpoint = crate::common::api_endpoints::ApprovalApiV4::InstanceSearchCc;
         let request = ApiRequest::<SearchCcResponseV4>::post(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/specified_rollback.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/specified_rollback.rs
@@ -89,11 +89,13 @@ impl SpecifiedRollbackRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/subscription.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/subscription.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use openlark_core::{SDKResult, api::ApiRequest, config::Config};
 
 use crate::common::api_endpoints::ApprovalApiV4;
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 
 /// 订阅审批实例状态变更事件请求（v4）
 ///
@@ -43,9 +43,13 @@ impl SubscribeInstanceRequestV4 {
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(endpoint.to_url())
             .body(serialize_params(&body, "订阅审批实例状态变更")?);
 
-        let resp = openlark_core::http::Transport::request(req, &self.config, Some(option)).await?;
-
-        extract_response_data(resp, "订阅审批实例状态变更")
+        openlark_core::http::Transport::request_typed(
+            req,
+            &self.config,
+            Some(option),
+            "订阅审批实例状态变更",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/instance/unsubscription.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/instance/unsubscription.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use openlark_core::{SDKResult, api::ApiRequest, config::Config};
 
 use crate::common::api_endpoints::ApprovalApiV4;
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 
 /// 退订审批实例状态变更事件请求（v4）
 ///
@@ -39,9 +39,13 @@ impl UnsubscribeInstanceRequestV4 {
         let req: ApiRequest<serde_json::Value> = ApiRequest::delete(endpoint.to_url())
             .body(serialize_params(&body, "退订审批实例状态变更")?);
 
-        let resp = openlark_core::http::Transport::request(req, &self.config, Some(option)).await?;
-
-        extract_response_data(resp, "退订审批实例状态变更")
+        openlark_core::http::Transport::request_typed(
+            req,
+            &self.config,
+            Some(option),
+            "退订审批实例状态变更",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/task/add_sign.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/task/add_sign.rs
@@ -11,7 +11,7 @@ use openlark_core::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-use crate::common::api_utils::{missing_response_data_error, request_serialization_error};
+use crate::common::api_utils::request_serialization_error;
 
 /// 审批任务加签请求体（用户级，v4）
 #[derive(Debug, Clone, Serialize, Default)]
@@ -133,14 +133,13 @@ impl AddSignTaskRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            missing_response_data_error(
-                "审批任务加签（用户级）",
-                response.raw_response.request_id.clone(),
-            )
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "审批任务加签（用户级）",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/task/approve.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/task/approve.rs
@@ -11,7 +11,7 @@ use openlark_core::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-use crate::common::api_utils::{missing_response_data_error, request_serialization_error};
+use crate::common::api_utils::request_serialization_error;
 
 /// 同意审批任务请求体（v4）
 #[derive(Debug, Clone, Serialize, Default)]
@@ -124,11 +124,13 @@ impl ApproveTaskRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            missing_response_data_error("同意审批任务", response.raw_response.request_id.clone())
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "同意审批任务",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/task/forward.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/task/forward.rs
@@ -11,7 +11,7 @@ use openlark_core::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-use crate::common::api_utils::{missing_response_data_error, request_serialization_error};
+use crate::common::api_utils::request_serialization_error;
 
 /// 转交审批任务请求体（用户级，v4）
 #[derive(Debug, Clone, Serialize, Default)]
@@ -109,14 +109,13 @@ impl ForwardTaskRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            missing_response_data_error(
-                "转交审批任务（用户级）",
-                response.raw_response.request_id.clone(),
-            )
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "转交审批任务（用户级）",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/task/list.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/task/list.rs
@@ -11,8 +11,6 @@ use openlark_core::{
 use serde::Deserialize;
 use std::sync::Arc;
 
-use crate::common::api_utils::missing_response_data_error;
-
 /// 审批摘要项（v4）
 #[derive(Debug, Clone, Deserialize)]
 pub struct TaskSummaryV4 {
@@ -169,14 +167,13 @@ impl ListTaskRequestV4 {
             request = request.query("page_token", page_token);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            missing_response_data_error(
-                "查询审批任务列表（用户级）",
-                response.raw_response.request_id.clone(),
-            )
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "查询审批任务列表（用户级）",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/task/pass.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/task/pass.rs
@@ -11,7 +11,7 @@ use openlark_core::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-use crate::common::api_utils::{missing_response_data_error, request_serialization_error};
+use crate::common::api_utils::request_serialization_error;
 
 /// 同意审批任务请求体（用户级，v4）
 #[derive(Debug, Clone, Serialize, Default)]
@@ -106,14 +106,13 @@ impl PassTaskRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            missing_response_data_error(
-                "同意审批任务（用户级）",
-                response.raw_response.request_id.clone(),
-            )
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "同意审批任务（用户级）",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/task/query.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/task/query.rs
@@ -11,8 +11,6 @@ use openlark_core::{
 use serde::Deserialize;
 use std::sync::Arc;
 
-use crate::common::api_utils::missing_response_data_error;
-
 /// 审批任务列表项（v4）
 #[derive(Debug, Clone, Deserialize)]
 pub struct TaskItemV4 {
@@ -130,11 +128,13 @@ impl QueryTaskRequestV4 {
             request = request.query("page_token", page_token);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            missing_response_data_error("查询审批任务", response.raw_response.request_id.clone())
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "查询审批任务",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/task/refuse.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/task/refuse.rs
@@ -11,7 +11,7 @@ use openlark_core::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-use crate::common::api_utils::{missing_response_data_error, request_serialization_error};
+use crate::common::api_utils::request_serialization_error;
 
 /// 拒绝审批任务请求体（用户级，v4）
 #[derive(Debug, Clone, Serialize, Default)]
@@ -97,14 +97,13 @@ impl RefuseTaskRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            missing_response_data_error(
-                "拒绝审批任务（用户级）",
-                response.raw_response.request_id.clone(),
-            )
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "拒绝审批任务（用户级）",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/task/reject.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/task/reject.rs
@@ -11,7 +11,7 @@ use openlark_core::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-use crate::common::api_utils::{missing_response_data_error, request_serialization_error};
+use crate::common::api_utils::request_serialization_error;
 
 /// 拒绝审批任务请求体（v4）
 #[derive(Debug, Clone, Serialize, Default)]
@@ -124,11 +124,13 @@ impl RejectTaskRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            missing_response_data_error("拒绝审批任务", response.raw_response.request_id.clone())
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "拒绝审批任务",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/task/resubmit.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/task/resubmit.rs
@@ -11,7 +11,7 @@ use openlark_core::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-use crate::common::api_utils::{missing_response_data_error, request_serialization_error};
+use crate::common::api_utils::request_serialization_error;
 
 /// 重新提交审批任务请求体（v4）
 #[derive(Debug, Clone, Serialize, Default)]
@@ -124,14 +124,13 @@ impl ResubmitTaskRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            missing_response_data_error(
-                "重新提交审批任务",
-                response.raw_response.request_id.clone(),
-            )
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "重新提交审批任务",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/task/rollback.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/task/rollback.rs
@@ -11,7 +11,7 @@ use openlark_core::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-use crate::common::api_utils::{missing_response_data_error, request_serialization_error};
+use crate::common::api_utils::request_serialization_error;
 
 /// 退回审批任务请求体（用户级，v4）
 #[derive(Debug, Clone, Serialize, Default)]
@@ -112,14 +112,13 @@ impl RollbackTaskRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            missing_response_data_error(
-                "退回审批任务（用户级）",
-                response.raw_response.request_id.clone(),
-            )
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "退回审批任务（用户级）",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/task/search.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/task/search.rs
@@ -56,11 +56,13 @@ impl SearchTaskRequestV4 {
         let api_endpoint = crate::common::api_endpoints::ApprovalApiV4::TaskSearch;
         let request = ApiRequest::<SearchTaskResponseV4>::post(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/task/subscription.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/task/subscription.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use openlark_core::{SDKResult, api::ApiRequest, config::Config};
 
 use crate::common::api_endpoints::ApprovalApiV4;
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 
 /// 订阅审批任务状态变更事件请求（v4）
 ///
@@ -43,9 +43,13 @@ impl SubscribeTaskRequestV4 {
         let req: ApiRequest<serde_json::Value> = ApiRequest::post(endpoint.to_url())
             .body(serialize_params(&body, "订阅审批任务状态变更")?);
 
-        let resp = openlark_core::http::Transport::request(req, &self.config, Some(option)).await?;
-
-        extract_response_data(resp, "订阅审批任务状态变更")
+        openlark_core::http::Transport::request_typed(
+            req,
+            &self.config,
+            Some(option),
+            "订阅审批任务状态变更",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/task/transfer.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/task/transfer.rs
@@ -90,11 +90,13 @@ impl TransferTaskRequestV4 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/approval/approval/v4/task/unsubscription.rs
+++ b/crates/openlark-workflow/src/approval/approval/v4/task/unsubscription.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use openlark_core::{SDKResult, api::ApiRequest, config::Config};
 
 use crate::common::api_endpoints::ApprovalApiV4;
-use crate::common::api_utils::{extract_response_data, serialize_params};
+use crate::common::api_utils::serialize_params;
 
 /// 退订审批任务状态变更事件请求（v4）
 ///
@@ -39,9 +39,13 @@ impl UnsubscribeTaskRequestV4 {
         let req: ApiRequest<serde_json::Value> = ApiRequest::delete(endpoint.to_url())
             .body(serialize_params(&body, "退订审批任务状态变更")?);
 
-        let resp = openlark_core::http::Transport::request(req, &self.config, Some(option)).await?;
-
-        extract_response_data(resp, "退订审批任务状态变更")
+        openlark_core::http::Transport::request_typed(
+            req,
+            &self.config,
+            Some(option),
+            "退订审批任务状态变更",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/board/board/v1/whiteboard/download_as_image.rs
+++ b/crates/openlark-workflow/src/board/board/v1/whiteboard/download_as_image.rs
@@ -102,11 +102,13 @@ impl DownloadWhiteboardAsImageRequestV1 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/board/board/v1/whiteboard/node/batch_delete.rs
+++ b/crates/openlark-workflow/src/board/board/v1/whiteboard/node/batch_delete.rs
@@ -88,9 +88,13 @@ impl BatchDeleteWhiteboardNodeRequestV1 {
 
         request = request.body(serialize_params(&self.body, "批量删除白板节点")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "批量删除白板节点")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "批量删除白板节点",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/board/board/v1/whiteboard/node/create.rs
+++ b/crates/openlark-workflow/src/board/board/v1/whiteboard/node/create.rs
@@ -137,11 +137,13 @@ impl CreateWhiteboardNodeRequestV1 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/board/board/v1/whiteboard/node/create_plantuml.rs
+++ b/crates/openlark-workflow/src/board/board/v1/whiteboard/node/create_plantuml.rs
@@ -127,11 +127,13 @@ impl CreatePlantumlNodeRequestV1 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/board/board/v1/whiteboard/node/list.rs
+++ b/crates/openlark-workflow/src/board/board/v1/whiteboard/node/list.rs
@@ -132,11 +132,13 @@ impl ListWhiteboardNodeRequestV1 {
             request = request.query_param("page_token", page_token);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/board/board/v1/whiteboard/theme.rs
+++ b/crates/openlark-workflow/src/board/board/v1/whiteboard/theme.rs
@@ -68,11 +68,13 @@ impl GetWhiteboardThemeRequestV1 {
         let api_endpoint = crate::common::api_endpoints::BoardApiV1::WhiteboardTheme(self.board_id);
         let request = ApiRequest::<GetWhiteboardThemeResponseV1>::get(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/board/board/v1/whiteboard/update_theme.rs
+++ b/crates/openlark-workflow/src/board/board/v1/whiteboard/update_theme.rs
@@ -97,11 +97,13 @@ impl UpdateWhiteboardThemeRequestV1 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/task/task/v2/task/search.rs
+++ b/crates/openlark-workflow/src/task/task/v2/task/search.rs
@@ -78,8 +78,7 @@ impl SearchTaskRequest {
             req = req.query("user_id_type", user_id_type);
         }
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "搜索任务")
+        Transport::request_typed(req, &self.config, Some(option), "搜索任务").await
     }
 }
 

--- a/crates/openlark-workflow/src/task/task/v2/task/set_ancestor_task.rs
+++ b/crates/openlark-workflow/src/task/task/v2/task/set_ancestor_task.rs
@@ -74,9 +74,13 @@ impl SetAncestorTaskRequest {
         let mut request = ApiRequest::<SetAncestorTaskResponse>::post(api_endpoint.to_url());
         request = request.body(serialize_params(&self.body, "设置父任务")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "设置父任务")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "设置父任务",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/task/task/v2/task_v2/list_related_task.rs
+++ b/crates/openlark-workflow/src/task/task/v2/task_v2/list_related_task.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/task-v2/task_v2/list_related_task>
 
-use crate::common::{TaskV2Endpoint, api_utils::*};
+use crate::common::TaskV2Endpoint;
 use openlark_core::{
     SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
@@ -123,9 +123,13 @@ impl ListRelatedTaskRequest {
             request = request.query("user_id_type", user_id_type);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "列取与我相关的任务")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "列取与我相关的任务",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/task/task/v2/task_v2/task_subscription.rs
+++ b/crates/openlark-workflow/src/task/task/v2/task_v2/task_subscription.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/task-v2/task_v2/task_subscription>
 
-use crate::common::{TaskV2Endpoint, api_utils::*};
+use crate::common::TaskV2Endpoint;
 use openlark_core::{
     SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
@@ -60,9 +60,13 @@ impl TaskSubscriptionRequest {
             request = request.query("user_id_type", user_id_type);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "订阅任务变更事件")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "订阅任务变更事件",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/task/task/v2/tasklist/search.rs
+++ b/crates/openlark-workflow/src/task/task/v2/tasklist/search.rs
@@ -78,8 +78,7 @@ impl SearchTasklistRequest {
             req = req.query("user_id_type", user_id_type);
         }
 
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "搜索清单")
+        Transport::request_typed(req, &self.config, Some(option), "搜索清单").await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/collaborator/batch_delete.rs
+++ b/crates/openlark-workflow/src/v1/task/collaborator/batch_delete.rs
@@ -81,11 +81,13 @@ impl BatchDeleteTaskCollaboratorRequestV1 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/collaborator/create.rs
+++ b/crates/openlark-workflow/src/v1/task/collaborator/create.rs
@@ -76,11 +76,13 @@ impl CreateTaskCollaboratorRequestV1 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/collaborator/delete.rs
+++ b/crates/openlark-workflow/src/v1/task/collaborator/delete.rs
@@ -58,11 +58,13 @@ impl DeleteTaskCollaboratorRequestV1 {
         );
         let request = ApiRequest::<DeleteTaskCollaboratorResponseV1>::delete(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/collaborator/list.rs
+++ b/crates/openlark-workflow/src/v1/task/collaborator/list.rs
@@ -89,11 +89,13 @@ impl ListTaskCollaboratorRequestV1 {
             request = request.query("page_token", page_token);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/comment/create.rs
+++ b/crates/openlark-workflow/src/v1/task/comment/create.rs
@@ -85,11 +85,13 @@ impl CreateTaskCommentRequestV1 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/comment/delete.rs
+++ b/crates/openlark-workflow/src/v1/task/comment/delete.rs
@@ -58,11 +58,13 @@ impl DeleteTaskCommentRequestV1 {
         );
         let request = ApiRequest::<DeleteTaskCommentResponseV1>::delete(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/comment/get.rs
+++ b/crates/openlark-workflow/src/v1/task/comment/get.rs
@@ -66,11 +66,13 @@ impl GetTaskCommentRequestV1 {
         );
         let request = ApiRequest::<GetTaskCommentResponseV1>::get(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/comment/list.rs
+++ b/crates/openlark-workflow/src/v1/task/comment/list.rs
@@ -95,11 +95,13 @@ impl ListTaskCommentRequestV1 {
             request = request.query("page_token", page_token);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/comment/update.rs
+++ b/crates/openlark-workflow/src/v1/task/comment/update.rs
@@ -85,11 +85,13 @@ impl UpdateTaskCommentRequestV1 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/complete.rs
+++ b/crates/openlark-workflow/src/v1/task/complete.rs
@@ -81,11 +81,13 @@ impl CompleteTaskRequestV1 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/create.rs
+++ b/crates/openlark-workflow/src/v1/task/create.rs
@@ -119,11 +119,13 @@ impl CreateTaskRequestV1 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/delete.rs
+++ b/crates/openlark-workflow/src/v1/task/delete.rs
@@ -49,11 +49,13 @@ impl DeleteTaskRequestV1 {
         let api_endpoint = crate::common::api_endpoints::TaskApiV1::TaskDelete(self.task_id);
         let request = ApiRequest::<DeleteTaskResponseV1>::delete(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/follower/batch_delete.rs
+++ b/crates/openlark-workflow/src/v1/task/follower/batch_delete.rs
@@ -80,11 +80,13 @@ impl BatchDeleteTaskFollowerRequestV1 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/follower/create.rs
+++ b/crates/openlark-workflow/src/v1/task/follower/create.rs
@@ -75,11 +75,13 @@ impl CreateTaskFollowerRequestV1 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/follower/delete.rs
+++ b/crates/openlark-workflow/src/v1/task/follower/delete.rs
@@ -58,11 +58,13 @@ impl DeleteTaskFollowerRequestV1 {
         );
         let request = ApiRequest::<DeleteTaskFollowerResponseV1>::delete(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/follower/list.rs
+++ b/crates/openlark-workflow/src/v1/task/follower/list.rs
@@ -89,11 +89,13 @@ impl ListTaskFollowerRequestV1 {
             request = request.query("page_token", page_token);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/get.rs
+++ b/crates/openlark-workflow/src/v1/task/get.rs
@@ -81,11 +81,13 @@ impl GetTaskRequestV1 {
         let api_endpoint = crate::common::api_endpoints::TaskApiV1::TaskGet(self.task_id);
         let request = ApiRequest::<GetTaskResponseV1>::get(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/list.rs
+++ b/crates/openlark-workflow/src/v1/task/list.rs
@@ -111,11 +111,13 @@ impl ListTaskRequestV1 {
             request = request.query("page_size", page_size.to_string());
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/patch.rs
+++ b/crates/openlark-workflow/src/v1/task/patch.rs
@@ -141,11 +141,13 @@ impl UpdateTaskRequestV1 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/reminder/create.rs
+++ b/crates/openlark-workflow/src/v1/task/reminder/create.rs
@@ -80,11 +80,13 @@ impl CreateTaskReminderRequestV1 {
 
         request = request.body(body_json);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/reminder/delete.rs
+++ b/crates/openlark-workflow/src/v1/task/reminder/delete.rs
@@ -58,11 +58,13 @@ impl DeleteTaskReminderRequestV1 {
         );
         let request = ApiRequest::<DeleteTaskReminderResponseV1>::delete(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/reminder/list.rs
+++ b/crates/openlark-workflow/src/v1/task/reminder/list.rs
@@ -62,11 +62,13 @@ impl ListTaskReminderRequestV1 {
             crate::common::api_endpoints::TaskApiV1::TaskReminderList(self.task_id.clone());
         let request = ApiRequest::<ListTaskReminderResponseV1>::get(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v1/task/uncomplete.rs
+++ b/crates/openlark-workflow/src/v1/task/uncomplete.rs
@@ -53,11 +53,13 @@ impl UncompleteTaskRequestV1 {
         let api_endpoint = crate::common::api_endpoints::TaskApiV1::TaskUncomplete(self.task_id);
         let request = ApiRequest::<UncompleteTaskResponseV1>::post(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        response.data.ok_or_else(|| {
-            openlark_core::error::validation_error("响应数据为空", "服务器没有返回有效的数据")
-        })
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "响应数据为空",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/attachment/delete.rs
+++ b/crates/openlark-workflow/src/v2/attachment/delete.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/task-v2/attachment/delete>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::attachment::models::DeleteAttachmentResponse;
 use openlark_core::{
     SDKResult,
@@ -47,9 +47,13 @@ impl DeleteAttachmentRequest {
         let api_endpoint = TaskApiV2::AttachmentDelete(self.attachment_guid.clone());
         let request = ApiRequest::<DeleteAttachmentResponse>::delete(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "删除附件")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "删除附件",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/attachment/get.rs
+++ b/crates/openlark-workflow/src/v2/attachment/get.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/task-v2/attachment/get>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::attachment::models::AttachmentInfo;
 use openlark_core::{
     SDKResult,
@@ -66,9 +66,13 @@ impl GetAttachmentRequest {
             request = request.query("user_id_type", user_id_type);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取附件")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取附件",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/attachment/list.rs
+++ b/crates/openlark-workflow/src/v2/attachment/list.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/task-v2/attachment/list>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::attachment::models::AttachmentInfo;
 use openlark_core::{
     SDKResult,
@@ -131,9 +131,13 @@ impl ListAttachmentsRequest {
             request = request.query("user_id_type", user_id_type);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "列取附件")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "列取附件",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/attachment/upload.rs
+++ b/crates/openlark-workflow/src/v2/attachment/upload.rs
@@ -109,9 +109,13 @@ impl UploadAttachmentRequest {
             request = request.query("user_id_type", user_id_type);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "上传附件")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "上传附件",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/comment/create.rs
+++ b/crates/openlark-workflow/src/v2/comment/create.rs
@@ -93,9 +93,13 @@ impl CreateCommentRequest {
             request = request.query("user_id_type", user_id_type);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "创建评论")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "创建评论",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/comment/delete.rs
+++ b/crates/openlark-workflow/src/v2/comment/delete.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/task-v2/comment/delete>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::comment::models::DeleteCommentResponse;
 use openlark_core::{
     SDKResult,
@@ -47,9 +47,13 @@ impl DeleteCommentRequest {
         let api_endpoint = TaskApiV2::CommentDelete(self.comment_guid.clone());
         let request = ApiRequest::<DeleteCommentResponse>::delete(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "删除评论")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "删除评论",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/comment/get.rs
+++ b/crates/openlark-workflow/src/v2/comment/get.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/task-v2/comment/get>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::comment::models::GetCommentResponse;
 use openlark_core::{
     SDKResult,
@@ -59,9 +59,13 @@ impl GetCommentRequest {
             request = request.query("user_id_type", user_id_type);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取评论")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取评论",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/comment/list.rs
+++ b/crates/openlark-workflow/src/v2/comment/list.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/task-v2/comment/list>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::comment::models::ListCommentsResponse;
 use openlark_core::{
     SDKResult,
@@ -115,9 +115,13 @@ impl ListCommentsRequest {
             request = request.query("user_id_type", user_id_type);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取评论列表")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取评论列表",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/comment/update.rs
+++ b/crates/openlark-workflow/src/v2/comment/update.rs
@@ -89,9 +89,13 @@ impl UpdateCommentRequest {
             request = request.query("user_id_type", user_id_type);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "更新评论")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "更新评论",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/custom_field/add.rs
+++ b/crates/openlark-workflow/src/v2/custom_field/add.rs
@@ -70,9 +70,13 @@ impl AddCustomFieldRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "将自定义字段加入资源")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "将自定义字段加入资源")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "将自定义字段加入资源",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/custom_field/create.rs
+++ b/crates/openlark-workflow/src/v2/custom_field/create.rs
@@ -67,9 +67,13 @@ impl CreateCustomFieldRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "创建自定义字段")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "创建自定义字段")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "创建自定义字段",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/custom_field/delete.rs
+++ b/crates/openlark-workflow/src/v2/custom_field/delete.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/task-v2/custom_field/delete>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::custom_field::models::DeleteCustomFieldResponse;
 use openlark_core::{
     SDKResult,
@@ -44,9 +44,13 @@ impl DeleteCustomFieldRequest {
         let api_endpoint = TaskApiV2::CustomFieldDelete(self.field_guid.clone());
         let request = ApiRequest::<DeleteCustomFieldResponse>::delete(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "删除自定义字段")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "删除自定义字段",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/custom_field/get.rs
+++ b/crates/openlark-workflow/src/v2/custom_field/get.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/task-v2/custom_field/get>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::custom_field::models::GetCustomFieldResponse;
 use openlark_core::{
     SDKResult,
@@ -44,9 +44,13 @@ impl GetCustomFieldRequest {
         let api_endpoint = TaskApiV2::CustomFieldGet(self.field_guid.clone());
         let request = ApiRequest::<GetCustomFieldResponse>::get(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取自定义字段")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取自定义字段",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/custom_field/list.rs
+++ b/crates/openlark-workflow/src/v2/custom_field/list.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/task-v2/custom_field/list>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::custom_field::models::ListCustomFieldsResponse;
 use openlark_core::{
     SDKResult,
@@ -67,9 +67,13 @@ impl ListCustomFieldsRequest {
             request = request.query("page_token", page_token);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取自定义字段列表")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取自定义字段列表",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/custom_field/option/create.rs
+++ b/crates/openlark-workflow/src/v2/custom_field/option/create.rs
@@ -100,9 +100,13 @@ impl CreateCustomFieldOptionRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "创建自定义字段选项")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "创建自定义字段选项")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "创建自定义字段选项",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/custom_field/option/patch.rs
+++ b/crates/openlark-workflow/src/v2/custom_field/option/patch.rs
@@ -96,9 +96,13 @@ impl UpdateCustomFieldOptionRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "更新自定义字段选项")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "更新自定义字段选项")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "更新自定义字段选项",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/custom_field/remove.rs
+++ b/crates/openlark-workflow/src/v2/custom_field/remove.rs
@@ -70,9 +70,13 @@ impl RemoveCustomFieldRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "将自定义字段移出资源")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "将自定义字段移出资源")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "将自定义字段移出资源",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/custom_field/update.rs
+++ b/crates/openlark-workflow/src/v2/custom_field/update.rs
@@ -65,9 +65,13 @@ impl UpdateCustomFieldRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "更新自定义字段")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "更新自定义字段")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "更新自定义字段",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/section/create.rs
+++ b/crates/openlark-workflow/src/v2/section/create.rs
@@ -62,9 +62,13 @@ impl CreateSectionRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "创建分组")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "创建分组")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "创建分组",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/section/delete.rs
+++ b/crates/openlark-workflow/src/v2/section/delete.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/task-v2/section/delete>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::section::models::DeleteSectionResponse;
 use openlark_core::{
     SDKResult,
@@ -47,9 +47,13 @@ impl DeleteSectionRequest {
         let api_endpoint = TaskApiV2::SectionDelete(self.section_guid.clone());
         let request = ApiRequest::<DeleteSectionResponse>::delete(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "删除分组")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "删除分组",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/section/get.rs
+++ b/crates/openlark-workflow/src/v2/section/get.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/task-v2/section/get>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::section::models::GetSectionResponse;
 use openlark_core::{
     SDKResult,
@@ -47,9 +47,13 @@ impl GetSectionRequest {
         let api_endpoint = TaskApiV2::SectionGet(self.section_guid.clone());
         let request = ApiRequest::<GetSectionResponse>::get(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取分组")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取分组",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/section/list.rs
+++ b/crates/openlark-workflow/src/v2/section/list.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/task-v2/section/list>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::section::models::ListSectionsResponse;
 use openlark_core::{
     SDKResult,
@@ -66,9 +66,13 @@ impl ListSectionsRequest {
             request = request.query("page_token", page_token);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取分组列表")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取分组列表",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/section/tasks.rs
+++ b/crates/openlark-workflow/src/v2/section/tasks.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/task-v2/section-tasks/list>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::task::models::TaskItem;
 use openlark_core::{
     SDKResult,
@@ -118,9 +118,13 @@ impl GetSectionTasksRequest {
             request = request.query("sort", sort.to_string());
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取自定义分组任务列表")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取自定义分组任务列表",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/section/update.rs
+++ b/crates/openlark-workflow/src/v2/section/update.rs
@@ -65,9 +65,13 @@ impl UpdateSectionRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "更新分组")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "更新分组")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "更新分组",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/task/add_dependencies.rs
+++ b/crates/openlark-workflow/src/v2/task/add_dependencies.rs
@@ -94,9 +94,13 @@ impl AddDependenciesRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "添加任务依赖")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "添加任务依赖")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "添加任务依赖",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/task/add_members.rs
+++ b/crates/openlark-workflow/src/v2/task/add_members.rs
@@ -94,9 +94,13 @@ impl AddMembersRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "添加任务成员")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "添加任务成员")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "添加任务成员",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/task/add_reminders.rs
+++ b/crates/openlark-workflow/src/v2/task/add_reminders.rs
@@ -94,9 +94,13 @@ impl AddRemindersRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "添加任务提醒")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "添加任务提醒")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "添加任务提醒",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/task/add_tasklist.rs
+++ b/crates/openlark-workflow/src/v2/task/add_tasklist.rs
@@ -88,9 +88,13 @@ impl AddTasklistRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "任务加入清单")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "任务加入清单")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "任务加入清单",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/task/complete.rs
+++ b/crates/openlark-workflow/src/v2/task/complete.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/task-v2/task/complete>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::task::models::CompleteTaskResponse;
 use openlark_core::{
     SDKResult,
@@ -44,9 +44,13 @@ impl CompleteTaskRequest {
         let api_endpoint = TaskApiV2::TaskComplete(self.task_guid.clone());
         let request = ApiRequest::<CompleteTaskResponse>::post(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "完成任务")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "完成任务",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/task/create.rs
+++ b/crates/openlark-workflow/src/v2/task/create.rs
@@ -128,9 +128,13 @@ impl CreateTaskRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "创建任务")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "创建任务")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "创建任务",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/task/delete.rs
+++ b/crates/openlark-workflow/src/v2/task/delete.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/task-v2/task/delete>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::task::models::DeleteTaskResponse;
 use openlark_core::{
     SDKResult,
@@ -44,9 +44,13 @@ impl DeleteTaskRequest {
         let api_endpoint = TaskApiV2::TaskDelete(self.task_guid.clone());
         let request = ApiRequest::<DeleteTaskResponse>::delete(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "删除任务")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "删除任务",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/task/get.rs
+++ b/crates/openlark-workflow/src/v2/task/get.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/task-v2/task/get>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::task::models::GetTaskResponse;
 use openlark_core::{
     SDKResult,
@@ -44,9 +44,13 @@ impl GetTaskRequest {
         let api_endpoint = TaskApiV2::TaskGet(self.task_guid.clone());
         let request = ApiRequest::<GetTaskResponse>::get(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取任务")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取任务",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/task/list.rs
+++ b/crates/openlark-workflow/src/v2/task/list.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/task-v2/task/list>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::task::models::ListTasksResponse;
 use openlark_core::{
     SDKResult,
@@ -126,9 +126,13 @@ impl ListTasksRequest {
             request = request.query("sort", sort.to_string());
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取任务列表")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取任务列表",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/task/remove_dependencies.rs
+++ b/crates/openlark-workflow/src/v2/task/remove_dependencies.rs
@@ -83,9 +83,13 @@ impl RemoveDependenciesRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "移除任务依赖")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "移除任务依赖")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "移除任务依赖",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/task/remove_members.rs
+++ b/crates/openlark-workflow/src/v2/task/remove_members.rs
@@ -83,9 +83,13 @@ impl RemoveMembersRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "移除任务成员")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "移除任务成员")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "移除任务成员",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/task/remove_reminders.rs
+++ b/crates/openlark-workflow/src/v2/task/remove_reminders.rs
@@ -83,9 +83,13 @@ impl RemoveRemindersRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "移除任务提醒")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "移除任务提醒")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "移除任务提醒",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/task/remove_tasklist.rs
+++ b/crates/openlark-workflow/src/v2/task/remove_tasklist.rs
@@ -76,9 +76,13 @@ impl RemoveTasklistRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "任务移出清单")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "任务移出清单")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "任务移出清单",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/task/subtask/create.rs
+++ b/crates/openlark-workflow/src/v2/task/subtask/create.rs
@@ -133,9 +133,13 @@ impl CreateSubtaskRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "创建子任务")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "创建子任务")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "创建子任务",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/task/subtask/list.rs
+++ b/crates/openlark-workflow/src/v2/task/subtask/list.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/task-v2/task-subtask/list>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::task::models::TaskItem;
 use openlark_core::{
     SDKResult,
@@ -90,9 +90,13 @@ impl ListSubtasksRequest {
             request = request.query("page_token", page_token);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取子任务列表")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取子任务列表",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/task/tasklists.rs
+++ b/crates/openlark-workflow/src/v2/task/tasklists.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/task-v2/task-tasklists/list>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use openlark_core::{
     SDKResult,
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
@@ -73,9 +73,13 @@ impl GetTaskTasklistsRequest {
         let api_endpoint = TaskApiV2::TaskGetTasklists(self.task_guid.clone());
         let request = ApiRequest::<GetTaskTasklistsResponse>::get(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "列取任务所在清单")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "列取任务所在清单",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/task/uncomplete.rs
+++ b/crates/openlark-workflow/src/v2/task/uncomplete.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/task-v2/task/uncomplete>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::task::models::UncompleteTaskResponse;
 use openlark_core::{
     SDKResult,
@@ -44,9 +44,13 @@ impl UncompleteTaskRequest {
         let api_endpoint = TaskApiV2::TaskUncomplete(self.task_guid.clone());
         let request = ApiRequest::<UncompleteTaskResponse>::post(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "取消完成任务")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "取消完成任务",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/task/update.rs
+++ b/crates/openlark-workflow/src/v2/task/update.rs
@@ -107,9 +107,13 @@ impl UpdateTaskRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "更新任务")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "更新任务")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "更新任务",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/tasklist/activity_subscription/create.rs
+++ b/crates/openlark-workflow/src/v2/tasklist/activity_subscription/create.rs
@@ -81,9 +81,13 @@ impl CreateActivitySubscriptionRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "创建动态订阅")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "创建动态订阅")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "创建动态订阅",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/tasklist/activity_subscription/delete.rs
+++ b/crates/openlark-workflow/src/v2/tasklist/activity_subscription/delete.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/task-v2/tasklist-activity_subscription/delete>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::tasklist::activity_subscription::models::DeleteActivitySubscriptionResponse;
 use openlark_core::{
     SDKResult,
@@ -59,9 +59,13 @@ impl DeleteActivitySubscriptionRequest {
         let request =
             ApiRequest::<DeleteActivitySubscriptionResponse>::delete(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "删除动态订阅")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "删除动态订阅",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/tasklist/activity_subscription/get.rs
+++ b/crates/openlark-workflow/src/v2/tasklist/activity_subscription/get.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/task-v2/tasklist-activity_subscription/get>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::tasklist::activity_subscription::models::GetActivitySubscriptionResponse;
 use openlark_core::{
     SDKResult,
@@ -58,9 +58,13 @@ impl GetActivitySubscriptionRequest {
         );
         let request = ApiRequest::<GetActivitySubscriptionResponse>::get(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取动态订阅")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取动态订阅",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/tasklist/activity_subscription/list.rs
+++ b/crates/openlark-workflow/src/v2/tasklist/activity_subscription/list.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/task-v2/tasklist-activity_subscription/list>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::tasklist::activity_subscription::models::ListActivitySubscriptionsResponse;
 use openlark_core::{
     SDKResult,
@@ -74,9 +74,13 @@ impl ListActivitySubscriptionsRequest {
             request = request.query("page_token", page_token);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "列取动态订阅")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "列取动态订阅",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/tasklist/activity_subscription/patch.rs
+++ b/crates/openlark-workflow/src/v2/tasklist/activity_subscription/patch.rs
@@ -92,9 +92,13 @@ impl UpdateActivitySubscriptionRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "更新动态订阅")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "更新动态订阅")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "更新动态订阅",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/tasklist/add_members.rs
+++ b/crates/openlark-workflow/src/v2/tasklist/add_members.rs
@@ -94,9 +94,13 @@ impl AddTasklistMembersRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "添加清单成员")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "添加清单成员")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "添加清单成员",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/tasklist/create.rs
+++ b/crates/openlark-workflow/src/v2/tasklist/create.rs
@@ -68,9 +68,13 @@ impl CreateTasklistRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "创建任务清单")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "创建任务清单")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "创建任务清单",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/tasklist/delete.rs
+++ b/crates/openlark-workflow/src/v2/tasklist/delete.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/task-v2/tasklist/delete>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::tasklist::models::DeleteTasklistResponse;
 use openlark_core::{
     SDKResult,
@@ -47,9 +47,13 @@ impl DeleteTasklistRequest {
         let api_endpoint = TaskApiV2::TasklistDelete(self.tasklist_guid.clone());
         let request = ApiRequest::<DeleteTasklistResponse>::delete(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "删除任务清单")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "删除任务清单",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/tasklist/get.rs
+++ b/crates/openlark-workflow/src/v2/tasklist/get.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/task-v2/tasklist/get>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::tasklist::models::GetTasklistResponse;
 use openlark_core::{
     SDKResult,
@@ -47,9 +47,13 @@ impl GetTasklistRequest {
         let api_endpoint = TaskApiV2::TasklistGet(self.tasklist_guid.clone());
         let request = ApiRequest::<GetTasklistResponse>::get(api_endpoint.to_url());
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取任务清单")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取任务清单",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/tasklist/list.rs
+++ b/crates/openlark-workflow/src/v2/tasklist/list.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/task-v2/tasklist/list>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::tasklist::models::ListTasklistsResponse;
 use openlark_core::{
     SDKResult,
@@ -66,9 +66,13 @@ impl ListTasklistsRequest {
             request = request.query("page_token", page_token);
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取任务清单列表")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取任务清单列表",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/tasklist/remove_members.rs
+++ b/crates/openlark-workflow/src/v2/tasklist/remove_members.rs
@@ -83,9 +83,13 @@ impl RemoveTasklistMembersRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "移除清单成员")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "移除清单成员")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "移除清单成员",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/tasklist/tasks.rs
+++ b/crates/openlark-workflow/src/v2/tasklist/tasks.rs
@@ -2,7 +2,7 @@
 //!
 //! docPath: <https://open.feishu.cn/document/server-docs/docs/task-v2/tasklist-tasks/list>
 
-use crate::common::{api_endpoints::TaskApiV2, api_utils::*};
+use crate::common::api_endpoints::TaskApiV2;
 use crate::v2::task::models::TaskItem;
 use openlark_core::{
     SDKResult,
@@ -118,9 +118,13 @@ impl GetTasklistTasksRequest {
             request = request.query("sort", sort.to_string());
         }
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "获取清单任务列表")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "获取清单任务列表",
+        )
+        .await
     }
 }
 

--- a/crates/openlark-workflow/src/v2/tasklist/update.rs
+++ b/crates/openlark-workflow/src/v2/tasklist/update.rs
@@ -71,9 +71,13 @@ impl UpdateTasklistRequest {
         let request_body = &self.body;
         request = request.body(serialize_params(request_body, "更新任务清单")?);
 
-        let response =
-            openlark_core::http::Transport::request(request, &self.config, Some(option)).await?;
-        extract_response_data(response, "更新任务清单")
+        openlark_core::http::Transport::request_typed(
+            request,
+            &self.config,
+            Some(option),
+            "更新任务清单",
+        )
+        .await
     }
 }
 


### PR DESCRIPTION
Closes #485 · Parent #470（楔子 step 5 · 其余 12 crate 迁移）

## What

把 workflow / security / auth / application / platform / helpdesk / cardkit / bot / user / webhook / ai / analytics 全部 leaf 的手写 response 抽取迁到 #479 canonical 入口 `Transport::request_typed`。**两个 commit**：

### commit 1 — core Option C（`extract_response_data` 修业务错误语义）
`extract_response_data` 此前把任何 data 缺失都当 `validation_error`，**业务错误（envelope code≠0）被误报成"空成功"并丢飞书 code/msg**（#470 user story 12）。改为区分：
- `code≠0`（业务错误）→ `api_error` 保留飞书 code/msg + request_id
- `code==0 缺 data` → 保留 `validation_error`
- 两分支都经 `map_context` 附 operation/resource/request_id

**根治 canonical 路径 gap**，惠及全部已迁 leaf（mail/HR 的业务错误现在也得到 `Api + msg`）。更是 security `.into_result()` 迁移**零回归的前置**（into_result 原本就保留 code/msg，没有 Option C 则迁移会丢）。加强契约测试断言 `CoreError::Api` + msg 保留。

### commit 2 — 12 crate 迁移（462 文件，+1652/-1907）
12 crate 形态比 mail/HR 更多样，脚本 `/tmp/migrate_485.py`（容忍 var 名、`Some(x)`/`None`/`Some(RequestOption::default())`、`config`/`&self.config`、fq/bare Transport、`=` 后换行、任意 validation_error 前缀+message）处理：
- **~530** `.data.ok_or_else` / `extract_response_data` / `missing_response_data_error` → `request_typed`（行为等价，补 operation/resource/request_id）
- **security 39** `.into_result()` → `request_typed`（CTX 取自各 leaf `//!` doc 首行；依赖 Option C 零回归）
- **5** `.data.unwrap_or(Default)` → `request_typed` + Response 类型加 `empty_success()`（set/apply/close/list 类 mutation API 声明空成功；与 `()` 删除类用 `ensure_success` 同构，零回归）
- 残留 `ok_or_else`（security/auth/helpdesk 等的 `self.body`/`.rule`/`.app_ticket`/`.name`/`.title`/`.content` **输入字段校验**）非响应抽取，合法保留
- ai `api_utils.rs` 移除零 caller 的 `extract_response_data` re-export（`serialize_params` 保留）

## Acceptance criteria

- [x] 12 crate leaf execute 零手写响应抽取（`into_result()`/`extract_response_data(`/`.data.ok_or`/`.data.unwrap_or` 抽取全清；webhook 用自有 `post_payload` 管道无抽取，N/A）
- [x] 各 crate 既有测试绿（~1459 + core 516 + mail 147 + HR 1952，全 0 failed）
- [x] 失败路径完整错误上下文（Option C：业务错误保 code/msg → Api；code==0 缺 data → validation_error；都附 operation/resource/request_id）

## 验证

- core 516 + mail 147 + HR 1952 + 12 crate ~1459 = **~4074 测试 / 0 failed**（Option C 对 merged crate 零回归）
- `cargo clippy` 双模式（`--all-features` / `--no-default-features`）13 crate 全清
- `cargo fmt --check`（workspace）+ `cargo doc`（core）全清
- code-review（Standards + Spec 双轴）：**0 发现 / 0 硬违规**

## 透明说明

- `raw.code as u16` 截断大飞书码（如 99991663→49263）是 `api_error` **既有惯例**（旧 `into_result()` 同样截断，非本 PR 引入）；飞书 code 经 msg/request_id 保留，契约测试不断言数字 status。未来可单独硬化，不属 #485。
- Option C 改 core 且影响已 merged 的 mail/HR（业务错误 Variant: Validation→Api）——是 #470 user story 12 的正向修复，未破坏既有测试（无测试断言业务错误 Variant）。
- `extract_response_data` core helper + 各 crate re-export 的最终删除留给 **#486**（contract 阶段）。