### PR TITLE
refactor(security): drop zero-consumer risk-assessment apparatus

### DIFF
--- a/.github/msrv/Cargo.lock
+++ b/.github/msrv/Cargo.lock
@@ -1833,7 +1833,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-test",
- "uuid",
  "wiremock",
 ]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,16 +51,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 先例为 ADR-0001 docs crate 砍 5 个 config-holder 子客户端（#365）；HR 不在原
     ADR scope，本次把同判据延伸到 HR。
 
-### Changed
+- **security：删除零消费者的风险评估装置（OpenSpec `2026-07-22-drop-security-risk-apparatus`）**：
+  `SecurityErrorExt` / `SecurityEvent` / `SecurityErrorAnalyzer` +
+  `analyze_security_risk` / `SecurityRiskAssessment` / `SecurityRiskLevel` /
+  `SecurityRiskType` / `SecurityAction` / `ComplianceImpact` 全仓零生产调用者
+  （仅 `error.rs` 自身测试使用），且不在 `lib.rs` / `prelude` re-export、无文档/示例
+  指向。OpenLark 是库、无内建 telemetry/escalation sink，风险评估的唯一可能消费者是
+  下游应用——零下游需求；保留即维护一条通往虚无的 hypothetical seam。整块删除。
+  - **例外跳过废弃周期**（`PUBLIC_API_STABILITY_POLICY` line 141）：零消费者 + 非主推面
+    → 废弃周期无对象可警告；先例 ADR-0001（v0.18 砍 pub 导航壳 + 迁移表）。连带移除
+    `uuid` 依赖（仅 `SecurityEvent` 使用）。
+  - **迁移**：以上类型从未在 prelude/示例主推；使用 `openlark_security::error::*` 中这些
+    类型的代码需移除。`SecurityError` 别名 / `SecurityResult` / `SecurityClient` / ACS
+    与安全合规叶子路径不受影响。
+  - **注**：#477/#480 新增的 `SecurityRiskClassify` trait 同属 unreleased 且一并删除，
+    对 0.19 消费者净零（从未发布）；原 `### Changed` 新增条目已随之移除。
 
-- **security：`CoreError` 风险分类收口到 extension trait（#477, #480）**：
-  新增 `SecurityRiskClassify for CoreError`（`fn security_risk_level(&self) ->
-  SecurityRiskLevel`），成为「error kind → `SecurityRiskLevel`」的唯一来源，覆盖
-  全部 12 个 variant（+ `#[non_exhaustive]` 兜底）并配单测（含关键 `Api` code 组合）。
-  `SecurityErrorAnalyzer::analyze_security_risk` 不再自己 match `CoreError` variant
-  做分级，改调 `err.security_risk_level()`；policy（风险类型归类、升级判定）保留——
-  升级口径仍是 Business/Internal，行为未变。非破坏、additive；为 #472 后续让
-  workflow/client 复用同一分类铺路。
+### Changed
 
 - **hr：域无关 HR 原语提升到 crate root（#473）**：
   `I18nText` / `FlexibleText` / `IdNameObject` / `CodeNameObject` /

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1833,7 +1833,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-test",
- "uuid",
  "wiremock",
 ]
 

--- a/crates/openlark-security/Cargo.toml
+++ b/crates/openlark-security/Cargo.toml
@@ -52,9 +52,6 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
 
-# 工具依赖
-uuid = { workspace = true }
-
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/crates/openlark-security/src/error.rs
+++ b/crates/openlark-security/src/error.rs
@@ -4,11 +4,10 @@
 //! 直接集成统一错误体系，提供类型安全和可观测性
 
 use openlark_core::error::{
-    CoreError, ErrorCode, ErrorContext, ErrorTrait, authentication_error, business_error,
-    configuration_error, network_error_with_details, permission_missing_error, rate_limit_error,
-    token_expired_error, validation_error,
+    CoreError, ErrorCode, ErrorContext, authentication_error, business_error, configuration_error,
+    network_error_with_details, permission_missing_error, rate_limit_error, token_expired_error,
+    validation_error,
 };
-use serde::Serialize;
 use std::time::Duration;
 
 // 导入内部结构体
@@ -341,279 +340,28 @@ pub fn map_feishu_security_error(
     }
 }
 
