### PR TITLE
refactor(hr): 删 7 dead config-holder facade (#474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   不再误导外部消费者当作稳定入口。纯可见性变更、无行为影响；唯一外部可观察
   效果是从公开 API 移除该函数。
 
+- **hr：删除 7 个 dead config-holder facade（#474）**：
+  `Hire` / `Attendance` / `Corehr` / `Payroll` / `Performance` /
+  `CompensationManagement` / `Ehr` 是纯 config holder（仅 `new()` + `config()`），
+  命中 ADR-0001 五项判据的 0 项（无 feature 门控 / 无版本路由 / 无路径绑定 / 无扇出 /
+  无真 helper）。删除 7 struct + `HrClient` 的 7 个 pub 字段 + 7 次 `config.clone()`
+  样板。`Okr` 保留（有 `v2()` 真路由）。HR 全域统一为 config-direct 直路径
+  （`client.hr.config()` 构造 leaf），消除「这个域用 fluent 还是直路径？」的歧义。
+  - **迁移**：`client.hr.attendance` / `.corehr` / `.hire` 等字段访问改为
+    `client.hr.config()` 直达 `Config` 构造 leaf 请求（lib.rs 文档的 canonical 写法）；
+    仅走这些字段的 `.config()` 的代码改为 `client.hr.config()`。`client.hr.okr.v2()`
+    不受影响。
+  - 先例为 ADR-0001 docs crate 砍 5 个 config-holder 子客户端（#365）；HR 不在原
+    ADR scope，本次把同判据延伸到 HR。
+
 ### Changed
 
 - **security：`CoreError` 风险分类收口到 extension trait（#477, #480）**：

--- a/crates/openlark-client/src/capability/catalog.rs
+++ b/crates/openlark-client/src/capability/catalog.rs
@@ -55,7 +55,7 @@ macro_rules! for_each_compiled_capability {
                 feature: "hr",
                 field: hr,
                 ty: openlark_hr::HrClient,
-                doc: "HR meta 调用链入口：client.hr.attendance / client.hr.corehr / client.hr.hire ...",
+                doc: "HR 入口：client.hr.config() 直达 leaf 构造 Request（7 域 config-holder facade 已砍，#474），client.hr.okr.v2() 保留 fluent",
                 init: |_core_config, _base_core_config| {
                     openlark_hr::HrClient::new(_core_config.clone())
                 },

--- a/crates/openlark-client/tests/hr_feature_contract.rs
+++ b/crates/openlark-client/tests/hr_feature_contract.rs
@@ -1,18 +1,18 @@
 //! `openlark-client/hr` feature 的最小对外契约检查。
 //!
-//! 该 feature 至少需要保证 `client.hr.attendance` 可用。
+//! 该 feature 至少需要保证 `client.hr.config()` 可用。
 
 #![cfg(feature = "hr")]
 
 use openlark_client::Client;
 
 #[test]
-fn hr_feature_exposes_attendance_entry() {
+fn hr_feature_exposes_config_entry() {
     let client = Client::builder()
         .app_id("test_app")
         .app_secret("test_secret")
         .build()
         .expect("client should build with hr feature");
 
-    assert_eq!(client.hr.attendance.config().app_id(), "test_app");
+    assert_eq!(client.hr.config().app_id(), "test_app");
 }

--- a/crates/openlark-hr/src/attendance/mod.rs
+++ b/crates/openlark-hr/src/attendance/mod.rs
@@ -1,28 +1,8 @@
-/// 考勤模块
-///
-/// 按照bizTag/project/version/resource/name.rs模式组织
-use openlark_core::config::Config;
+//! 考勤模块
+//!
+//! 按照bizTag/project/version/resource/name.rs模式组织
 
 /// attendance 项目模块。
 /// attendance 子模块。
 #[allow(clippy::module_inception)]
 pub mod attendance;
-
-/// 考勤服务
-/// Attendance 服务入口。
-#[derive(Debug, Clone)]
-pub struct Attendance {
-    config: Config,
-}
-
-impl Attendance {
-    /// 创建新的服务入口实例。
-    pub fn new(config: Config) -> Self {
-        Self { config }
-    }
-
-    /// 返回共享配置引用。
-    pub fn config(&self) -> &Config {
-        &self.config
-    }
-}

--- a/crates/openlark-hr/src/compensation_management/mod.rs
+++ b/crates/openlark-hr/src/compensation_management/mod.rs
@@ -1,26 +1,6 @@
-/// 薪酬管理模块
-///
-/// 按照bizTag/project/version/resource/name.rs模式组织
-use openlark_core::config::Config;
+//! 薪酬管理模块
+//!
+//! 按照bizTag/project/version/resource/name.rs模式组织
 
 /// compensation 子模块。
 pub mod compensation;
-
-/// 薪酬管理服务
-/// CompensationManagement 服务入口。
-#[derive(Debug, Clone)]
-pub struct CompensationManagement {
-    config: Config,
-}
-
-impl CompensationManagement {
-    /// 创建新的服务入口实例。
-    pub fn new(config: Config) -> Self {
-        Self { config }
-    }
-
-    /// 返回共享配置引用。
-    pub fn config(&self) -> &Config {
-        &self.config
-    }
-}

--- a/crates/openlark-hr/src/ehr/mod.rs
+++ b/crates/openlark-hr/src/ehr/mod.rs
@@ -1,28 +1,8 @@
-/// EHR 模块
-///
-/// 按照bizTag/project/version/resource/name.rs模式组织
-use openlark_core::config::Config;
+//! EHR 模块
+//!
+//! 按照bizTag/project/version/resource/name.rs模式组织
 
 /// ehr 项目模块。
 /// ehr 子模块。
 #[allow(clippy::module_inception)]
 pub mod ehr;
-
-/// EHR 服务
-/// Ehr 服务入口。
-#[derive(Debug, Clone)]
-pub struct Ehr {
-    config: Config,
-}
-
-impl Ehr {
-    /// 创建新的服务入口实例。
-    pub fn new(config: Config) -> Self {
-        Self { config }
-    }
-
-    /// 返回共享配置引用。
-    pub fn config(&self) -> &Config {
-        &self.config
-    }
-}

--- a/crates/openlark-hr/src/feishu_people/mod.rs
+++ b/crates/openlark-hr/src/feishu_people/mod.rs
@@ -1,26 +1,6 @@
-/// 飞书人事模块
-///
-/// 按照bizTag/project/version/resource/name.rs模式组织
-use openlark_core::config::Config;
+//! 飞书人事模块
+//!
+//! 按照bizTag/project/version/resource/name.rs模式组织
 
 /// corehr 子模块。
 pub mod corehr;
-
-/// 飞书人事服务
-/// Corehr 服务入口。
-#[derive(Debug, Clone)]
-pub struct Corehr {
-    config: Config,
-}
-
-impl Corehr {
-    /// 创建新的服务入口实例。
-    pub fn new(config: Config) -> Self {
-        Self { config }
-    }
-
-    /// 返回共享配置引用。
-    pub fn config(&self) -> &Config {
-        &self.config
-    }
-}

--- a/crates/openlark-hr/src/hire/mod.rs
+++ b/crates/openlark-hr/src/hire/mod.rs
@@ -1,28 +1,8 @@
-/// 招聘模块
-///
-/// 按照bizTag/project/version/resource/name.rs模式组织
-use openlark_core::config::Config;
+//! 招聘模块
+//!
+//! 按照bizTag/project/version/resource/name.rs模式组织
 
 /// hire 项目模块。
 /// hire 子模块。
 #[allow(clippy::module_inception)]
 pub mod hire;
-
-/// 招聘服务
-/// Hire 服务入口。
-#[derive(Debug, Clone)]
-pub struct Hire {
-    config: Config,
-}
-
-impl Hire {
-    /// 创建新的服务入口实例。
-    pub fn new(config: Config) -> Self {
-        Self { config }
-    }
-
-    /// 返回共享配置引用。
-    pub fn config(&self) -> &Config {
-        &self.config
-    }
-}

--- a/crates/openlark-hr/src/lib.rs
+++ b/crates/openlark-hr/src/lib.rs
@@ -69,42 +69,18 @@ pub mod prelude {
 use openlark_core::config::Config;
 use std::sync::Arc;
 
-/// HRClient：统一入口，提供 project-version-resource 链式访问
+/// HRClient：统一入口。
+///
+/// - `config()` 直达底层 `Config`，用于构造各域 leaf 请求
+///   （attendance/corehr/payroll/performance/compensation/hire/ehr）。
+/// - `okr` 保留 fluent v2 路由（`client.okr.v2()`）。
 #[derive(Debug, Clone)]
 pub struct HrClient {
     config: Arc<Config>,
 
-    #[cfg(feature = "attendance")]
-    /// 考勤入口。
-    pub attendance: attendance::Attendance,
-
-    #[cfg(feature = "corehr")]
-    /// 核心人力入口。
-    pub corehr: feishu_people::Corehr,
-
-    #[cfg(feature = "compensation")]
-    /// 薪酬管理入口。
-    pub compensation: compensation_management::CompensationManagement,
-
-    #[cfg(feature = "payroll")]
-    /// 薪资入口。
-    pub payroll: payroll::Payroll,
-
-    #[cfg(feature = "performance")]
-    /// 绩效入口。
-    pub performance: performance::Performance,
-
     #[cfg(feature = "okr")]
     /// OKR 入口。
     pub okr: okr::Okr,
-
-    #[cfg(feature = "hire")]
-    /// 招聘入口。
-    pub hire: hire::Hire,
-
-    #[cfg(feature = "ehr")]
-    /// 员工档案入口。
-    pub ehr: ehr::Ehr,
 }
 
 impl HrClient {
@@ -112,22 +88,8 @@ impl HrClient {
     pub fn new(config: Config) -> Self {
         let config = Arc::new(config);
         Self {
-            #[cfg(feature = "attendance")]
-            attendance: attendance::Attendance::new((*config).clone()),
-            #[cfg(feature = "corehr")]
-            corehr: feishu_people::Corehr::new((*config).clone()),
-            #[cfg(feature = "compensation")]
-            compensation: compensation_management::CompensationManagement::new((*config).clone()),
-            #[cfg(feature = "payroll")]
-            payroll: payroll::Payroll::new((*config).clone()),
-            #[cfg(feature = "performance")]
-            performance: performance::Performance::new((*config).clone()),
             #[cfg(feature = "okr")]
             okr: okr::Okr::new((*config).clone()),
-            #[cfg(feature = "hire")]
-            hire: hire::Hire::new((*config).clone()),
-            #[cfg(feature = "ehr")]
-            ehr: ehr::Ehr::new((*config).clone()),
             config,
         }
     }
@@ -166,77 +128,11 @@ mod tests {
         assert!(cloned.config().app_id() == "test_app");
     }
 
-    #[cfg(feature = "attendance")]
-    #[test]
-    fn test_hr_client_attendance_field() {
-        let config = create_test_config();
-        let client = HrClient::new(config);
-        assert_eq!(client.attendance.config().app_id(), "test_app");
-    }
-
-    #[cfg(feature = "attendance")]
-    #[test]
-    #[allow(deprecated)]
-    fn test_hr_client_attendance_method() {
-        let config = create_test_config();
-        let client = HrClient::new(config);
-        let attendance = client.attendance.clone();
-        assert_eq!(attendance.config().app_id(), "test_app");
-    }
-
-    #[cfg(feature = "corehr")]
-    #[test]
-    fn test_hr_client_corehr_field() {
-        let config = create_test_config();
-        let client = HrClient::new(config);
-        assert_eq!(client.corehr.config().app_id(), "test_app");
-    }
-
-    #[cfg(feature = "compensation")]
-    #[test]
-    fn test_hr_client_compensation_field() {
-        let config = create_test_config();
-        let client = HrClient::new(config);
-        assert_eq!(client.compensation.config().app_id(), "test_app");
-    }
-
-    #[cfg(feature = "payroll")]
-    #[test]
-    fn test_hr_client_payroll_field() {
-        let config = create_test_config();
-        let client = HrClient::new(config);
-        assert_eq!(client.payroll.config().app_id(), "test_app");
-    }
-
-    #[cfg(feature = "performance")]
-    #[test]
-    fn test_hr_client_performance_field() {
-        let config = create_test_config();
-        let client = HrClient::new(config);
-        assert_eq!(client.performance.config().app_id(), "test_app");
-    }
-
     #[cfg(feature = "okr")]
     #[test]
     fn test_hr_client_okr_field() {
         let config = create_test_config();
         let client = HrClient::new(config);
         assert_eq!(client.okr.config().app_id(), "test_app");
-    }
-
-    #[cfg(feature = "hire")]
-    #[test]
-    fn test_hr_client_hire_field() {
-        let config = create_test_config();
-        let client = HrClient::new(config);
-        assert_eq!(client.hire.config().app_id(), "test_app");
-    }
-
-    #[cfg(feature = "ehr")]
-    #[test]
-    fn test_hr_client_ehr_field() {
-        let config = create_test_config();
-        let client = HrClient::new(config);
-        assert_eq!(client.ehr.config().app_id(), "test_app");
     }
 }

--- a/crates/openlark-hr/src/payroll/mod.rs
+++ b/crates/openlark-hr/src/payroll/mod.rs
@@ -1,28 +1,8 @@
-/// 薪资模块
-///
-/// 按照bizTag/project/version/resource/name.rs模式组织
-use openlark_core::config::Config;
+//! 薪资模块
+//!
+//! 按照bizTag/project/version/resource/name.rs模式组织
 
 /// payroll 项目模块。
 /// payroll 子模块。
 #[allow(clippy::module_inception)]
 pub mod payroll;
-
-/// 薪资服务
-/// Payroll 服务入口。
-#[derive(Debug, Clone)]
-pub struct Payroll {
-    config: Config,
-}
-
-impl Payroll {
-    /// 创建新的服务入口实例。
-    pub fn new(config: Config) -> Self {
-        Self { config }
-    }
-
-    /// 返回共享配置引用。
-    pub fn config(&self) -> &Config {
-        &self.config
-    }
-}

--- a/crates/openlark-hr/src/performance/mod.rs
+++ b/crates/openlark-hr/src/performance/mod.rs
@@ -1,28 +1,8 @@
-/// 绩效模块
-///
-/// 按照bizTag/project/version/resource/name.rs模式组织
-use openlark_core::config::Config;
+//! 绩效模块
+//!
+//! 按照bizTag/project/version/resource/name.rs模式组织
 
 /// performance 项目模块。
 /// performance 子模块。
 #[allow(clippy::module_inception)]
 pub mod performance;
-
-/// 绩效服务
-/// Performance 服务入口。
-#[derive(Debug, Clone)]
-pub struct Performance {
-    config: Config,
-}
-
-impl Performance {
-    /// 创建新的服务入口实例。
-    pub fn new(config: Config) -> Self {
-        Self { config }
-    }
-
-    /// 返回共享配置引用。
-    pub fn config(&self) -> &Config {
-        &self.config
-    }
-}

--- a/docs/hr-testing-guide.md
+++ b/docs/hr-testing-guide.md
@@ -108,48 +108,53 @@ mod create_employee_builder_tests {
 以下展示一个结合 `rstest` 和 `wiremock` 的完整测试示例。
 
 ```rust
+use openlark_core::config::Config;
+use openlark_hr::feishu_people::corehr::v1::employee::batch_get::BatchGetRequest;
 use rstest::*;
-use wiremock::{MockServer, Mock, ResponseTemplate};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 use wiremock::matchers::{method, path};
-use open_lark::prelude::*;
-use open_lark::service::hr::corehr::v1::employee::*;
 
 #[tokio::test]
-async fn test_get_employee_integration() {
+async fn test_batch_get_employee_integration() {
     // 1. 启动 Mock Server
     let mock_server = MockServer::start().await;
-    
-    // 2. 配置预期行为
+
+    // 2. 配置预期行为：POST /open-apis/corehr/v1/employees/batch_get
     let response_body = serde_json::json!({
         "code": 0,
         "msg": "success",
         "data": {
-            "employee": {
+            "items": [{
                 "employee_id": "emp_123",
                 "name": "Test User"
-            }
+            }]
         }
     });
-    
-    Mock::given(method("GET"))
-        .and(path("/open-apis/corehr/v1/employees/emp_123"))
+
+    Mock::given(method("POST"))
+        .and(path("/open-apis/corehr/v1/employees/batch_get"))
         .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
         .mount(&mock_server)
         .await;
 
-    // 3. 构造 Client 并执行
+    // 3. 构造 HrClient 并执行
+    //    HR 域 config-holder facade 已删（#474）：直达 Config 构造 leaf 请求
     let config = Config::builder()
         .app_id("id")
         .app_secret("secret")
         .base_url(mock_server.uri())
         .build();
-    let client = Client::with_core_config(config).unwrap();
-    
-    let resp = client.hr.corehr.v1().employee().get("emp_123").execute().await.unwrap();
-    
+    let client = openlark_hr::HrClient::new(config);
+
+    let resp = BatchGetRequest::new(client.config().clone())
+        .employee_ids(vec!["emp_123".to_string()])
+        .execute()
+        .await
+        .unwrap();
+
     // 4. 断言结果
-    assert_eq!(resp.employee.employee_id, "emp_123");
-    assert_eq!(resp.employee.name, "Test User");
+    assert_eq!(resp.items[0].employee_id, "emp_123");
+    assert_eq!(resp.items[0].name, "Test User");
 }
 
 #[rstest]


### PR DESCRIPTION
Closes #474.

## 改动

删除 HR crate 7 个纯 config-holder facade（ADR-0001 五项判据全 0 命中）：

`Hire` / `Attendance` / `Corehr` / `Payroll` / `Performance` / `CompensationManagement` / `Ehr`（仅 `new()` + `config()`）。保留 `Okr`（有 `v2()` 真路由 = 判据 #2）。

- 删 7 struct（各自 `mod.rs`，`///`→`//!` 避免 clippy `empty_line_after_doc_comment`）
- `HrClient` 删 7 pub 字段 + 7 次 `config.clone()` + 8 个 getter 赋值测试
- HR 全域统一 config-direct 直路径：`client.hr.config()` 构造 leaf

## 迁移（breaking — 目标 0.19）

`client.hr.attendance` / `.corehr` / `.hire` / ... 字段访问 → `client.hr.config()` 直达 `Config` 构造 leaf 请求（lib.rs 文档的 canonical 写法）。`client.hr.okr.v2()` 不受影响。

附带更新：`hr_feature_contract` 测试改名 `exposes_config_entry` + 断言 `client.hr.config()`；`catalog.rs` facade doc 更新；`docs/hr-testing-guide.md` 旧 `client.hr.corehr.v1().employee().get()` fluent 谎言改为真实 `BatchGetRequest` 直路径（镜像 batch_get e2e 测试）；CHANGELOG 入 Breaking-0.19。

## 验证

- `cargo fmt --check` ✓
- `cargo build --workspace --all-features` ✓
- `cargo clippy --all-features -- -Dwarnings` ✓
- `cargo clippy --no-default-features -- -Dwarnings` ✓
- `cargo test --workspace --all-features`（全绿）✓
- `cargo doc --all-features -- -Dwarnings`（无 intra-doc 死链）✓
- `cargo machete`（无 unused deps）✓

先例：ADR-0001 docs crate 砍 5 config-holder 子客户端（#365）；HR 不在原 ADR scope，本次把同判据延伸到 HR。