### PR TITLE
ci(api-contracts): add attendance field drift monitor (non-strict)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,14 @@ jobs:
             --tokens \
             --strict tokens \
             --report-dir "$RUNNER_TEMP/api_contract_tokens/auth"
+      - name: Validate attendance fields (non-strict monitor; #526 防回归 baseline)
+        run: |
+          python3 tools/validate_api_contracts.py \
+            --crate openlark-hr \
+            --biz-tag attendance \
+            --fields \
+            --live-fields \
+            --report-dir "$RUNNER_TEMP/api_contract_fields/attendance"
       - name: Upload API contract reports
         if: always()
         uses: actions/upload-artifact@v4
@@ -91,6 +99,7 @@ jobs:
           path: |
             ${{ runner.temp }}/api_contracts
             ${{ runner.temp }}/api_contract_tokens
+            ${{ runner.temp }}/api_contract_fields
           retention-days: 14
 
   lint:

--- a/tools/validate_api_contracts.py
+++ b/tools/validate_api_contracts.py
@@ -59,6 +59,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--mapping", default="tools/api_coverage.toml", help="crate to bizTag mapping")
     parser.add_argument("--crate", dest="crate_name", help="Validate one mapped crate")
     parser.add_argument("--all-crates", action="store_true", help="Validate all mapped crates")
+    parser.add_argument(
+        "--biz-tag",
+        action="append",
+        help="进一步过滤到指定 bizTag（可多次传入）；覆盖 crate 的 biz_tags，用于子模块级 gate",
+    )
     parser.add_argument("--report-dir", default="reports/api_contracts", help="Report directory")
     parser.add_argument("--include-old", dest="skip_old", action="store_false", help="Include meta.Version=old APIs")
     parser.add_argument("--skip-old", dest="skip_old", action="store_true", default=True, help="Skip old APIs")
@@ -125,9 +130,10 @@ def validate_crate(
     field_retries: int = 1,
     max_field_apis: int = 0,
     tokens: bool = False,
+    biz_tag_filter: list[str] | None = None,
 ) -> ContractReport:
     src_path = Path(crate_config["src"])
-    biz_tags = list(crate_config.get("biz_tags") or [])
+    biz_tags = biz_tag_filter if biz_tag_filter else list(crate_config.get("biz_tags") or [])
     apis = load_api_identities(csv_path, filter_tags=biz_tags, skip_old_versions=skip_old)
     constants = load_endpoint_constants(src_path)
     enum_endpoints = load_enum_endpoints(src_path, constants)
@@ -244,6 +250,7 @@ def main() -> int:
             field_retries=args.field_retries,
             max_field_apis=args.max_field_apis,
             tokens=args.tokens,
+            biz_tag_filter=args.biz_tag,
         )
         for crate_name in crate_names
     ]


### PR DESCRIPTION
## What

Lands the attendance field-drift **monitor** (non-strict) in CI, plus the `--biz-tag` filter on `validate_api_contracts.py` that makes a sub-module-level gate possible.

## Why non-strict

Scoping the gate to `attendance` revealed **18 pre-existing required-field drifts across 8 APIs** (#533) — turning `--strict fields` on now would red the gate on every PR. This lands the monitor first (baseline visible in the `api-contracts` artifact), to be flipped to `--strict fields` once #533 is cleared.

## Changes

- `tools/validate_api_contracts.py`: new `--biz-tag` (repeatable) overrides the crate's `biz_tags`, enabling sub-module-level validation (e.g. just `attendance` within `openlark-hr`, instead of all 583 APIs)
- `.github/workflows/ci.yml`: new step **"Validate attendance fields (non-strict monitor)"** in the `api-contracts` job; its report added to the `api-contracts` artifact

## Verification

- `--biz-tag attendance` filters to 39 APIs (confirmed locally: 18 errors / 61 warnings — the #533 baseline)
- non-strict run exits 0 (won't fail the job) — only `--strict fields` fails on errors
- CI step ~1–2 min (39 API live detail fetches), within the job's 10-min timeout

## Follow-ups

- **#533** — clear the 18 attendance drifts, then flip this step to `--strict fields`
- Optional: document the monitor in `docs/api-contract-validation.md`