-/// 安全错误扩展特征
-pub trait SecurityErrorExt {
-    /// 检查是否为设备相关错误
-    fn is_device_error(&self) -> bool;
-
-    /// 检查是否为权限相关错误
-    fn is_permission_error(&self) -> bool;
-
-    /// 检查是否为合规相关错误
-    fn is_compliance_error(&self) -> bool;
-
-    /// 检查是否为认证相关错误
-    fn is_authentication_error(&self) -> bool;
-
-    /// 获取安全操作类型
-    fn security_operation(&self) -> Option<&str>;
-
-    /// 获取受影响的资源ID
-    fn affected_resource_id(&self) -> Option<&str>;
-
-    /// 生成安全事件报告
-    fn to_security_event(&self) -> SecurityEvent;
-}
-
-impl SecurityErrorExt for SecurityError {
-    fn is_device_error(&self) -> bool {
-        self.context().get_context("device_id").is_some()
-    }
-
-    fn is_permission_error(&self) -> bool {
-        matches!(
-            self,
-            CoreError::Authentication {
-                code: ErrorCode::PermissionMissing,
-                ..
-            }
-        )
-    }
-
-    fn is_compliance_error(&self) -> bool {
-        self.context().get_context("compliance_type").is_some()
-    }
-
-    fn is_authentication_error(&self) -> bool {
-        matches!(self, CoreError::Authentication { .. })
-    }
-
-    fn security_operation(&self) -> Option<&str> {
-        match self.context().get_context("operation") {
-            Some(s) => Some(s),
-            None => None,
-        }
-    }
-
-    fn affected_resource_id(&self) -> Option<&str> {
-        match self
-            .context()
-            .get_context("device_id")
-            .or_else(|| self.context().get_context("visitor_id"))
-        {
-            Some(s) => Some(s),
-            None => None,
-        }
-    }
-
-    fn to_security_event(&self) -> SecurityEvent {
-        SecurityEvent {
-            event_id: uuid::Uuid::new_v4().to_string(),
-            timestamp: chrono::Utc::now(),
-            event_type: "security_error".to_string(),
-            severity: "medium".to_string(),
-            operation: self.security_operation().unwrap_or("unknown").to_string(),
-            resource_id: self.affected_resource_id().map(|s| s.to_string()),
-            error_code: ErrorCode::InternalError,
-            message: "安全错误".to_string(),
-            context: serde_json::json!({}),
-        }
-    }
-}
-
-/// 安全事件记录
-#[derive(Debug, Clone, Serialize)]
-pub struct SecurityEvent {
-    /// 事件唯一标识符
-    pub event_id: String,
-    /// 事件发生时间戳
-    pub timestamp: chrono::DateTime<chrono::Utc>,
-    /// 事件类型
-    pub event_type: String,
-    /// 事件严重程度
-    pub severity: String,
-    /// 执行的操作类型
-    pub operation: String,
-    /// 受影响的资源ID（可选）
-    pub resource_id: Option<String>,
-    /// 错误代码
-    pub error_code: ErrorCode,
-    /// 事件描述消息
-    pub message: String,
-    /// 事件上下文信息
-    pub context: serde_json::Value,
-}
-
-/// 安全错误分析器
-#[derive(Debug, Clone, Copy)]
-pub struct SecurityErrorAnalyzer;
-
-impl SecurityErrorAnalyzer {
-    /// 分析安全错误的潜在风险
-    ///
-    /// 风险等级（`CoreError` variant → `SecurityRiskLevel`）已委托给
-    /// `SecurityRiskClassify` trait 的唯一来源；本函数只保留「拿到等级后做什么」
-    /// 的 policy：风险类型归类、是否升级、采取什么行动——不再自己 match
-    /// `CoreError` variant 做分级。
-    pub fn analyze_security_risk(error: &SecurityError) -> SecurityRiskAssessment {
-        let risk_level = error.security_risk_level();
-
-        let risk_type = if error.is_permission_error() {
-            SecurityRiskType::AccessControl
-        } else if error.is_compliance_error() {
-            SecurityRiskType::Compliance
-        } else if error.is_device_error() {
-            SecurityRiskType::DeviceSecurity
-        } else {
-            SecurityRiskType::General
-        };
-
-        SecurityRiskAssessment {
-            risk_level,
-            risk_type,
-            immediate_action: SecurityAction::LogAndMonitor,
-            // 升级策略沿用既有口径：仅 Business/Internal 升级为可处置事件。
-            // 注意权限缺失虽归 High，但原策略把它当作「仅监控」的访问控制事件、
-            // 不升级——本重构只收口分级（走 trait），不改这条 policy。
-            escalation_required: matches!(
-                error,
-                CoreError::Business { .. } | CoreError::Internal { .. }
-            ),
-            compliance_impact: ComplianceImpact::Low,
-        }
-    }
-}
-
-/// 安全风险评估
-#[derive(Debug, Clone, Copy, Serialize)]
-pub struct SecurityRiskAssessment {
-    /// 风险级别
-    pub risk_level: SecurityRiskLevel,
-    /// 风险类型
-    pub risk_type: SecurityRiskType,
-    /// 建议的立即行动
-    pub immediate_action: SecurityAction,
-    /// 是否需要升级处理
-    pub escalation_required: bool,
-    /// 合规性影响
-    pub compliance_impact: ComplianceImpact,
-}
-
-/// 安全风险级别
-#[derive(Debug, Clone, Copy, Serialize)]
-pub enum SecurityRiskLevel {
-    /// 低风险
-    Low,
-    /// 中等风险
-    Medium,
-    /// 高风险
-    High,
-    /// 严重风险
-    Critical,
-}
-
-/// 安全风险分类 extension trait（#472 / #477）。
-///
-/// 把「`CoreError` variant → `SecurityRiskLevel`」的分类表收敛为唯一来源：
-/// core 可以自由演化 variant，分类逻辑只在这一处 match。依赖方向正确——
-/// security 依赖 core，core 不依赖业务风险概念。
-///
-/// `CoreError` 标了 `#[non_exhaustive]`，外部 match 必须有 `_` 兜底；
-/// 这里对每个已知 variant 显式分类，`_` 只给未来新 variant 一个保守默认，
-/// 以便新增 variant 时维护者能在此处看到并补上分类。
-pub trait SecurityRiskClassify {
-    /// 按错误 kind 判定安全风险等级
-    fn security_risk_level(&self) -> SecurityRiskLevel;
-}
-
-impl SecurityRiskClassify for CoreError {
-    fn security_risk_level(&self) -> SecurityRiskLevel {
-        match self {
-            // 权限缺失：潜在越权访问，高风险（复用 SecurityErrorExt::is_permission_error，
-            // 避免与 is_permission_error 重复 PermissionMissing 判定）
-            CoreError::Authentication { .. } if self.is_permission_error() => {
-                SecurityRiskLevel::High
-            }
-            // 业务/合规违例：可审计的严重事件
-            CoreError::Business { .. } => SecurityRiskLevel::Critical,
-            // 内部错误：可能暴露系统状态或被利用，高风险
-            CoreError::Internal { .. } => SecurityRiskLevel::High,
-            // 输入校验失败：可能是探测/注入尝试，中风险
-            CoreError::Validation { .. } => SecurityRiskLevel::Medium,
-            // 非权限类的认证错误（token 失效等）：当前归类为 Low
-            CoreError::Authentication { .. } => SecurityRiskLevel::Low,
-            // 运维/基础设施类错误：不构成安全或合规风险
-            CoreError::Network(_)
-            | CoreError::Api(_)
-            | CoreError::Configuration { .. }
-            | CoreError::Serialization { .. }
-            | CoreError::Timeout { .. }
-            | CoreError::RateLimit { .. }
-            | CoreError::ServiceUnavailable { .. }
-            | CoreError::ResponseTooLarge { .. } => SecurityRiskLevel::Low,
-            // CoreError 标 #[non_exhaustive]：未来新增 variant 的保守默认，
-            // 新增 variant 时维护者应在此显式补分类。
-            _ => SecurityRiskLevel::Low,
-        }
-    }
-}
-
-/// 安全风险类型
-#[derive(Debug, Clone, Copy, Serialize)]
-pub enum SecurityRiskType {
-    /// 访问控制风险
-    AccessControl,
-    /// 身份认证风险
-    Authentication,
-    /// 设备安全风险
-    DeviceSecurity,
-    /// 合规性风险
-    Compliance,
-    /// 一般安全风险
-    General,
-}
-
-/// 安全行动建议
-#[derive(Debug, Clone, Copy, Serialize)]
-pub enum SecurityAction {
-    /// 撤销访问权限
-    RevokeAccess,
-    /// 启动调查程序
-    InitiateInvestigation,
-    /// 激活备份系统
-    ActivateBackup,
-    /// 记录并监控
-    LogAndMonitor,
-    /// 阻止请求
-    BlockRequest,
-}
-
-/// 合规性影响级别
-#[derive(Debug, Clone, Copy, Serialize)]
-pub enum ComplianceImpact {
-    /// 低影响
-    Low,
-    /// 中等影响
-    Medium,
-    /// 高影响
-    High,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlark_core::error::ErrorTrait;
 
     #[test]
     fn test_security_error_creation() {
         let error = SecurityErrorBuilder::device_not_found("device_123");
-        assert!(error.is_validation_error());
-        assert!(error.is_device_error());
+        assert!(matches!(error, CoreError::Validation { .. }));
+        assert!(error.context().get_context("device_id").is_some());
     }
 
     #[test]
     fn test_permission_error() {
         let error = SecurityErrorBuilder::access_denied("admin_panel", "insufficient_role");
-        assert!(error.is_permission_error());
+        assert!(matches!(
+            error,
+            CoreError::Authentication {
+                code: ErrorCode::PermissionMissing,
+                ..
+            }
+        ));
     }
 
     #[test]
@@ -623,150 +371,19 @@ mod tests {
             "data_retention_violation",
             Some("data_set_456"),
         );
-        assert!(error.is_compliance_error());
-    }
-
-    #[test]
-    fn test_security_event_generation() {
-        let error = SecurityErrorBuilder::device_not_found("device_123");
-        let event = error.to_security_event();
-        assert_eq!(event.message, "安全错误");
+        assert!(matches!(error, CoreError::Business { .. }));
+        assert!(error.context().get_context("compliance_type").is_some());
     }
 
     #[test]
     fn test_feishu_error_mapping() {
         let error = map_feishu_security_error(99991672, "权限不足", Some("req_123"));
-        assert!(error.is_permission_error());
-    }
-
-    #[test]
-    fn test_security_risk_assessment() {
-        let error = SecurityErrorBuilder::access_denied("secure_area", "no_clearance");
-        let assessment = SecurityErrorAnalyzer::analyze_security_risk(&error);
-        assert!(matches!(assessment.risk_level, SecurityRiskLevel::High));
-    }
-
-    #[test]
-    fn analyze_security_risk_preserves_escalation_policy() {
-        // 分级走 trait（security_risk_level），但升级策略保留既有口径：
-        // 仅 Business/Internal 升级为可处置事件。权限缺失虽归 High，
-        // 仍按原策略只监控、不升级（本重构不改 policy）。
-        let business = SecurityErrorAnalyzer::analyze_security_risk(&business_error("合规违例"));
-        assert!(matches!(business.risk_level, SecurityRiskLevel::Critical));
-        assert!(business.escalation_required);
-
-        let internal = SecurityErrorAnalyzer::analyze_security_risk(
-            &SecurityErrorBuilder::audit_log_failed("access_log", "disk full"),
-        );
-        assert!(matches!(internal.risk_level, SecurityRiskLevel::High));
-        assert!(internal.escalation_required);
-
-        let permission =
-            SecurityErrorAnalyzer::analyze_security_risk(&permission_missing_error(&["x"]));
-        assert!(matches!(permission.risk_level, SecurityRiskLevel::High));
-        assert!(
-            !permission.escalation_required,
-            "权限缺失按原策略不升级（仅监控）"
-        );
-
-        let network = SecurityErrorAnalyzer::analyze_security_risk(&network_error_with_details(
-            "net", None, None,
-        ));
-        assert!(matches!(network.risk_level, SecurityRiskLevel::Low));
-        assert!(!network.escalation_required);
-    }
-
-    // ===== #477: SecurityRiskClassify for CoreError 分类表 =====
-    // 分类表 = variant → SecurityRiskLevel 的唯一来源（trait impl）。
-    // 这里只断言外部行为（每个 variant → 预期等级），不耦合 impl 的 match 结构。
-
-    #[test]
-    fn security_risk_level_business_is_critical() {
-        let err = business_error("合规检查失败");
         assert!(matches!(
-            err.security_risk_level(),
-            SecurityRiskLevel::Critical
+            error,
+            CoreError::Authentication {
+                code: ErrorCode::PermissionMissing,
+                ..
+            }
         ));
-    }
-
-    #[test]
-    fn security_risk_level_permission_denied_is_high() {
-        let err = permission_missing_error(&["security:access"]);
-        assert!(matches!(err.security_risk_level(), SecurityRiskLevel::High));
-    }
-
-    #[test]
-    fn security_risk_level_internal_is_high() {
-        let err = SecurityErrorBuilder::audit_log_failed("access_log", "disk full");
-        assert!(matches!(err.security_risk_level(), SecurityRiskLevel::High));
-    }
-
-    #[test]
-    fn security_risk_level_validation_is_medium() {
-        let err = validation_error("device_id", "设备未找到");
-        assert!(matches!(
-            err.security_risk_level(),
-            SecurityRiskLevel::Medium
-        ));
-    }
-
-    #[test]
-    fn security_risk_level_non_permission_auth_is_low() {
-        // 认证失败但非权限缺失（如 token 无效）→ Low
-        let err = authentication_error("token invalid");
-        assert!(matches!(err.security_risk_level(), SecurityRiskLevel::Low));
-    }
-
-    #[test]
-    fn security_risk_level_operational_variants_are_low() {
-        // 运维/基础设施类错误，不构成安全或合规风险 → Low
-        let cases: [CoreError; 7] = [
-            network_error_with_details("net", None, None),
-            configuration_error("cfg"),
-            CoreError::Serialization {
-                message: "s".into(),
-                source: None,
-                code: ErrorCode::SerializationError,
-                ctx: Box::new(ErrorContext::new()),
-            },
-            SecurityErrorBuilder::security_check_timeout("check", Duration::from_secs(1)),
-            rate_limit_error(10, Duration::from_secs(60), None),
-            SecurityErrorBuilder::device_temporarily_unavailable("dev", None),
-            CoreError::ResponseTooLarge {
-                limit: 1024,
-                actual: 2048,
-                ctx: Box::new(ErrorContext::new()),
-            },
-        ];
-        for err in cases {
-            assert!(
-                matches!(err.security_risk_level(), SecurityRiskLevel::Low),
-                "expected Low for {err:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn security_risk_level_api_is_low_regardless_of_code() {
-        // Api 错误目前不按 ApiError.code 细分，统一 Low（忠实于既有分类）。
-        // 未来若要让 403/401 类 Api 升级为 High，只改这一处 impl 即可。
-        for api_code in [
-            ErrorCode::PermissionMissing,
-            ErrorCode::InternalError,
-            ErrorCode::TooManyRequests,
-        ] {
-            let err = CoreError::Api(Box::new(ApiError {
-                status: 500,
-                endpoint: "security".into(),
-                message: "m".into(),
-                source: None,
-                code: api_code,
-                ctx: Box::new(ErrorContext::new()),
-            }));
-            assert!(
-                matches!(err.security_risk_level(), SecurityRiskLevel::Low),
-                "Api({api_code:?}) expected Low"
-            );
-        }
     }
 }

--- a/openspec/changes/archive/2026-07-22-drop-security-risk-apparatus/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-22-drop-security-risk-apparatus/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/archive/2026-07-22-drop-security-risk-apparatus/design.md
+++ b/openspec/changes/archive/2026-07-22-drop-security-risk-apparatus/design.md
@@ -1,0 +1,82 @@
+## Context
+
+`openlark-security/src/error.rs`（772 行）有两类公开面：
+
+```
+error.rs
+├── 活面（保留）
+│   ├── SecurityError = CoreError（别名，lib.rs re-export）
+│   ├── SecurityResult<T>
+│   ├── SecurityErrorBuilder（domain 味构造器；另案 #500）
+│   └── map_feishu_security_error（飞书码映射；另案 #500）
+└── 死装置 344–600（删除）
+    ├── SecurityErrorExt trait + impl（谓词 + 事件方法）
+    ├── SecurityEvent
+    ├── SecurityErrorAnalyzer + analyze_security_risk
+    ├── SecurityRiskAssessment / SecurityRiskLevel / SecurityRiskType
+    ├── SecurityRiskClassify trait + CoreError impl
+    └── SecurityAction / ComplianceImpact
+```
+
+全仓 grep 实证：死装置 9 个类型 + trait 的全部符号，排除定义文件与 `target/` 后 **0 命中**。它们不在 `lib.rs` / `prelude` re-export（仅 `SecurityError` 别名 + `SecurityResult` 被 re-export），无文档/示例指向。security API 叶子经 `Transport::request_typed → Response::decode → CoreError` 构造错误，根本不走这套装置。
+
+`SecurityRiskClassify` trait（#472 / #477）把 `CoreError → SecurityRiskLevel` 分类表收口到一处，依赖方向正确；但风险评估功能 0 消费者——它是 hypothetical seam（1 adapter `CoreError`、0 调用者）。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 删除零消费者的风险分类装置（9 类型 + trait + 10 装置测试）
+- 改写 4 个 builder/mapper 测试，去掉对 `SecurityErrorExt` 谓词的依赖
+- 连带清理：移 `uuid` 依赖、删无用 `use serde::Serialize`
+- 保持真实 API（ACS / 安全合规叶子、`SecurityClient`、`SecurityError` 别名）路径与行为完全不变
+
+**Non-Goals:**
+- 不动 `SecurityErrorBuilder` / `map_feishu_security_error`（同源死代码，另案 #500；本 change 保持手术式范围）
+- 不重构 `error.rs` 其余活面
+- 不引入风险评估的替代实现（无消费者，YAGNI）
+
+## Decisions
+
+### Decision 1: 删除而非保留/接线
+
+**决策**：删整块装置。
+
+**为什么**：0 消费者 + 无 sink（库天然无）+ trait 解的是无人用之题。保留即维护一条通往虚无的 seam。"留并接真实消费者"需凭空发明一个今天不存在的消费者——投机性造功能，非深化。CLAUDE.md §3 + ADR-0001 理由 5 均拒绝「为未来预留是猜未来」。
+
+**备选**：保留 trait 仅作分类表（variant→level 单一来源）→ 否决（一张没人消费的分类表还是死代码；真有消费者时 10 行即可加回）。
+
+### Decision 2: 整块删 344–600（含 SecurityErrorExt），非部分切
+
+**决策**：从 `SecurityErrorExt` 到 `ComplianceImpact` 整块删（344–600），不保留谓词。
+
+**为什么**：谓词 `is_device_error / is_permission_error / is_compliance_error` 唯一非测试调用者就是 `analyze_security_risk`（随删）；事件方法 `to_security_event / security_operation / affected_resource_id` 只喂死的 `SecurityEvent`。整块是内聚死单元，deletion test 干净（删后复杂度不回归）。
+
+**注意（test 耦合）**：4 个 builder/mapper 测试经 `is_*_error()` 谓词依赖 `SecurityErrorExt`——删 Ext 会编译断裂。处置见 Decision 3。
+
+### Decision 3: 4 个断裂测试改写为直接断 CoreError variant
+
+**决策**：`test_security_error_creation` / `test_permission_error` / `test_compliance_error` / `test_feishu_error_mapping` 的断言从 `err.is_permission_error()` 等改为直接断 variant（如 `matches!(err, CoreError::Authentication { code: ErrorCode::PermissionMissing, .. })`），保留对 `SecurityErrorBuilder` / `map_feishu_security_error` 的覆盖。
+
+**为什么**：与"构造器另案、本次不动"立场一致；改写后测得更实（直接验 variant 而非谓词包装）。
+
+**备选**：连测试带构造器一起删 → 否决（扩大范围成"清空 error.rs 大半"，Kitchen Sink 风险 CLAUDE.md §10；构造器死活留作 #500）。
+
+### Decision 4: 落地走方案 B——breaking、0.19.0 硬删、例外跳过废弃周期
+
+**决策**：判 breaking（policy line 115「删除公开类型」），进 0.19.0 窗口硬删，不挂 `#[deprecated]`；CHANGELOG 迁移表 + 例外理由（policy line 141）。
+
+**为什么**：给零使用量类型挂 `#[deprecated`] 是纯表演（警告不到任何人），且项目刚于 2026-06-29 把全仓 `#[deprecated]` 清零，转头再挂是反讽。例外理由：零消费者 + 不在 prelude/文档/示例 + 从未主推 → 废弃周期无对象可警告。与 ADR-0001 先例一致（v0.18 窗口硬删 pub 导航壳 + CHANGELOG 迁移表）。
+
+**备选 A**（当作非稳定实验面现在硬删，套 policy line 26）→ 否决（钻漏洞；cargo-semver-checks / 严格审计仍判 breaking）。
+**备选 C**（先 `#[deprecated]` 再删）→ 否决（见上，表演 + 反讽）。
+
+### Decision 5: 连带清理 uuid + Serialize，chrono 留
+
+**决策**：移 `uuid`（仅 `SecurityEvent` 用）、删 `use serde::Serialize`（装置删除后无用）；`chrono` 保留（`openapi_logs/list_data.rs:53/59` 活叶子使用）。同步 `.github/msrv/Cargo.lock`（删依赖触发 msrv `--locked`）。
+
+## Risks / Trade-offs
+
+- **[BREAKING 公开 API]** 移除 9 个公开类型 + 1 trait → **缓解**：全仓 grep 实证零跨 crate 引用、零外部消费；不在 prelude/re-export/文档主推面；v0.19.0 breaking 窗口；CHANGELOG 迁移表 + 例外理由
+- **[4 测试编译断裂]** 删 `SecurityErrorExt` 谓词致 builder 测试断裂 → **缓解**：同 change 内改写为直接断 variant；`cargo test -p openlark-security` 验证
+- **[uuid 移除致 msrv --locked 失败]** 删依赖改 Cargo.lock → **缓解**：同步 `.github/msrv/Cargo.lock`（memory: 删/改依赖的 change 须同步 msrv pinned lockfile）；`cargo machete` 验 uuid 已无引用
+- **[误删活面]** 装置边界 344–600 紧邻活面 `map_feishu_security_error`（~299–342）→ **缓解**：cut 点在 343/344 空行处，清晰；`cargo build -p openlark-security --all-features` 验活面可达

