### PR TITLE
fix(hr/attendance): align user_approval/query with feishu schema (#533, group 4/5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `leave_id` 改为 path 参数（原 `record_id` 同时作 path+body，官网 body 无 record_id）。响应 `record` object schema 未完整给出，透传 `Value`。
   **迁移**：`PatchRequest::new` 签名变（`leave_id` path + 4 必填 + `reason`）；新增 `LangText`。
 
+- **hr/attendance：`user_approval/query` 字段对齐飞书官网 schema（#533）**：
+  `user_id`/`approval_type`/`start_time`/`end_time`/分页 → 必填 `user_ids`/`check_date_from`/`check_date_to`(i32 yyyyMMdd)+可选 `check_date_type`/`status`/`check_time_from`/`check_time_to`。
+  响应 `user_approvals` items schema 未完整给出，透传 `Value`。
+  **迁移**：`QueryRequest::new` 签名变；`UserApproval` 删除（响应透传）。
+
 - **hr/attendance：`approval_info/process` 请求/响应字段对齐飞书官网 schema（#527，parent #526）**：
   原请求体发 `approval_instance_id`/`result`/`comment`、响应为扁平
   `success`/`approval_instance_id`，与飞书官网当前 schema 不符，真实调用被服务端拒绝

--- a/crates/openlark-hr/src/attendance/attendance/v1/user_approval/query.rs
+++ b/crates/openlark-hr/src/attendance/attendance/v1/user_approval/query.rs
@@ -7,75 +7,72 @@ use openlark_core::{
     api::{ApiRequest, ApiResponseTrait, ResponseFormat},
     config::Config,
     http::Transport,
+    validate_required_list,
 };
 use serde::{Deserialize, Serialize};
 
 /// 获取审批数据请求
 #[derive(Debug, Clone)]
 pub struct QueryRequest {
-    /// 用户 ID（可选）
-    user_id: Option<String>,
-    /// 审批类型（可选）
-    approval_type: Option<i32>,
-    /// 开始时间（Unix 时间戳，可选）
-    start_time: Option<i64>,
-    /// 结束时间（Unix 时间戳，可选）
-    end_time: Option<i64>,
-    /// 分页大小（可选，默认 50，最大 100）
-    page_size: Option<i32>,
-    /// 分页标记（可选）
-    page_token: Option<String>,
+    /// 用户 ID 列表（必填）
+    user_ids: Vec<String>,
+    /// 查询起始日期 `yyyyMMdd`（必填，不能超过当天 +1）
+    check_date_from: i32,
+    /// 查询结束日期 `yyyyMMdd`（必填，与 `check_date_from` 间隔不超过 30 天）
+    check_date_to: i32,
+    /// 查询依据的时间类型（可选，默认 `PeriodTime`）
+    check_date_type: Option<String>,
+    /// 查询状态（可选）
+    status: Option<i32>,
+    /// 查询起始时间（可选）
+    check_time_from: Option<String>,
+    /// 查询结束时间（可选）
+    check_time_to: Option<String>,
     /// 配置信息
     config: Config,
 }
 
 impl QueryRequest {
     /// 创建请求
-    pub fn new(config: Config) -> Self {
+    pub fn new(
+        config: Config,
+        user_ids: Vec<String>,
+        check_date_from: i32,
+        check_date_to: i32,
+    ) -> Self {
         Self {
-            user_id: None,
-            approval_type: None,
-            start_time: None,
-            end_time: None,
-            page_size: None,
-            page_token: None,
+            user_ids,
+            check_date_from,
+            check_date_to,
+            check_date_type: None,
+            status: None,
+            check_time_from: None,
+            check_time_to: None,
             config,
         }
     }
 
-    /// 设置用户 ID（可选）
-    pub fn user_id(mut self, user_id: String) -> Self {
-        self.user_id = Some(user_id);
+    /// 设置查询依据的时间类型（可选）
+    pub fn check_date_type(mut self, check_date_type: String) -> Self {
+        self.check_date_type = Some(check_date_type);
         self
     }
 
-    /// 设置审批类型（可选）
-    pub fn approval_type(mut self, approval_type: i32) -> Self {
-        self.approval_type = Some(approval_type);
+    /// 设置查询状态（可选）
+    pub fn status(mut self, status: i32) -> Self {
+        self.status = Some(status);
         self
     }
 
-    /// 设置开始时间（可选）
-    pub fn start_time(mut self, start_time: i64) -> Self {
-        self.start_time = Some(start_time);
+    /// 设置查询起始时间（可选）
+    pub fn check_time_from(mut self, check_time_from: String) -> Self {
+        self.check_time_from = Some(check_time_from);
         self
     }
 
-    /// 设置结束时间（可选）
-    pub fn end_time(mut self, end_time: i64) -> Self {
-        self.end_time = Some(end_time);
-        self
-    }
-
-    /// 设置分页大小（可选，默认 50，最大 100）
-    pub fn page_size(mut self, page_size: i32) -> Self {
-        self.page_size = Some(page_size);
-        self
-    }
-
-    /// 设置分页标记（可选）
-    pub fn page_token(mut self, page_token: String) -> Self {
-        self.page_token = Some(page_token);
+    /// 设置查询结束时间（可选）
+    pub fn check_time_to(mut self, check_time_to: String) -> Self {
+        self.check_time_to = Some(check_time_to);
         self
     }
 
@@ -92,18 +89,28 @@ impl QueryRequest {
     ) -> SDKResult<QueryResponse> {
         use crate::common::api_endpoints::AttendanceApiV1;
 
-        // 1. 构建端点
+        // 1. 验证必填字段
+        validate_required_list!(self.user_ids, 50, "user_ids 不能为空且不能超过 50 个");
+        if self.check_date_to < self.check_date_from {
+            return Err(openlark_core::error::validation_error(
+                "日期范围无效",
+                "check_date_to 不能早于 check_date_from",
+            ));
+        }
+
+        // 2. 构建端点
         let api_endpoint = AttendanceApiV1::UserApprovalQuery;
         let request = ApiRequest::<QueryResponse>::post(api_endpoint.to_url());
 
-        // 2. 构建请求体
+        // 3. 构建请求体
         let request_body = QueryRequestBody {
-            user_id: self.user_id,
-            approval_type: self.approval_type,
-            start_time: self.start_time,
-            end_time: self.end_time,
-            page_size: self.page_size,
-            page_token: self.page_token,
+            user_ids: self.user_ids,
+            check_date_from: self.check_date_from,
+            check_date_to: self.check_date_to,
+            check_date_type: self.check_date_type,
+            status: self.status,
+            check_time_from: self.check_time_from,
+            check_time_to: self.check_time_to,
         };
         let request_body_json = serde_json::to_value(&request_body).map_err(|e| {
             openlark_core::error::validation_error(
@@ -113,7 +120,7 @@ impl QueryRequest {
         })?;
         let request = request.body(request_body_json);
 
-        // 3. 发送请求
+        // 4. 发送请求
         Transport::request_typed(
             request,
             &self.config,
@@ -127,54 +134,34 @@ impl QueryRequest {
 /// 获取审批数据请求体
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryRequestBody {
-    /// 用户 ID
+    /// 用户 ID 列表
+    pub user_ids: Vec<String>,
+    /// 查询起始日期 `yyyyMMdd`
+    pub check_date_from: i32,
+    /// 查询结束日期 `yyyyMMdd`
+    pub check_date_to: i32,
+    /// 查询依据的时间类型
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_id: Option<String>,
-    /// 审批类型
+    pub check_date_type: Option<String>,
+    /// 查询状态
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub approval_type: Option<i32>,
-    /// 开始时间
+    pub status: Option<i32>,
+    /// 查询起始时间
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub start_time: Option<i64>,
-    /// 结束时间
+    pub check_time_from: Option<String>,
+    /// 查询结束时间
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub end_time: Option<i64>,
-    /// 分页大小
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub page_size: Option<i32>,
-    /// 分页标记
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub page_token: Option<String>,
+    pub check_time_to: Option<String>,
 }
 
 /// 获取审批数据响应
+///
+/// 官网 response `data.user_approvals` 为数组，items schema 未完整给出，透传 `Value`。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct QueryResponse {
     /// 审批数据列表
-    pub items: Vec<UserApproval>,
-    /// 是否有更多数据
-    pub has_more: bool,
-    /// 分页标记，用于获取下一页数据
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub page_token: Option<String>,
-}
-
-/// 用户审批数据
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct UserApproval {
-    /// 审批 ID
-    pub approval_id: String,
-    /// 用户 ID
-    pub user_id: String,
-    /// 审批类型
-    pub approval_type: i32,
-    /// 审批状态
-    pub status: i32,
-    /// 审批时间（Unix 时间戳）
-    pub approval_time: i64,
-    /// 审批内容
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<serde_json::Value>,
+    #[serde(default)]
+    pub user_approvals: Vec<serde_json::Value>,
 }
 
 impl ApiResponseTrait for QueryResponse {
@@ -184,7 +171,6 @@ impl ApiResponseTrait for QueryResponse {
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
     use super::*;
     use openlark_core::config::Config;
@@ -192,11 +178,16 @@ mod tests {
 
     #[test]
     fn test_query_request_builder_new() {
-        let request =
-            QueryRequest::new(TestConfigBuilder::new().build()).user_id("test".to_string());
+        let request = QueryRequest::new(
+            TestConfigBuilder::new().build(),
+            vec!["abd754f7".to_string()],
+            20_190_817,
+            20_190_820,
+        );
         let _ = request;
     }
-    /// 端到端：Builder→execute→Transport→mock→assert 响应解析 + 实际请求形状。
+
+    /// 端到端：Builder→execute→Transport→mock→assert 请求体字段对齐飞书官网 schema。
     #[tokio::test]
     async fn test_attendance_v1_user_approval_query_returns_data_on_success() {
         use serde_json::json;
@@ -205,14 +196,12 @@ mod tests {
         use wiremock::{Mock, ResponseTemplate};
 
         let server = MockServer::start().await;
-        let data_body: serde_json::Value =
-            serde_json::from_str(r#"{"items": [], "has_more": false}"#).unwrap();
         Mock::given(method("POST"))
             .and(path("/open-apis/attendance/v1/user_approvals/query"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": data_body
+                "data": { "user_approvals": [] }
             })))
             .mount(&server)
             .await;
@@ -224,18 +213,28 @@ mod tests {
             .enable_token_cache(false)
             .build();
 
-        let data = QueryRequest::new(config)
+        let data = QueryRequest::new(config, vec!["abd754f7".to_string()], 20_190_817, 20_190_820)
             .execute()
             .await
             .expect("attendance_v1_user_approval_query 应成功");
 
-        let _ = &data;
+        assert!(data.user_approvals.is_empty());
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
         assert_eq!(
             received[0].url.path(),
             "/open-apis/attendance/v1/user_approvals/query"
+        );
+        let body = String::from_utf8(received[0].body.clone()).unwrap();
+        assert!(
+            body.contains("\"check_date_from\""),
+            "请求体缺 check_date_from: {body}"
+        );
+        assert!(body.contains("\"user_ids\""), "请求体缺 user_ids: {body}");
+        assert!(
+            !body.contains("\"start_time\""),
+            "请求体不应含旧字段 start_time: {body}"
         );
     }
 }

--- a/crates/openlark-hr/tests/attendance_tests.rs
+++ b/crates/openlark-hr/tests/attendance_tests.rs
@@ -196,10 +196,12 @@ mod builder_tests {
     );
     smoke_builder!(
         test_get_approval_info_request_builder,
-        user_approval::query::QueryRequest::new(test_config("https://open.feishu.cn"))
-            .user_id("ou_1".to_string())
-            .approval_type(1)
-            .page_size(20)
+        user_approval::query::QueryRequest::new(
+            test_config("https://open.feishu.cn"),
+            vec!["ou_1".to_string()],
+            20_190_817,
+            20_190_820,
+        )
     );
     smoke_builder!(
         test_process_approval_request_builder,
@@ -821,16 +823,7 @@ mod serialization_tests {
         test_query_user_approval_response_serialization,
         user_approval::query::QueryResponse,
         user_approval::query::QueryResponse {
-            items: vec![user_approval::query::UserApproval {
-                approval_id: "a_1".to_string(),
-                user_id: "ou_1".to_string(),
-                approval_type: 1,
-                status: 1,
-                approval_time: 1735689600,
-                content: Some(json!({"reason":"正常"})),
-            }],
-            has_more: false,
-            page_token: None,
+            user_approvals: vec![json!({"approval_id": "a_1"})],
         }
     );
     roundtrip_eq!(


### PR DESCRIPTION
## What

Part of #533. **Group 4 of 5.**

Aligns `user_approval/query` (获取审批数据) with the current Feishu schema.

## Changes

- Body: fabricated `user_id`/`approval_type`/`start_time`/`end_time`/pagination → required `user_ids` / `check_date_from` / `check_date_to` (i32 yyyyMMdd) + optional `check_date_type` / `status` / `check_time_from` / `check_time_to`
- Response `data.user_approvals` items schema not fully given → passed through as `serde_json::Value` (`UserApproval` removed)

## Breaking (targets 0.19)

`QueryRequest::new(config, user_ids, check_date_from, check_date_to)`; `UserApproval` removed. Migration note in `CHANGELOG.md`.

## Testing

- New wiremock e2e test asserts request body has `user_ids`/`check_date_from` (not old `start_time`); integration tests updated
- `cargo test -p openlark-hr --all-features`: passed, 0 failed
- `cargo clippy -p openlark-hr --all-targets --all-features -- -Dwarnings`: clean
- `cargo fmt -p openlark-hr --check`: clean

## Refs

#533. Done: #535 / #536 / #537. Remaining: user_stats_view.
