### PR TITLE
refactor(core): retire dead `ensure_success` + fix `request_typed` doc (#506)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -694,6 +694,8 @@ impl MultipartBuilder {
 
 类型安全的响应处理系统：
 
+> 历史示意：`into_result` 已随 #505 移除，现行 finisher 为 `Response::decode(context)`；以下为设计示意伪代码，与现行 API 有漂移。
+
 ```rust
 use openlark_core::api::{Response, RawResponse};
 
@@ -745,6 +747,8 @@ impl<T> Response<T> {
 #### 6.3.2 类型安全转换
 
 强类型的API响应处理：
+
+> 历史示意：`into_result` 已随 #505 移除，现行 finisher 为 `Response::decode(context)`；以下为设计示意伪代码，与现行 API 有漂移。
 
 ```rust
 // API响应特征
@@ -1729,6 +1733,8 @@ impl GracefulShutdownManager {
 #### 7.4.1 AsyncLarkClient trait
 
 异步客户端接口定义：
+
+> 历史示意：`into_result` 已随 #505 移除，现行 finisher 为 `Response::decode(context)`；以下为设计示意伪代码，与现行 API 有漂移。
 
 ```rust
 // 异步客户端特征
@@ -2840,6 +2846,8 @@ impl Default for RawResponse {
 #### 8.3.2 Response<T>类型安全包装
 
 类型安全的响应包装器：
+
+> 历史示意：`into_result` 已随 #505 移除，现行 finisher 为 `Response::decode(context)`；以下为设计示意伪代码，与现行 API 有漂移。
 
 ```rust
 // 类型安全的响应包装

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **迁移**：`response.into_result()` 改为 `response.decode(context)`。leaf 请求走
     `Transport::request_typed`，不直接调 finisher，不受影响。
 
+- **core：退役死 helper `ensure_success` + 修正 `request_typed` doc + #505 遗留清理（#506）**：
+  `ensure_success`（无 `data` 接口的 `code==0` 成功判断 helper）自 #470 leaf 全量迁入
+  `Transport::request_typed` 后生产零调用——删除/空成功类 API 改由响应类型的
+  `ApiResponseTrait` 声明解码策略，经 `request_typed` / `Response::decode` 收口，不再走
+  `request` + `ensure_success`。core 删 `api::helpers::ensure_success` + `api` 模块
+  re-export 会让 9 个业务 crate 的 `common::api_utils` re-export shim 断编译，故 core
+  删除与 9 shim 更新（workflow / communication / application / helpdesk / mail / docs /
+  platform / meeting / cardkit，去 `ensure_success` re-export + 模块 doc 同步）于本条
+  原子落绿。同步重写 `Transport::request_typed` doc 为「双入口分工」叙述（删除/空成功类
+  API 走 `request_typed`；`Transport::request` 仅留给需要原始 `Response<T>` 的下载 / 自定义
+  抽取路径），删除旧 doc「删除类 API 用 `request` + `ensure_success`」的谎言。
+  - **不走废弃周期**：零消费者 helper（全仓 0 调用方）→ 废弃周期无对象可警告；且属未发布
+    0.19 窗口。先例：#505（`into_result` 同型零消费者直删）。
+  - **#505 遗留清理**：`tests/unit/auth/auth_validation_tests.rs`（未接线的死副本）删 2 个
+    引用已删 `into_result` 的冗余测试 + 去 `Response` import（镜像 live 文件
+    `crates/openlark-auth/tests/auth_validation_tests.rs`；整棵 `tests/unit/` 死树处置另案）；
+    `ARCHITECTURE.md` 4 处 `into_result` 设计示意伪代码标注历史叙述。
+  - **迁移**：`ensure_success` 从未在 README / 示例主推（仅经 `common::api_utils` re-export
+    暴露）；使用 `crate::common::api_utils::ensure_success` 的代码需改走
+    `Transport::request_typed`（由响应类型声明解码策略）。`serialize_params` 不受影响。
+
 - **hr：删除 7 个 dead config-holder facade（#474）**：
   `Hire` / `Attendance` / `Corehr` / `Payroll` / `Performance` /
   `CompensationManagement` / `Ehr` 是纯 config holder（仅 `new()` + `config()`），

--- a/crates/openlark-application/src/common/api_utils.rs
+++ b/crates/openlark-application/src/common/api_utils.rs
@@ -1,6 +1,6 @@
 //! API 工具函数（re-export core canonical）。
 //!
-//! serialize_params / ensure_success 已下沉到
+//! serialize_params 已下沉到
 //! `openlark_core::api`（#330），本模块仅 re-export canonical copy，避免各 crate 各派生一份。
 
-pub use openlark_core::api::{ensure_success, serialize_params};
+pub use openlark_core::api::serialize_params;

--- a/crates/openlark-cardkit/src/common/api_utils.rs
+++ b/crates/openlark-cardkit/src/common/api_utils.rs
@@ -1,6 +1,6 @@
 //! API 工具函数（re-export core canonical）。
 //!
-//! serialize_params / ensure_success 已下沉到
+//! serialize_params 已下沉到
 //! `openlark_core::api`（#330），本模块仅 re-export canonical copy，避免各 crate 各派生一份。
 
-pub use openlark_core::api::{ensure_success, serialize_params};
+pub use openlark_core::api::serialize_params;

--- a/crates/openlark-communication/src/common/api_utils.rs
+++ b/crates/openlark-communication/src/common/api_utils.rs
@@ -1,6 +1,6 @@
 //! API 工具函数（re-export core canonical）。
 //!
-//! serialize_params / ensure_success 已下沉到
+//! serialize_params 已下沉到
 //! `openlark_core::api`（#330），本模块仅 re-export canonical copy，避免各 crate 各派生一份。
 
-pub use openlark_core::api::{ensure_success, serialize_params};
+pub use openlark_core::api::serialize_params;

--- a/crates/openlark-core/src/api/helpers.rs
+++ b/crates/openlark-core/src/api/helpers.rs
@@ -5,7 +5,6 @@
 //! （caller 传入的 context）/ `request_id`（响应携带时）结构化诊断上下文。
 
 use crate::SDKResult;
-use crate::api::Response;
 use crate::error::validation_error;
 
 /// 标准化参数序列化。
@@ -21,24 +20,6 @@ pub fn serialize_params<T: serde::Serialize>(
                 .add_context("resource", context);
         })
     })