--- a/openspec/changes/archive/2026-07-22-drop-security-risk-apparatus/proposal.md
+++ b/openspec/changes/archive/2026-07-22-drop-security-risk-apparatus/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+`openlark-security/src/error.rs:344–600` 的整套安全风险分类装置——`SecurityRiskClassify` trait（+ `CoreError` impl）、`SecurityErrorAnalyzer::analyze_security_risk`、`SecurityRiskAssessment`、`SecurityRiskLevel` / `SecurityRiskType` / `SecurityAction` / `ComplianceImpact`、`SecurityEvent`、以及 `SecurityErrorExt` 的事件/谓词方法——经全仓 grep 实证 **零生产调用者**：排除定义文件与 `target/` 后，`SecurityRiskClassify` / `analyze_security_risk` / `SecurityRiskAssessment` / `SecurityRiskLevel` / `SecurityRiskType` / `SecurityAction` / `ComplianceImpact` / `SecurityErrorAnalyzer` / `SecurityEvent` / `to_security_event` / `security_risk_level` 均无任何 crate / example / 其它 security 子模块引用，仅 `error.rs` 自身的测试使用。
+
+根因：OpenLark 是**库**（AGENTS.md 明示「不是长驻服务」），无内建 telemetry / escalation / metrics sink（grep `telemetry|escalat|audit|metrics_sink` 命中的 `platform/.../audit_log/` 是飞书审计日志 API 端点，非 SDK 自身风险评估的消费者）。风险评估装置的唯一可能消费者是**下游应用代码**，而它显示了零需求。
+
+`SecurityRiskClassify`（#472 / #477）本身理由成立——把 `CoreError → SecurityRiskLevel` 分类表收口到一处 match、依赖方向正确（security 依赖 core）。但它服务于一个**无消费者的功能**：一条修得很好的、通往虚无的 seam。保留它即持续付出维护与认知税（CLAUDE.md §3「为未来版本预留是猜未来，通常错」；ADR-0001 理由 5 同此口径）。v0.19.0 breaking 窗口将至，是删除时机。
+
+## What Changes
+
+- 删除 `error.rs:344–600` 的 9 个类型 + trait：`SecurityErrorExt`（trait + `SecurityError` impl）、`SecurityEvent`、`SecurityErrorAnalyzer` + `analyze_security_risk`、`SecurityRiskAssessment`、`SecurityRiskLevel`、`SecurityRiskClassify`（trait + `CoreError` impl）、`SecurityRiskType`、`SecurityAction`、`ComplianceImpact`
+- 删除 10 个仅测装置的测试（`test_security_event_generation` / `test_security_risk_assessment` / `analyze_security_risk_preserves_escalation_policy` / 7 个 `security_risk_level_*`）
+- 改写 4 个 builder/mapper 测试（`test_security_error_creation` / `test_permission_error` / `test_compliance_error` / `test_feishu_error_mapping`）：断言从 `is_*_error()`（`SecurityErrorExt` 谓词，将删）改为直接断 `CoreError` variant
+- 移除 `uuid` 依赖（仅 `SecurityEvent` 使用）+ 删变成无用的 `use serde::Serialize`
+- **BREAKING**：移除上述公开类型（`pub mod error` 内 `pub` 项，零外部引用）；走例外跳过废弃周期
+- 保留 `SecurityError = CoreError` 别名、`SecurityResult`、`SecurityErrorBuilder`、`map_feishu_security_error`、core 错误 helper re-export（叶子经 `Transport::request_typed → decode → CoreError` 构造错误，不走 `SecurityErrorBuilder`）
+
+## Capabilities
+
+### New Capabilities
+（无）
+
+### Modified Capabilities
+- `dead-code-lint-hygiene`：新增 requirement。现有 requirement 治理 `#[allow(dead_code)]` 抑制的可修复死字段；本 requirement 扩到另一类死代码——**零消费者 pub 分析/扩展面**（trait + analyzer + assessment 等装置，不被 lint 抑制、正常编译，但 0 生产调用者、不在 prelude/re-export/文档主推面）。此类面 SHALL 删除或接真实消费者（≥2 adapter），不得作为 hypothetical seam 长期保留。security 风险装置是其首个实例。
+
+## Impact
+
+- **crates/openlark-security**（改动集中于此，不跨 crate）：
+  - `src/error.rs`：删 344–600 装置 + 10 测试、改写 4 测试、删 `use serde::Serialize`
+  - `Cargo.toml`：移除 `uuid` 依赖
+- **公开 API（v0.19.0 breaking）**：移除 9 个公开类型 + 1 个 trait（零外部引用，删除无外部消费方成本）
+- **真实 API 路径**：不受影响——ACS / 安全合规叶子经 `Transport::request_typed` 调用，`SecurityClient` / `SecurityError` 别名 / `SecurityResult` 删除前后均可达且行为不变
+- **依赖**：移除 `uuid`；`chrono` 保留（`openapi_logs/list_data.rs` 活叶子使用）；无新增
+- **后续**：`SecurityErrorBuilder` + `map_feishu_security_error` 同为零消费者测试专属死代码，另案 #500 跟进（本 change 不扩大范围）

