### PR TITLE
fix(hr/attendance): align user_task_remedy family with feishu schema (#533, group 2/5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ⚠️ 原 `date` 为 i64 时间戳，官网实为 `month`/`day_no`/`date` 的 int32（yyyyMM/yyyymmdd）；响应 items schema 官网未完整给出，透传 `Value`。
   **迁移**：`UserDailyShift`/`TempShift`→`UserTmpDailyShift` 字段重构、`QueryRequest::new` 签名变（详见各 API docPath）。
 
+- **hr/attendance：`user_task_remedy` 族 2 API 字段对齐飞书官网 schema（#533）**：
+  `create`（`original_time`/`remedy_time`(i64)→`remedy_date`(i32 yyyyMMdd)/`punch_no`/`work_type`/`remedy_time`(string `yyyy-MM-dd HH:mm`)，删臆测的 `original_time`）、
+  `query`（`user_id`/`start_time`/`end_time`/分页→`user_ids`(必填)/`check_time_from`/`check_time_to`(string 秒级时间戳)/可选 `check_date_type`/`status`）。
+  响应 items schema 官网未完整给出，透传 `Value`。
+  **迁移**：`CreateRequest::new` / `QueryRequest::new` 签名变；`RemedyRecord` 删除（响应透传 `Value`）。
+
 - **hr/attendance：`approval_info/process` 请求/响应字段对齐飞书官网 schema（#527，parent #526）**：
   原请求体发 `approval_instance_id`/`result`/`comment`、响应为扁平
   `success`/`approval_instance_id`，与飞书官网当前 schema 不符，真实调用被服务端拒绝

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_task_remedy/create.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_task_remedy/create.rs
@@ -16,10 +16,14 @@ use serde::{Deserialize, Serialize};
 pub struct CreateRequest {
     /// 用户 ID（必填）
     user_id: String,
-    /// 原打卡时间（Unix 时间戳，必填）
-    original_time: i64,
-    /// 补卡时间（Unix 时间戳，必填）
-    remedy_time: i64,
+    /// 补卡日期，格式 `yyyyMMdd`（必填）
+    remedy_date: i32,
+    /// 第几次上下班（必填）：`0`=第 1 次，`1`=第 2 次，`2`=第 3 次；自由班制填 `0`
+    punch_no: i32,
+    /// 上班/下班（必填）：`1`=上班，`2`=下班；自由班制填 `0`
+    work_type: i32,
+    /// 补卡时间，格式 `yyyy-MM-dd HH:mm`（必填）
+    remedy_time: String,
     /// 补卡原因（必填）
     reason: String,
     /// 配置信息
@@ -31,13 +35,17 @@ impl CreateRequest {
     pub fn new(
         config: Config,
         user_id: String,
-        original_time: i64,
-        remedy_time: i64,
+        remedy_date: i32,
+        punch_no: i32,
+        work_type: i32,
+        remedy_time: String,
         reason: String,
     ) -> Self {
         Self {
             user_id,
-            original_time,
+            remedy_date,
+            punch_no,
+            work_type,
             remedy_time,
             reason,
             config,
@@ -59,6 +67,7 @@ impl CreateRequest {
 
         // 1. 验证必填字段
         validate_required!(self.user_id.trim(), "user_id");
+        validate_required!(self.remedy_time.trim(), "remedy_time");
         validate_required!(self.reason.trim(), "reason");
 
         // 2. 构建端点
@@ -68,7 +77,9 @@ impl CreateRequest {
         // 3. 构建请求体
         let request_body = CreateRequestBody {
             user_id: self.user_id,
-            original_time: self.original_time,
+            remedy_date: self.remedy_date,
+            punch_no: self.punch_no,
+            work_type: self.work_type,
             remedy_time: self.remedy_time,
             reason: self.reason,
         };
@@ -96,23 +107,26 @@ impl CreateRequest {
 pub struct CreateRequestBody {
     /// 用户 ID
     pub user_id: String,
-    /// 原打卡时间
-    pub original_time: i64,
-    /// 补卡时间
-    pub remedy_time: i64,
+    /// 补卡日期 `yyyyMMdd`
+    pub remedy_date: i32,
+    /// 第几次上下班
+    pub punch_no: i32,
+    /// 上班/下班
+    pub work_type: i32,
+    /// 补卡时间 `yyyy-MM-dd HH:mm`
+    pub remedy_time: String,
     /// 补卡原因
     pub reason: String,
 }
 
 /// 通知补卡审批发起响应
+///
+/// 官网 response `data.user_remedy` 为 object，schema 未完整给出，透传 `Value`。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CreateResponse {
-    /// 是否成功
-    pub success: bool,
-    /// 补卡申请 ID
-    pub remedy_id: String,
-    /// 审批实例 ID
-    pub approval_instance_id: String,
+    /// 补卡审批结果
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_remedy: Option<serde_json::Value>,
 }
 
 impl ApiResponseTrait for CreateResponse {
@@ -122,7 +136,6 @@ impl ApiResponseTrait for CreateResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
     use super::*;
     use openlark_core::config::Config;
@@ -132,14 +145,17 @@ mod tests {
     fn test_create_request_builder_new() {
         let request = CreateRequest::new(
             TestConfigBuilder::new().build(),
-            "test".to_string(),
+            "abd754f7".to_string(),
+            20_210_701,
+            0,
             1,
-            1,
-            "test".to_string(),
+            "2021-07-01 08:00".to_string(),
+            "忘记打卡".to_string(),
         );
         let _ = request;
     }
-    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+
+    /// 端到端：Builder→execute→Transport→mock→assert 请求体字段对齐飞书官网 schema。
     #[tokio::test]
     async fn test_attendance_v1_user_task_remedy_create_returns_data_on_success() {
         use serde_json::json;
@@ -148,16 +164,12 @@ mod tests {
         use wiremock::{Mock, ResponseTemplate};
 
         let server = MockServer::start().await;
-        let data_body: serde_json::Value = serde_json::from_str(
-            r#"{"success": false, "remedy_id": "test", "approval_instance_id": "test"}"#,
-        )
-        .unwrap();
         Mock::given(method("POST"))
             .and(path("/open-apis/attendance/v1/user_task_remedys"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": data_body
+                "data": { "user_remedy": { "remedy_id": "r_1" } }
             })))
             .mount(&server)
             .await;
@@ -171,22 +183,35 @@ mod tests {
 
         let data = CreateRequest::new(
             config,
-            "user_001".to_string(),
-            1_700_000_000,
-            1_700_000_000,
-            "reason_001".to_string(),
+            "abd754f7".to_string(),
+            20_210_701,
+            0,
+            1,
+            "2021-07-01 08:00".to_string(),
+            "忘记打卡".to_string(),
         )
         .execute()
         .await
         .expect("attendance_v1_user_task_remedy_create 应成功");
 
-        let _ = &data;
+        assert!(data.user_remedy.is_some());
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
         assert_eq!(
             received[0].url.path(),
             "/open-apis/attendance/v1/user_task_remedys"
+        );
+        let body = String::from_utf8(received[0].body.clone()).unwrap();
+        assert!(
+            body.contains("\"remedy_date\""),
+            "请求体缺 remedy_date: {body}"
+        );
+        assert!(body.contains("\"punch_no\""), "请求体缺 punch_no: {body}");
+        assert!(body.contains("\"work_type\""), "请求体缺 work_type: {body}");
+        assert!(
+            !body.contains("\"original_time\""),
+            "请求体不应含旧字段 original_time: {body}"
         );
     }
 }

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_task_remedy/query.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_task_remedy/query.rs
@@ -7,66 +7,54 @@ use openlark_core::{
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
+    validate_required, validate_required_list,
 };
 use serde::{Deserialize, Serialize};
 
 /// 获取补卡记录请求
 #[derive(Debug, Clone)]
 pub struct QueryRequest {
-    /// 用户 ID（可选）
-    user_id: Option<String>,
-    /// 开始时间（Unix 时间戳，可选）
-    start_time: Option<i64>,
-    /// 结束时间（Unix 时间戳，可选）
-    end_time: Option<i64>,
-    /// 分页大小（可选，默认 50，最大 100）
-    page_size: Option<i32>,
-    /// 分页标记（可选）
-    page_token: Option<String>,
+    /// 用户 ID 列表（必填，最多 50 个）
+    user_ids: Vec<String>,
+    /// 查询起始时间，精确到秒的时间戳（必填）
+    check_time_from: String,
+    /// 查询结束时间，精确到秒的时间戳（必填）
+    check_time_to: String,
+    /// 查询依据的时间类型（可选）
+    check_date_type: Option<String>,
+    /// 查询状态（可选，不填默认已通过）
+    status: Option<i32>,
     /// 配置信息
     config: Config,
 }
 
 impl QueryRequest {
     /// 创建请求
-    pub fn new(config: Config) -> Self {
+    pub fn new(
+        config: Config,
+        user_ids: Vec<String>,
+        check_time_from: String,
+        check_time_to: String,
+    ) -> Self {
         Self {
-            user_id: None,
-            start_time: None,
-            end_time: None,
-            page_size: None,
-            page_token: None,
+            user_ids,
+            check_time_from,
+            check_time_to,
+            check_date_type: None,
+            status: None,
             config,
         }
     }
 
-    /// 设置用户 ID（可选）
-    pub fn user_id(mut self, user_id: String) -> Self {
-        self.user_id = Some(user_id);
+    /// 设置查询依据的时间类型（可选）
+    pub fn check_date_type(mut self, check_date_type: String) -> Self {
+        self.check_date_type = Some(check_date_type);
         self
     }
 
-    /// 设置开始时间（可选）
-    pub fn start_time(mut self, start_time: i64) -> Self {
-        self.start_time = Some(start_time);
-        self
-    }
-
-    /// 设置结束时间（可选）
-    pub fn end_time(mut self, end_time: i64) -> Self {
-        self.end_time = Some(end_time);
-        self
-    }
-
-    /// 设置分页大小（可选，默认 50，最大 100）
-    pub fn page_size(mut self, page_size: i32) -> Self {
-        self.page_size = Some(page_size);
-        self
-    }
-
-    /// 设置分页标记（可选）
-    pub fn page_token(mut self, page_token: String) -> Self {
-        self.page_token = Some(page_token);
+    /// 设置查询状态（可选）
+    pub fn status(mut self, status: i32) -> Self {
+        self.status = Some(status);
         self
     }
 
@@ -83,17 +71,22 @@ impl QueryRequest {
     ) -> SDKResult<QueryResponse> {
         use crate::common::api_endpoints::AttendanceApiV1;
 
-        // 1. 构建端点
+        // 1. 验证必填字段
+        validate_required_list!(self.user_ids, 50, "user_ids 不能为空且不能超过 50 个");
+        validate_required!(self.check_time_from.trim(), "check_time_from");
+        validate_required!(self.check_time_to.trim(), "check_time_to");
+
+        // 2. 构建端点
         let api_endpoint = AttendanceApiV1::UserTaskRemedyQuery;
         let request = ApiRequest::<QueryResponse>::post(api_endpoint.to_url());
 
-        // 2. 构建请求体
+        // 3. 构建请求体
         let request_body = QueryRequestBody {
-            user_id: self.user_id,
-            start_time: self.start_time,
-            end_time: self.end_time,
-            page_size: self.page_size,
-            page_token: self.page_token,
+            user_ids: self.user_ids,
+            check_time_from: self.check_time_from,
+            check_time_to: self.check_time_to,
+            check_date_type: self.check_date_type,
+            status: self.status,
         };
         let request_body_json = serde_json::to_value(&request_body).map_err(|e| {
             openlark_core::error::validation_error(
@@ -103,7 +96,7 @@ impl QueryRequest {
         })?;
         let request = request.body(request_body_json);
 
-        // 3. 发送请求
+        // 4. 发送请求
         Transport::request_typed(
             request,
             &self.config,
@@ -117,52 +110,28 @@ impl QueryRequest {
 /// 获取补卡记录请求体
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryRequestBody {
-    /// 用户 ID
+    /// 用户 ID 列表
+    pub user_ids: Vec<String>,
+    /// 查询起始时间（秒级时间戳）
+    pub check_time_from: String,
+    /// 查询结束时间（秒级时间戳）
+    pub check_time_to: String,
+    /// 查询依据的时间类型
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_id: Option<String>,
-    /// 开始时间
+    pub check_date_type: Option<String>,
+    /// 查询状态
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub start_time: Option<i64>,
-    /// 结束时间
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub end_time: Option<i64>,
-    /// 分页大小
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub page_size: Option<i32>,
-    /// 分页标记
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub page_token: Option<String>,
+    pub status: Option<i32>,
 }
 
 /// 获取补卡记录响应
+///
+/// 官网 response `data.user_remedys` 为数组，items schema 未完整给出，透传 `Value`。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct QueryResponse {
     /// 补卡记录列表
-    pub items: Vec<RemedyRecord>,
-    /// 是否有更多数据
-    pub has_more: bool,
-    /// 分页标记，用于获取下一页数据
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub page_token: Option<String>,
-}
-
-/// 补卡记录
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct RemedyRecord {
-    /// 补卡记录 ID
-    pub remedy_id: String,
-    /// 用户 ID
-    pub user_id: String,
-    /// 原打卡时间
-    pub original_time: i64,
-    /// 补卡时间
-    pub remedy_time: i64,
-    /// 补卡原因
-    pub reason: String,
-    /// 审批状态
-    pub approval_status: i32,
-    /// 创建时间（Unix 时间戳）
-    pub created_at: i64,
+    #[serde(default)]
+    pub user_remedys: Vec<serde_json::Value>,
 }
 
 impl ApiResponseTrait for QueryResponse {
@@ -172,7 +141,6 @@ impl ApiResponseTrait for QueryResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
     use super::*;
     use openlark_core::config::Config;
@@ -180,11 +148,16 @@ mod tests {
 
     #[test]
     fn test_query_request_builder_new() {
-        let request =
-            QueryRequest::new(TestConfigBuilder::new().build()).user_id("test".to_string());
+        let request = QueryRequest::new(
+            TestConfigBuilder::new().build(),
+            vec!["abd754f7".to_string()],
+            "1566641088".to_string(),
+            "1592561088".to_string(),
+        );
         let _ = request;
     }
-    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+
+    /// 端到端：Builder→execute→Transport→mock→assert 请求体字段对齐飞书官网 schema。
     #[tokio::test]
     async fn test_attendance_v1_user_task_remedy_query_returns_data_on_success() {
         use serde_json::json;
@@ -193,14 +166,12 @@ mod tests {
         use wiremock::{Mock, ResponseTemplate};
 
         let server = MockServer::start().await;
-        let data_body: serde_json::Value =
-            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
         Mock::given(method("POST"))
             .and(path("/open-apis/attendance/v1/user_task_remedys/query"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": data_body
+                "data": { "user_remedys": [] }
             })))
             .mount(&server)
             .await;
@@ -212,18 +183,33 @@ mod tests {
             .enable_token_cache(false)
             .build();
 
-        let data = QueryRequest::new(config)
-            .execute()
-            .await
-            .expect("attendance_v1_user_task_remedy_query 应成功");
+        let data = QueryRequest::new(
+            config,
+            vec!["abd754f7".to_string()],
+            "1566641088".to_string(),
+            "1592561088".to_string(),
+        )
+        .execute()
+        .await
+        .expect("attendance_v1_user_task_remedy_query 应成功");
 
-        let _ = &data;
+        assert!(data.user_remedys.is_empty());
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
         assert_eq!(
             received[0].url.path(),
             "/open-apis/attendance/v1/user_task_remedys/query"
+        );
+        let body = String::from_utf8(received[0].body.clone()).unwrap();
+        assert!(
+            body.contains("\"check_time_from\""),
+            "请求体缺 check_time_from: {body}"
+        );
+        assert!(body.contains("\"user_ids\""), "请求体缺 user_ids: {body}");
+        assert!(
+            !body.contains("\"start_time\""),
+            "请求体不应含旧字段 start_time: {body}"
         );
     }
 }

--- a/crates/openlark-hr/tests/attendance_tests.rs
+++ b/crates/openlark-hr/tests/attendance_tests.rs
@@ -150,18 +150,21 @@ mod builder_tests {
         user_task_remedy::create::CreateRequest::new(
             test_config("https://open.feishu.cn"),
             "ou_1".to_string(),
-            1735689600,
-            1735693200,
+            20_210_701,
+            0,
+            1,
+            "2021-07-01 08:00".to_string(),
             "补卡".to_string(),
         )
     );
     smoke_builder!(
         test_query_user_task_remedy_request_builder,
-        user_task_remedy::query::QueryRequest::new(test_config("https://open.feishu.cn"))
-            .user_id("ou_1".to_string())
-            .start_time(1735689600)
-            .end_time(1735776000)
-            .page_size(20)
+        user_task_remedy::query::QueryRequest::new(
+            test_config("https://open.feishu.cn"),
+            vec!["ou_1".to_string()],
+            "1566641088".to_string(),
+            "1592561088".to_string(),
+        )
     );
     smoke_builder!(
         test_query_user_allowed_remedys_request_builder,
@@ -759,26 +762,14 @@ mod serialization_tests {
         test_create_user_task_remedy_response_serialization,
         user_task_remedy::create::CreateResponse,
         user_task_remedy::create::CreateResponse {
-            success: true,
-            remedy_id: "r_1".to_string(),
-            approval_instance_id: "ins_1".to_string(),
+            user_remedy: Some(serde_json::json!({ "remedy_id": "r_1" })),
         }
     );
     roundtrip_eq!(
         test_query_user_task_remedy_response_serialization,
         user_task_remedy::query::QueryResponse,
         user_task_remedy::query::QueryResponse {
-            items: vec![user_task_remedy::query::RemedyRecord {
-                remedy_id: "r_1".to_string(),
-                user_id: "ou_1".to_string(),
-                original_time: 1735689600,
-                remedy_time: 1735693200,
-                reason: "补卡".to_string(),
-                approval_status: 1,
-                created_at: 1735696800,
-            }],
-            has_more: false,
-            page_token: None,
+            user_remedys: vec![serde_json::json!({ "remedy_id": "r_1" })],
         }
     );
     roundtrip_eq!(


### PR DESCRIPTION
## What

Part of #533. **Group 2 of 5.**

Aligns the `user_task_remedy` family (create / query, 2 APIs) with the current Feishu schema.

## Changes

- **create** (通知补卡审批发起): drops fabricated `original_time`; `remedy_time` was `i64` → now `remedy_date`(i32 yyyyMMdd) / `punch_no`(i32) / `work_type`(i32) / `remedy_time`(string `yyyy-MM-dd HH:mm`)
- **query** (获取补卡记录): `user_id`/`start_time`/`end_time`/pagination → `user_ids`(required) / `check_time_from` / `check_time_to` (string second-precision timestamps) + optional `check_date_type` / `status`

Response `data.{user_remedy, user_remedys}` items schema not fully given by Feishu → passed through as `serde_json::Value`.

## Breaking (targets 0.19)

`CreateRequest::new(config, user_id, remedy_date, punch_no, work_type, remedy_time, reason)`; `QueryRequest::new(config, user_ids, check_time_from, check_time_to)`; `RemedyRecord` removed (response now `Value`). Migration note in `CHANGELOG.md`.

## Testing

- 2 new wiremock e2e tests + integration tests (builder smoke + response roundtrip) updated
- `cargo test -p openlark-hr --all-features`: **784 passed, 0 failed**
- `cargo clippy -p openlark-hr --all-targets --all-features -- -Dwarnings`: clean
- `cargo fmt -p openlark-hr --check`: clean

## Refs

#533. Done: group 1 (user_daily_shift, #535). Remaining: leave_accrual_record / user_approval / user_stats_view.
