### PR TITLE
fix(hr/attendance): align archive_rule/upload_report with feishu schema (#529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   → `DelReportRequest::new(config, month, operator_id, archive_rule_id).user_ids(..)`；
   `DelReportResponse { success, deleted_count }` → `DelReportResponse {}`（官网 `data` 为空对象）。
 
+- **hr/attendance：`archive_rule/upload_report` 请求/响应字段对齐飞书官网 schema（#529，parent #526）**：
+  原请求体发 `archive_rule_id`/`reports`（嵌套 `employee_id`/`stat_date`(i64 时间戳)/`field_data`/`field_id`）、
+  响应 `success`/`inserted_count`/`updated_count`/`failed_count`/`failed_employee_ids`，与飞书官网当前 schema
+  不符，真实调用被拒。对齐官网（详情接口 `apiSchema`）：请求体必填 `month`/`operator_id`/`archive_rule_id`
+  + 嵌套 `archive_report_datas: [{ member_id, start_time, end_time, field_datas: [{ code, value }] }]`
+  （⚠️ 原 `stat_date` 是 i64 时间戳，官网实为 `start_time`/`end_time` 的 `yyyyMMdd` 字符串），
+  响应改 `invalid_code`/`invalid_member_id`。
+  **迁移**：`UploadReportRequest::new(config, archive_rule_id, reports)`
+  → `new(config, month, operator_id, archive_rule_id).archive_report_datas(..)`；
+  `ReportData`/`FieldData` → `ArchiveReportData`/`ArchiveFieldData`
+  （`employee_id`→`member_id`、`stat_date`→`start_time`/`end_time`、`field_id`→`code`）；
+  `UploadReportResponse { success, inserted_count, ... }` → `{ invalid_code, invalid_member_id }`。
+
 - **core：删除 `auth::app_ticket::apply_app_ticket`（ADR-0002）**：
   全仓零外部调用者（仅 core 内 `http.rs::do_request` 触发 app_ticket 恢复时调用），
   却以 `pub` 暴露在公开 API 表面。鉴权 concern 浓缩进 `auth/` 时一并收口：恢复逻辑

--- a/crates/openlark-hr/src/attendance/attendance/v1/archive_rule/upload_report.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/archive_rule/upload_report.rs
@@ -7,29 +7,50 @@ use openlark_core::{
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
-    validate_required, validate_required_list,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 
 /// 写入归档报表结果请求
 #[derive(Debug, Clone)]
 pub struct UploadReportRequest {
+    /// 月份，格式 `yyyyMM`（必填）
+    month: String,
+    /// 操作者 ID（必填）
+    operator_id: String,
     /// 归档规则 ID（必填）
     archive_rule_id: String,
-    /// 报表数据列表（必填）
-    reports: Vec<ReportData>,
+    /// 归档报表内容，不超过 50 个（官网 schema 未标 required，但语义上是上传核心数据）
+    archive_report_datas: Option<Vec<ArchiveReportData>>,
     /// 配置信息
     config: Config,
 }
 
 impl UploadReportRequest {
     /// 创建请求
-    pub fn new(config: Config, archive_rule_id: String, reports: Vec<ReportData>) -> Self {
+    ///
+    /// - `month`: 月份，格式 `yyyyMM`
+    /// - `operator_id`: 操作者 ID
+    /// - `archive_rule_id`: 归档规则 ID
+    pub fn new(
+        config: Config,
+        month: String,
+        operator_id: String,
+        archive_rule_id: String,
+    ) -> Self {
         Self {
+            month,
+            operator_id,
             archive_rule_id,
-            reports,
+            archive_report_datas: None,
             config,
         }
+    }
+
+    /// 设置归档报表内容（不超过 50 个）
+    pub fn archive_report_datas(mut self, datas: Vec<ArchiveReportData>) -> Self {
+        self.archive_report_datas = Some(datas);
+        self
     }
 
     /// 执行请求
@@ -46,8 +67,9 @@ impl UploadReportRequest {
         use crate::common::api_endpoints::AttendanceApiV1;
 
         // 1. 验证必填字段
+        validate_required!(self.month.trim(), "month");
+        validate_required!(self.operator_id.trim(), "operator_id");
         validate_required!(self.archive_rule_id.trim(), "archive_rule_id");
-        validate_required_list!(self.reports, 100, "报表数据列表不能为空且不能超过 100 条");
 
         // 2. 构建端点
         let api_endpoint = AttendanceApiV1::ArchiveRuleUploadReport;
@@ -55,8 +77,10 @@ impl UploadReportRequest {
 
         // 3. 构建请求体
         let request_body = UploadReportRequestBody {
+            month: self.month,
+            operator_id: self.operator_id,
             archive_rule_id: self.archive_rule_id,
-            reports: self.reports,
+            archive_report_datas: self.archive_report_datas,
         };
         let request_body_json = serde_json::to_value(&request_body).map_err(|e| {
             openlark_core::error::validation_error(
@@ -80,46 +104,48 @@ impl UploadReportRequest {
 /// 写入归档报表结果请求体
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UploadReportRequestBody {
+    /// 月份，格式 `yyyyMM`
+    pub month: String,
+    /// 操作者 ID
+    pub operator_id: String,
     /// 归档规则 ID
     pub archive_rule_id: String,
-    /// 报表数据列表
-    pub reports: Vec<ReportData>,
+    /// 归档报表内容，不超过 50 个
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub archive_report_datas: Option<Vec<ArchiveReportData>>,
 }
 
-/// 报表数据
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ReportData {
-    /// 员工 ID
-    pub employee_id: String,
-    /// 统计日期（Unix 时间戳）
-    pub stat_date: i64,
-    /// 字段数据
-    pub field_data: Vec<FieldData>,
+/// 归档报表数据
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ArchiveReportData {
+    /// 用户 ID，对应 employee_type
+    pub member_id: String,
+    /// 考勤开始时间，格式 `yyyyMMdd`
+    pub start_time: String,
+    /// 考勤结束时间，格式 `yyyyMMdd`
+    pub end_time: String,
+    /// 字段结果，不超过 200 个
+    pub field_datas: Vec<ArchiveFieldData>,
 }
 
-/// 字段数据
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FieldData {
-    /// 字段 ID
-    pub field_id: String,
-    /// 字段值
-    pub value: serde_json::Value,
+/// 字段结果数据
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ArchiveFieldData {
+    /// 字段编码
+    pub code: String,
+    /// 字段结果值
+    pub value: String,
 }
 
 /// 写入归档报表结果响应
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct UploadReportResponse {
-    /// 是否成功
-    pub success: bool,
-    /// 成功写入的记录数
-    pub inserted_count: i32,
-    /// 更新的记录数
-    pub updated_count: i32,
-    /// 失败的记录数
-    pub failed_count: i32,
-    /// 失败的员工 ID 列表
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub failed_employee_ids: Option<Vec<String>>,
+    /// 无效的字段编码列表
+    #[serde(default)]
+    pub invalid_code: Vec<String>,
+    /// 无效的用户 ID 列表，对应 employee_type
+    #[serde(default)]
+    pub invalid_member_id: Vec<String>,
 }
 
 impl ApiResponseTrait for UploadReportResponse {
@@ -132,7 +158,29 @@ impl ApiResponseTrait for UploadReportResponse {
 mod tests {
     use super::*;
     use openlark_core::config::Config;
-    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    use openlark_core::testing::prelude::TestConfigBuilder;
+
+    #[test]
+    fn test_upload_report_request_builder_new() {
+        let request = UploadReportRequest::new(
+            TestConfigBuilder::new().build(),
+            "202409".to_string(),
+            "ax11d".to_string(),
+            "1".to_string(),
+        )
+        .archive_report_datas(vec![ArchiveReportData {
+            member_id: "1aaxxd".to_string(),
+            start_time: "20210109".to_string(),
+            end_time: "20210109".to_string(),
+            field_datas: vec![ArchiveFieldData {
+                code: "abd754f7".to_string(),
+                value: "1".to_string(),
+            }],
+        }]);
+        let _ = request;
+    }
+
+    /// 端到端：Builder→execute→Transport→mock→assert 请求体字段对齐飞书官网 schema。
     #[tokio::test]
     async fn test_attendance_v1_archive_rule_upload_report_returns_data_on_success() {
         use serde_json::json;
@@ -141,16 +189,15 @@ mod tests {
         use wiremock::{Mock, ResponseTemplate};
 
         let server = MockServer::start().await;
-        let data_body: serde_json::Value = serde_json::from_str(
-            r#"{"success": false, "inserted_count": 0, "updated_count": 0, "failed_count": 0}"#,
-        )
-        .unwrap();
         Mock::given(method("POST"))
             .and(path("/open-apis/attendance/v1/archive_rule/upload_report"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": data_body
+                "data": {
+                    "invalid_code": ["1"],
+                    "invalid_member_id": ["a1xud"]
+                }
             })))
             .mount(&server)
             .await;
@@ -164,24 +211,55 @@ mod tests {
 
         let data = UploadReportRequest::new(
             config,
-            "archive_rule_001".to_string(),
-            vec![ReportData {
-                employee_id: "employee_id_1".to_string(),
-                stat_date: 1,
-                field_data: vec![],
-            }],
+            "202409".to_string(),
+            "ax11d".to_string(),
+            "1".to_string(),
         )
+        .archive_report_datas(vec![ArchiveReportData {
+            member_id: "1aaxxd".to_string(),
+            start_time: "20210109".to_string(),
+            end_time: "20210109".to_string(),
+            field_datas: vec![ArchiveFieldData {
+                code: "abd754f7".to_string(),
+                value: "1".to_string(),
+            }],
+        }])
         .execute()
         .await
         .expect("attendance_v1_archive_rule_upload_report 应成功");
 
-        let _ = &data;
+        // 响应解析对齐官网 schema
+        assert_eq!(data.invalid_code, vec!["1".to_string()]);
+        assert_eq!(data.invalid_member_id, vec!["a1xud".to_string()]);
 
+        // 请求体对齐官网字段，且不含旧错误字段
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
         assert_eq!(
             received[0].url.path(),
             "/open-apis/attendance/v1/archive_rule/upload_report"
+        );
+        let body = String::from_utf8(received[0].body.clone()).unwrap();
+        assert!(body.contains("\"month\""), "请求体缺 month: {body}");
+        assert!(
+            body.contains("\"operator_id\""),
+            "请求体缺 operator_id: {body}"
+        );
+        assert!(
+            body.contains("\"archive_rule_id\""),
+            "请求体缺 archive_rule_id: {body}"
+        );
+        assert!(
+            body.contains("\"archive_report_datas\""),
+            "请求体缺 archive_report_datas: {body}"
+        );
+        assert!(
+            body.contains("\"member_id\""),
+            "请求体缺 archive_report_data.member_id: {body}"
+        );
+        assert!(
+            !body.contains("\"reports\""),
+            "请求体不应含旧字段 reports: {body}"
         );
     }
 }


### PR DESCRIPTION
## What

Closes #529 (parent #526). Third and final sibling of the attendance field-drift fix (#530 / #531 being the other two).

Aligns `attendance/v1/archive_rule/upload_report` request body and response with the current Feishus schema. The previous implementation used `reports` (with `employee_id` / `stat_date` (i64 timestamp) / `field_data` / `field_id`) and returned `success` / `inserted_count` / `failed_count` / ... — field names and types wrong, so real calls were rejected.

## Changes

- **Request body**: required `month` / `operator_id` / `archive_rule_id` + nested `archive_report_datas: [{ member_id, start_time, end_time, field_datas: [{ code, value }] }]`
- **Response**: `{ invalid_code: Vec<String>, invalid_member_id: Vec<String> }` (was fabricated success/counts)

⚠️ Notable: `stat_date` was an `i64` timestamp; the official schema is `start_time` / `end_time` as `yyyyMMdd` **strings**.

Schema source: Feishu detail API `apiSchema`.

## Breaking (targets 0.19)

```rust
// before
UploadReportRequest::new(config, archive_rule_id, reports /* Vec<ReportData> */)
ReportData { employee_id, stat_date: i64, field_data: Vec<FieldData { field_id, value }> }
UploadReportResponse { success, inserted_count, updated_count, failed_count, failed_employee_ids }

// after
UploadReportRequest::new(config, month, operator_id, archive_rule_id).archive_report_datas(..)
ArchiveReportData { member_id, start_time: String, end_time: String, field_datas: Vec<ArchiveFieldData { code, value }> }
UploadReportResponse { invalid_code: Vec<String>, invalid_member_id: Vec<String> }
```

Migration note also in `CHANGELOG.md` ([Unreleased] → Changed (Breaking — 目标 0.19)).

## Testing

- New wiremock e2e test mocks the official response and asserts the request body contains `month` / `operator_id` / `archive_rule_id` / `archive_report_datas` / `member_id` (and *not* the old `reports`)
- `cargo test -p openlark-hr --all-features`: **783 passed, 0 failed**
- `cargo clippy -p openlark-hr --all-targets --all-features -- -Dwarnings`: clean
- `cargo fmt -p openlark-hr --check`: clean

## Notes

- Completes the #526 attendance field-drift fix (with #530 / #531). `CHANGELOG.md` may conflict on merge — three entries land in the `[Unreleased] → Changed (Breaking)` section; resolve by keeping all three.
