### PR TITLE
refactor(core): drop Response::into_result, decode becomes sole finisher (#505)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     的代码需移除（仓内零引用）。`Transport::request_typed` / leaf builder /
     `api::prelude` 其余类型不受影响。
 
+- **core：`Response::into_result` 删除，`decode` 收为唯一 finisher（#505）**：
+  自 #486（`extract_response_data` 自由函数收敛为 `Response::decode`）起，
+  `into_result` 生产零调用——仅 2 个错位的 `openlark-auth` 测试调用，且其一断言
+  旧的「成功（code=0）无 data 误报为 api 错误」行为（#470 user-story-12 刻意修掉）。
+  删除即收口二者在「成功 code=0 但无 data」上的设计分歧（`into_result` 返 `Api`、
+  `decode` 返 `Validation`——后者才是真正的抽取失败语义）。`Response<T>` 只剩唯一
+  finisher，正确行为由核心 `decode_*` 测试单点覆盖（auth crate 不再重复）。
+  - **不走废弃周期**：零消费者公开方法 → 废弃周期无对象可警告；且属未发布 0.19 窗口。
+    先例：#504（同型零消费者 seam 直删）+ #471。
+  - **迁移**：`response.into_result()` 改为 `response.decode(context)`。leaf 请求走
+    `Transport::request_typed`，不直接调 finisher，不受影响。
+
 - **hr：删除 7 个 dead config-holder facade（#474）**：
   `Hire` / `Attendance` / `Corehr` / `Payroll` / `Performance` /
   `CompensationManagement` / `Ehr` 是纯 config holder（仅 `new()` + `config()`），

--- a/crates/openlark-auth/tests/auth_validation_tests.rs
+++ b/crates/openlark-auth/tests/auth_validation_tests.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use openlark_auth::auth::auth::v3::*;
 use openlark_core::{
-    api::responses::{RawResponse, Response},
+    api::responses::RawResponse,
     config::Config,
     error::{CoreError, ErrorTrait, timeout_error},
 };
@@ -85,45 +85,6 @@ mod validation_tests {
         assert_eq!(raw.msg, "invalid app credentials");
         assert_eq!(raw.request_id.as_deref(), Some("req_123"));
         assert!(!raw.is_success());
-    }
-
-    #[test]
-    fn test_validation_api_error_response_into_result_returns_api_error() {
-        let response = Response::<serde_json::Value>::new(
-            None,
-            RawResponse {
-                code: 400,
-                msg: "bad request".to_string(),
-                request_id: Some("req_bad".to_string()),
-                data: None,
-                error: None,
-            },
-        );
-
-        let result = response.into_result();
-        assert!(matches!(result, Err(CoreError::Api(_))));
-
-        let err = result.expect_err("应返回 API 错误");
-        assert!(err.to_string().contains("bad request"));
-    }
-
-    #[test]
-    fn test_validation_success_response_without_data_returns_api_error() {
-        let response = Response::<serde_json::Value>::new(
-            None,
-            RawResponse {
-                code: 0,
-                msg: "ok".to_string(),
-                request_id: Some("req_empty_data".to_string()),
-                data: None,
-                error: None,
-            },
-        );
-
-        let result = response.into_result();
-        assert!(matches!(result, Err(CoreError::Api(_))));
-        let err = result.expect_err("应返回 API 错误");
-        assert!(err.to_string().contains("响应数据为空"));
     }
 
     #[tokio::test]

--- a/crates/openlark-core/src/api/responses.rs
+++ b/crates/openlark-core/src/api/responses.rs
@@ -229,32 +229,6 @@ impl<T> Response<T> {
         &self.raw_response
     }
 
-    /// 转换为结果类型
-    pub fn into_result(self) -> Result<T, crate::error::CoreError> {
-        let is_success = self.is_success();
-        let code = self.raw_response.code;
-        let request_id = self.raw_response.request_id.clone();
-
-        if is_success {
-            match self.data {
-                Some(data) => Ok(data),
-                None => Err(crate::error::api_error(
-                    code as u16,
-                    "response",
-                    "响应数据为空",
-                    request_id,
-                )),
-            }
-        } else {
-            Err(crate::error::api_error(
-                code as u16,
-                "response",
-                self.raw_response.msg.clone(),
-                request_id,
-            ))
-        }
-    }
-
     /// Canonical finisher：从 `Response<T>` 抽取 typed `T`（#486 起 `extract_response_data`
     /// 自由函数收敛到此方法）。
     ///


### PR DESCRIPTION
Closes #505

## What

Delete `Response::into_result` from `openlark-core` so `decode` is the sole finisher (parent #503 — cleaning up #470's leftover zero-consumer seams, 0.19 breaking).

## Why

Since #486 collapsed `extract_response_data` into `Response::decode`, `into_result` has had zero production call sites — only 2 misplaced `openlark-auth` tests called it, and one of those asserted the old "success (code=0) with no data → misreported as `Api` error" behaviour that #470 user-story-12 deliberately fixed. Deleting it closes the design divergence between the two finishers on "success code=0 but no data" (`into_result` → `Api` "响应数据为空"; `decode` → `Validation` — the correct extraction-failure semantics). The right behaviour stays covered once, in core `decode_*`.

## Changes

- Delete `Response::into_result` (`crates/openlark-core/src/api/responses.rs`); `decode` is the only finisher
- Delete 2 redundant finisher tests in `crates/openlark-auth/tests/auth_validation_tests.rs` (core `decode_missing_data_is_validation_error_with_context` / `decode_business_error_is_api_error_preserving_msg` already cover the correct behaviour)
- Drop the now-unused `Response` import (`RawResponse` still used by `test_validation_api_error_response_parsing`)
- CHANGELOG bullet under `### Changed (Breaking — 目标 0.19)`

## Verification

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -Dwarnings`
- `cargo clippy --workspace --all-targets --no-default-features -- -Dwarnings`
- `cargo test --workspace --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`

Two independent `/code-review` passes (Standards + Spec) — clean; both flagged the same two **out-of-scope** follow-ups (pre-existing dead duplicate `tests/unit/auth/auth_validation_tests.rs` referencing `into_result`, and illustrative `ARCHITECTURE.md` pseudo-code refs — neither is live API surface, left for separate cleanup).

No deprecation cycle: zero-consumer public method + unreleased 0.19 window (precedent #504 / #471). No dependency change → msrv / cargo-deny unaffected.
