### PR TITLE
fix(hr/attendance): align approval_info/process with feishu schema (#527)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (Breaking — 目标 0.19)
 
+- **hr/attendance：`approval_info/process` 请求/响应字段对齐飞书官网 schema（#527，parent #526）**：
+  原请求体发 `approval_instance_id`/`result`/`comment`、响应为扁平
+  `success`/`approval_instance_id`，与飞书官网当前 schema 不符，真实调用被服务端拒绝
+  （必填字段缺失 / 字段名错误）。本地 wiremock 测试因 mock 抄自错误实现而全绿，掩盖了 drift。
+  对齐官网（详情接口 `apiSchema`）：请求体必填 `approval_id`/`approval_type`/`status`
+  （删臆测的 `comment`），响应改嵌套 `approval_info: { approval_id, approval_type, status }`。
+  **迁移**：`ProcessRequest::new(config, approval_instance_id, result)` + `.comment(..)`
+  → `ProcessRequest::new(config, approval_id, approval_type, status)`；
+  `ProcessResponse { success, approval_instance_id }`
+  → `ProcessResponse { approval_info: ApprovalInfo { approval_id, approval_type, status } }`。
+
 - **core：删除 `auth::app_ticket::apply_app_ticket`（ADR-0002）**：
   全仓零外部调用者（仅 core 内 `http.rs::do_request` 触发 app_ticket 恢复时调用），
   却以 `pub` 暴露在公开 API 表面。鉴权 concern 浓缩进 `auth/` 时一并收口：恢复逻辑

--- a/crates/openlark-hr/src/attendance/attendance/v1/approval_info/process.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/approval_info/process.rs
@@ -15,30 +15,28 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone)]
 pub struct ProcessRequest {
     /// 审批实例 ID（必填）
-    approval_instance_id: String,
-    /// 审批结果（必填）
-    result: i32,
-    /// 审批意见（可选）
-    comment: Option<String>,
+    approval_id: String,
+    /// 审批类型（必填）：`leave`(请假) / `out`(外出) / `overtime`(加班) / `trip`(出差) / `remedy`(补卡)
+    approval_type: String,
+    /// 审批状态（必填）：`1`(不通过) / `2`(通过) / `4`(撤销)
+    status: i32,
     /// 配置信息
     config: Config,
 }
 
 impl ProcessRequest {
     /// 创建请求
-    pub fn new(config: Config, approval_instance_id: String, result: i32) -> Self {
+    ///
+    /// - `approval_id`: 审批实例 ID
+    /// - `approval_type`: 审批类型（`leave` / `out` / `overtime` / `trip` / `remedy`）
+    /// - `status`: 审批状态（`1`=不通过, `2`=通过, `4`=撤销）
+    pub fn new(config: Config, approval_id: String, approval_type: String, status: i32) -> Self {
         Self {
-            approval_instance_id,
-            result,
-            comment: None,
+            approval_id,
+            approval_type,
+            status,
             config,
         }
-    }
-
-    /// 设置审批意见（可选）
-    pub fn comment(mut self, comment: String) -> Self {
-        self.comment = Some(comment);
-        self
     }
 
     /// 执行请求
@@ -55,7 +53,8 @@ impl ProcessRequest {
         use crate::common::api_endpoints::AttendanceApiV1;
 
         // 1. 验证必填字段
-        validate_required!(self.approval_instance_id.trim(), "approval_instance_id");
+        validate_required!(self.approval_id.trim(), "approval_id");
+        validate_required!(self.approval_type.trim(), "approval_type");
 
         // 2. 构建端点
         let api_endpoint = AttendanceApiV1::ApprovalInfoProcess;
@@ -63,9 +62,9 @@ impl ProcessRequest {
 
         // 3. 构建请求体
         let request_body = ProcessRequestBody {
-            approval_instance_id: self.approval_instance_id,
-            result: self.result,
-            comment: self.comment,
+            approval_id: self.approval_id,
+            approval_type: self.approval_type,
+            status: self.status,
         };
         let request_body_json = serde_json::to_value(&request_body).map_err(|e| {
             openlark_core::error::validation_error(
@@ -90,21 +89,29 @@ impl ProcessRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProcessRequestBody {
     /// 审批实例 ID
-    pub approval_instance_id: String,
-    /// 审批结果
-    pub result: i32,
-    /// 审批意见
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub comment: Option<String>,
+    pub approval_id: String,
+    /// 审批类型（`leave` / `out` / `overtime` / `trip` / `remedy`）
+    pub approval_type: String,
+    /// 审批状态（`1`=不通过, `2`=通过, `4`=撤销）
+    pub status: i32,
 }
 
 /// 通知审批状态更新响应
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ProcessResponse {
-    /// 是否成功
-    pub success: bool,
+    /// 审批信息
+    pub approval_info: ApprovalInfo,
+}
+
+/// 审批信息
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ApprovalInfo {
     /// 审批实例 ID
-    pub approval_instance_id: String,
+    pub approval_id: String,
+    /// 审批类型
+    pub approval_type: String,
+    /// 审批状态（`0`=待审批, `1`=未通过, `2`=已通过, `3`=已取消, `4`=已撤回）
+    pub status: i32,
 }
 
 impl ApiResponseTrait for ProcessResponse {
@@ -122,10 +129,16 @@ mod tests {
 
     #[test]
     fn test_process_request_builder_new() {
-        let request = ProcessRequest::new(TestConfigBuilder::new().build(), "test".to_string(), 1);
+        let request = ProcessRequest::new(
+            TestConfigBuilder::new().build(),
+            "6737202939523236113".to_string(),
+            "remedy".to_string(),
+            4,
+        );
         let _ = request;
     }
-    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+
+    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 请求体字段对齐飞书官网 schema。
     #[tokio::test]
     async fn test_attendance_v1_approval_info_process_returns_data_on_success() {
         use serde_json::json;
@@ -134,14 +147,19 @@ mod tests {
         use wiremock::{Mock, ResponseTemplate};
 
         let server = MockServer::start().await;
-        let data_body: serde_json::Value =
-            serde_json::from_str(r#"{"success": false, "approval_instance_id": "test"}"#).unwrap();
+        // 飞书官网真实 response schema：data.approval_info.{approval_id, approval_type, status}
         Mock::given(method("POST"))
             .and(path("/open-apis/attendance/v1/approval_infos/process"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": data_body
+                "data": {
+                    "approval_info": {
+                        "approval_id": "6737202939523236113",
+                        "approval_type": "remedy",
+                        "status": 0
+                    }
+                }
             })))
             .mount(&server)
             .await;
@@ -153,18 +171,45 @@ mod tests {
             .enable_token_cache(false)
             .build();
 
-        let data = ProcessRequest::new(config, "approval_instance_001".to_string(), 1)
-            .execute()
-            .await
-            .expect("attendance_v1_approval_info_process 应成功");
+        let data = ProcessRequest::new(
+            config,
+            "6737202939523236113".to_string(),
+            "remedy".to_string(),
+            4,
+        )
+        .execute()
+        .await
+        .expect("attendance_v1_approval_info_process 应成功");
 
-        let _ = &data;
+        // 响应解析对齐官网 schema（嵌套 approval_info）
+        assert_eq!(data.approval_info.approval_id, "6737202939523236113");
+        assert_eq!(data.approval_info.approval_type, "remedy");
+        assert_eq!(data.approval_info.status, 0);
 
+        // 请求体对齐官网必填字段，且不含旧错误字段
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
         assert_eq!(
             received[0].url.path(),
             "/open-apis/attendance/v1/approval_infos/process"
+        );
+        let body = String::from_utf8(received[0].body.clone()).unwrap();
+        assert!(
+            body.contains("\"approval_id\""),
+            "请求体缺 approval_id: {body}"
+        );
+        assert!(
+            body.contains("\"approval_type\""),
+            "请求体缺 approval_type: {body}"
+        );
+        assert!(body.contains("\"status\""), "请求体缺 status: {body}");
+        assert!(
+            !body.contains("approval_instance_id"),
+            "请求体不应含旧字段 approval_instance_id: {body}"
+        );
+        assert!(
+            !body.contains("\"result\""),
+            "请求体不应含旧字段 result: {body}"
         );
     }
 }

--- a/crates/openlark-hr/tests/attendance_tests.rs
+++ b/crates/openlark-hr/tests/attendance_tests.rs
@@ -203,9 +203,9 @@ mod builder_tests {
         approval_info::process::ProcessRequest::new(
             test_config("https://open.feishu.cn"),
             "ins_1".to_string(),
-            1,
+            "remedy".to_string(),
+            4,
         )
-        .comment("通过".to_string())
     );
 
     smoke_builder!(
@@ -846,8 +846,11 @@ mod serialization_tests {
         test_process_approval_response_serialization,
         approval_info::process::ProcessResponse,
         approval_info::process::ProcessResponse {
-            success: true,
-            approval_instance_id: "ins_1".to_string(),
+            approval_info: approval_info::process::ApprovalInfo {
+                approval_id: "ins_1".to_string(),
+                approval_type: "remedy".to_string(),
+                status: 0,
+            },
         }
     );
 


### PR DESCRIPTION
## What

Closes #527 (parent #526).

Aligns `attendance/v1/approval_info/process` request body and response with the current Feishu schema. The previous implementation sent `approval_instance_id`/`result`/`comment` and returned a flat `success`/`approval_instance_id` — neither matched Feishu, so real calls were rejected (missing required / wrong names). Local wiremock tests stayed green only because the mock copied the wrong implementation, masking the drift.

## Changes

- **Request body**: required `approval_id` / `approval_type` / `status` (drops the speculative `comment`, which is not in the official schema)
- **Response**: nested `approval_info: { approval_id, approval_type, status }` (was flat `success` / `approval_instance_id`)

Schema source: Feishu detail API `apiSchema` (the docPath `.md` returns 404).

## Breaking (targets 0.19)

Per `docs/TYPED_API_SEMVER_RULES.md`:

```rust
// before
ProcessRequest::new(config, approval_instance_id, result).comment(..)
ProcessResponse { success, approval_instance_id }

// after
ProcessRequest::new(config, approval_id, approval_type, status)
ProcessResponse { approval_info: ApprovalInfo { approval_id, approval_type, status } }
```

Migration note also added to `CHANGELOG.md` ([Unreleased] → Changed (Breaking — 目标 0.19)).

## Testing

- Existing wiremock e2e test rewritten to mock the **official response schema** and assert the request body contains `approval_id`/`approval_type`/`status` (and *not* the old fields)
- Integration tests (builder smoke + response roundtrip) updated in lockstep
- `cargo test -p openlark-hr --all-features`: **782+ passed, 0 failed**
- `cargo clippy -p openlark-hr --all-targets --all-features -- -Dwarnings`: clean
- `cargo fmt -p openlark-hr --check`: clean

## Out of scope

- `archive_rule/del_report` (#528) and `upload_report` (#529) — separate PRs, same pattern
- CI field-gate (防回归) — separate spec
