### PR TITLE
fix(hr/attendance): align user_daily_shift family with feishu schema (#533, group 1/5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (Breaking — 目标 0.19)
 
+- **hr/attendance：`user_daily_shift` 族 3 API 字段对齐飞书官网 schema（#533）**：
+  `batch_create`（`shifts`→`user_daily_shifts`[{group_id,shift_id,month,user_id,day_no,is_clear_schedule}]，加可选 `operator_id`）、
+  `batch_create_temp`（`TempShift`→`user_tmp_daily_shifts`[{group_id,user_id,date,shift_name,punch_time_simple_rules[{on_time,off_time}]}]）、
+  `query`（`start_date`/`end_date`(i64)→`check_date_from`/`check_date_to`(i32 yyyyMMdd)，`user_ids` 改必填）。
+  ⚠️ 原 `date` 为 i64 时间戳，官网实为 `month`/`day_no`/`date` 的 int32（yyyyMM/yyyymmdd）；响应 items schema 官网未完整给出，透传 `Value`。
+  **迁移**：`UserDailyShift`/`TempShift`→`UserTmpDailyShift` 字段重构、`QueryRequest::new` 签名变（详见各 API docPath）。
+
 - **hr/attendance：`approval_info/process` 请求/响应字段对齐飞书官网 schema（#527，parent #526）**：
   原请求体发 `approval_instance_id`/`result`/`comment`、响应为扁平
   `success`/`approval_instance_id`，与飞书官网当前 schema 不符，真实调用被服务端拒绝

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_daily_shift/batch_create.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_daily_shift/batch_create.rs
@@ -14,16 +14,28 @@ use serde::{Deserialize, Serialize};
 /// 创建或修改排班表请求
 #[derive(Debug, Clone)]
 pub struct BatchCreateRequest {
-    /// 排班记录列表（必填）
-    shifts: Vec<UserDailyShift>,
+    /// 排班表信息列表（必填，不超过 50 个）
+    user_daily_shifts: Vec<UserDailyShift>,
+    /// 操作人 UID（可选；未走「API 接入」流程时为必填）
+    operator_id: Option<String>,
     /// 配置信息
     config: Config,
 }
 
 impl BatchCreateRequest {
     /// 创建请求
-    pub fn new(config: Config, shifts: Vec<UserDailyShift>) -> Self {
-        Self { shifts, config }
+    pub fn new(config: Config, user_daily_shifts: Vec<UserDailyShift>) -> Self {
+        Self {
+            user_daily_shifts,
+            operator_id: None,
+            config,
+        }
+    }
+
+    /// 设置操作人 UID（可选）
+    pub fn operator_id(mut self, operator_id: String) -> Self {
+        self.operator_id = Some(operator_id);
+        self
     }
 
     /// 执行请求
@@ -40,7 +52,11 @@ impl BatchCreateRequest {
         use crate::common::api_endpoints::AttendanceApiV1;
 
         // 1. 验证必填字段
-        validate_required_list!(self.shifts, 100, "shifts 不能为空且不能超过 100 个");
+        validate_required_list!(
+            self.user_daily_shifts,
+            50,
+            "user_daily_shifts 不能为空且不能超过 50 个"
+        );
 
         // 2. 构建端点
         let api_endpoint = AttendanceApiV1::UserDailyShiftBatchCreate;
@@ -48,7 +64,8 @@ impl BatchCreateRequest {
 
         // 3. 构建请求体
         let request_body = BatchCreateRequestBody {
-            shifts: self.shifts,
+            user_daily_shifts: self.user_daily_shifts,
+            operator_id: self.operator_id,
         };
         let request_body_json = serde_json::to_value(&request_body).map_err(|e| {
             openlark_core::error::validation_error(
@@ -72,36 +89,39 @@ impl BatchCreateRequest {
 /// 创建或修改排班表请求体
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BatchCreateRequestBody {
-    /// 排班记录列表
-    pub shifts: Vec<UserDailyShift>,
+    /// 排班表信息列表
+    pub user_daily_shifts: Vec<UserDailyShift>,
+    /// 操作人 UID
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operator_id: Option<String>,
 }
 
 /// 用户每日排班记录
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct UserDailyShift {
+    /// 考勤组 ID
+    pub group_id: String,
+    /// 班次 ID（传 `0` 代表休息）
+    pub shift_id: String,
+    /// 月份，格式 `yyyyMM`
+    pub month: i32,
     /// 用户 ID
     pub user_id: String,
-    /// 排班日期（Unix 时间戳）
-    pub date: i64,
-    /// 班次 ID
-    pub shift_id: String,
-    /// 工作时长（小时）
+    /// 日期
+    pub day_no: i32,
+    /// 是否清空班次（优先于 `shift_id`，为 `true` 时 `shift_id` 失效）
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub work_hours: Option<f64>,
+    pub is_clear_schedule: Option<bool>,
 }
 
 /// 创建或修改排班表响应
+///
+/// 官网 response `data.user_daily_shifts` 为数组，items 结构 schema 未完整给出，透传 `Value`。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BatchCreateResponse {
-    /// 是否成功
-    pub success: bool,
-    /// 成功处理的记录数
-    pub processed_count: i32,
-    /// 失败的记录数
-    pub failed_count: i32,
-    /// 失败的排班记录索引列表
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub failed_indices: Option<Vec<i32>>,
+    /// 排班表信息列表
+    #[serde(default)]
+    pub user_daily_shifts: Vec<serde_json::Value>,
 }
 
 impl ApiResponseTrait for BatchCreateResponse {
@@ -114,7 +134,25 @@ impl ApiResponseTrait for BatchCreateResponse {
 mod tests {
     use super::*;
     use openlark_core::config::Config;
-    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    use openlark_core::testing::prelude::TestConfigBuilder;
+
+    #[test]
+    fn test_batch_create_request_builder_new() {
+        let request = BatchCreateRequest::new(
+            TestConfigBuilder::new().build(),
+            vec![UserDailyShift {
+                group_id: "6737202939523236110".to_string(),
+                shift_id: "6753520403404030215".to_string(),
+                month: 202_101,
+                user_id: "abd754f7".to_string(),
+                day_no: 21,
+                is_clear_schedule: None,
+            }],
+        );
+        let _ = request;
+    }
+
+    /// 端到端：Builder→execute→Transport→mock→assert 请求体字段对齐飞书官网 schema。
     #[tokio::test]
     async fn test_attendance_v1_user_daily_shift_batch_create_returns_data_on_success() {
         use serde_json::json;
@@ -123,9 +161,6 @@ mod tests {
         use wiremock::{Mock, ResponseTemplate};
 
         let server = MockServer::start().await;
-        let data_body: serde_json::Value =
-            serde_json::from_str(r#"{"success": false, "processed_count": 0, "failed_count": 0}"#)
-                .unwrap();
         Mock::given(method("POST"))
             .and(path(
                 "/open-apis/attendance/v1/user_daily_shifts/batch_create",
@@ -133,7 +168,7 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": data_body
+                "data": { "user_daily_shifts": [] }
             })))
             .mount(&server)
             .await;
@@ -148,23 +183,36 @@ mod tests {
         let data = BatchCreateRequest::new(
             config,
             vec![UserDailyShift {
-                user_id: "user_id_1".to_string(),
-                date: 1,
-                shift_id: "shift_id_1".to_string(),
-                work_hours: None,
+                group_id: "6737202939523236110".to_string(),
+                shift_id: "6753520403404030215".to_string(),
+                month: 202_101,
+                user_id: "abd754f7".to_string(),
+                day_no: 21,
+                is_clear_schedule: None,
             }],
         )
         .execute()
         .await
         .expect("attendance_v1_user_daily_shift_batch_create 应成功");
 
-        let _ = &data;
+        assert!(data.user_daily_shifts.is_empty());
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
         assert_eq!(
             received[0].url.path(),
             "/open-apis/attendance/v1/user_daily_shifts/batch_create"
+        );
+        let body = String::from_utf8(received[0].body.clone()).unwrap();
+        assert!(
+            body.contains("\"user_daily_shifts\""),
+            "请求体缺 user_daily_shifts: {body}"
+        );
+        assert!(body.contains("\"month\""), "请求体缺 month: {body}");
+        assert!(body.contains("\"day_no\""), "请求体缺 day_no: {body}");
+        assert!(
+            !body.contains("\"shifts\""),
+            "请求体不应含旧字段 shifts: {body}"
         );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_daily_shift/batch_create_temp.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_daily_shift/batch_create_temp.rs
@@ -14,16 +14,28 @@ use serde::{Deserialize, Serialize};
 /// 创建或修改临时排班请求
 #[derive(Debug, Clone)]
 pub struct BatchCreateTempRequest {
-    /// 临时排班记录列表（必填）
-    shifts: Vec<TempShift>,
+    /// 临时班表信息列表（必填，不超过 50 个）
+    user_tmp_daily_shifts: Vec<UserTmpDailyShift>,
+    /// 操作人 UID（可选）
+    operator_id: Option<String>,
     /// 配置信息
     config: Config,
 }
 
 impl BatchCreateTempRequest {
     /// 创建请求
-    pub fn new(config: Config, shifts: Vec<TempShift>) -> Self {
-        Self { shifts, config }
+    pub fn new(config: Config, user_tmp_daily_shifts: Vec<UserTmpDailyShift>) -> Self {
+        Self {
+            user_tmp_daily_shifts,
+            operator_id: None,
+            config,
+        }
+    }
+
+    /// 设置操作人 UID（可选）
+    pub fn operator_id(mut self, operator_id: String) -> Self {
+        self.operator_id = Some(operator_id);
+        self
     }
 
     /// 执行请求
@@ -40,7 +52,11 @@ impl BatchCreateTempRequest {
         use crate::common::api_endpoints::AttendanceApiV1;
 
         // 1. 验证必填字段
-        validate_required_list!(self.shifts, 100, "shifts 不能为空且不能超过 100 个");
+        validate_required_list!(
+            self.user_tmp_daily_shifts,
+            50,
+            "user_tmp_daily_shifts 不能为空且不能超过 50 个"
+        );
 
         // 2. 构建端点
         let api_endpoint = AttendanceApiV1::UserDailyShiftBatchCreateTemp;
@@ -48,7 +64,8 @@ impl BatchCreateTempRequest {
 
         // 3. 构建请求体
         let request_body = BatchCreateTempRequestBody {
-            shifts: self.shifts,
+            user_tmp_daily_shifts: self.user_tmp_daily_shifts,
+            operator_id: self.operator_id,
         };
         let request_body_json = serde_json::to_value(&request_body).map_err(|e| {
             openlark_core::error::validation_error(
@@ -72,35 +89,45 @@ impl BatchCreateTempRequest {
 /// 创建或修改临时排班请求体
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BatchCreateTempRequestBody {
-    /// 临时排班记录列表
-    pub shifts: Vec<TempShift>,
+    /// 临时班表信息列表
+    pub user_tmp_daily_shifts: Vec<UserTmpDailyShift>,
+    /// 操作人 UID
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operator_id: Option<String>,
 }
 
-/// 临时排班记录
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TempShift {
+/// 临时班表记录
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct UserTmpDailyShift {
+    /// 考勤组 ID
+    pub group_id: String,
     /// 用户 ID
     pub user_id: String,
-    /// 排班日期（Unix 时间戳）
-    pub date: i64,
-    /// 班次 ID
-    pub shift_id: String,
-    /// 是否为临时排班
-    pub is_temp: bool,
-    /// 工作时长（小时）
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub work_hours: Option<f64>,
+    /// 日期，格式 `yyyymmdd`（如 `20240120`）
+    pub date: i32,
+    /// 班次名称
+    pub shift_name: String,
+    /// 打卡规则（不超过 6 个）
+    pub punch_time_simple_rules: Vec<PunchTimeSimpleRule>,
+}
+
+/// 打卡规则
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PunchTimeSimpleRule {
+    /// 上班时间，格式 `HH:MM`
+    pub on_time: String,
+    /// 下班时间，格式 `HH:MM`（次日 2 点填 `"26:00"`）
+    pub off_time: String,
 }
 
 /// 创建或修改临时排班响应
+///
+/// 官网 response `data.user_tmp_daily_shifts` 为数组，items schema 未完整给出，透传 `Value`。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BatchCreateTempResponse {
-    /// 是否成功
-    pub success: bool,
-    /// 成功处理的记录数
-    pub processed_count: i32,
-    /// 失败的记录数
-    pub failed_count: i32,
+    /// 临时班表信息列表
+    #[serde(default)]
+    pub user_tmp_daily_shifts: Vec<serde_json::Value>,
 }
 
 impl ApiResponseTrait for BatchCreateTempResponse {
@@ -113,7 +140,27 @@ impl ApiResponseTrait for BatchCreateTempResponse {
 mod tests {
     use super::*;
     use openlark_core::config::Config;
-    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+    use openlark_core::testing::prelude::TestConfigBuilder;
+
+    #[test]
+    fn test_batch_create_temp_request_builder_new() {
+        let request = BatchCreateTempRequest::new(
+            TestConfigBuilder::new().build(),
+            vec![UserTmpDailyShift {
+                group_id: "6737202939523236110".to_string(),
+                user_id: "abd754f7".to_string(),
+                date: 20_240_120,
+                shift_name: "临时早班".to_string(),
+                punch_time_simple_rules: vec![PunchTimeSimpleRule {
+                    on_time: "9:00".to_string(),
+                    off_time: "18:00".to_string(),
+                }],
+            }],
+        );
+        let _ = request;
+    }
+
+    /// 端到端：Builder→execute→Transport→mock→assert 请求体字段对齐飞书官网 schema。
     #[tokio::test]
     async fn test_attendance_v1_user_daily_shift_batch_create_temp_returns_data_on_success() {
         use serde_json::json;
@@ -122,9 +169,6 @@ mod tests {
         use wiremock::{Mock, ResponseTemplate};
 
         let server = MockServer::start().await;
-        let data_body: serde_json::Value =
-            serde_json::from_str(r#"{"success": false, "processed_count": 0, "failed_count": 0}"#)
-                .unwrap();
         Mock::given(method("POST"))
             .and(path(
                 "/open-apis/attendance/v1/user_daily_shifts/batch_create_temp",
@@ -132,7 +176,7 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": data_body
+                "data": { "user_tmp_daily_shifts": [] }
             })))
             .mount(&server)
             .await;
@@ -146,25 +190,41 @@ mod tests {
 
         let data = BatchCreateTempRequest::new(
             config,
-            vec![TempShift {
-                user_id: "user_id_1".to_string(),
-                date: 1,
-                shift_id: "shift_id_1".to_string(),
-                is_temp: true,
-                work_hours: None,
+            vec![UserTmpDailyShift {
+                group_id: "6737202939523236110".to_string(),
+                user_id: "abd754f7".to_string(),
+                date: 20_240_120,
+                shift_name: "临时早班".to_string(),
+                punch_time_simple_rules: vec![PunchTimeSimpleRule {
+                    on_time: "9:00".to_string(),
+                    off_time: "18:00".to_string(),
+                }],
             }],
         )
         .execute()
         .await
         .expect("attendance_v1_user_daily_shift_batch_create_temp 应成功");
 
-        let _ = &data;
+        assert!(data.user_tmp_daily_shifts.is_empty());
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
         assert_eq!(
             received[0].url.path(),
             "/open-apis/attendance/v1/user_daily_shifts/batch_create_temp"
+        );
+        let body = String::from_utf8(received[0].body.clone()).unwrap();
+        assert!(
+            body.contains("\"user_tmp_daily_shifts\""),
+            "请求体缺 user_tmp_daily_shifts: {body}"
+        );
+        assert!(
+            body.contains("\"shift_name\""),
+            "请求体缺 shift_name: {body}"
+        );
+        assert!(
+            !body.contains("\"shifts\""),
+            "请求体不应含旧字段 shifts: {body}"
         );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_daily_shift/query.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_daily_shift/query.rs
@@ -7,56 +7,41 @@ use openlark_core::{
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
-    validate_required,
+    validate_required_list,
 };
 use serde::{Deserialize, Serialize};
 
 /// 查询排班表请求
 #[derive(Debug, Clone)]
 pub struct QueryRequest {
-    /// 用户 ID 列表（可选）
-    user_ids: Option<Vec<String>>,
-    /// 开始日期（Unix 时间戳，必填）
-    start_date: i64,
-    /// 结束日期（Unix 时间戳，必填）
-    end_date: i64,
-    /// 分页大小（可选，默认 50，最大 100）
-    page_size: Option<i32>,
-    /// 分页标记（可选）
-    page_token: Option<String>,
+    /// 用户 ID 列表（必填，最多 50 人）
+    user_ids: Vec<String>,
+    /// 查询起始工作日（必填，格式 `yyyyMMdd`）
+    check_date_from: i32,
+    /// 查询结束工作日（必填，格式 `yyyyMMdd`）
+    check_date_to: i32,
     /// 配置信息
     config: Config,
 }
 
 impl QueryRequest {
     /// 创建请求
-    pub fn new(config: Config, start_date: i64, end_date: i64) -> Self {
+    ///
+    /// - `user_ids`: 用户 ID 列表（最多 50 人）
+    /// - `check_date_from`: 起始工作日（`yyyyMMdd`）
+    /// - `check_date_to`: 结束工作日（`yyyyMMdd`）
+    pub fn new(
+        config: Config,
+        user_ids: Vec<String>,
+        check_date_from: i32,
+        check_date_to: i32,
+    ) -> Self {
         Self {
-            user_ids: None,
-            start_date,
-            end_date,
-            page_size: None,
-            page_token: None,
+            user_ids,
+            check_date_from,
+            check_date_to,
             config,
         }
-    }
-
-    /// 设置用户 ID 列表（可选）
-    pub fn user_ids(mut self, user_ids: Vec<String>) -> Self {
-        self.user_ids = Some(user_ids);
-        self
-    }
-
-    /// 设置分页大小（可选，默认 50，最大 100）
-    pub fn page_size(mut self, page_size: i32) -> Self {
-        self.page_size = Some(page_size);
-        self
-    }
-
-    /// 设置分页标记（可选）
-    pub fn page_token(mut self, page_token: String) -> Self {
-        self.page_token = Some(page_token);
-        self
     }
 
     /// 执行请求
@@ -72,39 +57,24 @@ impl QueryRequest {
     ) -> SDKResult<QueryResponse> {
         use crate::common::api_endpoints::AttendanceApiV1;
 
-        if self.start_date <= 0 {
+        // 1. 验证必填字段
+        validate_required_list!(self.user_ids, 50, "user_ids 不能为空且不能超过 50 个");
+        if self.check_date_to < self.check_date_from {
             return Err(openlark_core::error::validation_error(
-                "start_date 无效",
-                "start_date 必须为正整数时间戳",
+                "日期范围无效",
+                "check_date_to 不能早于 check_date_from",
             ));
-        }
-        if self.end_date <= 0 {
-            return Err(openlark_core::error::validation_error(
-                "end_date 无效",
-                "end_date 必须为正整数时间戳",
-            ));
-        }
-        if self.end_date < self.start_date {
-            return Err(openlark_core::error::validation_error(
-                "时间范围无效",
-                "end_date 不能早于 start_date",
-            ));
-        }
-        if let Some(user_ids) = self.user_ids.as_ref() {
-            validate_required!(user_ids, "user_ids");
         }
 
-        // 1. 构建端点
+        // 2. 构建端点
         let api_endpoint = AttendanceApiV1::UserDailyShiftQuery;
         let request = ApiRequest::<QueryResponse>::post(api_endpoint.to_url());
 
-        // 2. 构建请求体
+        // 3. 构建请求体
         let request_body = QueryRequestBody {
             user_ids: self.user_ids,
-            start_date: self.start_date,
-            end_date: self.end_date,
-            page_size: self.page_size,
-            page_token: self.page_token,
+            check_date_from: self.check_date_from,
+            check_date_to: self.check_date_to,
         };
         let request_body_json = serde_json::to_value(&request_body).map_err(|e| {
             openlark_core::error::validation_error(
@@ -114,7 +84,7 @@ impl QueryRequest {
         })?;
         let request = request.body(request_body_json);
 
-        // 3. 发送请求
+        // 4. 发送请求
         Transport::request_typed(
             request,
             &self.config,
@@ -129,47 +99,21 @@ impl QueryRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryRequestBody {
     /// 用户 ID 列表
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_ids: Option<Vec<String>>,
-    /// 开始日期
-    pub start_date: i64,
-    /// 结束日期
-    pub end_date: i64,
-    /// 分页大小
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub page_size: Option<i32>,
-    /// 分页标记
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub page_token: Option<String>,
+    pub user_ids: Vec<String>,
+    /// 查询起始工作日（`yyyyMMdd`）
+    pub check_date_from: i32,
+    /// 查询结束工作日（`yyyyMMdd`）
+    pub check_date_to: i32,
 }
 
 /// 查询排班表响应
+///
+/// 官网 response `data.user_daily_shifts` 为数组，items schema 未完整给出，透传 `Value`。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct QueryResponse {
     /// 排班记录列表
-    pub items: Vec<UserDailyShift>,
-    /// 是否有更多数据
-    pub has_more: bool,
-    /// 分页标记，用于获取下一页数据
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub page_token: Option<String>,
-}
-
-/// 用户每日排班记录
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct UserDailyShift {
-    /// 用户 ID
-    pub user_id: String,
-    /// 排班日期（Unix 时间戳）
-    pub date: i64,
-    /// 班次 ID
-    pub shift_id: String,
-    /// 班次名称
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub shift_name: Option<String>,
-    /// 工作时长（小时）
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub work_hours: Option<f64>,
+    #[serde(default)]
+    pub user_daily_shifts: Vec<serde_json::Value>,
 }
 
 impl ApiResponseTrait for QueryResponse {
@@ -179,7 +123,6 @@ impl ApiResponseTrait for QueryResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
     use super::*;
     use openlark_core::config::Config;
@@ -187,10 +130,16 @@ mod tests {
 
     #[test]
     fn test_query_request_builder_new() {
-        let request = QueryRequest::new(TestConfigBuilder::new().build(), 1, 1);
+        let request = QueryRequest::new(
+            TestConfigBuilder::new().build(),
+            vec!["abd754f7".to_string()],
+            20_190_817,
+            20_190_820,
+        );
         let _ = request;
     }
-    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+
+    /// 端到端：Builder→execute→Transport→mock→assert 请求体字段对齐飞书官网 schema。
     #[tokio::test]
     async fn test_attendance_v1_user_daily_shift_query_returns_data_on_success() {
         use serde_json::json;
@@ -199,14 +148,12 @@ mod tests {
         use wiremock::{Mock, ResponseTemplate};
 
         let server = MockServer::start().await;
-        let data_body: serde_json::Value =
-            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
         Mock::given(method("POST"))
             .and(path("/open-apis/attendance/v1/user_daily_shifts/query"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": data_body
+                "data": { "user_daily_shifts": [] }
             })))
             .mount(&server)
             .await;
@@ -218,18 +165,31 @@ mod tests {
             .enable_token_cache(false)
             .build();
 
-        let data = QueryRequest::new(config, 1_700_000_000, 1_700_000_000)
+        let data = QueryRequest::new(config, vec!["abd754f7".to_string()], 20_190_817, 20_190_820)
             .execute()
             .await
             .expect("attendance_v1_user_daily_shift_query 应成功");
 
-        let _ = &data;
+        assert!(data.user_daily_shifts.is_empty());
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
         assert_eq!(
             received[0].url.path(),
             "/open-apis/attendance/v1/user_daily_shifts/query"
+        );
+        let body = String::from_utf8(received[0].body.clone()).unwrap();
+        assert!(
+            body.contains("\"check_date_from\""),
+            "请求体缺 check_date_from: {body}"
+        );
+        assert!(
+            body.contains("\"check_date_to\""),
+            "请求体缺 check_date_to: {body}"
+        );
+        assert!(
+            !body.contains("\"start_date\""),
+            "请求体不应含旧字段 start_date: {body}"
         );
     }
 }


### PR DESCRIPTION
## What

Part of #533 (attendance remaining field drift). **Group 1 of 5.**

Aligns the `user_daily_shift` family (3 APIs) with the current Feishu schema.

## Changes

- **batch_create**: `shifts` → `user_daily_shifts` [{ group_id, shift_id, month(yyyyMM), user_id, day_no, is_clear_schedule? }]; + optional `operator_id`
- **batch_create_temp**: `TempShift` → `user_tmp_daily_shifts` [{ group_id, user_id, date(yyyymmdd), shift_name, punch_time_simple_rules [{ on_time, off_time }] }]
- **query**: `start_date`/`end_date` (i64 timestamps) → `check_date_from`/`check_date_to` (i32 yyyyMMdd); `user_ids` now required (was `Option`)

⚠️ Notable: the old `date: i64` (Unix timestamp) was wrong — the official schema uses `month` / `day_no` / `date` as **int32** (yyyyMM / day-no / yyyymmdd). Response `data.{user_daily_shifts, user_tmp_daily_shifts}` items schema is not fully given by Feishu, so passed through as `serde_json::Value`.

## Breaking (targets 0.19)

Builder signatures change: `UserDailyShift` (new fields), `TempShift` → `UserTmpDailyShift`, `QueryRequest::new(config, user_ids, check_date_from, check_date_to)`. Migration note in `CHANGELOG.md`.

## Testing

- 3 new wiremock e2e tests mock the official response + assert request body fields (and absence of old `shifts` / `start_date`)
- `cargo test -p openlark-hr --all-features`: **786 passed, 0 failed**
- `cargo clippy -p openlark-hr --all-targets --all-features -- -Dwarnings`: clean
- `cargo fmt -p openlark-hr --check`: clean

## Refs

#533. Remaining groups: `user_task_remedy` / `leave_accrual_record` / `user_approval` / `user_stats_view`.