--- a/openspec/changes/archive/2026-07-22-drop-security-risk-apparatus/specs/dead-code-lint-hygiene/spec.md
+++ b/openspec/changes/archive/2026-07-22-drop-security-risk-apparatus/specs/dead-code-lint-hygiene/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: 零消费者 pub 分析/扩展面 SHALL 删除或接真实消费者
+
+openlark 公开模块中的分析/扩展装置（trait + analyzer + assessment / 事件类型等，如 `SecurityRiskClassify` + `analyze_security_risk` + `SecurityRiskAssessment`）若同时满足：(a) 全仓 grep 排除定义文件与 `target/` 后 **0 生产调用者**、(b) **不在** `lib.rs` / `prelude` re-export、文档示例或主推调用路径，SHALL **删除**，或接到真实消费者（≥2 adapter）使 seam 成立；不得作为 hypothetical seam（1 adapter、0 caller）长期保留。OpenLark 是库（非长驻服务），无内建 telemetry / escalation / metrics sink，分析装置的唯一可能消费者是下游应用——零下游需求时维护该面是认知税与维护负担。本 requirement 扩展 `dead-code-lint-hygiene` 的治理范围：从「不用 `#[allow(dead_code)]` 抑制可修复死字段」延伸到「不保留零消费者 pub 分析面」（后者不被 lint 抑制、正常编译，但同样是死代码）。`openlark-security` 的风险分类装置（`error.rs:344–600`）是其首个实例。
+
+#### Scenario: security 风险分类装置移除
+
+- **WHEN** 变更后在 `crates/openlark-security/src/` 中 grep `SecurityRiskClassify|analyze_security_risk|SecurityRiskAssessment|SecurityRiskLevel|SecurityRiskType|SecurityAction|ComplianceImpact|SecurityErrorAnalyzer|SecurityEvent|to_security_event|security_risk_level`
+- **THEN** 命中数为 0（9 类型 + trait + Ext 事件方法定义全删）
+
+#### Scenario: 全仓无装置符号外部引用
+
+- **WHEN** 变更后在仓库中 grep 同组符号（排除 `target/`）
+- **THEN** 命中数为 0（删除前已实证零外部引用，删除后亦无残留）
+
+#### Scenario: uuid 依赖随装置移除
+
+- **WHEN** 变更后检查 `crates/openlark-security/Cargo.toml`
+- **THEN** 不含 `uuid`（`SecurityEvent` 是其唯一消费者）；`cargo machete` 不报 unused dep
+
+#### Scenario: 活面与真实 API 路径不受影响
+
+- **WHEN** 变更后构造 `SecurityClient::new(config)` 并调用 ACS / 安全合规叶子（如 `client.acs.v1().users().list()`）
+- **THEN** 编译通过、行为不变；`SecurityError = CoreError` 别名、`SecurityResult`、`SecurityErrorBuilder`、`map_feishu_security_error` 仍可达
+
+#### Scenario: security crate 编译与测试通过
+
+- **WHEN** 运行 `cargo build -p openlark-security --all-features` 与 `cargo test -p openlark-security --all-features`
+- **THEN** 均通过；4 个改写的 builder/mapper 测试以直接断 `CoreError` variant 形式通过

