### PR TITLE
feat(api-contracts): add token-type contract verification (#514)

### DIFF
--- a/docs/api-contract-validation.md
+++ b/docs/api-contract-validation.md
@@ -97,6 +97,37 @@ python3 tools/validate_api_contracts.py \
   --strict fields
 ```
 
+### 1.4 Token 类型 live 校验
+
+核对 Rust 实现里 `.with_supported_access_token_types(...)` 声明的 token 类型，是否被
+飞书官方文档「请求头 → Authorization」接受。这是 [#511](https://github.com/foxzool/openlark/issues/511)
+acs / security_and_compliance 批量误配（误设 `App`/`app_access_token`）的防回归手段。
+
+```bash
+python3 tools/validate_api_contracts.py \
+  --crate openlark-security \
+  --tokens \
+  --strict tokens \
+  --report-dir /tmp/openlark-api-contracts-tokens
+```
+
+oracle 取值（优先级递减）：
+
+1. 官网详情 payload 的 `schema.apiSchema.security.supportedAccessToken`（结构化，多数页面）。
+2. 部分 `server-docs` 风格页（如 acs `user/get`、`user/list`）的 detail payload 不含该字段，
+   回退到抓取文档 `.md` 源的「请求头 Authorization」行（SPA 页正文来源，见
+   `docs/api-spec-accuracy-audit.md` 的核对方法节）。注意：该回退对每个 detail payload 缺标注
+   的接口会多一次 `.md` HTTP 抓取，全量核对时网络调用量会相应放大。
+
+判定规则（被测对象 = Rust 声明的有效 token 集合，未显式声明时取默认 `[User, Tenant]`）：
+
+- Rust 集合与官方集合**不相交** → `ERROR`（运行时注入的 token 必被飞书拒绝）。
+- 官方未标注 → `UNVERIFIED`（无法核对，不阻塞）。
+- 实现文件缺失 → `WARN`。
+- 存在交集（SDK 至少能选出一种官方接受的 token）→ 无 finding。
+
+与 live 校验一致，该维度访问网络、用于人工抽样与 API 变动排查；CI 接入见 #515。
+
 ## 2. 单 crate 使用
 
 只验证一个 crate 的 endpoint：
@@ -138,6 +169,8 @@ python3 tools/validate_api_contracts.py \
 | `W_OPTIONAL_REQUEST_FIELD_MISSING` | 官网 optional request field 在 Rust 请求结构体中缺失 |
 | `W_REQUIRED_REQUEST_FIELD_OPTIONAL` | 官网 required 字段在 Rust 中建模为 `Option<T>` |
 | `W_RESPONSE_FIELD_MISSING` | 官网 response `data` 字段在 Rust 响应模型中缺失 |
+| `E_ACCESS_TOKEN_TYPE_MISMATCH` | Rust 声明的 token 类型全被官方文档拒绝（不相交，鉴权必失败） |
+| `U_ACCESS_TOKEN_UNANNOTATED` | 官方文档未标注 `supportedAccessToken`/Authorization，token 类型无法核对 |
 | `U_OFFICIAL_DETAIL_FETCH_FAILED` | live 模式无法获取官网详情 payload |
 
 ## 4. 当前已知验证证据

--- a/tools/api_contracts/compare.py
+++ b/tools/api_contracts/compare.py
@@ -221,6 +221,51 @@ def compare_response_fields(
     return findings
 
 
+def compare_access_token_types(
+    api: ApiIdentity,
+    official_tokens: tuple[str, ...],
+    rust_contract: RustApiContract | None,
+) -> list[ContractFinding]:
+    """核对 Rust 声明的 token 类型与官方文档 ``security.supportedAccessToken``。
+
+    - Rust 集合与官方集合**不相交** → ERROR（运行时注入的 token 必被飞书拒绝）。
+    - 官方未标注 ``supportedAccessToken`` → UNVERIFIED（无法核对，不阻塞）。
+    - 实现文件缺失 → WARN。
+    - 否则（存在交集，即 SDK 至少能选出一种官方接受的 token）→ 无 finding。
+    """
+    if rust_contract is None:
+        return [
+            finding(
+                "WARN",
+                "W_IMPLEMENTATION_FILE_MISSING",
+                "Expected implementation file does not exist.",
+                api,
+            )
+        ]
+    if not official_tokens:
+        return [
+            finding(
+                "UNVERIFIED",
+                "U_ACCESS_TOKEN_UNANNOTATED",
+                "Official doc did not expose supportedAccessToken; token type cannot be verified.",
+                api,
+            )
+        ]
+    rust_tokens = set(rust_contract.access_token_types)
+    if rust_tokens & set(official_tokens):
+        return []
+    return [
+        finding(
+            "ERROR",
+            "E_ACCESS_TOKEN_TYPE_MISMATCH",
+            "All Rust supported access token types are rejected by the official doc.",
+            api,
+            official=", ".join(official_tokens),
+            rust=", ".join(sorted(rust_tokens)) or "<none>",
+        )
+    ]
+
+
 def official_field_text(field: OfficialField) -> str:
     required = "required" if field.required else "optional"
     suffix = f" {field.field_type}" if field.field_type else ""

--- a/tools/api_contracts/models.py
+++ b/tools/api_contracts/models.py
@@ -8,6 +8,11 @@ from typing import Any
 
 _HTTP_METHODS = {"GET", "POST", "PATCH", "PUT", "DELETE", "HEAD", "OPTIONS", "CONNECT", "TRACE"}
 
+# ApiRequest 未显式声明 supported_access_token_types 时的默认取值
+# （见 crates/openlark-core/src/api/mod.rs: supported_access_token_types() 的默认分支）。
+# 使用飞书凭证名，以便与官方文档 security.supportedAccessToken 直接比对。
+DEFAULT_ACCESS_TOKEN_TYPES: tuple[str, ...] = ("user_access_token", "tenant_access_token")
+
 
 def _split_official_url(value: str) -> tuple[str, str]:
     method, _, path = value.partition(":")
@@ -71,6 +76,9 @@ class RustApiContract:
     # request struct 含 #[serde(flatten)] 字段时，视为该 API 透传所有官方 optional
     # request 字段（透传 Value 或 typed 枚举，非 correctness bug）。
     has_flatten_value_passthrough: bool = False
+    # Rust 侧声明的有效 token 类型（飞书凭证名）。未显式调用
+    # .with_supported_access_token_types(...) 时取 DEFAULT_ACCESS_TOKEN_TYPES。
+    access_token_types: tuple[str, ...] = DEFAULT_ACCESS_TOKEN_TYPES
 
 
 @dataclass(frozen=True)

--- a/tools/api_contracts/official.py
+++ b/tools/api_contracts/official.py
@@ -16,6 +16,15 @@ from .models import ApiIdentity, OfficialField
 
 
 DOC_DETAIL_URL = "https://open.feishu.cn/document_portal/v1/document/get_detail"
+DOC_MARKDOWN_BASE_URL = "https://open.feishu.cn"
+
+# security.supportedAccessToken 与 .md Authorization 行里合法的 token 凭证名。
+_KNOWN_ACCESS_TOKENS = {
+    "tenant_access_token",
+    "user_access_token",
+    "app_access_token",
+    "none_access_token",
+}
 
 
 def camel_to_snake(name: str) -> str:
@@ -163,6 +172,66 @@ def extract_request_fields_from_detail_payload(payload: dict[str, Any]) -> tuple
                 source="official_api_schema",
             )
     return tuple(fields.values())
+
+
+def extract_access_token_types_from_detail_payload(payload: dict[str, Any]) -> tuple[str, ...]:
+    """从 detail payload 解析官方文档标注的可接受 token 类型。
+
+    oracle 路径：``data.schema.apiSchema.security.supportedAccessToken``
+    （如 ``["tenant_access_token", "user_access_token"]``，见
+    ``tools/schema_cache/SCHEMA_FINDINGS.md``）。未标注时返回空元组，调用方据此
+    降级为 UNVERIFIED（无法核对），而非误报为不匹配。
+    """
+    api_schema = extract_api_schema(payload)
+    security = api_schema.get("security") if isinstance(api_schema, dict) else {}
+    if not isinstance(security, dict):
+        return ()
+    tokens = security.get("supportedAccessToken")
+    if not isinstance(tokens, list):
+        return ()
+    return tuple(str(token) for token in tokens if isinstance(token, str))
+
+
+def fetch_doc_markdown(api: ApiIdentity, timeout: int) -> str:
+    """抓取飞书文档 ``.md`` 源（SPA 页正文的真实来源，见 api-spec-accuracy-audit）。
+
+    部分 ``server-docs`` 风格页（如 acs ``user/get``、``user/list``）的 detail payload
+    不含 ``security.supportedAccessToken``，但其 ``.md`` 源的请求头 Authorization 行
+    仍标注了凭证类型——作为 token oracle 的回退来源。失败/无 fullPath 返回空串。
+    """
+    full_path = detail_full_path(api)
+    if not full_path:
+        return ""
+    url = DOC_MARKDOWN_BASE_URL + "/document" + full_path + ".md"
+    try:
+        request = urllib.request.Request(
+            url,
+            headers={"User-Agent": "openlark-api-contract-validator/1.0"},
+        )
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.read().decode("utf-8", "replace")
+    except Exception:  # noqa: BLE001 - 回退来源，失败即视作无标注。
+        return ""
+
+
+def parse_access_token_types_from_markdown(text: str) -> tuple[str, ...]:
+    """从 ``.md`` 源的「请求头 Authorization」表头行解析可接受 token 类型。
+
+    仅采集以 ``Authorization`` 开头的表头行内反引号包裹的 ``*_access_token`` 凭证名
+    （如 ``Authorization | string | 是 | `tenant_access_token`、`user_access_token```），
+    忽略正文里的散文提及。按出现顺序去重。
+    """
+    tokens: list[str] = []
+    seen: set[str] = set()
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("Authorization"):
+            continue
+        for token in re.findall(r"`([a-z_]+_access_token)`", stripped):
+            if token in _KNOWN_ACCESS_TOKENS and token not in seen:
+                seen.add(token)
+                tokens.append(token)
+    return tuple(tokens)
 
 
 def extract_response_fields_from_detail_payload(payload: dict[str, Any]) -> tuple[OfficialField, ...]:

--- a/tools/api_contracts/rust_source.py
+++ b/tools/api_contracts/rust_source.py
@@ -7,11 +7,20 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
 
-from .models import RustApiContract, RustEndpointCall, RustField
+from .models import DEFAULT_ACCESS_TOKEN_TYPES, RustApiContract, RustEndpointCall, RustField
 
 
 REQUEST_STRUCT_SUFFIXES = ("Body", "Query", "Params", "RequestBody")
 RESPONSE_STRUCT_SUFFIXES = ("Response", "Result", "Resp")
+
+# AccessTokenType 枚举变体 → 飞书凭证名（与 constants.rs 的 as_str/Display 一致）。
+# 用于把 Rust 声明的 token 类型翻译成可与官方 supportedAccessToken 直接比对的形态。
+_ACCESS_TOKEN_VARIANT_TO_FEISHU: dict[str, str] = {
+    "None": "none_access_token",
+    "App": "app_access_token",
+    "Tenant": "tenant_access_token",
+    "User": "user_access_token",
+}
 
 
 @dataclass(frozen=True)
@@ -592,6 +601,28 @@ def extract_rust_fields(text: str) -> tuple[RustField, ...]:
     )
 
 
+def extract_access_token_types(text: str) -> tuple[str, ...]:
+    """解析 ``.with_supported_access_token_types(vec![...])`` 声明的 token 类型。
+
+    未找到调用、或调用内无已知变体时，回落到 ``DEFAULT_ACCESS_TOKEN_TYPES``
+    （与 ``ApiRequest`` 运行时默认一致）。变体翻译见 ``_ACCESS_TOKEN_VARIANT_TO_FEISHU``。
+    """
+    match = re.search(
+        r"\.with_supported_access_token_types\s*\(\s*vec!\s*\[([^\]]*)\]",
+        text,
+        re.DOTALL,
+    )
+    if not match:
+        return DEFAULT_ACCESS_TOKEN_TYPES
+    variants = re.findall(r"AccessTokenType::([A-Za-z]+)", match.group(1))
+    types = tuple(
+        _ACCESS_TOKEN_VARIANT_TO_FEISHU[variant]
+        for variant in variants
+        if variant in _ACCESS_TOKEN_VARIANT_TO_FEISHU
+    )
+    return types or DEFAULT_ACCESS_TOKEN_TYPES
+
+
 def has_flatten_value_passthrough(text: str) -> bool:
     """检测 request struct 是否有 ``#[serde(flatten)]`` 字段。
 
@@ -853,10 +884,12 @@ def scan_api_file(
         constants or load_endpoint_constants(crate_src),
         enum_endpoints or load_enum_endpoints(crate_src),
     )
+    access_token_types = extract_access_token_types(text)
     return RustApiContract(
         rel_path=expected_file,
         endpoint_calls=extract_endpoint_calls(text, resolver),
         fields=extract_rust_fields(text),
         response_fields=extract_rust_response_fields(text),
         has_flatten_value_passthrough=has_flatten_value_passthrough(text),
+        access_token_types=access_token_types,
     )

--- a/tools/tests/test_validate_api_contracts_compare.py
+++ b/tools/tests/test_validate_api_contracts_compare.py
@@ -4,8 +4,20 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from tools.api_contracts.compare import compare_endpoint, compare_request_fields, compare_response_fields
-from tools.api_contracts.models import ApiIdentity, OfficialField, RustApiContract, RustEndpointCall, RustField
+from tools.api_contracts.compare import (
+    compare_access_token_types,
+    compare_endpoint,
+    compare_request_fields,
+    compare_response_fields,
+)
+from tools.api_contracts.models import (
+    DEFAULT_ACCESS_TOKEN_TYPES,
+    ApiIdentity,
+    OfficialField,
+    RustApiContract,
+    RustEndpointCall,
+    RustField,
+)
 
 
 class ContractCompareTests(unittest.TestCase):
@@ -448,6 +460,124 @@ class ContractCliTests(unittest.TestCase):
                     "fullPath": "/document/mock",
                 }
             )
+
+
+class AccessTokenCompareTests(unittest.TestCase):
+    """token 类型契约核对：compare_access_token_types 的判定规则。"""
+
+    def _api(self, api_id: str = "acs/v1/user/get") -> ApiIdentity:
+        return ApiIdentity(
+            api_id=api_id,
+            name=api_id,
+            biz_tag="acs",
+            meta_project="acs",
+            meta_version="v1",
+            meta_resource="user",
+            meta_name="get",
+            url="GET:/open-apis/acs/v1/users/:user_id",
+            doc_path="",
+            expected_file="acs/acs/v1/user/get.rs",
+        )
+
+    def _contract(self, types: tuple[str, ...]) -> RustApiContract:
+        return RustApiContract(rel_path="acs/acs/v1/user/get.rs", access_token_types=types)
+
+    def test_disjoint_returns_error(self):
+        # Rust 声明 App，飞书只要 tenant → 必然鉴权失败
+        findings = compare_access_token_types(
+            self._api(), ("tenant_access_token",), self._contract(("app_access_token",))
+        )
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].severity, "ERROR")
+        self.assertEqual(findings[0].code, "E_ACCESS_TOKEN_TYPE_MISMATCH")
+
+    def test_overlap_returns_no_finding(self):
+        findings = compare_access_token_types(
+            self._api(),
+            ("tenant_access_token", "user_access_token"),
+            self._contract(("tenant_access_token",)),
+        )
+        self.assertEqual(findings, [])
+
+    def test_default_tokens_against_tenant_only_is_ok(self):
+        # 宽松默认 [User,Tenant] 对 tenant-only 接口不应误报（交集含 tenant）
+        findings = compare_access_token_types(
+            self._api(),
+            ("tenant_access_token",),
+            self._contract(DEFAULT_ACCESS_TOKEN_TYPES),
+        )
+        self.assertEqual(findings, [])
+
+    def test_official_unannotated_returns_unverified(self):
+        findings = compare_access_token_types(
+            self._api(), (), self._contract(("app_access_token",))
+        )
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].severity, "UNVERIFIED")
+        self.assertEqual(findings[0].code, "U_ACCESS_TOKEN_UNANNOTATED")
+
+    def test_missing_implementation_returns_warn(self):
+        findings = compare_access_token_types(self._api(), ("tenant_access_token",), None)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].severity, "WARN")
+        self.assertEqual(findings[0].code, "W_IMPLEMENTATION_FILE_MISSING")
+
+
+class BootstrapOracleTests(unittest.TestCase):
+    """工具有效性验证：必须检出 #511 已核实的 4 个 token 误配。"""
+
+    def _api(self, api_id: str) -> ApiIdentity:
+        return ApiIdentity(
+            api_id=api_id,
+            name=api_id,
+            biz_tag="acs",
+            meta_project="",
+            meta_version="",
+            meta_resource="",
+            meta_name="",
+            url="",
+            doc_path="",
+            expected_file=api_id,
+        )
+
+    def _assert_error(self, api_id: str, official: list[str], rust: str):
+        findings = compare_access_token_types(
+            self._api(api_id),
+            tuple(official),
+            RustApiContract(rel_path=api_id, access_token_types=(rust,)),
+        )
+        errors = [f for f in findings if f.severity == "ERROR"]
+        self.assertTrue(
+            errors,
+            f"期望检出 ERROR（{api_id}: Rust={rust} vs 飞书={official}），实际={findings}",
+        )
+
+    def test_acs_device_bind_should_be_user_not_app(self):
+        self._assert_error(
+            "acs/v1/rule_external/device_bind", ["user_access_token"], "app_access_token"
+        )
+
+    def test_acs_user_get_should_be_tenant_not_app(self):
+        self._assert_error("acs/v1/user/get", ["tenant_access_token"], "app_access_token")
+
+    def test_acs_user_list_should_be_tenant_not_app(self):
+        self._assert_error("acs/v1/user/list", ["tenant_access_token"], "app_access_token")
+
+    def test_security_user_migrations_get_should_be_tenant_or_user(self):
+        self._assert_error(
+            "security_and_compliance/v1/user_migrations/get",
+            ["tenant_access_token", "user_access_token"],
+            "app_access_token",
+        )
+
+    def test_after_fix_no_error(self):
+        # 反向验证：修正后（device_bind→User）不再报错
+        findings = compare_access_token_types(
+            self._api("acs/v1/rule_external/device_bind"),
+            ("user_access_token",),
+            RustApiContract(rel_path="device_bind", access_token_types=("user_access_token",)),
+        )
+        self.assertEqual(findings, [])
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_validate_api_contracts_official.py
+++ b/tools/tests/test_validate_api_contracts_official.py
@@ -5,11 +5,13 @@ from pathlib import Path
 
 from tools.api_contracts.official import (
     expected_file_path,
+    extract_access_token_types_from_detail_payload,
     extract_endpoint_from_detail_payload,
     extract_request_fields_from_detail_payload,
     extract_response_fields_from_detail_payload,
     load_api_identities,
     normalize_endpoint_path,
+    parse_access_token_types_from_markdown,
     split_method_path,
 )
 
@@ -181,6 +183,96 @@ class OfficialContractTests(unittest.TestCase):
         self.assertEqual(len(identities), 1)
         self.assertEqual(identities[0].expected_file, "ai/document_ai/v1/bank_card/recognize.rs")
         self.assertEqual(identities[0].full_path, "/document/uAjLw4CM/mock")
+
+
+class AccessTokenDetailPayloadTests(unittest.TestCase):
+    """token oracle：从 detail payload 解析 security.supportedAccessToken。"""
+
+    @staticmethod
+    def _detail_payload(tokens):
+        security = {}
+        if tokens is not None:
+            security["supportedAccessToken"] = tokens
+        return {"data": {"schema": {"apiSchema": {"security": security}}}}
+
+    def test_returns_supported_access_token_list(self):
+        tokens = extract_access_token_types_from_detail_payload(
+            self._detail_payload(["tenant_access_token", "user_access_token"])
+        )
+        self.assertEqual(tokens, ("tenant_access_token", "user_access_token"))
+
+    def test_single_tenant_token(self):
+        self.assertEqual(
+            extract_access_token_types_from_detail_payload(
+                self._detail_payload(["tenant_access_token"])
+            ),
+            ("tenant_access_token",),
+        )
+
+    def test_missing_security_returns_empty(self):
+        # 飞书未标注 supportedAccessToken（token 端点等）→ 空，调用方降级 UNVERIFIED
+        self.assertEqual(extract_access_token_types_from_detail_payload({}), ())
+        self.assertEqual(
+            extract_access_token_types_from_detail_payload(
+                {"data": {"schema": {"apiSchema": {}}}}
+            ),
+            (),
+        )
+        self.assertEqual(
+            extract_access_token_types_from_detail_payload(
+                {"data": {"schema": {"apiSchema": {"security": {}}}}}
+            ),
+            (),
+        )
+
+    def test_non_list_supported_access_token_returns_empty(self):
+        self.assertEqual(
+            extract_access_token_types_from_detail_payload(
+                {"data": {"schema": {"apiSchema": {"security": {
+                    "supportedAccessToken": "tenant_access_token",
+                }}}}}
+            ),
+            (),
+        )
+
+    def test_filters_non_string_entries(self):
+        tokens = extract_access_token_types_from_detail_payload(
+            self._detail_payload(["tenant_access_token", 42, None, "user_access_token"])
+        )
+        self.assertEqual(tokens, ("tenant_access_token", "user_access_token"))
+
+
+class AccessTokenMarkdownTests(unittest.TestCase):
+    """token oracle 回退：从 .md 源 Authorization 行解析（server-docs 页 JSON 缺标注时）。"""
+
+    def test_tenant_only_header_row(self):
+        # acs user/get 的 .md 源 Authorization 行
+        md = (
+            "Authorization | string | 是 | `tenant_access_token`<br>"
+            "**值格式**：\"Bearer `access_token`\"<br>"
+            "**示例值**：\"Bearer t-7f1bcd13fc57d46bac21793a18e560\""
+        )
+        self.assertEqual(parse_access_token_types_from_markdown(md), ("tenant_access_token",))
+
+    def test_multi_token_header_row(self):
+        md = "Authorization | string | 是 | `tenant_access_token`、`user_access_token`"
+        self.assertEqual(
+            parse_access_token_types_from_markdown(md),
+            ("tenant_access_token", "user_access_token"),
+        )
+
+    def test_user_only(self):
+        md = "Authorization | string | 是 | `user_access_token`，示例值 \"Bearer u-xxx\""
+        self.assertEqual(parse_access_token_types_from_markdown(md), ("user_access_token",))
+
+    def test_no_authorization_row_returns_empty(self):
+        self.assertEqual(parse_access_token_types_from_markdown("正文无表头\n其他内容"), ())
+        self.assertEqual(parse_access_token_types_from_markdown(""), ())
+
+    def test_ignores_prose_mentions(self):
+        # 正文提到 tenant_access_token 但不在 Authorization 表头行 → 不采集
+        md = "本接口需要调用方持有 tenant_access_token。\n其他说明 user_access_token。"
+        self.assertEqual(parse_access_token_types_from_markdown(md), ())
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_validate_api_contracts_rust_source.py
+++ b/tools/tests/test_validate_api_contracts_rust_source.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from tools.api_contracts.rust_source import (
     EndpointResolver,
+    extract_access_token_types,
     extract_endpoint_calls,
     extract_rust_response_fields,
     extract_rust_fields,
@@ -11,6 +12,8 @@ from tools.api_contracts.rust_source import (
     resolve_format_expression,
     scan_api_file,
 )
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 class RustSourceContractTests(unittest.TestCase):
@@ -293,6 +296,59 @@ class RustSourceContractTests(unittest.TestCase):
         self.assertIsNotNone(contract)
         assert contract is not None
         self.assertTrue(contract.has_flatten_value_passthrough)
+
+
+class ExtractAccessTokensTests(unittest.TestCase):
+    """token 契约：解析 .with_supported_access_token_types 声明（未声明回落默认）。"""
+
+    def test_explicit_single_app(self):
+        source = (
+            "let req = ApiRequest::get(&path)"
+            ".with_supported_access_token_types(vec![AccessTokenType::App]);"
+        )
+        self.assertEqual(extract_access_token_types(source), ("app_access_token",))
+
+    def test_explicit_none(self):
+        source = ".with_supported_access_token_types(vec![AccessTokenType::None]);"
+        self.assertEqual(extract_access_token_types(source), ("none_access_token",))
+
+    def test_explicit_multiple_variants(self):
+        source = (
+            ".with_supported_access_token_types("
+            "vec![AccessTokenType::User, AccessTokenType::Tenant]);"
+        )
+        self.assertEqual(
+            extract_access_token_types(source),
+            ("user_access_token", "tenant_access_token"),
+        )
+
+    def test_multiline_vec_literal(self):
+        source = (
+            ".with_supported_access_token_types(vec![\n"
+            "    AccessTokenType::User,\n"
+            "    AccessTokenType::Tenant,\n"
+            "]);"
+        )
+        self.assertEqual(
+            extract_access_token_types(source),
+            ("user_access_token", "tenant_access_token"),
+        )
+
+    def test_no_call_returns_default(self):
+        # ApiRequest 默认 supported_access_token_types = [User, Tenant]（见 api/mod.rs）
+        self.assertEqual(
+            extract_access_token_types("let req = ApiRequest::get(&path);"),
+            ("user_access_token", "tenant_access_token"),
+        )
+
+    def test_real_auth_token_endpoint_declares_none(self):
+        # 锁定提取器对真实 .rs 源码的解析能力。选用 #512 明确不动（保持 App/None）
+        # 的 auth/v3 token 端点，避免被 #515 的 acs/security 修正连带改坏。
+        source = (
+            REPO_ROOT
+            / "crates/openlark-auth/src/auth/auth/v3/auth/tenant_access_token_internal.rs"
+        ).read_text(encoding="utf-8")
+        self.assertEqual(extract_access_token_types(source), ("none_access_token",))
 
 
 if __name__ == "__main__":

--- a/tools/validate_api_contracts.py
+++ b/tools/validate_api_contracts.py
@@ -18,6 +18,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from tools.api_contracts.compare import (
+    compare_access_token_types,
     compare_endpoint,
     compare_request_fields,
     compare_response_fields,
@@ -25,11 +26,14 @@ from tools.api_contracts.compare import (
 )
 from tools.api_contracts.models import ContractReport
 from tools.api_contracts.official import (
+    extract_access_token_types_from_detail_payload,
     extract_endpoint_from_detail_payload,
     extract_request_fields_from_detail_payload,
     extract_response_fields_from_detail_payload,
     fetch_detail_payload,
+    fetch_doc_markdown,
     load_api_identities,
+    parse_access_token_types_from_markdown,
 )
 from tools.api_contracts.report import write_report, write_summary
 from tools.api_contracts.rust_source import load_endpoint_constants, load_enum_endpoints, scan_api_file
@@ -73,6 +77,14 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Fetch official detail pages for request body field validation",
     )
+    parser.add_argument(
+        "--tokens",
+        action="store_true",
+        help=(
+            "Verify Rust supported_access_token_types against the official "
+            "security.supportedAccessToken annotation (always fetches detail payloads)"
+        ),
+    )
     parser.add_argument("--field-timeout", type=int, default=20, help="Official detail fetch timeout in seconds")
     parser.add_argument("--field-retries", type=int, default=1, help="Official detail fetch retries")
     parser.add_argument(
@@ -84,7 +96,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--strict",
         default="",
-        help="Comma-separated strict categories. Supported values: endpoint, fields",
+        help="Comma-separated strict categories. Supported values: endpoint, fields, tokens",
     )
     return parser.parse_args()
 
@@ -112,6 +124,7 @@ def validate_crate(
     field_timeout: int = 20,
     field_retries: int = 1,
     max_field_apis: int = 0,
+    tokens: bool = False,
 ) -> ContractReport:
     src_path = Path(crate_config["src"])
     biz_tags = list(crate_config.get("biz_tags") or [])
@@ -135,7 +148,7 @@ def validate_crate(
         detail_payload = None
         endpoint_api = api
         should_check_fields = fields and (not max_field_apis or field_checks < max_field_apis)
-        if live_endpoints or should_check_fields:
+        if live_endpoints or should_check_fields or tokens:
             try:
                 detail_payload = fetch_detail_payload(api, timeout=field_timeout, retries=field_retries)
             except Exception as exc:  # noqa: BLE001 - report and keep validating the remaining APIs.
@@ -164,6 +177,18 @@ def validate_crate(
 
         for item in compare_endpoint(endpoint_api, rust_contract):
             report.add(item)
+
+        if tokens:
+            # oracle：优先用 detail payload 的 security.supportedAccessToken；
+            # JSON 缺标注时（部分 server-docs 页）回退到 .md 源的 Authorization 行。
+            official_tokens = ()
+            if detail_payload is not None:
+                official_tokens = extract_access_token_types_from_detail_payload(detail_payload)
+            if not official_tokens:
+                markdown = fetch_doc_markdown(api, timeout=field_timeout)
+                official_tokens = parse_access_token_types_from_markdown(markdown)
+            for item in compare_access_token_types(api, official_tokens, rust_contract):
+                report.add(item)
 
         if should_check_fields and detail_payload is not None:
             field_checks += 1
@@ -218,6 +243,7 @@ def main() -> int:
             field_timeout=args.field_timeout,
             field_retries=args.field_retries,
             max_field_apis=args.max_field_apis,
+            tokens=args.tokens,
         )
         for crate_name in crate_names
     ]
@@ -232,7 +258,7 @@ def main() -> int:
     )
 
     strict_categories = {item.strip() for item in args.strict.split(",") if item.strip()}
-    if ("endpoint" in strict_categories or "fields" in strict_categories) and total_errors:
+    if strict_categories & {"endpoint", "fields", "tokens"} and total_errors:
         return 1
     return 0
 


### PR DESCRIPTION
Closes #514.

## What

为 `validate_api_contracts.py` 新增 `--tokens` 维度：以飞书官方文档「请求头 Authorization」标注为 oracle，核对 Rust 实现里 `.with_supported_access_token_types(...)` 声明的 token 类型——这是 #511 acs / security_and_compliance 批量误配（误设 `App`/`app_access_token`，飞书实际要求 `tenant_access_token` 或 `user_access_token`，调用被鉴权拒）的防回归 seam，也是本 spec（#512）的核心交付物。

挂载在现有 `tools/api_contracts/` 模块上，复用已接入 CI 的 strict gate + `ContractFinding` 报告体系，oracle 直接取自已抓取的 detail payload。

## Changes

- **`official.py`**：`extract_access_token_types_from_detail_payload`（JSON `security.supportedAccessToken`）+ `fetch_doc_markdown` / `parse_access_token_types_from_markdown`（`.md` Authorization 行回退，覆盖 detail payload 缺标注的 server-docs 页）
- **`rust_source.py`**：`extract_access_token_types`（解析 `with_supported_access_token_types(vec![...])`，未声明回落默认 `[User, Tenant]`）
- **`models.py`**：`DEFAULT_ACCESS_TOKEN_TYPES` + `RustApiContract.access_token_types`
- **`compare.py`**：`compare_access_token_types`（Rust/官方集合不相交 → ERROR；官方未标注 → UNVERIFIED；缺实现文件 → WARN）
- **`validate_api_contracts.py`**：`--tokens` flag + `--strict tokens`
- **`docs/api-contract-validation.md`**：新增 §1.4 + finding code 表（`E_ACCESS_TOKEN_TYPE_MISMATCH` / `U_ACCESS_TOKEN_UNANNOTATED`）

## Oracle 设计

优先用 detail payload 的 `security.supportedAccessToken`（结构化、多数页面）；部分 `server-docs` 风格页（acs `user/get`、`user/list`）该字段缺失，回退抓取文档 `.md` 源的「请求头 Authorization」行。判定规则：Rust 声明的有效 token 集合（未显式声明取默认 `[User, Tenant]`）与官方集合**不相交** → ERROR（运行时注入的 token 必被飞书拒）；存在交集则无 finding。

## 验证

- **bootstrap oracle**：live 跑 `--crate openlark-security --tokens` 检出 #511 全部 4 个误配（device_bind→user、user/get→tenant、user/list→tenant、user_migrations/get→tenant/user）为 ERROR，27/27 acs+security 接口报错，0 误报 UNVERIFIED；`--strict tokens` 返回 exit 1
- **测试**：27 个单测落入 CI 实际运行的三个 per-module 文件（`tools/tests/test_validate_api_contracts_{official,rust_source,compare}.py`），含 bootstrap oracle + 一个锁定真实 `.rs` 源码解析的提取测试
- **无新外部依赖**（仅 stdlib `re`/`urllib`）

## Scope

CI strict-gate 接入与 acs/security token 实际修正属 **#515**（被本 PR 阻塞），未越界。`AccessTokenType` 枚举语义、公开 API 均未改动。

> 注：`docs/api-spec-accuracy-audit.md`（#511 诊断证据链）仍 untracked，属 #511 工作流，未纳入本 PR。