### PR TITLE
refactor(core): tighten Transport::do_send to pub(crate) (#478)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **迁移**：仅走 `client.<domain>` 字段访问的代码零影响；使用 `Client::registry()` /
     prelude 导出的 trait / `registry_error()` 的代码需移除这些调用。
 
+- **core：`Transport::do_send` 收为 `pub(crate)`（#478）**：
+  全仓零外部调用者（仅 core 内 `do_request` 调用 + 一处注释引用），却以 `pub`
+  暴露在公开 API 表面。收紧后接口诚实反映「core 内部 HTTP 发送实现细节」，
+  不再误导外部消费者当作稳定入口。纯可见性变更、无行为影响；唯一外部可观察
+  效果是从公开 API 移除该函数。
+
 ### Changed
 
 - **security：`CoreError` 风险分类收口到 extension trait（#477, #480）**：

--- a/crates/openlark-core/src/http.rs
+++ b/crates/openlark-core/src/http.rs
@@ -164,7 +164,7 @@ impl<T: ApiResponseTrait + std::fmt::Debug + for<'de> serde::Deserialize<'de>> T
     }
 
     /// 执行 HTTP 请求
-    pub async fn do_send(
+    pub(crate) async fn do_send(
         raw_request: RequestBuilder,
         body: Vec<u8>,
         multi_part: bool,


### PR DESCRIPTION
## 背景

Closes #478（#472 epic「顺带小项」）

`Transport::do_send` 是 core 内部 HTTP 发送辅助方法，唯一调用者是同 `impl` 块的兄弟方法 `do_request`（第三处仓库级引用是 `request_execution/mod.rs` 的一条注释）。却以 `pub` 暴露为公开 API，把内部实现细节误传为稳定入口。

## 改动

- `crates/openlark-core/src/http.rs:167`：`pub` → `pub(crate)`（单行收紧，函数体不变）
- `CHANGELOG.md`：`[Unreleased] > Changed (Breaking — 目标 0.19)` 下新增条目。pub→pub(crate) 是从公开 API 移除函数，按 SemVer 属破坏性，跟随 #471 同节先例。

## 验证

- `cargo fmt --check` ✅
- `cargo build --workspace --all-features` ✅（编译器在全部 feature 组合下接受 `pub(crate)` = 证实零外部调用者，即 acceptance 第二条）
- `cargo clippy --workspace --all-targets --all-features -- -Dwarnings` ✅
- `cargo clippy --workspace --all-targets --no-default-features -- -Dwarnings` ✅
- `cargo doc --workspace --all-features`（`-D warnings`）✅

## 备注

issue #478 前提「只 core 内 doc 注释引用」略不精确——实际还有一处 `do_request` 内部调用（CHANGELOG 已校正为「仅 core 内 `do_request` 调用 + 一处注释引用」）。不影响实现。