--- a/openspec/changes/archive/2026-07-22-drop-security-risk-apparatus/tasks.md
+++ b/openspec/changes/archive/2026-07-22-drop-security-risk-apparatus/tasks.md
@@ -1,0 +1,32 @@
+# Tasks
+
+## 1. 删除风险装置代码 + 处置测试（crates/openlark-security/src/error.rs）
+
+- [x]1.1 删除 `error.rs:344–600`：`SecurityErrorExt`（trait + impl）· `SecurityEvent` · `SecurityErrorAnalyzer` + `analyze_security_risk` · `SecurityRiskAssessment` · `SecurityRiskLevel` · `SecurityRiskClassify`（trait + `CoreError` impl）· `SecurityRiskType` · `SecurityAction` · `ComplianceImpact`。cut 点在 343/344 空行（紧邻活面 `map_feishu_security_error`），保留 `SecurityErrorBuilder` 与 `map_feishu_security_error`
+- [x]1.2 删除 10 个装置测试：`test_security_event_generation` · `test_security_risk_assessment` · `analyze_security_risk_preserves_escalation_policy` · 7 个 `security_risk_level_*`（含 `#477 SecurityRiskClassify` 整段注释块）
+- [x]1.3 改写 4 个 builder/mapper 测试，断言改为直接断 `CoreError` variant：
+  - `test_security_error_creation`：`is_device_error()` → `matches!(error, CoreError::Validation { .. })` + ctx 含 `device_id`
+  - `test_permission_error`：`is_permission_error()` → `matches!(error, CoreError::Authentication { code: ErrorCode::PermissionMissing, .. })`
+  - `test_compliance_error`：`is_compliance_error()` → 断 ctx 含 `compliance_type`
+  - `test_feishu_error_mapping`：`is_permission_error()` → `matches!(error, CoreError::Authentication { code: ErrorCode::PermissionMissing, .. })`
+
+## 2. 依赖与 import 清理
+
+- [x]2.1 从 `crates/openlark-security/Cargo.toml` 移除 `uuid = { workspace = true }`（仅 `SecurityEvent` 使用）
+- [x]2.2 删 `error.rs:11` 的 `use serde::Serialize;`（装置删除后变成无用 import）
+- [x]2.3 同步 `.github/msrv/Cargo.lock`（删 uuid 致 Cargo.lock 变动）
+
+## 3. CHANGELOG 迁移条目
+
+- [x]3.1 在 CHANGELOG 加 v0.19.0 breaking 条目：移除 security 风险评估装置公开类型，附迁移说明 + 例外理由（零消费者 / 非主推面 / 引 ADR-0001 + policy line 141）
+
+## 4. 验证（CI 三元组 + 标准）
+
+- [x]4.1 `cargo fmt --check` 通过
+- [x]4.2 `cargo clippy --workspace --all-targets --all-features -- -Dwarnings` 通过
+- [x]4.3 `cargo clippy --workspace --all-targets --no-default-features -- -Dwarnings` 通过
+- [x]4.4 `cargo test --workspace --all-features` 通过（改写后的 4 测试 + 既有 security 测试不破坏）
+- [x]4.5 `cargo doc --workspace --all-features` 通过（intra-doc 链无断；无残留装置符号 doc）
+- [x]4.6 `cargo machete` 通过（uuid 已无引用）
+- [x]4.7 msrv `--locked` 通过（`.github/msrv/Cargo.lock` 同步后）
+- [x]4.8 真实 API 路径未受影响：grep 确认 `SecurityClient` / `SecurityError` 别名 / `SecurityResult` / ACS 与安全合规叶子未改动

