### PR TITLE
refactor: delete extract_response_data helper + add drift CI guard (#486)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,8 @@ jobs:
         run: bash tools/check_no_dead_code_allows.sh
       - name: Check Transport/reqwest boundary
         run: bash tools/check_reqwest_boundary.sh
+      - name: Check no handwritten response extraction (drift guard #470/#486)
+        run: python3 tools/check_no_handwritten_extraction.py
       - name: Run clippy (no default features)
         run: cargo clippy --workspace --all-targets --no-default-features -- -D warnings
 

--- a/crates/openlark-ai/src/common/api_utils.rs
+++ b/crates/openlark-ai/src/common/api_utils.rs
@@ -1,6 +1,6 @@
 //! API 工具函数（re-export core canonical）。
 //!
-//! serialize_params 已下沉到 `openlark::api`（#330）。extract_response_data 原 re-export
-//! 在 #485 迁移到 Transport::request_typed 后零 caller，移除（core helper 删除留给 #486）。
+//! serialize_params re-export core canonical（#330 下沉）。响应抽取走 Transport::request_typed
+//! / Response::decode（#470 楔子），不再经本模块。
 
 pub use openlark_core::api::serialize_params;

--- a/crates/openlark-application/src/common/api_utils.rs
+++ b/crates/openlark-application/src/common/api_utils.rs
@@ -1,6 +1,6 @@
 //! API 工具函数（re-export core canonical）。
 //!
-//! serialize_params / extract_response_data / ensure_success 已下沉到
+//! serialize_params / ensure_success 已下沉到
 //! `openlark_core::api`（#330），本模块仅 re-export canonical copy，避免各 crate 各派生一份。
 
-pub use openlark_core::api::{ensure_success, extract_response_data, serialize_params};
+pub use openlark_core::api::{ensure_success, serialize_params};

--- a/crates/openlark-cardkit/src/common/api_utils.rs
+++ b/crates/openlark-cardkit/src/common/api_utils.rs
@@ -1,6 +1,6 @@
 //! API 工具函数（re-export core canonical）。
 //!
-//! serialize_params / extract_response_data / ensure_success 已下沉到
+//! serialize_params / ensure_success 已下沉到
 //! `openlark_core::api`（#330），本模块仅 re-export canonical copy，避免各 crate 各派生一份。
 
-pub use openlark_core::api::{ensure_success, extract_response_data, serialize_params};
+pub use openlark_core::api::{ensure_success, serialize_params};

--- a/crates/openlark-communication/src/common/api_utils.rs
+++ b/crates/openlark-communication/src/common/api_utils.rs
@@ -1,6 +1,6 @@
 //! API 工具函数（re-export core canonical）。
 //!
-//! serialize_params / extract_response_data / ensure_success 已下沉到
+//! serialize_params / ensure_success 已下沉到
 //! `openlark_core::api`（#330），本模块仅 re-export canonical copy，避免各 crate 各派生一份。
 
-pub use openlark_core::api::{ensure_success, extract_response_data, serialize_params};
+pub use openlark_core::api::{ensure_success, serialize_params};

--- a/crates/openlark-core/src/api/helpers.rs
+++ b/crates/openlark-core/src/api/helpers.rs
@@ -6,7 +6,7 @@
 
 use crate::SDKResult;
 use crate::api::Response;
-use crate::error::{api_error, validation_error};
+use crate::error::validation_error;
 
 /// 标准化参数序列化。
 ///
@@ -21,35 +21,6 @@ pub fn serialize_params<T: serde::Serialize>(
                 .add_context("resource", context);
         })
     })