-}
-
-/// 无 data 接口：仅用 `code==0` 判断成功。
-///
-/// 用于响应不含 `data` 字段的 API。失败时附加 `operation=ensure_success` + `resource=<context>`。
-pub fn ensure_success(response: Response<serde_json::Value>, context: &str) -> SDKResult<()> {
-    if response.raw_response.is_success() {
-        Ok(())
-    } else {
-        Err(
-            validation_error("response.code", response.raw_response.msg.to_string()).map_context(
-                |ctx| {
-                    ctx.set_operation("ensure_success")
-                        .add_context("resource", context);
-                },
-            ),
-        )
-    }
 }
 
 #[cfg(test)]

--- a/crates/openlark-core/src/api/mod.rs
+++ b/crates/openlark-core/src/api/mod.rs
@@ -398,7 +398,7 @@ pub mod responses;
 
 // 重新导出
 
-pub use helpers::{ensure_success, serialize_params};
+pub use helpers::serialize_params;
 
 // 测试
 

--- a/crates/openlark-core/src/http.rs
+++ b/crates/openlark-core/src/http.rs
@@ -115,9 +115,10 @@ impl<T: ApiResponseTrait + std::fmt::Debug + for<'de> serde::Deserialize<'de>> T
     /// 机制携带 `operation`（= `extract_response_data`）+ `resource`（= `context`）
     /// + 响应携带的 `request_id`，便于排障与飞书服务端对账。
     ///
