### PR TITLE
refactor(hr): hoist domain-agnostic primitives to common::shared_models (#473)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   升级口径仍是 Business/Internal，行为未变。非破坏、additive；为 #472 后续让
   workflow/client 复用同一分类铺路。
 
+- **hr：域无关 HR 原语提升到 crate root（#473）**：
+  `I18nText` / `FlexibleText` / `IdNameObject` / `CodeNameObject` /
+  `PaginatedResponse<T>` / `CatalogItem` / `LocalizedLabel` 这 7 个域无关原语
+  从 `hire::hire::common_models`（1270 行）迁至新模块 `common::shared_models`
+  （crate root），canonical 路径改为 `openlark_hr::common::shared_models::*`。
+  `hire` 反过来从此处 import；6 个兄弟域（attendance/corehr/payroll/performance/
+  compensation/ehr）按需 opt-in 即可获得 typed i18n，不再侧向伸手进 hire 子树或
+  退回 `serde_json::Value`。先例为 `okr::okr::v2::common::models` 跨叶消重（#336）。
+  - **非破坏**：序列化形状逐字不变；`hire::hire::common_models` 经 `#[deprecated]`
+    按名再导出这 7 个类型，保留一个过渡周期——既有全路径 import 仍可解析，仅多一条
+    deprecation 提示。下个 breaking 窗口（0.19）删除该 alias。
+
 ## [0.18.0] - 2026-07-20
 
 > WebSocket 公开 API 破坏性变更随 **0.18.0** workspace 版本一并发出（见下 Breaking）。

--- a/crates/openlark-hr/src/common/mod.rs
+++ b/crates/openlark-hr/src/common/mod.rs
@@ -2,6 +2,8 @@
 pub mod api_endpoints;
 /// HR 通用模型定义。
 pub mod models;
+/// 域无关的 HR 共享原型类型（i18n 文本、ID+name 引用、分页壳等）。
+pub mod shared_models;
 
 /// 重新导出模型类型
 pub use self::models::*;

--- a/crates/openlark-hr/src/common/shared_models.rs
+++ b/crates/openlark-hr/src/common/shared_models.rs
@@ -1,0 +1,148 @@
+//! 域无关的 HR 共享原型类型。
+//!
+//! 这些类型（国际化文本、ID+name 引用、分页响应壳、目录项等）不是 hire
+//! 专属语义，而是所有 HR 域（attendance / corehr / payroll / performance /
+//! compensation / ehr / hire）都可能复用的通用原语，因此提升到 crate root。
+//!
+//! 历史上它们曾定义在 `hire::hire::common_models`，6 个兄弟域要 typed i18n
+//! 只能侧向伸手进 hire 子树；提升后 canonical 路径为
+//! `crate::common::shared_models`，`hire` 反过来从此处 import。先例见
+//! `okr::okr::v2::common::models` 的跨叶消重（#336），本次把同一模式抬到全局（#473）。
+//!
+//! 序列化契约：字段名与 serde 属性与原 hire 定义逐字一致，wire 格式不变。
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// 国际化文本。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct I18nText {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// `zh_cn` 字段。
+    pub zh_cn: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// `en_us` 字段。
+    pub en_us: Option<String>,
+    #[serde(default, flatten)]
+    /// 扩展字段。
+    pub extra: HashMap<String, Value>,
+}
+
+/// 可兼容普通字符串或多语言对象的文本字段。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum FlexibleText {
+    /// `Plain` 变体。
+    Plain(String),
+    /// `I18n` 变体。
+    I18n(I18nText),
+}
+
+impl FlexibleText {
+    /// 提供 `zh_cn_or_plain` 能力。
+    pub fn zh_cn_or_plain(&self) -> Option<&str> {
+        match self {
+            Self::Plain(value) => Some(value.as_str()),
+            Self::I18n(value) => value.zh_cn.as_deref().or(value.en_us.as_deref()),
+        }
+    }
+}
+
+/// 常见的 ID + 名称引用对象。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct IdNameObject {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// 标识。
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// 名称。
+    pub name: Option<I18nText>,
+    #[serde(default, flatten)]
+    /// 扩展字段。
+    pub extra: HashMap<String, Value>,
+}
+
+/// 带 code + name 的区域对象。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct CodeNameObject {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// `code` 字段。
+    pub code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// 名称。
+    pub name: Option<I18nText>,
+    #[serde(default, flatten)]
+    /// 扩展字段。
+    pub extra: HashMap<String, Value>,
+}
+
+/// 通用分页响应壳。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct PaginatedResponse<T> {
+    #[serde(default)]
+    /// 结果项列表。
+    pub items: Vec<T>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// 下一页分页标记。
+    pub page_token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// 是否还有更多结果。
+    pub has_more: Option<bool>,
+    #[serde(default, flatten)]
+    /// 扩展字段。
+    pub extra: HashMap<String, Value>,
+}
+
+/// 末尾长尾接口常见的目录/模板类对象。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct CatalogItem {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// 标识。
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// `code` 字段。
+    pub code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// 名称。
+    pub name: Option<FlexibleText>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// 标题。
+    pub title: Option<FlexibleText>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// `i18n_name` 字段。
+    pub i18n_name: Option<I18nText>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// `description` 字段。
+    pub description: Option<FlexibleText>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// `status` 字段。
+    pub status: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// `active_status` 字段。
+    pub active_status: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// `version` 字段。
+    pub version: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// `parent_id` 字段。
+    pub parent_id: Option<String>,
+    #[serde(default, flatten)]
+    /// 扩展字段。
+    pub extra: HashMap<String, Value>,
+}
+
+/// `zh_name` / `en_name` 形式的双语文本。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct LocalizedLabel {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// `zh_name` 字段。
+    pub zh_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// `en_name` 字段。
+    pub en_name: Option<String>,
+    #[serde(default, flatten)]
+    /// 扩展字段。
+    pub extra: HashMap<String, Value>,
+}