-}
-
-/// 标准化响应数据提取。
-///
-/// 响应 `data` 为空时，区分两种失败（#470 user story 12：业务错误不再被误报为空成功）：
-/// - 业务错误（`code != 0`）：返回 `api_error` 保留飞书 `code` / `msg`；
-/// - `code == 0` 但缺 `data`：返回 `validation_error`（真正抽取失败）。
-///
-/// 两种失败都经 `map_context` 附加 `operation=extract_response_data` +
-/// `resource=<context>` + 响应携带的 `request_id`。
-pub fn extract_response_data<T>(response: Response<T>, context: &str) -> SDKResult<T> {
-    if let Some(data) = response.data {
-        return Ok(data);
-    }
-
-    let raw = response.raw_response;
-    let request_id = raw.request_id.clone();
-    let err = if raw.code != 0 {
-        api_error(raw.code as u16, "response", raw.msg, request_id.clone())
-    } else {
-        validation_error("response.data", "服务器没有返回有效的数据")
-    };
-    Err(err.map_context(|ctx| {
-        ctx.set_operation("extract_response_data")
-            .add_context("resource", context);
-        if let Some(req_id) = request_id.as_ref().filter(|r| !r.trim().is_empty()) {
-            ctx.set_request_id(req_id);
-        }
-    }))
 }
 
 /// 无 data 接口：仅用 `code==0` 判断成功。
@@ -73,30 +44,11 @@ pub fn ensure_success(response: Response<serde_json::Value>, context: &str) -> S
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::RawResponse;
 
     #[test]
     fn serialize_params_success() {
         let params = vec!["a", "b"];
         let v = serialize_params(&params, "测试").expect("序列化应成功");
         assert_eq!(v, serde_json::json!(["a", "b"]));
-    }
-
-    #[test]
-    fn extract_response_data_some() {
-        let response: Response<String> = Response {
-            data: Some("x".to_string()),
-            raw_response: RawResponse::success(),
-        };
-        assert_eq!(extract_response_data(response, "测试").unwrap(), "x");
-    }
-
-    #[test]
-    fn extract_response_data_empty_is_error() {
-        let response: Response<String> = Response {
-            data: None,
-            raw_response: RawResponse::success(),
-        };
-        assert!(extract_response_data(response, "测试").is_err());
     }
 }

--- a/crates/openlark-core/src/api/mod.rs
+++ b/crates/openlark-core/src/api/mod.rs
@@ -399,7 +399,7 @@ pub mod traits;
 
 // 重新导出
 
-pub use helpers::{ensure_success, extract_response_data, serialize_params};
+pub use helpers::{ensure_success, serialize_params};
 pub use traits::{AsyncApiClient, SyncApiClient};
 
 // 测试

--- a/crates/openlark-core/src/api/responses.rs
+++ b/crates/openlark-core/src/api/responses.rs
@@ -254,6 +254,36 @@ impl<T> Response<T> {
             ))
         }
     }
+
+    /// Canonical finisher：从 `Response<T>` 抽取 typed `T`（#486 起 `extract_response_data`
+    /// 自由函数收敛到此方法）。
+    ///
+    /// `data` 存在则返回；缺失时区分两种失败（#470 user story 12：业务错误不再被误报为空成功）：
+    /// - 业务错误（`code != 0`）：`api_error` 保留飞书 `code` / `msg`；
+    /// - `code == 0` 缺 `data`：`validation_error`（真正抽取失败）。
+    ///
+    /// 两种失败都经 `map_context` 附 `operation=extract_response_data` +
+    /// `resource=<context>` + 响应 `request_id`。供 `Transport::request_typed`（核心）
+    /// 与持有 `Response<T>` 的 facade 组合层收尾用；leaf 不应直接调用（走 request_typed）。
+    pub fn decode(self, context: &str) -> Result<T, crate::error::CoreError> {
+        if let Some(data) = self.data {
+            return Ok(data);
+        }
+        let raw = self.raw_response;
+        let request_id = raw.request_id.clone();
+        let err = if raw.code != 0 {
+            crate::error::api_error(raw.code as u16, "response", raw.msg, request_id.clone())
+        } else {
+            crate::error::validation_error("response.data", "服务器没有返回有效的数据")
+        };
+        Err(err.map_context(|ctx| {
+            ctx.set_operation("extract_response_data")
+                .add_context("resource", context);
+            if let Some(req_id) = request_id.as_ref().filter(|r| !r.trim().is_empty()) {
+                ctx.set_request_id(req_id);
+            }
+        }))
+    }
 }
 
 // 为常见类型实现 ApiResponseTrait
