### PR TITLE
ci(api-contracts): flip attendance field gate to strict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,13 +83,14 @@ jobs:
             --tokens \
             --strict tokens \
             --report-dir "$RUNNER_TEMP/api_contract_tokens/auth"
-      - name: Validate attendance fields (non-strict monitor; #526 防回归 baseline)
+      - name: Validate attendance fields (strict gate; #526/#533 防回归)
         run: |
           python3 tools/validate_api_contracts.py \
             --crate openlark-hr \
             --biz-tag attendance \
             --fields \
             --live-fields \
+            --strict fields \
             --report-dir "$RUNNER_TEMP/api_contract_fields/attendance"
       - name: Upload API contract reports
         if: always()


### PR DESCRIPTION
## What

Flips the attendance field-validation step (added in #534) from non-strict **monitor** to a **strict gate** by adding `--strict fields`.

## Why now

#533 (attendance's 18 required-field drifts) is fully resolved — #535-539 all merged. Local re-verify on current main:

```
validate_api_contracts.py --crate openlark-hr --biz-tag attendance --fields --live-fields --strict fields
→ 0 error / exit 0
```

So the strict gate will **not** red on a clean tree; it now actively **blocks** any new attendance field drift (the original #526 bug class — fields that compile + pass wiremock but get rejected by Feishu).

## Change

- `.github/workflows/ci.yml`: step renamed "non-strict monitor" → "strict gate"; adds `--strict fields` (the `api-contracts` job fails on any `E_REQUIRED_REQUEST_FIELD_MISSING`)

## Testing

- Local `--strict fields` exits 0 (0 errors) on post-#535-539 main
- YAML syntax validated (`python3 -c yaml.safe_load`)

## Refs

#526 (root cause), #533 (cleared), #534 (the monitor being upgraded).