--- a/crates/openlark-hr/src/hire/hire/common_models.rs
+++ b/crates/openlark-hr/src/hire/hire/common_models.rs
@@ -1,129 +1,27 @@
-//! Hire 业务域通用响应模型。
+//! Hire 业务域专属响应模型。
 //!
-//! 用于承接第一批 typed response 收敛中反复出现的 i18n、分页、引用对象、
-//! 金额与附件元数据等结构，避免在每个 API 文件里重复定义。
+//! 域无关的 HR 原语（`I18nText` / `FlexibleText` / `IdNameObject` /
+//! `CodeNameObject` / `PaginatedResponse` / `CatalogItem` / `LocalizedLabel`）
+//! 已迁至 crate root：[`crate::common::shared_models`]。本模块保留 hire 专属
+//! 摘要类型（职位 / 投递 / 面试 / offer / 生态 / 猎头 等），并经 deprecated
+//! re-export 再导出已迁移的原语，为既有全路径 import 留一个过渡周期（#473）。
 
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-/// 国际化文本。
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-pub struct I18nText {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// `zh_cn` 字段。
-    pub zh_cn: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// `en_us` 字段。
-    pub en_us: Option<String>,
-    #[serde(default, flatten)]
-    /// 扩展字段。
-    pub extra: HashMap<String, Value>,
-}
-
-/// 可兼容普通字符串或多语言对象的文本字段。
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-pub enum FlexibleText {
-    /// `Plain` 变体。
-    Plain(String),
-    /// `I18n` 变体。
-    I18n(I18nText),
-}
-
-impl FlexibleText {
-    /// 提供 `zh_cn_or_plain` 能力。
-    pub fn zh_cn_or_plain(&self) -> Option<&str> {
-        match self {
-            Self::Plain(value) => Some(value.as_str()),
-            Self::I18n(value) => value.zh_cn.as_deref().or(value.en_us.as_deref()),
-        }
-    }
-}
-
-/// 常见的 ID + 名称引用对象。
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-pub struct IdNameObject {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// 标识。
-    pub id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// 名称。
-    pub name: Option<I18nText>,
-    #[serde(default, flatten)]
-    /// 扩展字段。
-    pub extra: HashMap<String, Value>,
-}
-
-/// 带 code + name 的区域对象。
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-pub struct CodeNameObject {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// `code` 字段。
-    pub code: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// 名称。
-    pub name: Option<I18nText>,
-    #[serde(default, flatten)]
-    /// 扩展字段。
-    pub extra: HashMap<String, Value>,
-}
-
-/// 通用分页响应壳。
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-pub struct PaginatedResponse<T> {
-    #[serde(default)]
-    /// 结果项列表。
-    pub items: Vec<T>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// 下一页分页标记。
-    pub page_token: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// 是否还有更多结果。
-    pub has_more: Option<bool>,
-    #[serde(default, flatten)]
-    /// 扩展字段。
-    pub extra: HashMap<String, Value>,
-}
-
-/// 末尾长尾接口常见的目录/模板类对象。
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-pub struct CatalogItem {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// 标识。
-    pub id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// `code` 字段。
-    pub code: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// 名称。
-    pub name: Option<FlexibleText>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// 标题。
-    pub title: Option<FlexibleText>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// `i18n_name` 字段。
-    pub i18n_name: Option<I18nText>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// `description` 字段。
-    pub description: Option<FlexibleText>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// `status` 字段。
-    pub status: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// `active_status` 字段。
-    pub active_status: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// `version` 字段。
-    pub version: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// `parent_id` 字段。
-    pub parent_id: Option<String>,
-    #[serde(default, flatten)]
-    /// 扩展字段。
-    pub extra: HashMap<String, Value>,
-}
+// 向后兼容 re-export：这 7 个域无关原语已迁至 crate root
+// （`crate::common::shared_models`），此处按名再导出保留一个过渡周期，将在下个
+// breaking 版本移除（#473）。功能上保证既有全路径 import 仍可解析（不破坏编译）。
+// 注意：rustc 当前不会为 `pub use` 重导出在消费端触发 deprecation 告警——这里的
+// `#[deprecated]` 主要作 rustdoc 标记 + 未来 Rust 版本转发兼容；alias 的实际移除
+// 以下个 breaking 窗口的 grep（`common_models::(I18nText|FlexibleText|...)`）为准。
+#[deprecated(note = "用 crate::common::shared_models，将在下个 breaking 版本移除")]
+pub use crate::common::shared_models::{
+    CatalogItem, CodeNameObject, FlexibleText, I18nText, IdNameObject, LocalizedLabel,
+    PaginatedResponse,
+};
 
 /// 面试任务摘要。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