@@ -373,5 +403,47 @@ mod tests {
         assert_eq!(parsed.raw_response.code, 400);
         assert_eq!(parsed.raw_response.msg, "Bad Request");
         assert!(!parsed.is_success());
+    }
+
+    // Response::decode（#486：extract_response_data 收敛到此方法）
+
+    #[test]
+    fn decode_returns_data_on_success() {
+        let response: Response<String> = Response {
+            data: Some("x".to_string()),
+            raw_response: RawResponse::success(),
+        };
+        assert_eq!(response.decode("测试").unwrap(), "x");
+    }
+
+    #[test]
+    fn decode_missing_data_is_validation_error_with_context() {
+        let response: Response<String> = Response {
+            data: None,
+            raw_response: RawResponse::success(),
+        };
+        let err = response.decode("测试").expect_err("缺 data 应报错");
+        let ctx = err.ctx();
+        assert_eq!(ctx.operation(), Some("extract_response_data"));
+        assert_eq!(ctx.get_context("resource"), Some("测试"));
+    }
+
+    #[test]
+    fn decode_business_error_is_api_error_preserving_msg() {
+        let response: Response<String> = Response {
+            data: None,
+            raw_response: RawResponse {
+                code: 99991663,
+                msg: "permission denied".to_string(),
+                request_id: Some("rid-x".to_string()),
+                ..RawResponse::success()
+            },
+        };
+        let err = response.decode("测试").expect_err("业务错误应报错");
+        assert_eq!(err.ctx().request_id(), Some("rid-x"));
+        match err {
+            crate::error::CoreError::Api(api) => assert!(api.message.contains("permission denied")),
+            other => panic!("expected Api for business error, got: {other:?}"),
+        }
     }
 }

--- a/crates/openlark-core/src/http.rs
+++ b/crates/openlark-core/src/http.rs
@@ -111,16 +111,13 @@ impl<T: ApiResponseTrait + std::fmt::Debug + for<'de> serde::Deserialize<'de>> T
 
     /// Canonical typed-request 入口（#479）：焊合 [`Transport::request`] + 抽取 typed `T`。
     ///
-    /// 成功时直接返回 typed `T`；抽取失败时错误经 canonical helper 的 `map_context`
+    /// 成功时直接返回 typed `T`；抽取失败时错误经 [`Response::decode`] 的 `map_context`
     /// 机制携带 `operation`（= `extract_response_data`）+ `resource`（= `context`）
     /// + 响应携带的 `request_id`，便于排障与飞书服务端对账。
     ///
