### PR TITLE
fix(security): correct acs/security token types + CI token gate (#515)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,13 +71,18 @@ jobs:
             --all-crates \
             --strict endpoint \
             --report-dir "$RUNNER_TEMP/api_contracts"
-      - name: Validate access-token types (acs/security regression gate, #511)
+      - name: Validate access-token types (security + auth regression gate, #511)
         run: |
           python3 tools/validate_api_contracts.py \
             --crate openlark-security \
             --tokens \
             --strict tokens \
-            --report-dir "$RUNNER_TEMP/api_contract_tokens"
+            --report-dir "$RUNNER_TEMP/api_contract_tokens/security"
+          python3 tools/validate_api_contracts.py \
+            --crate openlark-auth \
+            --tokens \
+            --strict tokens \
+            --report-dir "$RUNNER_TEMP/api_contract_tokens/auth"
       - name: Upload API contract reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,12 +71,21 @@ jobs:
             --all-crates \
             --strict endpoint \
             --report-dir "$RUNNER_TEMP/api_contracts"
+      - name: Validate access-token types (acs/security regression gate, #511)
+        run: |
+          python3 tools/validate_api_contracts.py \
+            --crate openlark-security \
+            --tokens \
+            --strict tokens \
+            --report-dir "$RUNNER_TEMP/api_contract_tokens"
       - name: Upload API contract reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: api-contracts
-          path: ${{ runner.temp }}/api_contracts
+          path: |
+            ${{ runner.temp }}/api_contracts
+            ${{ runner.temp }}/api_contract_tokens
           retention-days: 14
 
   lint:

--- a/crates/openlark-client/src/client/tests.rs
+++ b/crates/openlark-client/src/client/tests.rs
@@ -663,9 +663,11 @@ mod security_propagation_tests {
     use wiremock::matchers::{body_json, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    async fn mount_app_token(server: &MockServer, token: &str) {
+    /// acs 用户/设备类接口按飞书文档要求 tenant_access_token（#511/#515），
+    /// 故 security leaf 走 tenant_access_token/internal 取证。
+    async fn mount_tenant_token(server: &MockServer, token: &str) {
         Mock::given(method("POST"))
-            .and(path("/open-apis/auth/v3/app_access_token/internal"))
+            .and(path("/open-apis/auth/v3/tenant_access_token/internal"))
             .and(body_json(serde_json::json!({
                 "app_id": "root_app",
                 "app_secret": "root_secret"
@@ -673,9 +675,8 @@ mod security_propagation_tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "code": 0,
                 "msg": "success",
-                "app_access_token": token,
-                "expire": 7200,
-                "tenant_access_token": "unused_tenant_token"
+                "tenant_access_token": token,
+                "expire": 7200
             })))
             .mount(server)
             .await;
@@ -696,7 +697,7 @@ mod security_propagation_tests {
     #[tokio::test]
     async fn root_client_security_leaf_uses_installed_provider_and_returns_typed_data() {
         let server = MockServer::start().await;
-        mount_app_token(&server, "root_provider_token").await;
+        mount_tenant_token(&server, "root_provider_token").await;
 
         Mock::given(method("GET"))
             .and(path("/open-apis/acs/v1/users"))
@@ -732,7 +733,7 @@ mod security_propagation_tests {
         assert!(!list_resp.has_more);
 
         let rec = server.received_requests().await.unwrap_or_default();
-        assert_eq!(rec.len(), 2, "应先取 app token，再调用 security leaf");
+        assert_eq!(rec.len(), 2, "应先取 tenant token，再调用 security leaf");
         assert!(
             rec.iter()
                 .any(|req| req.url.path() == "/open-apis/acs/v1/users"),
@@ -744,7 +745,7 @@ mod security_propagation_tests {
     #[tokio::test]
     async fn root_client_security_leaf_preserves_retryable_error_and_request_id() {
         let server = MockServer::start().await;
-        mount_app_token(&server, "root_error_provider_token").await;
+        mount_tenant_token(&server, "root_error_provider_token").await;
 
         Mock::given(method("GET"))
             .and(path("/open-apis/acs/v1/users"))

--- a/crates/openlark-security/src/acs/acs/v1/access_record/access_photo/get.rs
+++ b/crates/openlark-security/src/acs/acs/v1/access_record/access_photo/get.rs
@@ -39,7 +39,7 @@ impl GetAccessPhotoRequest {
             self.access_record_id
         );
         let req: ApiRequest<serde_json::Value> =
-            ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
+            ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "下载开门时的人脸识别图片").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/access_record/list.rs
+++ b/crates/openlark-security/src/acs/acs/v1/access_record/list.rs
@@ -53,7 +53,7 @@ impl ListAccessRecordsRequest {
             ApiRequest::get("/open-apis/acs/v1/access_records")
                 .query_opt("page_size", self.page_size.map(|v| v.to_string()))
                 .query_opt("page_token", self.page_token.as_ref())
-                .with_supported_access_token_types(vec![AccessTokenType::App]);
+                .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "获取门禁记录列表").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/client_device/get.rs
+++ b/crates/openlark-security/src/acs/acs/v1/client_device/get.rs
@@ -36,7 +36,7 @@ impl GetClientDeviceRequest {
 
         let path = format!("/open-apis/acs/v1/client_devices/{}", self.device_id);
         let req: ApiRequest<serde_json::Value> =
-            ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
+            ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "获取客户端设备认证信息").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/device/approve.rs
+++ b/crates/openlark-security/src/acs/acs/v1/device/approve.rs
@@ -47,8 +47,8 @@ impl ApproveDeviceRequest {
         validate_required!(self.device_id, "device_id 不能为空");
 
         let path = format!("/open-apis/acs/v1/devices/{}/approve", self.device_id);
-        let mut req: ApiRequest<serde_json::Value> =
-            ApiRequest::post(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
+        let mut req: ApiRequest<serde_json::Value> = ApiRequest::post(&path)
+            .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
         if let Some(body) = self.body {
             req = req.body(body);
         }

--- a/crates/openlark-security/src/acs/acs/v1/device/create.rs
+++ b/crates/openlark-security/src/acs/acs/v1/device/create.rs
@@ -44,7 +44,7 @@ impl CreateDeviceRequest {
 
         let req: ApiRequest<serde_json::Value> = ApiRequest::post("/open-apis/acs/v1/devices")
             .body(body)
-            .with_supported_access_token_types(vec![AccessTokenType::App]);
+            .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "新增设备").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/device/delete.rs
+++ b/crates/openlark-security/src/acs/acs/v1/device/delete.rs
@@ -35,8 +35,8 @@ impl DeleteDeviceRequest {
         validate_required!(self.device_id, "device_id 不能为空");
 
         let path = format!("/open-apis/acs/v1/devices/{}", self.device_id);
-        let req: ApiRequest<serde_json::Value> =
-            ApiRequest::delete(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
+        let req: ApiRequest<serde_json::Value> = ApiRequest::delete(&path)
+            .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "删除设备").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/device/get.rs
+++ b/crates/openlark-security/src/acs/acs/v1/device/get.rs
@@ -36,7 +36,7 @@ impl GetDeviceRequest {
 
         let path = format!("/open-apis/acs/v1/devices/{}", self.device_id);
         let req: ApiRequest<serde_json::Value> =
-            ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
+            ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "获取单个设备信息").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/device/list.rs
+++ b/crates/openlark-security/src/acs/acs/v1/device/list.rs
@@ -62,7 +62,7 @@ impl ListDevicesRequest {
             .query_opt("page_size", self.page_size.map(|v| v.to_string()))
             .query_opt("page_token", self.page_token.as_ref())
             .query_opt("device_type", self.device_type.as_ref())
-            .with_supported_access_token_types(vec![AccessTokenType::App]);
+            .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "获取门禁设备列表").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/device/query.rs
+++ b/crates/openlark-security/src/acs/acs/v1/device/query.rs
@@ -36,7 +36,7 @@ impl QueryDeviceRequest {
 
         let path = format!("/open-apis/acs/v1/devices/{}/query", self.device_id);
         let req: ApiRequest<serde_json::Value> =
-            ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
+            ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "查询设备信息").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/device/update.rs
+++ b/crates/openlark-security/src/acs/acs/v1/device/update.rs
@@ -48,7 +48,7 @@ impl UpdateDeviceRequest {
 
         let path = format!("/open-apis/acs/v1/devices/{}", self.device_id);
         let mut req: ApiRequest<serde_json::Value> =
-            ApiRequest::put(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
+            ApiRequest::put(&path).with_supported_access_token_types(vec![AccessTokenType::Tenant]);
         if let Some(body) = self.body {
             req = req.body(body);
         }

--- a/crates/openlark-security/src/acs/acs/v1/face/create.rs
+++ b/crates/openlark-security/src/acs/acs/v1/face/create.rs
@@ -44,7 +44,7 @@ impl FaceCreateRequest {
 
         let req: ApiRequest<serde_json::Value> = ApiRequest::post("/open-apis/acs/v1/faces")
             .body(body)
-            .with_supported_access_token_types(vec![AccessTokenType::App]);
+            .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "创建人脸").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/face/delete.rs
+++ b/crates/openlark-security/src/acs/acs/v1/face/delete.rs
@@ -35,8 +35,8 @@ impl FaceDeleteRequest {
         validate_required!(self.face_id, "face_id 不能为空");
 
         let path = format!("/open-apis/acs/v1/faces/{}", self.face_id);
-        let req: ApiRequest<serde_json::Value> =
-            ApiRequest::delete(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
+        let req: ApiRequest<serde_json::Value> = ApiRequest::delete(&path)
+            .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "删除人脸").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/face/get.rs
+++ b/crates/openlark-security/src/acs/acs/v1/face/get.rs
@@ -36,7 +36,7 @@ impl FaceGetRequest {
 
         let path = format!("/open-apis/acs/v1/faces/{}", self.face_id);
         let req: ApiRequest<serde_json::Value> =
-            ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
+            ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "获取人脸信息").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/rule_external/create.rs
+++ b/crates/openlark-security/src/acs/acs/v1/rule_external/create.rs
@@ -69,7 +69,7 @@ impl CreateRuleExternalRequest {
                 .query("rule_id", &self.rule_id)
                 .query_opt("user_id_type", self.user_id_type.as_ref())
                 .body(wrapped)
-                .with_supported_access_token_types(vec![AccessTokenType::App]);
+                .with_supported_access_token_types(vec![AccessTokenType::User]);
 
         Transport::request_typed(req, &self.config, Some(option), "创建或更新权限组").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/rule_external/delete.rs
+++ b/crates/openlark-security/src/acs/acs/v1/rule_external/delete.rs
@@ -40,7 +40,7 @@ impl DeleteRuleExternalRequest {
         let req: ApiRequest<serde_json::Value> =
             ApiRequest::delete("/open-apis/acs/v1/rule_external")
                 .query("rule_id", &self.rule_id)
-                .with_supported_access_token_types(vec![AccessTokenType::App]);
+                .with_supported_access_token_types(vec![AccessTokenType::User]);
 
         Transport::request_typed(req, &self.config, Some(option), "删除权限组").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/rule_external/device_bind.rs
+++ b/crates/openlark-security/src/acs/acs/v1/rule_external/device_bind.rs
@@ -76,7 +76,7 @@ impl BindDeviceToRuleRequest {
                         validation_error("设备绑定权限组", format!("序列化失败: {e}"))
                     })?,
                 )
-                .with_supported_access_token_types(vec![AccessTokenType::App]);
+                .with_supported_access_token_types(vec![AccessTokenType::User]);
 
         Transport::request_typed(req, &self.config, Some(option), "设备绑定权限组").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/rule_external/get.rs
+++ b/crates/openlark-security/src/acs/acs/v1/rule_external/get.rs
@@ -49,7 +49,7 @@ impl GetRuleExternalRequest {
         let req: ApiRequest<serde_json::Value> = ApiRequest::get("/open-apis/acs/v1/rule_external")
             .query("device_id", &self.device_id)
             .query_opt("user_id_type", self.user_id_type.as_ref())
-            .with_supported_access_token_types(vec![AccessTokenType::App]);
+            .with_supported_access_token_types(vec![AccessTokenType::User]);
 
         Transport::request_typed(req, &self.config, Some(option), "获取权限组信息").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/user/create.rs
+++ b/crates/openlark-security/src/acs/acs/v1/user/create.rs
@@ -44,7 +44,7 @@ impl CreateUserRequest {
 
         let req: ApiRequest<serde_json::Value> = ApiRequest::post("/open-apis/acs/v1/users")
             .body(body)
-            .with_supported_access_token_types(vec![AccessTokenType::App]);
+            .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "创建用户").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/user/delete.rs
+++ b/crates/openlark-security/src/acs/acs/v1/user/delete.rs
@@ -35,8 +35,8 @@ impl DeleteUserRequest {
         validate_required!(self.user_id, "user_id 不能为空");
 
         let path = format!("/open-apis/acs/v1/users/{}", self.user_id);
-        let req: ApiRequest<serde_json::Value> =
-            ApiRequest::delete(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
+        let req: ApiRequest<serde_json::Value> = ApiRequest::delete(&path)
+            .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "删除用户").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/user/face/get.rs
+++ b/crates/openlark-security/src/acs/acs/v1/user/face/get.rs
@@ -55,7 +55,7 @@ impl GetUserFaceRequest {
 
         let path = format!("/open-apis/acs/v1/users/{}/face", self.user_id);
         let req: ApiRequest<FaceData> =
-            ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
+            ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "下载用户人脸图片").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/user/face/update.rs
+++ b/crates/openlark-security/src/acs/acs/v1/user/face/update.rs
@@ -52,7 +52,7 @@ impl UpdateUserFaceRequest {
         let path = format!("/open-apis/acs/v1/users/{}/face", self.user_id);
         let req: ApiRequest<serde_json::Value> = ApiRequest::put(&path)
             .body(body)
-            .with_supported_access_token_types(vec![AccessTokenType::App]);
+            .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "上传用户人脸图片").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/user/get.rs
+++ b/crates/openlark-security/src/acs/acs/v1/user/get.rs
@@ -38,7 +38,7 @@ impl GetUserRequest {
 
         let path = format!("/open-apis/acs/v1/users/{}", self.user_id);
         let req: ApiRequest<serde_json::Value> =
-            ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
+            ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "获取单个用户信息").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/user/list.rs
+++ b/crates/openlark-security/src/acs/acs/v1/user/list.rs
@@ -89,7 +89,7 @@ impl ListUsersRequest {
             .query_opt("page_size", self.page_size.map(|v| v.to_string()))
             .query_opt("page_token", self.page_token.as_ref())
             .query_opt("department_id", self.department_id.as_ref())
-            .with_supported_access_token_types(vec![AccessTokenType::App]);
+            .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "获取用户列表").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/user/patch.rs
+++ b/crates/openlark-security/src/acs/acs/v1/user/patch.rs
@@ -47,8 +47,8 @@ impl PatchUserRequest {
         validate_required!(self.user_id, "user_id 不能为空");
 
         let path = format!("/open-apis/acs/v1/users/{}", self.user_id);
-        let mut req: ApiRequest<serde_json::Value> =
-            ApiRequest::patch(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
+        let mut req: ApiRequest<serde_json::Value> = ApiRequest::patch(&path)
+            .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
         if let Some(body) = self.body {
             req = req.body(body);
         }

--- a/crates/openlark-security/src/acs/acs/v1/visitor/create.rs
+++ b/crates/openlark-security/src/acs/acs/v1/visitor/create.rs
@@ -44,7 +44,7 @@ impl CreateVisitorRequest {
 
         let req: ApiRequest<serde_json::Value> = ApiRequest::post("/open-apis/acs/v1/visitors")
             .body(body)
-            .with_supported_access_token_types(vec![AccessTokenType::App]);
+            .with_supported_access_token_types(vec![AccessTokenType::User]);
 
         Transport::request_typed(req, &self.config, Some(option), "添加访客").await
     }

--- a/crates/openlark-security/src/acs/acs/v1/visitor/delete.rs
+++ b/crates/openlark-security/src/acs/acs/v1/visitor/delete.rs
@@ -35,8 +35,8 @@ impl DeleteVisitorRequest {
         validate_required!(self.visitor_id, "visitor_id 不能为空");
 
         let path = format!("/open-apis/acs/v1/visitors/{}", self.visitor_id);
-        let req: ApiRequest<serde_json::Value> =
-            ApiRequest::delete(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
+        let req: ApiRequest<serde_json::Value> = ApiRequest::delete(&path)
+            .with_supported_access_token_types(vec![AccessTokenType::User]);
 
         Transport::request_typed(req, &self.config, Some(option), "删除访客").await
     }

--- a/crates/openlark-security/src/lib.rs
+++ b/crates/openlark-security/src/lib.rs
@@ -45,7 +45,8 @@
 //!
 //! ### acs (v1) - 访问控制系统
 //!
-//! 所有端点走 `openlark_core::Transport` + App access token，返回响应 `data` 字段内容。
+//! 所有端点走 `openlark_core::Transport`，token 类型按飞书文档 Authorization 标注
+//! （用户/设备/记录类 `tenant_access_token`，权限组/访客类 `user_access_token`），返回响应 `data` 字段内容。
 //! 各 Service 是门面，方法返回 `*Request` 构建器（`.execute()` 发请求）。
 //!
 //! #### 用户管理 (users)
@@ -256,15 +257,18 @@ mod construction_tests {
 
     /// 代表性 compliance (security_and_compliance v2) leaf 也应收到 retained canonical Config。
     /// 证明与 ACS 相同：base_url、headers、token_provider 完整保留。
+    ///
+    /// 用 `device_records().list()`（tenant_access_token）而非 `mine()`：后者按飞书文档要求
+    /// user_access_token（#515），而本测试的 token provider 只供 tenant/app 凭证、不设
+    /// `option.user_access_token`，User 类 leaf 会在 `validate()` 直接被拒（http.rs:361）。
+    /// 本测试验证的是 config 传播，与具体 leaf 无关，故选 tenant 类代表 leaf。
     #[tokio::test]
     async fn security_client_new_canonical_config_propagates_to_compliance_v2_leaf() {
         let server = MockServer::start().await;
 
         // 精确匹配 header，证明 token provider 和自定义 header 传播
         Mock::given(method("GET"))
-            .and(path(
-                "/open-apis/security_and_compliance/v2/device_records/mine",
-            ))
+            .and(path("/open-apis/security_and_compliance/v2/device_records"))
             .and(header("Authorization", "Bearer test_tok_from_provider"))
             .and(header("X-Compliance-Test", "propagated"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
@@ -296,7 +300,7 @@ mod construction_tests {
             .security_and_compliance
             .v2()
             .device_records()
-            .mine()
+            .list()
             .execute()
             .await
             .expect("compliance v2 leaf 应成功");
@@ -304,7 +308,7 @@ mod construction_tests {
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1, "应只发一次 compliance leaf 请求");
         assert!(
-            received[0].url.path().contains("/device_records/mine"),
+            received[0].url.path().contains("/device_records"),
             "请求路径应指向 compliance v2 leaf"
         );
     }
@@ -400,13 +404,12 @@ mod construction_tests {
     }
 
     /// Compliance v2 业务错误必须保留 retry 语义与 request ID。
+    /// 同上用 `list()`（tenant）而非 `mine()`（user，#515）：测试只配 tenant/app 凭证。
     #[tokio::test]
     async fn compliance_v2_preserves_retryable_error_and_request_id() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .and(path(
-                "/open-apis/security_and_compliance/v2/device_records/mine",
-            ))
+            .and(path("/open-apis/security_and_compliance/v2/device_records"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "code": 429,
                 "msg": "compliance v2 rate limited",
@@ -428,7 +431,7 @@ mod construction_tests {
             .security_and_compliance
             .v2()
             .device_records()
-            .mine()
+            .list()
             .execute()
             .await
             .expect_err("compliance v2 业务错误必须向上传播");

--- a/crates/openlark-security/src/security/security_and_compliance/v1/multi_geo_entity/tenant/get.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/multi_geo_entity/tenant/get.rs
@@ -53,7 +53,10 @@ impl ListMultiGeoEntityTenantsRequest {
             ApiRequest::get("/open-apis/security_and_compliance/v1/multi_geo_entity/tenant")
                 .query_opt("page_size", self.page_size.map(|v| v.to_string()))
                 .query_opt("page_token", self.page_token.as_ref())
-                .with_supported_access_token_types(vec![AccessTokenType::App]);
+                .with_supported_access_token_types(vec![
+                    AccessTokenType::Tenant,
+                    AccessTokenType::User,
+                ]);
 
         Transport::request_typed(req, &self.config, Some(option), "获取地理位置列表").await
     }

--- a/crates/openlark-security/src/security/security_and_compliance/v1/openapi_logs/list_data.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/openapi_logs/list_data.rs
@@ -70,7 +70,7 @@ impl ListOpenApiLogsRequest {
         let req: ApiRequest<serde_json::Value> =
             ApiRequest::post("/open-apis/security_and_compliance/v1/openapi_logs/list_data")
                 .body(self.body)
-                .with_supported_access_token_types(vec![AccessTokenType::App]);
+                .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "获取 OpenAPI 审计日志数据").await
     }

--- a/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/cancel.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/cancel.rs
@@ -36,7 +36,10 @@ impl CancelUserMigrationRequest {
         let req: ApiRequest<serde_json::Value> =
             ApiRequest::post("/open-apis/security_and_compliance/v1/user_migrations/cancel")
                 .body(body)
-                .with_supported_access_token_types(vec![AccessTokenType::App]);
+                .with_supported_access_token_types(vec![
+                    AccessTokenType::Tenant,
+                    AccessTokenType::User,
+                ]);
 
         Transport::request_typed(req, &self.config, Some(option), "取消用户迁移").await
     }

--- a/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/create.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/create.rs
@@ -45,7 +45,10 @@ impl CreateUserMigrationRequest {
         let req: ApiRequest<serde_json::Value> =
             ApiRequest::post("/open-apis/security_and_compliance/v1/user_migrations")
                 .body(self.body)
-                .with_supported_access_token_types(vec![AccessTokenType::App]);
+                .with_supported_access_token_types(vec![
+                    AccessTokenType::Tenant,
+                    AccessTokenType::User,
+                ]);
 
         Transport::request_typed(req, &self.config, Some(option), "创建用户迁移").await
     }

--- a/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/get.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/get.rs
@@ -36,7 +36,7 @@ impl GetUserMigrationRequest {
             "/open-apis/security_and_compliance/v1/user_migrations/{}",
             self.migration_id
         ))
-        .with_supported_access_token_types(vec![AccessTokenType::App]);
+        .with_supported_access_token_types(vec![AccessTokenType::Tenant, AccessTokenType::User]);
 
         Transport::request_typed(req, &self.config, Some(option), "获取单个用户迁移状态").await
     }

--- a/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/search.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v1/user_migrations/search.rs
@@ -45,7 +45,10 @@ impl SearchUserMigrationsRequest {
         let req: ApiRequest<serde_json::Value> =
             ApiRequest::post("/open-apis/security_and_compliance/v1/user_migrations/search")
                 .body(self.body)
-                .with_supported_access_token_types(vec![AccessTokenType::App]);
+                .with_supported_access_token_types(vec![
+                    AccessTokenType::Tenant,
+                    AccessTokenType::User,
+                ]);
 
         Transport::request_typed(req, &self.config, Some(option), "批量获取用户迁移状态").await
     }

--- a/crates/openlark-security/src/security/security_and_compliance/v2/device_apply_records/approve.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v2/device_apply_records/approve.rs
@@ -96,7 +96,7 @@ impl ApproveDeviceApplyRecordRequest {
                 serde_json::to_value(&self.body)
                     .map_err(|e| validation_error("审批设备申报", format!("序列化失败: {e}")))?,
             )
-            .with_supported_access_token_types(vec![AccessTokenType::App]);
+            .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "审批设备申报").await
     }

--- a/crates/openlark-security/src/security/security_and_compliance/v2/device_records/create.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v2/device_records/create.rs
@@ -48,7 +48,7 @@ impl CreateDeviceRecordRequest {
         let req: ApiRequest<serde_json::Value> =
             ApiRequest::post("/open-apis/security_and_compliance/v2/device_records")
                 .body(body)
-                .with_supported_access_token_types(vec![AccessTokenType::App]);
+                .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "新增设备记录").await
     }

--- a/crates/openlark-security/src/security/security_and_compliance/v2/device_records/delete.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v2/device_records/delete.rs
@@ -38,8 +38,8 @@ impl DeleteDeviceRecordRequest {
             "/open-apis/security_and_compliance/v2/device_records/{}",
             self.device_record_id
         );
-        let req: ApiRequest<serde_json::Value> =
-            ApiRequest::delete(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
+        let req: ApiRequest<serde_json::Value> = ApiRequest::delete(&path)
+            .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "删除设备").await
     }

--- a/crates/openlark-security/src/security/security_and_compliance/v2/device_records/get.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v2/device_records/get.rs
@@ -39,7 +39,7 @@ impl GetDeviceRecordRequest {
             self.device_record_id
         );
         let req: ApiRequest<serde_json::Value> =
-            ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
+            ApiRequest::get(&path).with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "获取单个设备信息").await
     }

--- a/crates/openlark-security/src/security/security_and_compliance/v2/device_records/list.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v2/device_records/list.rs
@@ -106,7 +106,7 @@ impl ListDeviceRecordsRequest {
                     self.personal_device.map(|v| v.to_string()),
                 )
                 .query_opt("compliance_status", self.compliance_status.as_ref())
-                .with_supported_access_token_types(vec![AccessTokenType::App]);
+                .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
         Transport::request_typed(req, &self.config, Some(option), "查询设备信息列表").await
     }

--- a/crates/openlark-security/src/security/security_and_compliance/v2/device_records/mine.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v2/device_records/mine.rs
@@ -63,7 +63,7 @@ impl GetMyDeviceRecordsRequest {
                 .query_opt("page_size", self.page_size.map(|v| v.to_string()))
                 .query_opt("page_token", self.page_token.as_ref())
                 .query_opt("status", self.status.as_ref())
-                .with_supported_access_token_types(vec![AccessTokenType::App]);
+                .with_supported_access_token_types(vec![AccessTokenType::User]);
 
         Transport::request_typed(req, &self.config, Some(option), "获取我的设备认证信息").await
     }

--- a/crates/openlark-security/src/security/security_and_compliance/v2/device_records/update.rs
+++ b/crates/openlark-security/src/security/security_and_compliance/v2/device_records/update.rs
@@ -51,7 +51,7 @@ impl UpdateDeviceRecordRequest {
             self.device_record_id
         );
         let mut req: ApiRequest<serde_json::Value> =
-            ApiRequest::put(&path).with_supported_access_token_types(vec![AccessTokenType::App]);
+            ApiRequest::put(&path).with_supported_access_token_types(vec![AccessTokenType::Tenant]);
         if let Some(body) = self.body {
             req = req.body(body);
         }

--- a/docs/api-contract-validation.md
+++ b/docs/api-contract-validation.md
@@ -33,7 +33,7 @@ python3 tools/validate_api_contracts.py --all-crates --strict endpoint
 - `reports/api_contracts/crates/<crate>.md`
 - `reports/api_contracts/crates/<crate>.json`
 
-CI 当前只启用这一层 strict gate。
+CI 启用本层（全仓离线 endpoint）与 token 层（`openlark-security`，见 §1.4）两个 strict gate。
 
 ### 1.2 Endpoint live 校验
 
@@ -126,7 +126,10 @@ oracle 取值（优先级递减）：
 - 实现文件缺失 → `WARN`。
 - 存在交集（SDK 至少能选出一种官方接受的 token）→ 无 finding。
 
-与 live 校验一致，该维度访问网络、用于人工抽样与 API 变动排查；CI 接入见 #515。
+与 live 校验一致，该维度访问网络。CI 对 `openlark-security` 启用 `--strict tokens`，作为
+[#511](https://github.com/foxzool/openlark/issues/511) acs / security_and_compliance 误配的回归
+gate（与 endpoint strict gate 同级）。全仓 live 核对因每个接口都要抓取详情 payload、调用量过大，
+未纳入 CI；其他 crate 用 `just api-contract-tokens <crate>` 人工抽样。
 
 ## 2. 单 crate 使用
 

--- a/docs/api-contract-validation.md
+++ b/docs/api-contract-validation.md
@@ -125,6 +125,10 @@ oracle 取值（优先级递减）：
 - 官方未标注 → `UNVERIFIED`（无法核对，不阻塞）。
 - 实现文件缺失 → `WARN`。
 - 存在交集（SDK 至少能选出一种官方接受的 token）→ 无 finding。
+- 声明 `None`（自行管理鉴权、bypass token cache）但源码手动注入
+  `Authorization: Bearer <self.token_field>` 的端点（如 OIDC `authen/v1/user_info/get`），
+  按实际注入的 token 类型核对，而非 `none_access_token`——避免把「手动注入 user token」
+  误判为 disjoint `ERROR`。真正无鉴权（声明 `None` 且无手动注入）对要求 token 的文档仍报 `ERROR`。
 
 与 live 校验一致，该维度访问网络。CI 对 `openlark-security` 启用 `--strict tokens`，作为
 [#511](https://github.com/foxzool/openlark/issues/511) acs / security_and_compliance 误配的回归

--- a/docs/api-contract-validation.md
+++ b/docs/api-contract-validation.md
@@ -130,10 +130,11 @@ oracle 取值（优先级递减）：
   按实际注入的 token 类型核对，而非 `none_access_token`——避免把「手动注入 user token」
   误判为 disjoint `ERROR`。真正无鉴权（声明 `None` 且无手动注入）对要求 token 的文档仍报 `ERROR`。
 
-与 live 校验一致，该维度访问网络。CI 对 `openlark-security` 启用 `--strict tokens`，作为
-[#511](https://github.com/foxzool/openlark/issues/511) acs / security_and_compliance 误配的回归
-gate（与 endpoint strict gate 同级）。全仓 live 核对因每个接口都要抓取详情 payload、调用量过大，
-未纳入 CI；其他 crate 用 `just api-contract-tokens <crate>` 人工抽样。
+与 live 校验一致，该维度访问网络。CI 对 `openlark-security` 与 `openlark-auth` 启用
+`--strict tokens`，作为 [#511](https://github.com/foxzool/openlark/issues/511) acs /
+security_and_compliance 误配的回归 gate（与 endpoint strict gate 同级；auth 覆盖 OIDC token
+端点）。全仓 live 核对因每个接口都要抓取详情 payload、调用量过大，未纳入 CI；其他 crate 用
+`just api-contract-tokens <crate>` 人工抽样。
 
 ## 2. 单 crate 使用
 

--- a/justfile
+++ b/justfile
@@ -50,6 +50,11 @@ api-contracts:
   @echo "🔍 Validating typed API endpoint contracts..."
   python3 tools/validate_api_contracts.py --all-crates --strict endpoint
 
+# Validate access-token types against official docs (#511 regression gate; default: openlark-security)
+api-contract-tokens CRATE="openlark-security":
+  @echo "🔍 Validating typed API access-token types against official docs..."
+  python3 tools/validate_api_contracts.py --crate {{CRATE}} --tokens --strict tokens --report-dir reports/api_contract_tokens
+
 # Validate request/response fields against current official docs for one crate
 api-contract-fields CRATE="openlark-ai" MAX="5":
   @echo "🔍 Validating typed API fields against current official docs..."

--- a/tools/api_contracts/compare.py
+++ b/tools/api_contracts/compare.py
@@ -252,6 +252,10 @@ def compare_access_token_types(
             )
         ]
     rust_tokens = set(rust_contract.access_token_types)
+    # 声明 None（自行管理鉴权，bypass token cache）但手动注入 token 的端点（如 OIDC
+    # userinfo）：用实际注入的 token 类型替代 none 做比对，避免误报 disjoint ERROR。
+    if rust_tokens == {"none_access_token"} and rust_contract.manual_auth_token:
+        rust_tokens = {rust_contract.manual_auth_token}
     if rust_tokens & set(official_tokens):
         return []
     return [

--- a/tools/api_contracts/models.py
+++ b/tools/api_contracts/models.py
@@ -79,6 +79,11 @@ class RustApiContract:
     # Rust 侧声明的有效 token 类型（飞书凭证名）。未显式调用
     # .with_supported_access_token_types(...) 时取 DEFAULT_ACCESS_TOKEN_TYPES。
     access_token_types: tuple[str, ...] = DEFAULT_ACCESS_TOKEN_TYPES
+    # 声明 None（自行管理鉴权，bypass token cache）但手动注入
+    # ``Authorization: Bearer <self.token_field>`` 时，实际注入的 token 凭证名
+    # （如 OIDC userinfo 注入 user_access_token）。compare 据此把 none_access_token
+    # 替换为该类型核对，避免误报 disjoint ERROR。未检测到注入时为空串。
+    manual_auth_token: str = ""
 
 
 @dataclass(frozen=True)

--- a/tools/api_contracts/rust_source.py
+++ b/tools/api_contracts/rust_source.py
@@ -623,6 +623,34 @@ def extract_access_token_types(text: str) -> tuple[str, ...]:
     return types or DEFAULT_ACCESS_TOKEN_TYPES
 
 
+# 手动注入 ``Authorization: Bearer <self.field>`` 的 struct 字段 → 飞书凭证名。
+# 声明 ``AccessTokenType::None`` 的端点（如 OIDC userinfo）自行管理鉴权：从 struct
+# 字段取 token 并手设 Authorization header，bypass token cache。
+_MANUAL_TOKEN_FIELD_TO_FEISHU: dict[str, str] = {
+    "user_access_token": "user_access_token",
+    "tenant_access_token": "tenant_access_token",
+    "app_access_token": "app_access_token",
+}
+
+
+def extract_manual_auth_token(text: str) -> str:
+    """检测 request 是否手动注入 ``Authorization: Bearer <self.token_field>``。
+
+    用于声明 ``AccessTokenType::None``（bypass token cache）的端点：它们的实际 token
+    由 struct 字段提供并手设 header，validator 据此把 ``none_access_token`` 替换为该
+    实际类型核对，避免误报 disjoint ERROR（#515 的 auth/user_info 误报根因）。
+
+    匹配 ``format!("Bearer ...", self.<field>)`` 形态；未检测到返回空串。
+    """
+    for field, feishu_name in _MANUAL_TOKEN_FIELD_TO_FEISHU.items():
+        if re.search(
+            r'format!\(\s*"Bearer\b[^"]*"\s*,\s*self\.' + field + r"\b",
+            text,
+        ):
+            return feishu_name
+    return ""
+
+
 def has_flatten_value_passthrough(text: str) -> bool:
     """检测 request struct 是否有 ``#[serde(flatten)]`` 字段。
 
@@ -892,4 +920,5 @@ def scan_api_file(
         response_fields=extract_rust_response_fields(text),
         has_flatten_value_passthrough=has_flatten_value_passthrough(text),
         access_token_types=access_token_types,
+        manual_auth_token=extract_manual_auth_token(text),
     )

--- a/tools/tests/test_validate_api_contracts_compare.py
+++ b/tools/tests/test_validate_api_contracts_compare.py
@@ -580,5 +580,44 @@ class BootstrapOracleTests(unittest.TestCase):
         self.assertEqual(findings, [])
 
 
+class ManualAuthTokenReconciliationTests(unittest.TestCase):
+    """声明 None 但手动注入 token（OIDC userinfo）的端点：按实际注入类型核对，不误报 ERROR（#515）。"""
+
+    def _api(self):
+        return ApiIdentity(
+            api_id="authen/v1/user_info/get",
+            name="获取用户信息",
+            biz_tag="auth",
+            meta_project="auth",
+            meta_version="v1",
+            meta_resource="user_info",
+            meta_name="get",
+            url="",
+            doc_path="",
+            expected_file="auth/authen/v1/user_info/get.rs",
+        )
+
+    def test_none_declared_with_manual_user_token_matches_user_doc(self):
+        # 声明 None + 手动注入 user_access_token ↔ 文档 user_access_token → 无 finding
+        contract = RustApiContract(
+            rel_path="auth/authen/v1/user_info/get.rs",
+            access_token_types=("none_access_token",),
+            manual_auth_token="user_access_token",
+        )
+        self.assertEqual(
+            compare_access_token_types(self._api(), ("user_access_token",), contract),
+            [],
+        )
+
+    def test_none_declared_without_manual_injection_still_errors(self):
+        # 真正无鉴权（None、无手动注入）对要求 user 的文档仍报 ERROR
+        contract = RustApiContract(
+            rel_path="x.rs",
+            access_token_types=("none_access_token",),
+        )
+        findings = compare_access_token_types(self._api(), ("user_access_token",), contract)
+        self.assertTrue(any(f.code == "E_ACCESS_TOKEN_TYPE_MISMATCH" for f in findings))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/tests/test_validate_api_contracts_rust_source.py
+++ b/tools/tests/test_validate_api_contracts_rust_source.py
@@ -6,6 +6,7 @@ from tools.api_contracts.rust_source import (
     EndpointResolver,
     extract_access_token_types,
     extract_endpoint_calls,
+    extract_manual_auth_token,
     extract_rust_response_fields,
     extract_rust_fields,
     load_endpoint_constants,
@@ -349,6 +350,48 @@ class ExtractAccessTokensTests(unittest.TestCase):
             / "crates/openlark-auth/src/auth/auth/v3/auth/tenant_access_token_internal.rs"
         ).read_text(encoding="utf-8")
         self.assertEqual(extract_access_token_types(source), ("none_access_token",))
+
+
+class ExtractManualAuthTokenTests(unittest.TestCase):
+    """token 契约：识别声明 None 但手动注入 ``Authorization: Bearer`` 的端点（OIDC userinfo）。
+
+    声明 ``AccessTokenType::None`` 表示自行管理鉴权（bypass token cache）。validator 据此
+    把 ``none_access_token`` 替换为实际注入的 token 类型，避免误报 disjoint ERROR（#515）。
+    """
+
+    def test_detects_manual_user_token_bearer_injection(self):
+        source = (
+            "ApiRequest::get(&path)"
+            '.header("Authorization", format!("Bearer {}", self.user_access_token))'
+            ".with_supported_access_token_types(vec![AccessTokenType::None]);"
+        )
+        self.assertEqual(extract_manual_auth_token(source), "user_access_token")
+
+    def test_detects_multiline_header_injection(self):
+        # 真实 userinfo 写法：header 调用跨多行
+        source = (
+            "ApiRequest::get(api_endpoint.path())\n"
+            "    .header(\n"
+            '        "Authorization",\n'
+            '        format!("Bearer {}", self.user_access_token),\n'
+            "    )\n"
+            "    .with_supported_access_token_types(vec![AccessTokenType::None]);"
+        )
+        self.assertEqual(extract_manual_auth_token(source), "user_access_token")
+
+    def test_no_bearer_injection_returns_empty(self):
+        # 真正无鉴权的 token 签发端点（tenant_access_token_internal）：声明 None 但不注入 Bearer
+        source = (
+            "ApiRequest::post(path)"
+            ".with_supported_access_token_types(vec![AccessTokenType::None]);"
+        )
+        self.assertEqual(extract_manual_auth_token(source), "")
+
+    def test_real_userinfo_source_detected(self):
+        source = (
+            REPO_ROOT / "crates/openlark-auth/src/auth/authen/v1/user_info/get.rs"
+        ).read_text(encoding="utf-8")
+        self.assertEqual(extract_manual_auth_token(source), "user_access_token")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #515.

## What

用 #514 的核对工具修正 `openlark-security` 的 acs/v1 与 security_and_compliance/v1,v2 的 token 类型误配（误设 App/app_access_token → 飞书文档要求的 tenant/user），并把 token 维度接入 CI strict gate。

## Changes

- **token 修正（39 leaf）**：acs 用户/设备/face/client_device → tenant；acs rule_external/visitor → user；security device_record/openapi_log/user_migration/multi_geo → tenant(+user)。27 个为 validator 核对的官方 API；另 12 个 acs leaf 不在 CSV、docPath 404，按 acs 永不为 app-type 的资源族推断改为 tenant（非文档背书）。
- **CI token gate**：api-contracts job 加 `--strict tokens`，覆盖 openlark-security + openlark-auth（#511 回归 + OIDC token 端点），peer 到 endpoint strict gate；加 `just api-contract-tokens`。
- **validator 增强**：声明 None 但手动注入 `Authorization: Bearer <self.token_field>` 的端点（OIDC userinfo）按实际注入类型核对，消掉 auth/user_info 误报——不能把声明改 User（会注入空 token、破坏 OIDC）。全仓 token 核对 0 ERROR。

## Verification

- openlark-security / openlark-auth `--strict tokens`：均 0 ERROR（security 原 27、auth 原 1 误报）
- validator 测试三模块：65 passed（含 6 新增）
- `cargo test --workspace --all-features`：6086 passed, 0 failed
- fmt / clippy(--all-features + --no-default-features)：clean

## Notes

- 12 个 acs 孤儿 leaf 的 tenant 是资源族推断、非文档背书（docPath 404），若日后发现真实文档要求 user 需再校正。
- authen/v1 的 4 个 OIDC token 端点保持 App（#512 明确不动），已验证未改。
- 全仓 live token gate 因 ~1530 次抓取未纳入 CI；其他 crate 用 `just api-contract-tokens <crate>` 抽样。