-    /// 全部 leaf 已迁入本入口（#482 mail / #483 HR / #484 communication+meeting+docs /
-    /// #485 其余）。无 `data` 载荷的删除类 API 继续用 `Transport::request` +
-    /// `ensure_success`，不经本入口。
+    /// 全部 leaf 已迁入本入口，含删除/空成功类 API（由响应类型的 [`ApiResponseTrait`] 声明
+    /// 解码策略）。兄弟入口 [`Transport::request`] 仅留给需要原始 `Response<T>` 的下载 /
+    /// 自定义抽取路径（按 Content-Disposition 取文件名、size 上限校验、对外返回
+    /// `Response<Vec<u8>>`），不再经 `ensure_success`（#470 后零消费者，随 #506 删除）。
     pub async fn request_typed<R: Send>(
         req: ApiRequest<R>,
         config: &Config,

--- a/crates/openlark-docs/src/common/api_utils.rs
+++ b/crates/openlark-docs/src/common/api_utils.rs
@@ -1,12 +1,12 @@
 /// API通用工具函数（re-export core canonical + 本域 error 构造器）。
 ///
-/// `serialize_params` / `ensure_success` 已下沉到
+/// `serialize_params` 已下沉到
 /// `openlark_core::api`（#330），本模块 re-export canonical copy；保留 docs 域专用的
 /// `missing_response_data_error`（bitable 等叶子直接复用其错误形状）。
 use openlark_core::error;
 
 // canonical HTTP 管道 helper（#330 下沉到 core）
-pub use openlark_core::api::{ensure_success, serialize_params};
+pub use openlark_core::api::serialize_params;
 
 const ERROR_COMPONENT: &str = "openlark-docs";
 

--- a/crates/openlark-helpdesk/src/common/api_utils.rs
+++ b/crates/openlark-helpdesk/src/common/api_utils.rs
@@ -1,6 +1,6 @@
 //! API 工具函数（re-export core canonical）。
 //!
-//! serialize_params / ensure_success 已下沉到
+//! serialize_params 已下沉到
 //! `openlark_core::api`（#330），本模块仅 re-export canonical copy，避免各 crate 各派生一份。
 
-pub use openlark_core::api::{ensure_success, serialize_params};
+pub use openlark_core::api::serialize_params;

--- a/crates/openlark-mail/src/common/api_utils.rs
+++ b/crates/openlark-mail/src/common/api_utils.rs
@@ -1,6 +1,6 @@
 //! API 工具函数（re-export core canonical）。
 //!
-//! serialize_params / ensure_success 已下沉到
+//! serialize_params 已下沉到
 //! `openlark_core::api`（#330），本模块仅 re-export canonical copy，避免各 crate 各派生一份。
 
-pub use openlark_core::api::{ensure_success, serialize_params};
+pub use openlark_core::api::serialize_params;

--- a/crates/openlark-meeting/src/common/api_utils.rs
+++ b/crates/openlark-meeting/src/common/api_utils.rs
@@ -1,10 +1,10 @@
 //! API 工具函数（re-export core canonical + validate_required_field）。
 //!
-//! serialize_params / ensure_success 已下沉到
+//! serialize_params 已下沉到
 //! `openlark_core::api`（#330）；保留 meeting 域的 validate_required_field（会议叶子复用）。
 use openlark_core::{SDKResult, error};
 
-pub use openlark_core::api::{ensure_success, serialize_params};
+pub use openlark_core::api::serialize_params;
 
 /// 标准化必填字段校验。
 pub fn validate_required_field<T: AsRef<str>>(

--- a/crates/openlark-platform/src/common/api_utils.rs
+++ b/crates/openlark-platform/src/common/api_utils.rs
@@ -1,6 +1,6 @@
 //! API 工具函数（re-export core canonical）。
 //!
-//! serialize_params / ensure_success 已下沉到
+//! serialize_params 已下沉到
 //! `openlark_core::api`（#330），本模块仅 re-export canonical copy，避免各 crate 各派生一份。
 
-pub use openlark_core::api::{ensure_success, serialize_params};
+pub use openlark_core::api::serialize_params;

--- a/crates/openlark-workflow/src/common/api_utils.rs
+++ b/crates/openlark-workflow/src/common/api_utils.rs
@@ -1,13 +1,13 @@
 /// API通用工具函数（re-export core canonical + 本域 error 构造器）。
 ///
-/// `serialize_params` / `ensure_success` 已下沉到
+/// `serialize_params` 已下沉到
 /// `openlark_core::api`（#330），本模块 re-export canonical copy；保留 workflow 域专用的
 /// 标准 error 构造器（`missing_response_data_error` / `request_serialization_error`），
 /// 多处审批任务叶子直接复用其错误形状。
 use openlark_core::error;
 
 // canonical HTTP 管道 helper（#330 下沉到 core）
-pub use openlark_core::api::{ensure_success, serialize_params};
+pub use openlark_core::api::serialize_params;
 
 const ERROR_COMPONENT: &str = "openlark-workflow";
 

--- a/tests/unit/auth/auth_validation_tests.rs
+++ b/tests/unit/auth/auth_validation_tests.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use openlark_auth::auth::auth::v3::*;
 use openlark_core::{
-    api::responses::{RawResponse, Response},
+    api::responses::RawResponse,
     config::Config,
     error::{timeout_error, CoreError, ErrorTrait},
 };
@@ -79,45 +79,6 @@ mod validation_tests {
         assert_eq!(raw.msg, "invalid app credentials");
         assert_eq!(raw.request_id.as_deref(), Some("req_123"));
         assert!(!raw.is_success());
-    }
-
-    #[test]
-    fn test_api_error_response_into_result_returns_api_error() {
-        let response = Response::<serde_json::Value>::new(
-            None,
-            RawResponse {
-                code: 400,
-                msg: "bad request".to_string(),
-                request_id: Some("req_bad".to_string()),
-                data: None,
-                error: None,
-            },
-        );
-
-        let result = response.into_result();
-        assert!(matches!(result, Err(CoreError::Api(_))));
-
-        let err = result.expect_err("应返回 API 错误");
-        assert!(err.to_string().contains("bad request"));
-    }
-
-    #[test]
-    fn test_success_response_without_data_returns_api_error() {
-        let response = Response::<serde_json::Value>::new(
-            None,
-            RawResponse {
-                code: 0,
-                msg: "ok".to_string(),
-                request_id: Some("req_empty_data".to_string()),
-                data: None,
-                error: None,
-            },
-        );
-
-        let result = response.into_result();
-        assert!(matches!(result, Err(CoreError::Api(_))));
-        let err = result.expect_err("应返回 API 错误");
-        assert!(err.to_string().contains("响应数据为空"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #506.

## What

退役零消费者死 helper `ensure_success`（#470 leaf 全量迁入 `Transport::request_typed` 后全仓 0 调用方），并修正 `Transport::request_typed` 的谎言文档。core 删除 + shim 更新同 ticket 原子落绿。

## Changes

- **core**：删 `api::helpers::ensure_success`（保留 `serialize_params`）+ 清随之 unused 的 `Response` import + 去 `api` 模块 re-export
- **9 个业务 crate** `common::api_utils` shim：去 `ensure_success` re-export + 模块 doc 同步（workflow / communication / application / helpdesk / mail / docs / platform / meeting / **cardkit**）
- **`Transport::request_typed` doc**：按批准文案重写为「双入口分工」叙述（删除/空成功类 API 走 `request_typed`，由响应类型 `ApiResponseTrait` 声明解码策略；`request` 仅留给需要原始 `Response<T>` 的下载/自定义抽取路径）
- **#505 遗留**：`tests/unit/auth/auth_validation_tests.rs`（未接线的死副本）删 2 个 `into_result` 测试 + 去 `Response` import（镜像 live 文件）；`ARCHITECTURE.md` 4 处 `into_result` 伪代码标注历史叙述

## Notes

- Issue 文本写「8 shim」，实际 9 个（cardkit 较 issue 新，跳过会断编译）——全 9 个更新，非 scope creep
- ARCHITECTURE.md 选「标注历史叙述」而非改 `decode(context)`：伪代码用了假类型名（`LarkAPIError` 等），重命名会连带修其它漂移（issue 明确禁止）
- `request_typed` doc 归属按 code-review 建议精化为「#470 后零消费者，随 #506 删除」（原批准文案「随 #470 删除」会把符号删除误归于 #470）
- 0.19 breaking；零消费者 helper 不走废弃周期（先例 #505）

## Verification

`cargo fmt --check` · `clippy --all-features` + `--no-default-features` (`-Dwarnings`) · `RUSTDOCFLAGS=-Dwarnings cargo doc` · `cargo machete` 全绿；`cargo test --workspace --all-features` **12172 passed / 0 failed**。