### PR TITLE
refactor(hr): unify endpoint path-params to variant-carried convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **注**：#477/#480 新增的 `SecurityRiskClassify` trait 同属 unreleased 且一并删除，
     对 0.19 消费者净零（从未发布）；原 `### Changed` 新增条目已随之移除。
 
+- **hr：端点枚举 path-param 统一为 variant 携带（OpenSpec `2026-07-22-unify-hr-endpoint-path-params`）**：
+  `api_endpoints.rs` 6 个端点从 Convention B（unit variant + URL 字面 `{}` + 叶子
+  `.to_url().replace("{}", id)`）统一到 Convention A（`Variant(param) =>
+  format!("/.../{param}")`，参数编译期检查）：`AttendanceApiV1::{UserFlowGet,
+  FileDownload, LeaveAccrualRecordPatch, LeaveEmployExpireRecordGet, UserStatsViewUpdate}`
+  + `FeishuPeopleApiV1::ProcessFormVariableDataGet`。B 丢类型安全、`{}` 是魔法串、
+  叶子可能忘记 `.replace` 致坏 URL 静默发出；A 让缺参成编译期错误。
+  - **行为逐字不变**：URL 字符串前后相同，6 个 wiremock e2e 测试不变即过。
+  - **例外跳过废弃周期**（policy line 141 + ADR-0001 先例）：pub variant 形态 unit→tuple
+    是 breaking，但 0 外部消费者（外部用 leaf builder）+ 行为保持 → 废弃周期无对象。
+  - **迁移**：直接构造这些 variant（如 `AttendanceApiV1::UserFlowGet`）的代码需改为传参
+    （`UserFlowGet(id)`）；走 leaf builder 的代码零影响。
+  - **非目标**：不做全量 macro 深化（532 arm）或不采纳 `API_PATH_PREFIX`（另案）。
+
 ### Changed
 
 - **hr：域无关 HR 原语提升到 crate root（#473）**：