@@ -145,7 +43,7 @@ pub struct InterviewTaskSummary {
     pub status: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// `interviewer` 字段。
-    pub interviewer: Option<IdNameObject>,
+    pub interviewer: Option<crate::common::shared_models::IdNameObject>,
     #[serde(default, flatten)]
     /// 扩展字段。
     pub extra: HashMap<String, Value>,
@@ -165,7 +63,7 @@ pub struct TalentOperationLogEntry {
     pub application_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// `operator` 字段。
-    pub operator: Option<IdNameObject>,
+    pub operator: Option<crate::common::shared_models::IdNameObject>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// `operation_type` 字段。
     pub operation_type: Option<String>,
@@ -375,20 +273,6 @@ pub struct HireAttachment {
     pub extra: HashMap<String, Value>,
 }
 
-/// `zh_name` / `en_name` 形式的双语文本。
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-pub struct LocalizedLabel {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// `zh_name` 字段。
-    pub zh_name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// `en_name` 字段。
-    pub en_name: Option<String>,
-    #[serde(default, flatten)]
-    /// 扩展字段。
-    pub extra: HashMap<String, Value>,
-}
-
 /// 投递所关联的职位摘要。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct ApplicationJobInfo {
@@ -483,7 +367,7 @@ pub struct ApplicationInterviewRecord {
     pub status: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// `interviewer` 字段。
-    pub interviewer: Option<IdNameObject>,
+    pub interviewer: Option<crate::common::shared_models::IdNameObject>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// 分数。
     pub score: Option<ScoreInfo>,

--- a/crates/openlark-hr/src/hire/hire/v1/interview_feedback_form/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/interview_feedback_form/list.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::CatalogItem;
+use crate::common::shared_models::CatalogItem;
 
 /// `ListRequestBody`。
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/crates/openlark-hr/src/hire/hire/v1/interview_record/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/interview_record/list.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::{I18nText, IdNameObject};
+use crate::common::shared_models::{I18nText, IdNameObject};
 
 /// `ListRequestBody`。
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/crates/openlark-hr/src/hire/hire/v1/interview_registration_schema/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/interview_registration_schema/list.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::CatalogItem;
+use crate::common::shared_models::CatalogItem;
 
 /// `ListRequestBody`。
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/crates/openlark-hr/src/hire/hire/v1/interview_round_type/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/interview_round_type/list.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::CatalogItem;
+use crate::common::shared_models::CatalogItem;
 
 /// `ListRequestBody`。
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/crates/openlark-hr/src/hire/hire/v1/job_function/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/job_function/list.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::CatalogItem;
+use crate::common::shared_models::CatalogItem;
 
 /// 获取职能分类列表请求
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/job_process/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/job_process/list.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::CatalogItem;
+use crate::common::shared_models::CatalogItem;
 
 /// 获取招聘流程信息请求
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/job_requirement_schema/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/job_requirement_schema/list.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::CatalogItem;
+use crate::common::shared_models::CatalogItem;
 
 /// 获取招聘需求模板列表请求
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/job_schema/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/job_schema/list.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::CatalogItem;
+use crate::common::shared_models::CatalogItem;
 
 /// 获取职位模板请求
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/job_type/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/job_type/list.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::CatalogItem;
+use crate::common::shared_models::CatalogItem;
 
 /// 获取职位类别列表请求
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/location/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/location/list.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::{CodeNameObject, I18nText};
+use crate::common::shared_models::{CodeNameObject, I18nText};
 
 /// `ListRequest` 请求。
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/minutes/get.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/minutes/get.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::I18nText;
+use crate::common::shared_models::I18nText;
 
 /// `GetRequest` 请求。
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/offer_application_form/get.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/offer_application_form/get.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::I18nText;
+use crate::common::shared_models::I18nText;
 
 /// 获取 Offer 申请表信息请求
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/offer_application_form/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/offer_application_form/list.rs
@@ -72,7 +72,7 @@ pub struct OfferApplicationFormSummary {
     pub id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// 名称。
-    pub name: Option<crate::hire::hire::common_models::I18nText>,
+    pub name: Option<crate::common::shared_models::I18nText>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// `create_time` 字段。
     pub create_time: Option<String>,

--- a/crates/openlark-hr/src/hire/hire/v1/offer_approval_template/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/offer_approval_template/list.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::CatalogItem;
+use crate::common::shared_models::CatalogItem;
 
 /// 获取 Offer 审批流列表请求
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/offer_schema/get.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/offer_schema/get.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::I18nText;
+use crate::common::shared_models::I18nText;
 
 /// 获取 Offer 申请表详细信息请求
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/portal_apply_schema/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/portal_apply_schema/list.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::CatalogItem;
+use crate::common::shared_models::CatalogItem;
 
 /// 获取申请表模板列表请求
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/questionnaire/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/questionnaire/list.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::CatalogItem;
+use crate::common::shared_models::CatalogItem;
 
 /// 获取面试满意度问卷列表请求
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/referral/search.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/referral/search.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::IdNameObject;
+use crate::common::shared_models::IdNameObject;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 struct SearchRequestBody {

--- a/crates/openlark-hr/src/hire/hire/v1/referral_account/get_account_assets.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/referral_account/get_account_assets.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::I18nText;
+use crate::common::shared_models::I18nText;
 
 use crate::hire::hire::common_models::BonusAmount;
 

--- a/crates/openlark-hr/src/hire/hire/v1/referral_website/job_post/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/referral_website/job_post/list.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::{CodeNameObject, I18nText, IdNameObject};
+use crate::common::shared_models::{CodeNameObject, I18nText, IdNameObject};
 
 /// `ListRequest` 请求。
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/registration_schema/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/registration_schema/list.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::CatalogItem;
+use crate::common::shared_models::CatalogItem;
 
 /// 获取信息登记表列表请求
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/resume_source/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/resume_source/list.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::CatalogItem;
+use crate::common::shared_models::CatalogItem;
 
 /// 获取简历来源列表请求
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/role/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/role/list.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::I18nText;
+use crate::common::shared_models::I18nText;
 
 /// `ListRequest` 请求。
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/subject/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/subject/list.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::{I18nText, IdNameObject};
+use crate::common::shared_models::{I18nText, IdNameObject};
 
 /// `ListRequest` 请求。
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/talent_object/query.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/talent_object/query.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::I18nText;
+use crate::common::shared_models::I18nText;
 
 /// 获取人才字段请求。
 ///

--- a/crates/openlark-hr/src/hire/hire/v1/talent_pool/search.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/talent_pool/search.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::I18nText;
+use crate::common::shared_models::I18nText;
 
 /// `SearchRequest` 请求。
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/talent_tag/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/talent_tag/list.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::I18nText;
+use crate::common::shared_models::I18nText;
 
 /// `ListRequest` 请求。
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/termination_reason/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/termination_reason/list.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::I18nText;
+use crate::common::shared_models::I18nText;
 
 /// `ListRequest` 请求。
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/test/search.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/test/search.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::CatalogItem;
+use crate::common::shared_models::CatalogItem;
 
 /// 获取笔试列表请求
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/user_role/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/user_role/list.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::{I18nText, IdNameObject};
+use crate::common::shared_models::{I18nText, IdNameObject};
 
 /// `ListRequest` 请求。
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v1/website/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v1/website/list.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::I18nText;
+use crate::common::shared_models::I18nText;
 
 /// `ListRequest` 请求。
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v2/interview_record/list.rs
+++ b/crates/openlark-hr/src/hire/hire/v2/interview_record/list.rs
@@ -13,7 +13,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::{AttachmentMeta, I18nText, IdNameObject, ScoreInfo};
+use crate::common::shared_models::{I18nText, IdNameObject};
+use crate::hire::hire::common_models::{AttachmentMeta, ScoreInfo};
 
 /// `ListRequest` 请求。
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/src/hire/hire/v2/talent/get.rs
+++ b/crates/openlark-hr/src/hire/hire/v2/talent/get.rs
@@ -13,7 +13,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::hire::hire::common_models::{AttachmentMeta, I18nText};
+use crate::common::shared_models::I18nText;
+use crate::hire::hire::common_models::AttachmentMeta;
 
 /// 获取人才详情请求
 #[derive(Debug, Clone)]

--- a/crates/openlark-hr/tests/hire_tests.rs
+++ b/crates/openlark-hr/tests/hire_tests.rs
@@ -489,7 +489,7 @@ mod serialization_tests {
         interview_record::get::GetResponse {
             id: Some("ir_001".to_string()),
             conclusion: Some(1),
-            interviewer: Some(openlark_hr::hire::hire::common_models::IdNameObject {
+            interviewer: Some(openlark_hr::common::shared_models::IdNameObject {
                 id: Some("ou_interviewer".to_string()),
                 ..Default::default()
             }),
@@ -2009,10 +2009,10 @@ mod serialization_tests {
         test_interview_feedback_form_list_response_serialization,
         interview_feedback_form::list::ListResponse,
         interview_feedback_form::list::ListResponse {
-            items: vec![openlark_hr::hire::hire::common_models::CatalogItem {
+            items: vec![openlark_hr::common::shared_models::CatalogItem {
                 id: Some("form_1".to_string()),
-                title: Some(openlark_hr::hire::hire::common_models::FlexibleText::I18n(
-                    openlark_hr::hire::hire::common_models::I18nText {
+                title: Some(openlark_hr::common::shared_models::FlexibleText::I18n(
+                    openlark_hr::common::shared_models::I18nText {
                         zh_cn: Some("通用评价表".to_string()),
                         en_us: Some("Default Form".to_string()),
                         extra: Default::default(),
@@ -2243,9 +2243,9 @@ mod serialization_tests {
         test_job_type_list_response_serialization,
         job_type::list::ListResponse,
         job_type::list::ListResponse {
-            items: vec![openlark_hr::hire::hire::common_models::CatalogItem {
+            items: vec![openlark_hr::common::shared_models::CatalogItem {
                 id: Some("type_1".to_string()),
-                name: Some(openlark_hr::hire::hire::common_models::FlexibleText::Plain(
+                name: Some(openlark_hr::common::shared_models::FlexibleText::Plain(
                     "研发".to_string(),
                 )),
                 ..Default::default()


### PR DESCRIPTION
## 背景（#473）

`I18nText` / `FlexibleText` / `IdNameObject` / `CodeNameObject` / `PaginatedResponse<T>` / `CatalogItem` / `LocalizedLabel` 这 7 个**域无关 HR 原语**原本困在 `hire/hire/common_models.rs`（1270 行）。6 个兄弟域（attendance / corehr / payroll / performance / compensation / ehr）要 typed i18n 只能侧向伸手进 hire 子树，多数域嫌烦直接退回 `serde_json::Value`。

## 改动

- 新增 crate-root 模块 `common::shared_models`，迁入这 7 个原语（serde 属性逐字一致，wire 格式不变）。canonical 路径：`openlark_hr::common::shared_models::*`。
- `hire` 反过来从此处 import；`common_models.rs` 仅保留 hire 专属摘要类型。
- 全部内部调用点迁移到新路径（33 个 `src/` 叶子 + `tests/hire_tests.rs` 3 处序列化断言）。
- CHANGELOG `### Changed` 加条目。先例：`okr::okr::v2::common::models` 跨叶消重（#336）。

## 非破坏性

序列化形状逐字不变；`hire::hire::common_models` 经 `#[deprecated]` **按名**再导出这 7 个类型，保留一个过渡周期——既有全路径 import 仍可解析，不破坏编译。下个 breaking 窗口（0.19）删除该 alias。

### 对 spec 字面的有意偏离

spec 写的是 glob（`pub use crate::common::shared_models::*;`）；实现用**按名**再导出（恰好 7 个）。理由：glob 会把未来新增到 `shared_models` 的任意类型静默暴露到旧路径，破坏「一个周期后删除」的承诺。spec 评审（双轴 code-review）判定这更贴合 spec 意图且更安全。

### 已知限制（已在代码内标注）

rustc 当前**不会**为 `pub use` 重导出在消费端触发 deprecation 告警（已用最小 repro 验证：lib `#[deprecated] pub use inner::Foo;` → 消费端零告警）。因此这里的 `#[deprecated]` 主要作 rustdoc 标记 + 未来 Rust 版本转发兼容；spec 的硬保证（既有 import 不被破坏）成立，但迁移推动信号为空——alias 的实际移除以下个 breaking 窗口的 grep（`common_models::(I18nText|FlexibleText|...)`）为准。已在 `common_models.rs:14-19` 注释说明。

## 不在范围（spec 明确 out of scope）

- `common/models.rs` 改名（名实不符，follow-up）
- 强制 6 域立即 opt-in（按需，非本 spec 目标）
- `hire/hire/` inception 折叠、`api_endpoints.rs` 按域拆分

## 验证

- `cargo build --workspace --all-features`：clean
- `cargo clippy -p openlark-hr --all-targets --all-features -- -Dwarnings`：clean
- `cargo clippy -p openlark-hr --all-targets --no-default-features -- -Dwarnings`：clean
- `cargo fmt --check`：clean
- `cargo doc -p openlark-hr --all-features`：clean（intra-doc 链解析）
- `cargo test -p openlark-hr --all-features`：**1952 passed, 0 failed**（含 hire 叶子测试 + 序列化契约测试，证明 wire 格式不变）
- 双轴 `/code-review`（Standards + Spec）：无硬违规，所有 finding 均为非阻塞判断或已披露限制

Closes #473