### PR TITLE
docs(api-template): replace extract_response_data with request_typed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     按名再导出这 7 个类型，保留一个过渡周期——既有全路径 import 仍可解析，仅多一条
     deprecation 提示。下个 breaking 窗口（0.19）删除该 alias。
 
+- **docs：API 实现模板修正 `extract_response_data` → `Transport::request_typed` doc-drift（#507）**：
+  `docs/api-implementation-template.md` 仍教人 import + 调用 #486 已删的自由函数
+  `extract_response_data`（模板早已坏）。改为展示真实 leaf 形态
+  `Transport::request_typed(req, &config, Some(option), "中文名")`（与 `okr/objective/get`、
+  `tasklist` 等现网 leaf 一致），删掉对应 import 与检查点项。`error-context-policy.md`
+  引用的 operation *字符串* `"extract_response_data"`（由 `Response::decode` 经
+  `set_operation` 发出）准确，不动。纯文档，无代码/rustdoc 改动。
+
 ## [0.18.0] - 2026-07-20
 
 > WebSocket 公开 API 破坏性变更随 **0.18.0** workspace 版本一并发出（见下 Breaking）。

--- a/docs/api-implementation-template.md
+++ b/docs/api-implementation-template.md
@@ -45,7 +45,7 @@ use std::sync::Arc;
 
 use crate::common::{
     api_endpoints::{ProjectApiV1},  // 根据实际 crate 调整
-    api_utils::{extract_response_data, serialize_params},
+    api_utils::serialize_params,
 };
 
 // ============================================================================
@@ -159,11 +159,8 @@ impl {Name}Request {
             api_request = api_request.query("{query_key}", query);
         }
 
-        // 5. 发送请求（关键：必须透传 option）
-        let response = Transport::request(api_request, &self.config, Some(option)).await?;
-
-        // 6. 提取响应数据
-        extract_response_data(response, "{API 中文名称}")
+        // 5. 发送请求并抽取 typed 响应（关键：必须透传 option；统一走 request_typed）
+        Transport::request_typed(api_request, &self.config, Some(option), "{API 中文名称}").await
     }
 }
 
@@ -205,7 +202,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::{
-    common::api_utils::{extract_response_data, serialize_params},
+    common::api_utils::serialize_params,
     endpoints::{IM_V1_MESSAGES},  // 常量端点
 };
 
@@ -256,9 +253,8 @@ impl {Name}Request {
             req = req.query("{query_key}", query);
         }
 
-        // 关键：透传 option
-        let resp = Transport::request(req, &self.config, Some(option)).await?;
-        extract_response_data(resp, "{API 中文名称}")
+        // 关键：透传 option；统一走 request_typed
+        Transport::request_typed(req, &self.config, Some(option), "{API 中文名称}").await
     }
 }
 ```
@@ -352,9 +348,8 @@ pub async fn execute_with_options(
     let req: ApiRequest<CreateMessageResponse> = ApiRequest::post(IM_V1_MESSAGES)
         .body(serialize_params(&body, "发送消息")?);
 
-    // ✅ 正确：透传 option 到 Transport
-    let resp = Transport::request(req, &self.config, Some(option)).await?;
-    extract_response_data(resp, "发送消息")
+    // ✅ 正确：透传 option 到 Transport；统一走 request_typed
+    Transport::request_typed(req, &self.config, Some(option), "发送消息").await
 }
 ```
 
@@ -679,7 +674,7 @@ async fn test_api_with_user_access_token() {
 - [ ] **端点使用**: 使用常量或 enum，禁止硬编码 URL
 - [ ] **execute 方法**: 提供 `execute()` 和 `execute_with_options()` 两个方法
 - [ ] **RequestOption 透传**: `Transport::request(..., Some(option))`
-- [ ] **错误处理**: 使用 `extract_response_data` 提取响应
+- [ ] **错误处理**: 统一走 `Transport::request_typed(.., "中文名")` 抽取 typed 响应
 
 ### 7.2 导出检查点
 
@@ -723,7 +718,7 @@ use std::sync::Arc;
 // 工具导入
 use crate::common::{
     api_endpoints::{ProjectApiV1},
-    api_utils::{extract_response_data, serialize_params},
+    api_utils::serialize_params,
 };
 ```
 


### PR DESCRIPTION
## What

Closes #507 (parent #503). Fixes doc-drift in the canonical "how to implement an API" template: `docs/api-implementation-template.md` still taught importing and calling the free function `extract_response_data`, which #486 removed (collapsed into `Response::decode`, surfaced via `Transport::request_typed`). The template was already broken.

## Changes

- Replace the two-step `Transport::request(..)? + extract_response_data(resp, ..)` with the real leaf form `Transport::request_typed(req, &self.config, Some(option), "中文名").await` at all three call sites (§2.1 enum template, §2.2 constant template, §4.2 RequestOption example).
- Drop `extract_response_data` from the three import blocks (§2.1, §2.2, §8.1 quick-ref) and update the §7.1 checklist item.
- `serialize_params` is retained — it is still live and still imported from `crate::common::api_utils`.
- `docs/error-context-policy.md` is **untouched**: it references the operation *string* `"extract_response_data"` emitted by `Response::decode` via `set_operation`, which remains accurate.

## Verification

- Pure docs change (template + CHANGELOG only); no `.rs`, rustdoc, Cargo.toml, or deps touched.
- Arg-by-arg match with live leaves confirmed (`okr/objective/get`, `tasklist` delete, `cardkit/element/create`).
- `rg extract_response_data docs/api-implementation-template.md` → no matches.
- `cargo doc --workspace --all-features` → green (exit 0).
- CHANGELOG gets a `type:docs` bullet under Unreleased > Changed.

## Scope

In-scope only the template doc + the CHANGELOG bullet (issue says "纯文档改动"). Other `extract_response_data` mentions (codegen `tools/*.py`, per-crate READMEs, historical superpowers plan/specs, the surviving operation string) are intentionally out of scope.