--- a/openspec/specs/dead-code-lint-hygiene/spec.md
+++ b/openspec/specs/dead-code-lint-hygiene/spec.md
@@ -40,3 +40,26 @@ openlark 公开源代码 SHALL 不使用外层 `#[allow(dead_code)]` **或内层
 - **WHEN** 运行 `cargo test --workspace`
 - **THEN** 全部测试通过（389 删除无行为影响；3 字段修正不破坏 v1 API）
 
+### Requirement: 零消费者 pub 分析/扩展面 SHALL 删除或接真实消费者
+openlark 公开模块中的分析/扩展装置（trait + analyzer + assessment / 事件类型等，如 `SecurityRiskClassify` + `analyze_security_risk` + `SecurityRiskAssessment`）若同时满足：(a) 全仓 grep 排除定义文件与 `target/` 后 **0 生产调用者**、(b) **不在** `lib.rs` / `prelude` re-export、文档示例或主推调用路径，SHALL **删除**，或接到真实消费者（≥2 adapter）使 seam 成立；不得作为 hypothetical seam（1 adapter、0 caller）长期保留。OpenLark 是库（非长驻服务），无内建 telemetry / escalation / metrics sink，分析装置的唯一可能消费者是下游应用——零下游需求时维护该面是认知税与维护负担。本 requirement 扩展 `dead-code-lint-hygiene` 的治理范围：从「不用 `#[allow(dead_code)]` 抑制可修复死字段」延伸到「不保留零消费者 pub 分析面」（后者不被 lint 抑制、正常编译，但同样是死代码）。`openlark-security` 的风险分类装置（`error.rs:344–600`）是其首个实例。
+
+#### Scenario: security 风险分类装置移除
+- **WHEN** 变更后在 `crates/openlark-security/src/` 中 grep `SecurityRiskClassify|analyze_security_risk|SecurityRiskAssessment|SecurityRiskLevel|SecurityRiskType|SecurityAction|ComplianceImpact|SecurityErrorAnalyzer|SecurityEvent|to_security_event|security_risk_level`
+- **THEN** 命中数为 0（9 类型 + trait + Ext 事件方法定义全删）
+
+#### Scenario: 全仓无装置符号外部引用
+- **WHEN** 变更后在仓库中 grep 同组符号（排除 `target/`）
+- **THEN** 命中数为 0（删除前已实证零外部引用，删除后亦无残留）
+
+#### Scenario: uuid 依赖随装置移除
+- **WHEN** 变更后检查 `crates/openlark-security/Cargo.toml`
+- **THEN** 不含 `uuid`（`SecurityEvent` 是其唯一消费者）；`cargo machete` 不报 unused dep
+
+#### Scenario: 活面与真实 API 路径不受影响
+- **WHEN** 变更后构造 `SecurityClient::new(config)` 并调用 ACS / 安全合规叶子（如 `client.acs.v1().users().list()`）
+- **THEN** 编译通过、行为不变；`SecurityError = CoreError` 别名、`SecurityResult`、`SecurityErrorBuilder`、`map_feishu_security_error` 仍可达
+
+#### Scenario: security crate 编译与测试通过
+- **WHEN** 运行 `cargo build -p openlark-security --all-features` 与 `cargo test -p openlark-security --all-features`
+- **THEN** 均通过；4 个改写的 builder/mapper 测试以直接断 `CoreError` variant 形式通过
+