-    /// 与既有 `Transport::request` + `extract_response_data` 两步 idiom **行为等价**，
-    /// 仅把两步收成一次调用。入口本身 additive（无破坏性公开 API 变更）；leaf 正按
-    /// crate 增量迁入（#482 mail 已迁，#483-#485 其余），旧 helper
-    /// `extract_response_data` 在零剩余 caller 后由 #486 删除。
-    /// 无 `data` 载荷的删除类 API 继续用 `Transport::request` + `ensure_success`，
-    /// 不经本入口。
+    /// 全部 leaf 已迁入本入口（#482 mail / #483 HR / #484 communication+meeting+docs /
+    /// #485 其余）。无 `data` 载荷的删除类 API 继续用 `Transport::request` +
+    /// `ensure_success`，不经本入口。
     pub async fn request_typed<R: Send>(
         req: ApiRequest<R>,
         config: &Config,
@@ -128,7 +125,7 @@ impl<T: ApiResponseTrait + std::fmt::Debug + for<'de> serde::Deserialize<'de>> T
         context: &str,
     ) -> Result<T, CoreError> {
         let response = Self::request(req, config, option).await?;
-        crate::api::extract_response_data(response, context)
+        response.decode(context)
     }
 
     async fn do_request<R: Send>(

--- a/crates/openlark-docs/src/common/api_utils.rs
+++ b/crates/openlark-docs/src/common/api_utils.rs
@@ -1,12 +1,12 @@
 /// API通用工具函数（re-export core canonical + 本域 error 构造器）。
 ///
-/// `serialize_params` / `extract_response_data` / `ensure_success` 已下沉到
+/// `serialize_params` / `ensure_success` 已下沉到
 /// `openlark_core::api`（#330），本模块 re-export canonical copy；保留 docs 域专用的
 /// `missing_response_data_error`（bitable 等叶子直接复用其错误形状）。
 use openlark_core::error;
 
 // canonical HTTP 管道 helper（#330 下沉到 core）
-pub use openlark_core::api::{ensure_success, extract_response_data, serialize_params};
+pub use openlark_core::api::{ensure_success, serialize_params};
 
 const ERROR_COMPONENT: &str = "openlark-docs";
 

--- a/crates/openlark-docs/src/common/chain.rs
+++ b/crates/openlark-docs/src/common/chain.rs
@@ -815,7 +815,7 @@ impl DocsClient {
         let resp = DownloadFileRequest::new(self.config().clone(), file_token)
             .execute()
             .await?;
-        openlark_core::api::extract_response_data(resp, "下载 Drive 文件")
+        resp.decode("下载 Drive 文件")
     }
 
     /// 按范围下载 Drive 文件内容。
@@ -831,7 +831,7 @@ impl DocsClient {
             .range(range.to_string())
             .execute()
             .await?;
-        openlark_core::api::extract_response_data(resp, "按范围下载 Drive 文件")
+        resp.decode("按范围下载 Drive 文件")
     }
 
     /// 获取指定知识空间下的所有节点，自动处理分页。

--- a/crates/openlark-helpdesk/src/common/api_utils.rs
+++ b/crates/openlark-helpdesk/src/common/api_utils.rs
@@ -1,6 +1,6 @@
 //! API 工具函数（re-export core canonical）。
 //!
-//! serialize_params / extract_response_data / ensure_success 已下沉到
+//! serialize_params / ensure_success 已下沉到
 //! `openlark_core::api`（#330），本模块仅 re-export canonical copy，避免各 crate 各派生一份。
 
-pub use openlark_core::api::{ensure_success, extract_response_data, serialize_params};
+pub use openlark_core::api::{ensure_success, serialize_params};

--- a/crates/openlark-mail/src/common/api_utils.rs
+++ b/crates/openlark-mail/src/common/api_utils.rs
@@ -1,6 +1,6 @@
 //! API 工具函数（re-export core canonical）。
 //!
-//! serialize_params / extract_response_data / ensure_success 已下沉到
+//! serialize_params / ensure_success 已下沉到
 //! `openlark_core::api`（#330），本模块仅 re-export canonical copy，避免各 crate 各派生一份。
 
-pub use openlark_core::api::{ensure_success, extract_response_data, serialize_params};
+pub use openlark_core::api::{ensure_success, serialize_params};

--- a/crates/openlark-meeting/src/common/api_utils.rs
+++ b/crates/openlark-meeting/src/common/api_utils.rs
@@ -1,10 +1,10 @@
 //! API 工具函数（re-export core canonical + validate_required_field）。
 //!
-//! serialize_params / extract_response_data / ensure_success 已下沉到
+//! serialize_params / ensure_success 已下沉到
 //! `openlark_core::api`（#330）；保留 meeting 域的 validate_required_field（会议叶子复用）。
 use openlark_core::{SDKResult, error};
 
-pub use openlark_core::api::{ensure_success, extract_response_data, serialize_params};
+pub use openlark_core::api::{ensure_success, serialize_params};
 
 /// 标准化必填字段校验。
 pub fn validate_required_field<T: AsRef<str>>(

--- a/crates/openlark-platform/src/common/api_utils.rs
+++ b/crates/openlark-platform/src/common/api_utils.rs
@@ -1,6 +1,6 @@
 //! API 工具函数（re-export core canonical）。
 //!
-//! serialize_params / extract_response_data / ensure_success 已下沉到
+//! serialize_params / ensure_success 已下沉到
 //! `openlark_core::api`（#330），本模块仅 re-export canonical copy，避免各 crate 各派生一份。
 
-pub use openlark_core::api::{ensure_success, extract_response_data, serialize_params};
+pub use openlark_core::api::{ensure_success, serialize_params};

--- a/crates/openlark-workflow/src/common/api_utils.rs
+++ b/crates/openlark-workflow/src/common/api_utils.rs
@@ -1,13 +1,13 @@
 /// API通用工具函数（re-export core canonical + 本域 error 构造器）。
 ///
-/// `serialize_params` / `extract_response_data` / `ensure_success` 已下沉到
+/// `serialize_params` / `ensure_success` 已下沉到
 /// `openlark_core::api`（#330），本模块 re-export canonical copy；保留 workflow 域专用的
 /// 标准 error 构造器（`missing_response_data_error` / `request_serialization_error`），
 /// 多处审批任务叶子直接复用其错误形状。
 use openlark_core::error;
 
 // canonical HTTP 管道 helper（#330 下沉到 core）
-pub use openlark_core::api::{ensure_success, extract_response_data, serialize_params};
+pub use openlark_core::api::{ensure_success, serialize_params};
 
 const ERROR_COMPONENT: &str = "openlark-workflow";
 

--- a/tools/check_no_handwritten_extraction.py
+++ b/tools/check_no_handwritten_extraction.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""#486 CI guard：禁止业务 crate leaf 重新出现手写 response 抽取（防 #470 楔子迁移后 drift）。
+
+leaf 必须走 canonical 入口 `Transport::request_typed`（或 facade 用 `Response::decode`）。
+本脚本扫业务 crate src，标记以下 drift 模式：
+  - `.data.ok_or_else(`     —— 应走 request_typed
+  - `.into_result()`        —— Response::into_result，应走 request_typed / decode
+  - `.data.unwrap_or[`      —— 应走 request_typed + empty_success 声明空成功
+
+openlark-core 豁免（定义 Response::decode/into_result 等）。每个文件的 `#[cfg(test)]`
+mod 块剥离（测试不计）。命中即 exit 1。
+
+用法：python3 tools/check_no_handwritten_extraction.py
+"""
+from __future__ import annotations
+
+import glob
+import re
+import sys
+
+PATTERNS = [
+    (re.compile(r"\.data\s*\.ok_or_else"),
+     ".data.ok_or_else — 用 Transport::request_typed"),
+    (re.compile(r"\.into_result\(\)"),
+     ".into_result() — 用 Transport::request_typed（facade 用 Response::decode）"),
+    (re.compile(r"\.data\s*\.unwrap_or"),
+     ".data.unwrap_or — 用 request_typed + 给 Response 类型声明 empty_success"),
+]
+
+ALLOW_CRATES = {"openlark-core"}  # core 定义这些；非业务 leaf
+
+
+def strip_test_mod(src: str) -> str:
+    """剥离 `#[cfg(test)] mod IDENT { ... }`（含 `#[cfg(all(test, ...))]` 等）test mod 块。
+
+    用花括号配对精准剥整个 test mod，而非朴素截到首个 `#[cfg(test)]`——后者对早期
+    内联 cfg(test) 文件会误删其后全部生产代码（drift 漏抓）。fn 级 `#[cfg(test)]`
+    不剥（罕见，且测试 fn 内 pattern 非 drift）。
+    """
+    mod_open = re.compile(r"#\[cfg\([^[]*test[^[]*\)\]\s*mod\s+\w+\s*\{")
+    out: list[str] = []
+    i, n = 0, len(src)
+    while i < n:
+        m = mod_open.match(src, i)
+        if m:
+            # 花括号配对找到 mod 闭合 }
+            depth, j = 1, m.end()  # m.end() 指向 '{' 之后
+            while j < n and depth > 0:
+                ch = src[j]
+                if ch == "{":
+                    depth += 1
+                elif ch == "}":
+                    depth -= 1
+                j += 1
+            i = j
+            # 吃掉块后一个换行（避免留空行）
+            if i < n and src[i] == "\n":
+                i += 1
+        else:
+            out.append(src[i])
+            i += 1
+    return "".join(out)
+
+
+def main() -> int:
+    violations: list[str] = []
+    for path in sorted(glob.glob("crates/openlark-*/src/**/*.rs", recursive=True)):
+        crate = path.split("/")[1]
+        if crate in ALLOW_CRATES:
+            continue
+        src = open(path, encoding="utf-8").read()
+        for ln, line in enumerate(strip_test_mod(src).splitlines(), 1):
+            for pat, msg in PATTERNS:
+                if pat.search(line):
+                    violations.append(f"{path}:{ln}: {msg}\n    {line.strip()}")
+    if violations:
+        print(f"❌ 发现 {len(violations)} 处手写 response 抽取（#470 canonical 路径 drift）：\n")
+        for v in violations:
+            print(f"  {v}\n")
+        print("迁到 Transport::request_typed（facade 持有 Response<T> 的用 Response::decode）。见 #470/#486。")
+        return 1
+    print("✅ 业务 crate 无手写 response 抽取（全走 canonical 入口）")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #486 · Closes #470（楔子 step 6 · contract 收尾，**整个 #470 楔子完成**）

## What

`extract_response_data` 自由函数的抽取逻辑收敛到 `Response::decode(ctx)` 方法（#479 当初提的 finisher 备选），删除自由函数 + 23 处 re-export，加 grep CI guard 防 drift。

### extract_response_data → Response::decode
逻辑完全等价（#485 Option C：`data` 缺失时业务错误 code≠0 → `api_error` 保飞书 code/msg；code==0 → `validation_error`；两失败都 `map_context` 附 operation/resource/request_id）：
- `Transport::request_typed`（http.rs）：`crate::api::extract_response_data(response, ctx)` → `response.decode(ctx)`
- docs `chain.rs` 2 处 facade（download_drive_file，`DownloadFileRequest` 签名冻结返回 `Response<Vec<u8>>` 做 max_size 校验）：`resp.decode(ctx)`
- core `api/mod.rs` + 10 个 crate `common/api_utils.rs` 移除 `extract_response_data` re-export（保留 `serialize_params` / `ensure_success`）
- 3 个新 `Response::decode` 单测（success / validation_error / api_error 保 msg+request_id）

### CI drift guard（`tools/check_no_handwritten_extraction.py`）
扫业务 crate leaf，标 `.data.ok_or_else` / `.into_result()` / `.data.unwrap_or` 三种手写抽取 drift；`#[cfg(test)] mod {}` 块**花括号配对精准剥离**（非朴素截首处 `#[cfg(test)]`——后者对早期内联 cfg(test) 文件漏抓 drift，code-review 指出已修）；openlark-core 豁免。接入 `ci.yml` lint job（与 `check_no_dead_code_allows` / `check_reqwest_boundary` 同列）。

## Acceptance criteria

- [x] `extract_response_data` 删除后全仓编译绿（删除三连：`cargo machete` 无 unused deps / `cargo doc -D` intra-doc 绿 / msrv lockfile 未改依赖不受影响）
- [x] CI guard 对故意引入的手写抽取 fail（clean exit 0 / 注入 exit 1；含早期 cfg(test) mod 后 drift 的硬化 case）
- [x] guard 接入 CI workflow（ci.yml lint job）

## 验证

- 全仓编译 0 error/warning；**6133 测试零回归**（含 3 个新 Response::decode 单测）
- `cargo clippy` 双模式（`--all-features` / `--no-default-features`）全清；`cargo fmt` workspace 全清
- `cargo machete --with-metadata` 无 unused deps；`RUSTDOCFLAGS="-D warnings" cargo doc` 绿
- code-review（Standards + Spec 双轴）：0 硬违规 / AC 全满足；1 判断项（guard false negative）已修

## 透明说明（非本票 scope，留后续）

- `extract_response_data` 无残留**调用**（grep `extract_response_data(` 全仓 0 命中）；残留引用均为 operation 字符串标签（`set_operation("extract_response_data")`，诊断稳定 + #479 契约测试断言它）、doc 注释、`codegen_render.py:292`（活跃 codegen，重跑会立即编译失败或被 guard 抓，drift 无法静默回流——#217-222 codegen 债）。
- docs/workflow api_utils.rs 的 `missing_response_data_error` 本地 helper（#484 迁后零 caller，pub + crate 专属）+ docs/workflow 间 `attach_standard_error_context` 逐字重复（Duplicated Code，达抽象阈值）——留独立小票清理。
- `Response::into_result` 方法保留（provided，guard 防业务 leaf 调用）。

---

**#470 楔子（6 票）全部完成**：#479 入口 · #482 mail · #483 HR · #484 comm+meeting+docs · #485 其余 12 crate + Option C · #486 删 helper + CI guard。全部 leaf 响应抽取统一走 `Transport::request_typed` / `Response::decode` canonical 路径，错误一致携带 operation/resource/request_id，业务错误保飞书 code/msg。