--- a/crates/openlark-hr/src/attendance/attendance/v1/file/download.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/file/download.rs
@@ -43,9 +43,7 @@ impl DownloadRequest {
         validate_required!(self.photo_id.trim(), "photo_id");
 
         // 2. 构建端点
-        let api_endpoint = AttendanceApiV1::FileDownload
-            .to_url()
-            .replace("{}", &self.photo_id);
+        let api_endpoint = AttendanceApiV1::FileDownload(self.photo_id.clone()).to_url();
         let request = ApiRequest::<DownloadResponse>::get(&api_endpoint);
         // 3. 发送请求
         Transport::request_typed(

--- a/crates/openlark-hr/src/attendance/attendance/v1/leave_accrual_record/patch.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/leave_accrual_record/patch.rs
@@ -49,9 +49,8 @@ impl PatchRequest {
         validate_required!(self.record_id.trim(), "record_id");
 
         // 2. 构建端点
-        let api_endpoint = AttendanceApiV1::LeaveAccrualRecordPatch
-            .to_url()
-            .replace("{}", &self.record_id);
+        let api_endpoint =
+            AttendanceApiV1::LeaveAccrualRecordPatch(self.record_id.clone()).to_url();
         let request = ApiRequest::<PatchResponse>::patch(&api_endpoint);
 
         // 3. 构建请求体

--- a/crates/openlark-hr/src/attendance/attendance/v1/leave_employ_expire_record/get.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/leave_employ_expire_record/get.rs
@@ -88,9 +88,7 @@ impl GetRequest {
 
         // 1. 构建端点
         let record_key = format!("{}-{}", self.expire_time_start, self.expire_time_end);
-        let api_endpoint = AttendanceApiV1::LeaveEmployExpireRecordGet
-            .to_url()
-            .replace("{}", &record_key);
+        let api_endpoint = AttendanceApiV1::LeaveEmployExpireRecordGet(record_key).to_url();
         let mut request = ApiRequest::<GetResponse>::get(&api_endpoint);
 
         // 2. 添加查询参数

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_flow/get.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_flow/get.rs
@@ -62,9 +62,7 @@ impl GetUserFlowRequest {
         validate_required!(self.user_flow_id.trim(), "打卡流水 ID 不能为空");
 
         // 2. 构建端点
-        let api_endpoint = AttendanceApiV1::UserFlowGet
-            .to_url()
-            .replace("{}", &self.user_flow_id);
+        let api_endpoint = AttendanceApiV1::UserFlowGet(self.user_flow_id.clone()).to_url();
         let mut request = ApiRequest::<GetUserFlowResponse>::get(&api_endpoint);
 
         // 3. 添加查询参数（可选）

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_stats_view/update.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_stats_view/update.rs
@@ -63,9 +63,7 @@ impl UpdateRequest {
         validate_required_list!(self.field_ids, 50, "field_ids 不能为空且不能超过 50 个");
 
         // 2. 构建端点
-        let api_endpoint = AttendanceApiV1::UserStatsViewUpdate
-            .to_url()
-            .replace("{}", &self.view_id);
+        let api_endpoint = AttendanceApiV1::UserStatsViewUpdate(self.view_id.clone()).to_url();
         let request = ApiRequest::<UpdateResponse>::put(&api_endpoint);
 
         // 3. 构建请求体

--- a/crates/openlark-hr/src/common/api_endpoints.rs
+++ b/crates/openlark-hr/src/common/api_endpoints.rs
@@ -88,7 +88,7 @@ pub enum AttendanceApiV1 {
     /// 删除打卡流水
     UserFlowBatchDel,
     /// 获取打卡流水
-    UserFlowGet,
+    UserFlowGet(String),
     /// 批量查询打卡流水
     UserFlowQuery,
 
@@ -116,7 +116,7 @@ pub enum AttendanceApiV1 {
     /// 上传用户人脸识别照片
     FileUpload,
     /// 下载用户人脸识别照片
-    FileDownload,
+    FileDownload(String),
 
     // === archive_rule 资源 (4个) ===
     /// 查询所有归档规则
@@ -130,11 +130,11 @@ pub enum AttendanceApiV1 {
 
     // === leave_accrual_record 资源 (1个) ===
     /// 修改发放记录
-    LeaveAccrualRecordPatch,
+    LeaveAccrualRecordPatch(String),
 
     // === leave_employ_expire_record 资源 (1个) ===
     /// 通过过期时间获取发放记录
-    LeaveEmployExpireRecordGet,
+    LeaveEmployExpireRecordGet(String),
 
     // === user_stats_data 资源 (1个) ===
     /// 查询用户统计数据
@@ -148,7 +148,7 @@ pub enum AttendanceApiV1 {
     /// 查询用户统计视图
     UserStatsViewQuery,
     /// 更新用户统计视图
-    UserStatsViewUpdate,
+    UserStatsViewUpdate(String),
 
     // === approval_info 资源 (1个) ===
     /// 通知审批状态更新
@@ -205,7 +205,9 @@ impl AttendanceApiV1 {
             AttendanceApiV1::UserFlowBatchDel => {
                 "/open-apis/attendance/v1/user_flows/batch_del".to_string()
             }
-            AttendanceApiV1::UserFlowGet => "/open-apis/attendance/v1/user_flows/{}".to_string(),
+            AttendanceApiV1::UserFlowGet(user_flow_id) => {
+                format!("/open-apis/attendance/v1/user_flows/{user_flow_id}")
+            }
             AttendanceApiV1::UserFlowQuery => {
                 "/open-apis/attendance/v1/user_flows/query".to_string()
             }
@@ -239,8 +241,8 @@ impl AttendanceApiV1 {
 
             // file
             AttendanceApiV1::FileUpload => "/open-apis/attendance/v1/files/upload".to_string(),
-            AttendanceApiV1::FileDownload => {
-                "/open-apis/attendance/v1/files/{}/download".to_string()
+            AttendanceApiV1::FileDownload(photo_id) => {
+                format!("/open-apis/attendance/v1/files/{photo_id}/download")
             }
 
             // archive_rule
@@ -256,13 +258,13 @@ impl AttendanceApiV1 {
             }
 
             // leave_accrual_record
-            AttendanceApiV1::LeaveAccrualRecordPatch => {
-                "/open-apis/attendance/v1/leave_accrual_record/{}".to_string()
+            AttendanceApiV1::LeaveAccrualRecordPatch(record_id) => {
+                format!("/open-apis/attendance/v1/leave_accrual_record/{record_id}")
             }
 
             // leave_employ_expire_record
-            AttendanceApiV1::LeaveEmployExpireRecordGet => {
-                "/open-apis/attendance/v1/leave_employ_expire_records/{}".to_string()
+            AttendanceApiV1::LeaveEmployExpireRecordGet(record_key) => {
+                format!("/open-apis/attendance/v1/leave_employ_expire_records/{record_key}")
             }
 
             // user_stats_data
@@ -279,8 +281,8 @@ impl AttendanceApiV1 {
             AttendanceApiV1::UserStatsViewQuery => {
                 "/open-apis/attendance/v1/user_stats_views/query".to_string()
             }
-            AttendanceApiV1::UserStatsViewUpdate => {
-                "/open-apis/attendance/v1/user_stats_views/{}".to_string()
+            AttendanceApiV1::UserStatsViewUpdate(view_id) => {
+                format!("/open-apis/attendance/v1/user_stats_views/{view_id}")
             }
 
             // approval_info
@@ -2535,7 +2537,7 @@ pub enum FeishuPeopleApiV1 {
     /// `PreHirePatch` 变体。
     PreHirePatch(String),
     /// 获取流程表单数据
-    ProcessFormVariableDataGet,
+    ProcessFormVariableDataGet(String),
     /// 查询异动原因
     TransferReasonQuery,
     /// 查询异动类型
@@ -3069,8 +3071,8 @@ impl FeishuPeopleApiV1 {
             FeishuPeopleApiV1::PreHirePatch(pre_hire_id) => {
                 format!("/open-apis/corehr/v1/pre_hires/{pre_hire_id}")
             }
-            FeishuPeopleApiV1::ProcessFormVariableDataGet => {
-                "/open-apis/corehr/v1/processes/{}/form_variable_data".to_string()
+            FeishuPeopleApiV1::ProcessFormVariableDataGet(process_id) => {
+                format!("/open-apis/corehr/v1/processes/{process_id}/form_variable_data")
             }
             FeishuPeopleApiV1::TransferReasonQuery => {
                 "/open-apis/corehr/v1/transfer_reasons/query".to_string()

--- a/crates/openlark-hr/src/feishu_people/corehr/v1/process/form_variable_data/get.rs
+++ b/crates/openlark-hr/src/feishu_people/corehr/v1/process/form_variable_data/get.rs
@@ -49,9 +49,8 @@ impl GetRequest {
 
         validate_required!(self.process_id.trim(), "process_id 不能为空");
 
-        let api_endpoint = CorehrApiV1::ProcessFormVariableDataGet;
-        let request =
-            ApiRequest::<GetResponse>::get(api_endpoint.to_url().replace("{}", &self.process_id));
+        let api_endpoint = CorehrApiV1::ProcessFormVariableDataGet(self.process_id.clone());
+        let request = ApiRequest::<GetResponse>::get(api_endpoint.to_url());
         Transport::request_typed(
             request,
             &self.config,

--- a/openspec/changes/archive/2026-07-22-unify-hr-endpoint-path-params/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-22-unify-hr-endpoint-path-params/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/archive/2026-07-22-unify-hr-endpoint-path-params/design.md
+++ b/openspec/changes/archive/2026-07-22-unify-hr-endpoint-path-params/design.md
@@ -1,0 +1,35 @@
+## Context
+
+`api_endpoints.rs`（3605 行，11 enum，~532 match arm）是 HR 的类型安全端点表。叶子消费：`XxxApiV1::Variant(...).to_url()` → 喂 `ApiRequest::get/put/...`。path-param 有两套约定并存（见 proposal Why）。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 把 6 个 Convention B 端点统一到 Convention A（variant 带参、编译期查）
+- 行为逐字保持（URL 同串）→ 6 个 e2e 测试不变即过
+- 防"忘记 `.replace`"的静默 `{}` URL 运行时 bug 类（Convention A 让缺参成编译期错误）
+
+**Non-Goals:**
+- 不做全量 macro/derive 深化（187 端点 / 532 arm）—— deletion test 下 enum 挣得位置，payoff 部分已实现（URL 已集中 1 文件）；grilling Q1 否决 A
+- 不采纳 `API_PATH_PREFIX` 常量（532 arm 机械改，换"单一来源永不改变的串"，不抵成本）—— grilling Q2 收窄
+- 不动 Convention A 端点、不重构 endpoint 表结构（更大议题，ADR-0001 硬约束 3 已 park）
+
+## Decisions
+
+### Decision 1: 只做 B→A 统一，不做全量深化 / 不采纳前缀常量
+
+grilling 三问：(Q1) 范围 → B 有界清理；(Q2) 收窄 → 只做 `{}` 统一（6 端点），丢前缀（532 arm）；(Q3) 落地 → 方案 B（breaking、0.19.0、例外跳废弃周期）。详见 proposal Why。
+
+### Decision 2: clone vs move
+
+self 字段用 `.clone()`（保留字段供后续 body 用——patch/update 的 record_id/view_id 后续入 body；与原 `.replace` 的 borrow 意图一致）。本地 `record_key`（leave_employ_expire_record/get 计算得出、后续不用）用 move。
+
+### Decision 3: 落地方案 B（同候选 1 先例）
+
+pub variant 形态 unit→tuple 是 SemVer-breaking（cargo-semver-checks 会标）。但：行为逐字不变 + variant 仅被本 crate 6 叶子构造（0 外部消费者，外部用 leaf builder）→ 废弃周期无对象可警告。0.19.0 硬删、引 policy line 141 + ADR-0001 先例。比候选 1（删除）更低风险（行为保持）。
+
+## Risks / Trade-offs
+
+- **[BREAKING 公开 API]** 6 个 pub variant 形态变更 → **缓解**：行为逐字保持；0 外部消费者；v0.19.0 窗口；CHANGELOG 迁移表 + 例外理由
+- **[clone 微开销]** patch/update 叶子 clone record_id/view_id → **缓解**：原 `.replace` 也是 borrow（非 move），clone 等价语义；一次 String clone 可忽略
+- **[record_key 含 `-` 入 path]** `leave_employ_expire_records/{start}-{end}` → **缓解**：原 `.replace` 已如此（行为不变），是否应改 query-param 是另一议题

--- a/openspec/changes/archive/2026-07-22-unify-hr-endpoint-path-params/proposal.md
+++ b/openspec/changes/archive/2026-07-22-unify-hr-endpoint-path-params/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+`openlark-hr/src/common/api_endpoints.rs` 的端点枚举长期并存两套 path-param 约定：
+
+- **Convention A（类型安全）**：variant 携带参数 → `GroupDelete(group_id) => format!("/.../{group_id}")`。参数编译期检查，缺参即编译失败。
+- **Convention B（丢类型安全）**：unit variant + URL 字面 `{}` + 叶子 `.to_url().replace("{}", id)`。`{}` 是魔法串，叶子**可能忘记 `.replace`** → 带 `{}` 的坏 URL 静默发往飞书服务器（运行时 bug，编译期不可见）。
+
+6 个端点用 Convention B：`AttendanceApiV1::{UserFlowGet, FileDownload, LeaveAccrualRecordPatch, LeaveEmployExpireRecordGet, UserStatsViewUpdate}` + `FeishuPeopleApiV1::ProcessFormVariableDataGet`（经 `CorehrApiV1` 别名消费）。B 严格劣于 A。URL 字符串迁移前后**逐字相同**（行为保持），纯属一致性 + 防回归收敛。
+
+源自 `/improve-codebase-architecture` 候选 3（3605 行 endpoint 表）。初看是"shallow module"，grilling 核实后重塑为"path-param 约定不一致"——deletion test 下 enum 挣得位置（类型安全端点身份），故不做全量 macro 深化（payoff 部分已实现 + 532 arm 太大），只收敛这 6 个 B→A。
+
+## What Changes
+
+- 6 个 variant：unit → tuple `(String)`（参数名按叶子字段：`user_flow_id / photo_id / record_id / record_key / view_id / process_id`）
+- 6 个 `to_url` arm：`"/.../{}".to_string()` → `format!("/.../{param}")`
+- 6 个叶子：`Variant.to_url().replace("{}", &x)` → `Variant(x.clone()).to_url()`（本地 `record_key` 用 move）；删 `.replace`
+- **BREAKING**：pub variant 形态变更（unit→tuple），但行为逐字保持（URL 同串）；0 外部消费者（外部用 leaf builder，不直接构 variant）
+- 不动 Convention A 端点、不动 `/open-apis/` 前缀（532 arm 机械改、`API_PATH_PREFIX` 常量采纳另案——前缀是永不改变的飞书平台串，收益不抵成本）
+
+## Capabilities
+
+### New Capabilities
+- `hr-endpoint-path-params`：HR 端点枚举的 path-param SHALL 由 variant 携带（Convention A），不得用 `{}` 占位 + 叶子 `.replace()`（Convention B）。
+
+### Modified Capabilities
+（无）
+
+## Impact
+
+- **crates/openlark-hr**（改动集中于此，不跨 crate）：
+  - `src/common/api_endpoints.rs`：6 variant 定义 + 6 `to_url` arm
+  - `src/attendance/attendance/v1/{user_flow/get, file/download, leave_accrual_record/patch, leave_employ_expire_record/get, user_stats_view/update}.rs` + `src/feishu_people/corehr/v1/process/form_variable_data/get.rs`：端点构造改传参
+- **公开 API（v0.19.0 breaking）**：6 个 pub variant 形态 unit→tuple（零外部引用）
+- **运行时行为**：逐字不变（6 个 wiremock e2e 测试断言的 URL path 前后一致）
+- **依赖**：无新增、无删除

--- a/openspec/changes/archive/2026-07-22-unify-hr-endpoint-path-params/specs/hr-endpoint-path-params/spec.md
+++ b/openspec/changes/archive/2026-07-22-unify-hr-endpoint-path-params/specs/hr-endpoint-path-params/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: HR 端点枚举 path-param SHALL 由 variant 携带
+
+`openlark-hr` 端点枚举（`common/api_endpoints.rs`）中带路径参数的端点 SHALL 用 **variant 携带参数**的约定（Convention A：`Variant(param) => format!("/.../{param}")`，参数编译期检查），不得用 unit variant + URL 字面 `{}` 占位 + 叶子 `.to_url().replace("{}", id)` 的约定（Convention B）。Convention B 丢类型安全、`{}` 是魔法串、且叶子可能忘记 `.replace` 致带 `{}` 的坏 URL 静默发往服务器（运行时 bug，编译期不可见）。新增/重构带 path-param 的端点 SHALL 走 Convention A。
+
+#### Scenario: 6 个原 Convention B 端点改为 variant 带参
+
+- **WHEN** 变更后在 `crates/openlark-hr/src/common/api_endpoints.rs` 中检查 `UserFlowGet / FileDownload / LeaveAccrualRecordPatch / LeaveEmployExpireRecordGet / UserStatsViewUpdate / ProcessFormVariableDataGet`
+- **THEN** 均为 tuple variant `(String)`，`to_url` arm 用 `format!` 绑定具名参数，无字面 `{}`
+
+#### Scenario: 叶子不再 `.replace("{}")`
+
+- **WHEN** 在 `crates/openlark-hr/src/` 中 grep `\.replace\("\{\}"`
+- **THEN** 命中数为 0（path-param 经 variant 传入，不经字符串替换）
+
+#### Scenario: URL 行为逐字不变
+
+- **WHEN** 运行 6 个相关 wiremock e2e 测试（`test_attendance_v1_user_flow_get_*` / `*_file_download_*` / `*_leave_accrual_record_patch_*` / `*_leave_employ_expire_record_get_*` / `*_user_stats_view_update_*` / corehr `*_form_variable_data_get_*`）
+- **THEN** 均通过；断言的请求 URL path 与迁移前逐字一致（参数已正确填入，非 `{}`）
+
+#### Scenario: HR crate 编译与测试通过
+
+- **WHEN** 运行 `cargo build -p openlark-hr --all-features` 与 `cargo test -p openlark-hr --all-features`
+- **THEN** 均通过

--- a/openspec/changes/archive/2026-07-22-unify-hr-endpoint-path-params/tasks.md
+++ b/openspec/changes/archive/2026-07-22-unify-hr-endpoint-path-params/tasks.md
@@ -1,0 +1,28 @@
+# Tasks
+
+## 1. api_endpoints.rs — 6 端点 variant + to_url arm 改 Convention A
+
+- [x] 1.1 `AttendanceApiV1::UserFlowGet` → `(String)`；arm `"/user_flows/{}"` → `format!("/user_flows/{user_flow_id}")`
+- [x] 1.2 `AttendanceApiV1::FileDownload` → `(String)`；arm `"/files/{}/download"` → `format!("/files/{photo_id}/download")`
+- [x] 1.3 `AttendanceApiV1::LeaveAccrualRecordPatch` → `(String)`；arm → `format!("/leave_accrual_record/{record_id}")`
+- [x] 1.4 `AttendanceApiV1::LeaveEmployExpireRecordGet` → `(String)`；arm → `format!("/leave_employ_expire_records/{record_key}")`
+- [x] 1.5 `AttendanceApiV1::UserStatsViewUpdate` → `(String)`；arm → `format!("/user_stats_views/{view_id}")`
+- [x] 1.6 `FeishuPeopleApiV1::ProcessFormVariableDataGet` → `(String)`；arm → `format!("/corehr/v1/processes/{process_id}/form_variable_data")`
+
+## 2. 6 叶子改传参给 variant（删 .replace）
+
+- [x] 2.1 `attendance/v1/user_flow/get.rs`：`UserFlowGet(self.user_flow_id.clone()).to_url()`
+- [x] 2.2 `attendance/v1/file/download.rs`：`FileDownload(self.photo_id.clone()).to_url()`
+- [x] 2.3 `attendance/v1/leave_accrual_record/patch.rs`：`LeaveAccrualRecordPatch(self.record_id.clone()).to_url()`（record_id 后续入 body，须 clone）
+- [x] 2.4 `attendance/v1/leave_employ_expire_record/get.rs`：`LeaveEmployExpireRecordGet(record_key).to_url()`（本地 record_key，move）
+- [x] 2.5 `attendance/v1/user_stats_view/update.rs`：`UserStatsViewUpdate(self.view_id.clone()).to_url()`（view_id 后续入 body，须 clone）
+- [x] 2.6 `feishu_people/corehr/v1/process/form_variable_data/get.rs`：`CorehrApiV1::ProcessFormVariableDataGet(self.process_id.clone()).to_url()`
+
+## 3. 验证
+
+- [x] 3.1 `cargo build -p openlark-hr --all-features` 通过
+- [x] 3.2 `cargo test -p openlark-hr --all-features` 通过（6 个 wiremock e2e URL 断言前后逐字一致 → 不变即过）
+- [x] 3.3 HR 叶子无残留 `.replace("{}"` （grep = 0）
+- [x]3.4 `cargo fmt --check` + clippy×2（--all-features / --no-default-features，-Dwarnings）
+- [x]3.5 `cargo doc --workspace --all-features`（intra-doc）
+- [x]3.6 `cargo machete`

--- a/openspec/specs/hr-endpoint-path-params/spec.md
+++ b/openspec/specs/hr-endpoint-path-params/spec.md
@@ -1,0 +1,23 @@
+# hr-endpoint-path-params Specification
+
+## Purpose
+TBD - created by archiving change 2026-07-22-unify-hr-endpoint-path-params. Update Purpose after archive.
+## Requirements
+### Requirement: HR 端点枚举 path-param SHALL 由 variant 携带
+`openlark-hr` 端点枚举（`common/api_endpoints.rs`）中带路径参数的端点 SHALL 用 **variant 携带参数**的约定（Convention A：`Variant(param) => format!("/.../{param}")`，参数编译期检查），不得用 unit variant + URL 字面 `{}` 占位 + 叶子 `.to_url().replace("{}", id)` 的约定（Convention B）。Convention B 丢类型安全、`{}` 是魔法串、且叶子可能忘记 `.replace` 致带 `{}` 的坏 URL 静默发往服务器（运行时 bug，编译期不可见）。新增/重构带 path-param 的端点 SHALL 走 Convention A。
+
+#### Scenario: 6 个原 Convention B 端点改为 variant 带参
+- **WHEN** 变更后在 `crates/openlark-hr/src/common/api_endpoints.rs` 中检查 `UserFlowGet / FileDownload / LeaveAccrualRecordPatch / LeaveEmployExpireRecordGet / UserStatsViewUpdate / ProcessFormVariableDataGet`
+- **THEN** 均为 tuple variant `(String)`，`to_url` arm 用 `format!` 绑定具名参数，无字面 `{}`
+
+#### Scenario: 叶子不再 `.replace("{}")`
+- **WHEN** 在 `crates/openlark-hr/src/` 中 grep `\.replace\("\{\}"`
+- **THEN** 命中数为 0（path-param 经 variant 传入，不经字符串替换）
+
+#### Scenario: URL 行为逐字不变
+- **WHEN** 运行 6 个相关 wiremock e2e 测试（`test_attendance_v1_user_flow_get_*` / `*_file_download_*` / `*_leave_accrual_record_patch_*` / `*_leave_employ_expire_record_get_*` / `*_user_stats_view_update_*` / corehr `*_form_variable_data_get_*`）
+- **THEN** 均通过；断言的请求 URL path 与迁移前逐字一致（参数已正确填入，非 `{}`）
+
+#### Scenario: HR crate 编译与测试通过
+- **WHEN** 运行 `cargo build -p openlark-hr --all-features` 与 `cargo test -p openlark-hr --all-features`
+- **THEN** 均通过


### PR DESCRIPTION
## 背景

`api_endpoints.rs` 的 6 个端点用了**丢类型安全**的 Convention B（unit variant + URL 字面 `{}` + 叶子 `.to_url().replace("{}", id)`），与其余端点的 Convention A（`Variant(param) => format!`，编译期查参）不一致。B 的 `{}` 是魔法串，叶子可能忘记 `.replace` → 带 `{}` 的坏 URL 静默发往飞书服务器（运行时 bug，编译期不可见）。源自 `/improve-codebase-architecture` 候选 3。

## 改了什么

6 个端点 B→A：`AttendanceApiV1::{UserFlowGet, FileDownload, LeaveAccrualRecordPatch, LeaveEmployExpireRecordGet, UserStatsViewUpdate}` + `FeishuPeopleApiV1::ProcessFormVariableDataGet`（经 `CorehrApiV1` 别名消费）。variant unit→tuple(String)、to_url `{}`→`format!{named}`、叶子传参给 variant（删 `.replace`）。

## 关键点

- **行为逐字不变**：URL 字符串前后相同 → 6 个 wiremock e2e 测试断言同 path，不变即过。
- **防回归**：Convention A 让缺参成**编译期错误**（堵住"忘记 `.replace`"的静默 bug 类）。
- **BREAKING（方案 B）**：pub variant 形态 unit→tuple，0.19.0。例外跳废弃周期（policy line 141 + ADR-0001 先例）——0 外部消费者（外部用 leaf builder）+ 行为保持。比候选 1（删除）更低风险。
- **grilling 非目标**：不做全量 macro 深化（532 arm，enum 挣得位置）或不采纳 `API_PATH_PREFIX`（永不改变的串，532 arm 不值）——另案。

## 验证（全绿）

`cargo fmt --check` · `clippy×2`（--all-features / --no-default-features，-Dwarnings）· `test --workspace --all-features`（0 failed）· `cargo doc --workspace` · `cargo machete`。HR 叶子 `.replace("{}"` grep = 0。

## OpenSpec

`2026-07-22-unify-hr-endpoint-path-params`（已归档）；新 spec `hr-endpoint-path-params`（path-param SHALL 由 variant 携带）。

🤓 **Breaking change**（目标 0.19.0，semver-major）：6 个 pub variant 形态 unit→tuple。直接构造这些 variant 的代码需改为传参；走 leaf builder 的代码零影响。