### PR DESCRIPTION
## 背景

`/improve-codebase-architecture` 审查发现 `openlark-security/src/error.rs:344–600` 的整套风险评估装置**零生产调用者**（全仓 grep 实证），且不在 prelude / re-export / 文档主推面。OpenLark 是库、无 telemetry/escalation sink，风险评估的唯一可能消费者是下游应用——零下游需求。保留即维护一条通往虚无的 hypothetical seam。

## 删了什么

`SecurityErrorExt`（trait+impl）· `SecurityEvent` · `SecurityErrorAnalyzer`+`analyze_security_risk` · `SecurityRiskAssessment` · `SecurityRiskLevel` · `SecurityRiskClassify`（trait+impl）· `SecurityRiskType` · `SecurityAction` · `ComplianceImpact`（共 9 类型 + trait）+ 10 个装置测试。

**保留**：`SecurityError = CoreError` 别名 · `SecurityResult` · `SecurityErrorBuilder` · `map_feishu_security_error` · core 错误 helper re-export。真实 API 路径（ACS / 安全合规叶子）不受影响。

## 决策（grilling 共识）

- **删而非留**：0 消费者 + 无 sink + trait 解的是无人用之题（CLAUDE.md §3 / ADR-0001 理由 5）。
- **整块删 344–600**：谓词唯一非测试调用者是死 analyzer，内聚死单元。
- **方案 B**：判 breaking（policy line 115），进 **0.19.0**；硬删，**例外跳过废弃周期**（policy line 141：零消费者 + 非主推面 → 废弃周期无对象可警告；引 ADR-0001 先例）。不挂 `#[deprecated]`（项目刚 06-29 清零，不重新污染）。
- **4 个 builder 测试改写**：删 `SecurityErrorExt` 谓词致 4 测试断裂，改为直接断 `CoreError` variant（测得更实）。
- **连带清理**：删 `uuid` 依赖（仅 `SecurityEvent` 用）+ 无用 `serde::Serialize` / `ErrorTrait` import；同步 `.github/msrv/Cargo.lock`。

## CHANGELOG

`[Unreleased] → Changed (Breaking — 目标 0.19)` 加条目；移除失效的 #477/#480 unreleased 新增条目（`SecurityRiskClassify` 是 0.18.0 之后新增、现一并删除 → 对 0.19 消费者净零，从未发布）。

## 验证（全绿）

`cargo fmt --check` · `clippy --workspace --all-targets --all-features/-​-no-default-features -Dwarnings` · `test --workspace --all-features` · `doc --workspace --all-features` · `cargo machete` · msrv `--locked` 模拟 · 散文 doc-drift grep（0 引用）。

## OpenSpec

`2026-07-22-drop-security-risk-apparatus`（proposal/tasks/design/spec），已归档；新增 requirement 到 `dead-code-lint-hygiene`（零消费者 pub 分析面 SHALL 删除或接真实消费者）。

## 后续

`SecurityErrorBuilder` / `map_feishu_security_error` 同为零消费者测试专属死代码 → **另案 [#500](https://github.com/foxzool/openlark/issues/500)**，本 PR 不扩大范围。

🤓 **Breaking change**（目标 0.19.0，semver-major）：移除 9 个 pub 类型 + 1 trait。