### PR TITLE
fix(hr/attendance): align archive_rule/del_report with feishu schema (#528)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ProcessResponse { success, approval_instance_id }`
   → `ProcessResponse { approval_info: ApprovalInfo { approval_id, approval_type, status } }`。
 
+- **hr/attendance：`archive_rule/del_report` 请求/响应字段对齐飞书官网 schema（#528，parent #526）**：
+  原请求体发 `archive_rule_id`/`employee_ids`/`stat_dates`、响应 `success`/`deleted_count`，
+  与飞书官网当前 schema 不符，真实调用被拒（缺必填 `month`/`operator_id`）。本地 wiremock 测试
+  因 mock 抄自错误实现而全绿，掩盖了 drift。对齐官网（详情接口 `apiSchema`）：请求体必填
+  `month`/`operator_id`/`archive_rule_id`（可选 `user_ids`），响应 `data` 为空对象
+  （删臆测的 `success`/`deleted_count`）。
+  **迁移**：`DelReportRequest::new(config, archive_rule_id, employee_ids, stat_dates)`
+  → `DelReportRequest::new(config, month, operator_id, archive_rule_id).user_ids(..)`；
+  `DelReportResponse { success, deleted_count }` → `DelReportResponse {}`（官网 `data` 为空对象）。
+
 - **core：删除 `auth::app_ticket::apply_app_ticket`（ADR-0002）**：
   全仓零外部调用者（仅 core 内 `http.rs::do_request` 触发 app_ticket 恢复时调用），
   却以 `pub` 暴露在公开 API 表面。鉴权 concern 浓缩进 `auth/` 时一并收口：恢复逻辑

--- a/crates/openlark-hr/src/attendance/attendance/v1/archive_rule/del_report.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/archive_rule/del_report.rs
@@ -7,37 +7,50 @@ use openlark_core::{
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
-    validate_required, validate_required_list,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 
 /// 删除归档报表行数据请求
 #[derive(Debug, Clone)]
 pub struct DelReportRequest {
+    /// 月份，格式 `yyyyMM`（必填）
+    month: String,
+    /// 操作者 ID（必填）
+    operator_id: String,
     /// 归档规则 ID（必填）
     archive_rule_id: String,
-    /// 员工 ID 列表（必填）
-    employee_ids: Vec<String>,
-    /// 统计日期列表（必填）
-    stat_dates: Vec<i64>,
+    /// 用户 ID 列表（可选）
+    user_ids: Option<Vec<String>>,
     /// 配置信息
     config: Config,
 }
 
 impl DelReportRequest {
     /// 创建请求
+    ///
+    /// - `month`: 月份，格式 `yyyyMM`
+    /// - `operator_id`: 操作者 ID
+    /// - `archive_rule_id`: 归档规则 ID
     pub fn new(
         config: Config,
+        month: String,
+        operator_id: String,
         archive_rule_id: String,
-        employee_ids: Vec<String>,
-        stat_dates: Vec<i64>,
     ) -> Self {
         Self {
+            month,
+            operator_id,
             archive_rule_id,
-            employee_ids,
-            stat_dates,
+            user_ids: None,
             config,
         }
+    }
+
+    /// 设置用户 ID 列表（可选）
+    pub fn user_ids(mut self, user_ids: Vec<String>) -> Self {
+        self.user_ids = Some(user_ids);
+        self
     }
 
     /// 执行请求
@@ -54,17 +67,9 @@ impl DelReportRequest {
         use crate::common::api_endpoints::AttendanceApiV1;
 
         // 1. 验证必填字段
+        validate_required!(self.month.trim(), "month");
+        validate_required!(self.operator_id.trim(), "operator_id");
         validate_required!(self.archive_rule_id.trim(), "archive_rule_id");
-        validate_required_list!(
-            self.employee_ids,
-            100,
-            "员工 ID 列表不能为空且不能超过 100 个"
-        );
-        validate_required_list!(
-            self.stat_dates,
-            100,
-            "统计日期列表不能为空且不能超过 100 个"
-        );
 
         // 2. 构建端点
         let api_endpoint = AttendanceApiV1::ArchiveRuleDelReport;
@@ -72,9 +77,10 @@ impl DelReportRequest {
 
         // 3. 构建请求体
         let request_body = DelReportRequestBody {
+            month: self.month,
+            operator_id: self.operator_id,
             archive_rule_id: self.archive_rule_id,
-            employee_ids: self.employee_ids,
-            stat_dates: self.stat_dates,
+            user_ids: self.user_ids,
         };
         let request_body_json = serde_json::to_value(&request_body).map_err(|e| {
             openlark_core::error::validation_error(
@@ -98,22 +104,22 @@ impl DelReportRequest {
 /// 删除归档报表行数据请求体
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DelReportRequestBody {
+    /// 月份，格式 `yyyyMM`
+    pub month: String,
+    /// 操作者 ID
+    pub operator_id: String,
     /// 归档规则 ID
     pub archive_rule_id: String,
-    /// 员工 ID 列表
-    pub employee_ids: Vec<String>,
-    /// 统计日期列表
-    pub stat_dates: Vec<i64>,
+    /// 用户 ID 列表（可选）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_ids: Option<Vec<String>>,
 }
 
 /// 删除归档报表行数据响应
+///
+/// 飞书官网 response `data` 为空对象（无返回字段）。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct DelReportResponse {
-    /// 是否成功
-    pub success: bool,
-    /// 删除的记录数
-    pub deleted_count: i32,
-}
+pub struct DelReportResponse {}
 
 impl ApiResponseTrait for DelReportResponse {
     fn data_format() -> ResponseFormat {
@@ -125,7 +131,21 @@ impl ApiResponseTrait for DelReportResponse {
 mod tests {
     use super::*;
     use openlark_core::config::Config;
-    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    use openlark_core::testing::prelude::TestConfigBuilder;
+
+    #[test]
+    fn test_del_report_request_builder_new() {
+        let request = DelReportRequest::new(
+            TestConfigBuilder::new().build(),
+            "202409".to_string(),
+            "a111xd".to_string(),
+            "1".to_string(),
+        )
+        .user_ids(vec!["xx1uad".to_string()]);
+        let _ = request;
+    }
+
+    /// 端到端：Builder→execute→Transport→mock→assert 请求体字段对齐飞书官网 schema。
     #[tokio::test]
     async fn test_attendance_v1_archive_rule_del_report_returns_data_on_success() {
         use serde_json::json;
@@ -134,14 +154,13 @@ mod tests {
         use wiremock::{Mock, ResponseTemplate};
 
         let server = MockServer::start().await;
-        let data_body: serde_json::Value =
-            serde_json::from_str(r#"{"success": false, "deleted_count": 0}"#).unwrap();
+        // 飞书官网 response data 为空对象
         Mock::given(method("POST"))
             .and(path("/open-apis/attendance/v1/archive_rule/del_report"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": data_body
+                "data": {}
             })))
             .mount(&server)
             .await;
@@ -153,23 +172,41 @@ mod tests {
             .enable_token_cache(false)
             .build();
 
-        let data = DelReportRequest::new(
+        let _data = DelReportRequest::new(
             config,
-            "archive_rule_001".to_string(),
-            vec!["id_001".to_string()],
-            vec![1_700_000_000],
+            "202409".to_string(),
+            "a111xd".to_string(),
+            "1".to_string(),
         )
+        .user_ids(vec!["xx1uad".to_string()])
         .execute()
         .await
         .expect("attendance_v1_archive_rule_del_report 应成功");
 
-        let _ = &data;
-
+        // 请求体对齐官网必填字段，且不含旧错误字段
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
         assert_eq!(
             received[0].url.path(),
             "/open-apis/attendance/v1/archive_rule/del_report"
+        );
+        let body = String::from_utf8(received[0].body.clone()).unwrap();
+        assert!(body.contains("\"month\""), "请求体缺 month: {body}");
+        assert!(
+            body.contains("\"operator_id\""),
+            "请求体缺 operator_id: {body}"
+        );
+        assert!(
+            body.contains("\"archive_rule_id\""),
+            "请求体缺 archive_rule_id: {body}"
+        );
+        assert!(
+            !body.contains("employee_ids"),
+            "请求体不应含旧字段 employee_ids: {body}"
+        );
+        assert!(
+            !body.contains("stat_dates"),
+            "请求体不应含旧字段 stat_dates: {body}"
         );
     }
 }


### PR DESCRIPTION
## What

Closes #528 (parent #526).

Aligns `attendance/v1/archive_rule/del_report` request body and response with the current Feishus schema. The previous implementation sent `archive_rule_id`/`employee_ids`/`stat_dates` and returned `success`/`deleted_count` — neither matched Feishus, so real calls were rejected (missing required `month`/`operator_id`). Local wiremock tests stayed green only because the mock copied the wrong implementation.

## Changes

- **Request body**: required `month` / `operator_id` / `archive_rule_id` (optional `user_ids`)
- **Response**: `data` is an empty object (drops the speculative `success`/`deleted_count`)

Schema source: Feishu detail API `apiSchema`.

## Breaking (targets 0.19)

```rust
// before
DelReportRequest::new(config, archive_rule_id, employee_ids, stat_dates)
DelReportResponse { success, deleted_count }

// after
DelReportRequest::new(config, month, operator_id, archive_rule_id).user_ids(..)
DelReportResponse {} // data is empty
```

Migration note also in `CHANGELOG.md` ([Unreleased] → Changed (Breaking — 目标 0.19)).

## Testing

- New wiremock e2e test mocks the official response (`data: {}`) and asserts the request body contains `month`/`operator_id`/`archive_rule_id` (and *not* the old `employee_ids`/`stat_dates`)
- `cargo test -p openlark-hr --all-features`: **783 passed, 0 failed**
- `cargo clippy -p openlark-hr --all-targets --all-features -- -Dwarnings`: clean
- `cargo fmt -p openlark-hr --check`: clean

## Notes

- Same pattern as #530 (#527, `approval_info/process`). Both add a `CHANGELOG.md` entry to the `[Unreleased] → Changed (Breaking)` section, so a merge may conflict there — resolve by keeping both entries.
- `upload_report` (#529) is the remaining sibling, separate PR.
