### PR TITLE
fix(core): ApiError carries raw_code without u16 truncation

### DIFF
--- a/crates/openlark-client/src/error.rs
+++ b/crates/openlark-client/src/error.rs
@@ -3,7 +3,7 @@
 //! 基于 openlark-core 的现代化错误处理系统
 //! 直接使用 CoreError，提供类型安全和用户友好的错误管理
 
-use openlark_core::error::{ApiError, CoreError, ErrorCode, ErrorContext, ErrorTrait, ErrorType};
+use openlark_core::error::{CoreError, ErrorTrait, ErrorType};
 
 /// 🚨 OpenLark 客户端错误类型
 ///
@@ -53,29 +53,17 @@ pub fn user_identity_invalid_error(desc: impl Into<String>) -> Error {
 }
 
 /// 基于飞书通用 `code` 的统一错误映射（客户端自定义解析时可复用）
+///
+/// 委托 core `api_error`（`ErrorCode::from_code` 单路径）。#546 将删除本函数。
 pub fn from_feishu_response(
     code: i32,
     endpoint: impl Into<String>,
     message: impl Into<String>,
     request_id: Option<String>,
 ) -> Error {
-    // #544 编译同步：字面构造改 raw_code；映射收敛删除留给 #546。
-    let mapped = ErrorCode::from_feishu_code(code).unwrap_or_else(|| ErrorCode::from_code(code));
-
-    let mut ctx = ErrorContext::new();
-    ctx.add_context("feishu_code", code.to_string());
-    if let Some(req) = request_id {
-        ctx.set_request_id(req);
-    }
-
-    CoreError::Api(Box::new(ApiError {
-        raw_code: code,
-        endpoint: endpoint.into().into(),
-        message: message.into(),
-        source: None,
-        code: mapped,
-        ctx: Box::new(ctx),
-    }))
+    openlark_core::error::api_error(code, endpoint, message, request_id).map_context(|ctx| {
+        ctx.add_context("feishu_code", code.to_string());
+    })
 }
 
 /// 创建API错误

--- a/crates/openlark-client/src/error.rs
+++ b/crates/openlark-client/src/error.rs
@@ -3,9 +3,7 @@
 //! 基于 openlark-core 的现代化错误处理系统
 //! 直接使用 CoreError，提供类型安全和用户友好的错误管理
 
-use openlark_core::error::{
-    ApiError, CoreError, ErrorCategory, ErrorCode, ErrorContext, ErrorTrait, ErrorType,
-};
+use openlark_core::error::{ApiError, CoreError, ErrorCode, ErrorContext, ErrorTrait, ErrorType};
 
 /// 🚨 OpenLark 客户端错误类型
 ///
@@ -61,6 +59,7 @@ pub fn from_feishu_response(
     message: impl Into<String>,
     request_id: Option<String>,
 ) -> Error {
+    // #544 编译同步：字面构造改 raw_code；映射收敛删除留给 #546。
     let mapped = ErrorCode::from_feishu_code(code).unwrap_or_else(|| ErrorCode::from_code(code));
 
     let mut ctx = ErrorContext::new();
@@ -69,19 +68,8 @@ pub fn from_feishu_response(
         ctx.set_request_id(req);
     }
 
-    let status = mapped
-        .http_status()
-        .unwrap_or_else(|| match mapped.category() {
-            ErrorCategory::RateLimit => 429,
-            ErrorCategory::Authentication
-            | ErrorCategory::Permission
-            | ErrorCategory::Parameter => 400,
-            ErrorCategory::Resource => 404,
-            _ => 500,
-        });
-
     CoreError::Api(Box::new(ApiError {
-        status,
+        raw_code: code,
         endpoint: endpoint.into().into(),
         message: message.into(),
         source: None,
@@ -92,12 +80,12 @@ pub fn from_feishu_response(
 
 /// 创建API错误
 pub fn api_error(
-    status: u16,
+    raw_code: i32,
     endpoint: impl Into<String>,
     message: impl Into<String>,
     request_id: Option<String>,
 ) -> Error {
-    openlark_core::error::api_error(status, endpoint, message, request_id)
+    openlark_core::error::api_error(raw_code, endpoint, message, request_id)
 }
 
 /// 创建验证错误

--- a/crates/openlark-core/src/api/responses.rs
+++ b/crates/openlark-core/src/api/responses.rs
@@ -410,13 +410,14 @@ mod tests {
         assert_eq!(ctx.get_context("resource"), Some("测试"));
     }
 
+    /// 业务错误：保留 msg、request_id；#544 不截断——`raw_code` 原样 + `from_code` 分类 + Display 真码。
     #[test]
-    fn decode_business_error_is_api_error_preserving_msg() {
+    fn decode_business_error_preserves_msg_and_classifies_raw_code() {
         let response: Response<String> = Response {
             data: None,
             raw_response: RawResponse {
                 code: 99991663,
-                msg: "permission denied".to_string(),
+                msg: "tenant access token invalid".to_string(),
                 request_id: Some("rid-x".to_string()),
                 ..RawResponse::success()
             },
@@ -424,29 +425,12 @@ mod tests {
         let err = response.decode("测试").expect_err("业务错误应报错");
         assert_eq!(err.ctx().request_id(), Some("rid-x"));
         match err {
-            crate::error::CoreError::Api(api) => assert!(api.message.contains("permission denied")),
-            other => panic!("expected Api for business error, got: {other:?}"),
-        }
-    }
-
-    /// #544：业务错误码不截断——分类接通 `ErrorCode::from_code`，`raw_code` 原样保留。
-    #[test]
-    fn decode_business_error_classifies_raw_code_without_truncation() {
-        let response: Response<String> = Response {
-            data: None,
-            raw_response: RawResponse {
-                code: 99991663,
-                msg: "tenant access token invalid".to_string(),
-                request_id: Some("rid-raw".to_string()),
-                ..RawResponse::success()
-            },
-        };
-        let err = response
-            .decode("测试-raw_code")
-            .expect_err("业务错误应报错");
-        assert_eq!(err.ctx().request_id(), Some("rid-raw"));
-        match err {
             crate::error::CoreError::Api(api) => {
+                assert!(
+                    api.message.contains("tenant access token invalid"),
+                    "msg preserved: {}",
+                    api.message
+                );
                 assert_eq!(
                     api.raw_code, 99991663,
                     "raw_code must preserve full i32 feishu code"

--- a/crates/openlark-core/src/api/responses.rs
+++ b/crates/openlark-core/src/api/responses.rs
@@ -6,9 +6,16 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// 原始响应数据
+///
+/// `code` 是**双域共槽**：
+/// - 飞书业务信封：装入飞书 `code` 字段（可为 9 位 i32，如 `99991663`）；
+/// - HTTP 非 2xx 且无信封：装入合成 HTTP status（如 429/500）。
+///
+/// [`ErrorCode::from_code`] 同时含 HTTP status 臂与飞书业务码臂，是双域共槽
+/// 行为正确的依据——**不要**因命名困惑而拆字段；拆共槽属另案（ADR-0004 非目标）。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RawResponse {
-    /// 响应代码
+    /// 响应代码（双域共槽：飞书业务码或合成 HTTP status；见结构体文档）
     pub code: i32,
     /// 响应消息
     pub msg: String,
@@ -246,7 +253,8 @@ impl<T> Response<T> {
         let raw = self.raw_response;
         let request_id = raw.request_id.clone();
         let err = if raw.code != 0 {
-            crate::error::api_error(raw.code as u16, "response", raw.msg, request_id.clone())
+            // 传 raw.code 原值（i32），禁止 as u16 截断；分类经 ErrorCode::from_code
+            crate::error::api_error(raw.code, "response", raw.msg, request_id.clone())
         } else {
             crate::error::validation_error("response.data", "服务器没有返回有效的数据")
         };
@@ -417,6 +425,43 @@ mod tests {
         assert_eq!(err.ctx().request_id(), Some("rid-x"));
         match err {
             crate::error::CoreError::Api(api) => assert!(api.message.contains("permission denied")),
+            other => panic!("expected Api for business error, got: {other:?}"),
+        }
+    }
+
+    /// #544：业务错误码不截断——分类接通 `ErrorCode::from_code`，`raw_code` 原样保留。
+    #[test]
+    fn decode_business_error_classifies_raw_code_without_truncation() {
+        let response: Response<String> = Response {
+            data: None,
+            raw_response: RawResponse {
+                code: 99991663,
+                msg: "tenant access token invalid".to_string(),
+                request_id: Some("rid-raw".to_string()),
+                ..RawResponse::success()
+            },
+        };
+        let err = response
+            .decode("测试-raw_code")
+            .expect_err("业务错误应报错");
+        assert_eq!(err.ctx().request_id(), Some("rid-raw"));
+        match err {
+            crate::error::CoreError::Api(api) => {
+                assert_eq!(
+                    api.raw_code, 99991663,
+                    "raw_code must preserve full i32 feishu code"
+                );
+                assert_eq!(
+                    api.code,
+                    crate::error::ErrorCode::TenantAccessTokenInvalid,
+                    "classification must use from_code without u16 truncation"
+                );
+                let display = api.to_string();
+                assert!(
+                    display.contains("99991663"),
+                    "Display must show real code, not truncated garbage: {display}"
+                );
+            }
             other => panic!("expected Api for business error, got: {other:?}"),
         }
     }

--- a/crates/openlark-core/src/api/responses.rs
+++ b/crates/openlark-core/src/api/responses.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 /// - 飞书业务信封：装入飞书 `code` 字段（可为 9 位 i32，如 `99991663`）；
 /// - HTTP 非 2xx 且无信封：装入合成 HTTP status（如 429/500）。
 ///
-/// [`ErrorCode::from_code`] 同时含 HTTP status 臂与飞书业务码臂，是双域共槽
+/// [`crate::error::ErrorCode::from_code`] 同时含 HTTP status 臂与飞书业务码臂，是双域共槽
 /// 行为正确的依据——**不要**因命名困惑而拆字段；拆共槽属另案（ADR-0004 非目标）。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RawResponse {

--- a/crates/openlark-core/src/error/core.rs
+++ b/crates/openlark-core/src/error/core.rs
@@ -157,8 +157,8 @@ pub struct ErrorBuilder {
     message: Option<String>,
     /// 错误码
     code: Option<ErrorCode>,
-    /// HTTP 状态码
-    status: Option<u16>,
+    /// 原始错误码（飞书业务码或合成 HTTP status；双域共槽）
+    raw_code: Option<i32>,
     /// API 端点
     endpoint: Option<String>,
     /// 验证字段名
@@ -192,7 +192,7 @@ impl ErrorBuilder {
             kind,
             message: None,
             code: None,
-            status: None,
+            raw_code: None,
             endpoint: None,
             field: None,
             source: None,
@@ -220,9 +220,9 @@ impl ErrorBuilder {
         self
     }
 
-    /// 设置 HTTP 状态码
-    pub fn status(mut self, status: u16) -> Self {
-        self.status = Some(status);
+    /// 设置原始错误码（飞书业务码或 HTTP status 合成码）
+    pub fn raw_code(mut self, raw_code: i32) -> Self {
+        self.raw_code = Some(raw_code);
         self
     }
 
@@ -334,18 +334,16 @@ impl ErrorBuilder {
                 ctx: Box::new(self.ctx),
             },
             BuilderKind::Api => {
-                let status = self.status.unwrap_or(500);
+                let raw_code = self.raw_code.unwrap_or(500);
                 CoreError::Api(Box::new(ApiError {
-                    status,
+                    raw_code,
                     endpoint: self
                         .endpoint
                         .unwrap_or_else(|| "unknown".to_string())
                         .into(),
                     message: msg,
                     source: self.source,
-                    code: self
-                        .code
-                        .unwrap_or_else(|| ErrorCode::from_http_status(status)),
+                    code: self.code.unwrap_or_else(|| ErrorCode::from_code(raw_code)),
                     ctx: Box::new(self.ctx),
                 }))
             }
@@ -558,8 +556,8 @@ impl std::fmt::Display for NetworkError {
 /// API 错误
 #[derive(Debug)]
 pub struct ApiError {
-    /// HTTP 状态码
-    pub status: u16,
+    /// 原始错误码（飞书业务码或 HTTP 非 2xx 合成 status；与 `RawResponse.code` 同为双域共槽）
+    pub raw_code: i32,
     /// API 端点
     pub endpoint: Cow<'static, str>,
     /// 错误消息
@@ -574,7 +572,7 @@ pub struct ApiError {
 
 impl std::fmt::Display for ApiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} {}: {}", self.status, self.endpoint, self.message)
+        write!(f, "{} {}: {}", self.raw_code, self.endpoint, self.message)
     }
 }
 
@@ -593,7 +591,7 @@ impl Clone for CoreError {
                 ctx: ctx.clone(),
             },
             Self::Api(api) => Self::Api(Box::new(ApiError {
-                status: api.status,
+                raw_code: api.raw_code,
                 endpoint: api.endpoint.clone(),
                 message: api.message.clone(),
                 source: None,
@@ -722,17 +720,12 @@ impl CoreError {
 
     /// 简单 API 错误（便于兼容旧 CoreError::api_error）
     pub fn api_error(
-        status: i32,
+        raw_code: i32,
         endpoint: impl Into<String>,
         message: impl Into<String>,
         request_id: Option<impl Into<String>>,
     ) -> Self {
-        api_error(
-            status as u16,
-            endpoint,
-            message,
-            request_id.map(|id| id.into()),
-        )
+        api_error(raw_code, endpoint, message, request_id.map(|id| id.into()))
     }
 
     /// 仅带 message 的验证错误（默认字段 general）
@@ -772,7 +765,7 @@ impl CoreError {
     /// API 数据错误
     pub fn api_data_error(message: impl Into<String>) -> Self {
         Self::Api(Box::new(ApiError {
-            status: 500,
+            raw_code: 500,
             endpoint: "data_error".into(),
             message: format!("no data: {}", message.into()),
             source: None,
@@ -808,7 +801,9 @@ impl CoreError {
     pub fn is_retryable(&self) -> bool {
         match self {
             Self::Network(net) => net.policy.is_retryable(),
-            Self::Api(api) => matches!(api.status, 429 | 500..=599),
+            // #544 中间态：按 raw_code 范围判定（HTTP 合成码可重试；飞书 9 位码不可重试）。
+            // #545 再切到 api.code.is_retryable() variant 判定。
+            Self::Api(api) => matches!(api.raw_code, 429 | 500..=599),
             Self::Timeout { .. } => self.code().is_retryable(),
             Self::RateLimit { .. } => self.code().is_retryable(),
             Self::ServiceUnavailable { .. } => self.code().is_retryable(),
@@ -823,7 +818,8 @@ impl CoreError {
             Self::Network(net) => net.policy.retry_delay(attempt),
             Self::RateLimit { window, .. } => Some(*window),
             Self::ServiceUnavailable { retry_after, .. } => *retry_after,
-            Self::Api(api) if matches!(api.status, 429 | 500..=599) => {
+            // #544 中间态：谓词跟 raw_code；延迟公式保持 1<<attempt（#545 不改公式）。
+            Self::Api(api) if matches!(api.raw_code, 429 | 500..=599) => {
                 Some(Duration::from_secs(1 << attempt.min(5)))
             }
             _ => None,
@@ -1069,17 +1065,17 @@ impl CoreError {
 
     /// API 错误
     pub fn api(
-        status: u16,
+        raw_code: i32,
         endpoint: impl Into<Cow<'static, str>>,
         message: impl Into<String>,
         ctx: ErrorContext,
     ) -> Self {
         Self::Api(Box::new(ApiError {
-            status,
+            raw_code,
             endpoint: endpoint.into(),
             message: message.into(),
             source: None,
-            code: ErrorCode::from_http_status(status),
+            code: ErrorCode::from_code(raw_code),
             ctx: Box::new(ctx),
         }))
     }
@@ -1235,18 +1231,21 @@ pub fn authentication_error(message: impl Into<String>) -> CoreError {
 }
 
 /// 创建API错误
+///
+/// `raw_code` 为原始错误码（飞书业务码或 HTTP 合成 status），经
+/// [`ErrorCode::from_code`] 不截断分类。
 pub fn api_error(
-    status: u16,
+    raw_code: i32,
     endpoint: impl Into<String>,
     message: impl Into<String>,
     request_id: Option<String>,
 ) -> CoreError {
     CoreError::Api(Box::new(ApiError {
-        status,
+        raw_code,
         endpoint: endpoint.into().into(),
         message: message.into(),
         source: None,
-        code: ErrorCode::from_http_status(status),
+        code: ErrorCode::from_code(raw_code),
         ctx: {
             let mut ctx = ErrorContext::new();
             if let Some(req_id) = request_id {
@@ -1465,7 +1464,7 @@ mod tests {
     #[test]
     fn builder_creates_api_error_with_context() {
         let err = CoreError::api_builder()
-            .status(404)
+            .raw_code(404)
             .endpoint("/users/1")
             .message("not found")
             .request_id("req-123")

--- a/crates/openlark-core/src/error/mod.rs
+++ b/crates/openlark-core/src/error/mod.rs
@@ -363,7 +363,7 @@ mod tests {
     #[test]
     fn test_error_builder_api_error() {
         let error = CoreError::api_builder()
-            .status(429)
+            .raw_code(429)
             .endpoint("/api/rate-limited")
             .message("请求过于频繁")
             .request_id("req-rate-001")

--- a/crates/openlark-core/src/error/prelude.rs
+++ b/crates/openlark-core/src/error/prelude.rs
@@ -76,11 +76,11 @@ macro_rules! business_err {
 /// 创建API错误的宏
 #[macro_export]
 macro_rules! api_err {
-    ($status:expr, $endpoint:expr, $msg:expr) => {
-        $crate::error::api_error($status, $endpoint, $msg, None::<String>)
+    ($raw_code:expr, $endpoint:expr, $msg:expr) => {
+        $crate::error::api_error($raw_code, $endpoint, $msg, None::<String>)
     };
-    ($status:expr, $endpoint:expr, $fmt:expr, $($arg:tt)*) => {
-        $crate::error::api_error($status, $endpoint, format!($fmt, $($arg)*), None::<String>)
+    ($raw_code:expr, $endpoint:expr, $fmt:expr, $($arg:tt)*) => {
+        $crate::error::api_error($raw_code, $endpoint, format!($fmt, $($arg)*), None::<String>)
     };
 }
 

--- a/crates/openlark-core/tests/error_context_tests.rs
+++ b/crates/openlark-core/tests/error_context_tests.rs
@@ -309,7 +309,7 @@ mod tests {
     #[test]
     fn test_is_retryable_rate_limit() {
         let error = CoreError::api_builder()
-            .status(429)
+            .raw_code(429)
             .message("请求过于频繁")
             .build();
 
@@ -319,7 +319,7 @@ mod tests {
     #[test]
     fn test_is_retryable_server_error() {
         let error = CoreError::api_builder()
-            .status(503)
+            .raw_code(503)
             .message("服务不可用")
             .build();
 

--- a/crates/openlark-core/tests/transport_request_contract.rs
+++ b/crates/openlark-core/tests/transport_request_contract.rs
@@ -10,7 +10,7 @@ use openlark_core::{
     api::{ApiRequest, ApiResponseTrait, RequestData, ResponseFormat},
     config::Config,
     constants::AccessTokenType,
-    error::CoreError,
+    error::{CoreError, ErrorCode},
     http::Transport,
     req_option::RequestOption,
 };
@@ -1102,5 +1102,64 @@ async fn request_typed_failure_attaches_operation_resource_request_id() {
             );
         }
         other => panic!("expected CoreError::Api for business error, got: {other:?}"),
+    }
+}
+
+/// #544：飞书业务错误码解码不断裂——`request_typed` 生产路径分类为
+/// `TenantAccessTokenInvalid`，`raw_code` 原样，`X-Tt-Logid` 透传为 request_id。
+#[tokio::test]
+async fn request_typed_feishu_business_code_classifies_without_truncation() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/open-apis/contract/typed/token-invalid"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("X-Tt-Logid", "logid-token-invalid-544")
+                .set_body_json(serde_json::json!({
+                    "code": 99991663,
+                    "msg": "tenant access token invalid",
+                    "data": null
+                })),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let config = contract_config(&server.uri());
+    let req = get_req("/open-apis/contract/typed/token-invalid");
+
+    let err = Transport::<ContractData>::request_typed(
+        req,
+        &config,
+        Some(no_auth_option()),
+        "测试-token-invalid",
+    )
+    .await
+    .expect_err("feishu business error must surface as CoreError::Api");
+
+    assert_eq!(
+        err.ctx().request_id(),
+        Some("logid-token-invalid-544"),
+        "X-Tt-Logid must become request_id"
+    );
+
+    match &err {
+        CoreError::Api(api) => {
+            assert_eq!(
+                api.raw_code, 99991663,
+                "raw_code must preserve full 9-digit feishu code (no as u16 truncation)"
+            );
+            assert_eq!(
+                api.code,
+                ErrorCode::TenantAccessTokenInvalid,
+                "production path must classify via ErrorCode::from_code without truncation"
+            );
+            assert!(
+                api.message.contains("tenant access token invalid"),
+                "msg preserved: {}",
+                api.message
+            );
+        }
+        other => panic!("expected CoreError::Api, got: {other:?}"),
     }
 }

--- a/crates/openlark-core/tests/transport_request_contract.rs
+++ b/crates/openlark-core/tests/transport_request_contract.rs
@@ -1047,71 +1047,14 @@ async fn request_typed_custom_success_returns_typed() {
     assert_eq!(data.0, b"typed-custom-bytes");
 }
 
-/// 失败路径：业务错误 envelope（code≠0，data=null）→ `Transport::request` 仍返回
-/// `Ok(Response{data:None})`，`request_typed` 经 `extract_response_data` 抽取失败，
-/// 错误须附着 `operation` + `resource`(=context) + `request_id`（来自 envelope）。
+/// 失败路径：业务错误 envelope → `CoreError::Api`。
+/// - #485：保留 msg；附着 operation / resource / request_id
+/// - #544：不截断分类为 `TenantAccessTokenInvalid`，`raw_code` 原样；`X-Tt-Logid` 透传
 #[tokio::test]
-async fn request_typed_failure_attaches_operation_resource_request_id() {
+async fn request_typed_feishu_business_error_classifies_and_attaches_context() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/open-apis/contract/typed/fail"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "code": 99991663,
-            "msg": "permission denied",
-            "request_id": "rid-typed-fail",
-            "data": null
-        })))
-        .expect(1)
-        .mount(&server)
-        .await;
-
-    let config = contract_config(&server.uri());
-    let req = get_req("/open-apis/contract/typed/fail");
-
-    let err =
-        Transport::<ContractData>::request_typed(req, &config, Some(no_auth_option()), "文本翻译")
-            .await
-            .expect_err("business error envelope must surface as extraction failure");
-
-    // 经 canonical helper 的 map_context 附着的三件诊断上下文
-    let ctx = err.ctx();
-    assert_eq!(
-        ctx.operation(),
-        Some("extract_response_data"),
-        "operation should identify the canonical extraction step"
-    );
-    assert_eq!(
-        ctx.get_context("resource"),
-        Some("文本翻译"),
-        "resource should carry caller-provided context"
-    );
-    assert_eq!(
-        ctx.request_id(),
-        Some("rid-typed-fail"),
-        "request_id from envelope must be attached for server-side reconciliation"
-    );
-
-    // Option C (#485)：业务错误（code≠0）保留飞书 msg，返回 Api 错误（非 Validation）；
-    // 此前 canonical 路径把业务错误当"data 缺失"丢 msg。
-    match &err {
-        CoreError::Api(api) => {
-            assert!(
-                api.message.contains("permission denied"),
-                "business envelope msg must be preserved: {}",
-                api.message
-            );
-        }
-        other => panic!("expected CoreError::Api for business error, got: {other:?}"),
-    }
-}
-
-/// #544：飞书业务错误码解码不断裂——`request_typed` 生产路径分类为
-/// `TenantAccessTokenInvalid`，`raw_code` 原样，`X-Tt-Logid` 透传为 request_id。
-#[tokio::test]
-async fn request_typed_feishu_business_code_classifies_without_truncation() {
-    let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/open-apis/contract/typed/token-invalid"))
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("X-Tt-Logid", "logid-token-invalid-544")
@@ -1126,25 +1069,37 @@ async fn request_typed_feishu_business_code_classifies_without_truncation() {
         .await;
 
     let config = contract_config(&server.uri());
-    let req = get_req("/open-apis/contract/typed/token-invalid");
+    let req = get_req("/open-apis/contract/typed/fail");
 
-    let err = Transport::<ContractData>::request_typed(
-        req,
-        &config,
-        Some(no_auth_option()),
-        "测试-token-invalid",
-    )
-    .await
-    .expect_err("feishu business error must surface as CoreError::Api");
+    let err =
+        Transport::<ContractData>::request_typed(req, &config, Some(no_auth_option()), "文本翻译")
+            .await
+            .expect_err("business error envelope must surface as extraction failure");
 
+    let ctx = err.ctx();
     assert_eq!(
-        err.ctx().request_id(),
+        ctx.operation(),
+        Some("extract_response_data"),
+        "operation should identify the canonical extraction step"
+    );
+    assert_eq!(
+        ctx.get_context("resource"),
+        Some("文本翻译"),
+        "resource should carry caller-provided context"
+    );
+    assert_eq!(
+        ctx.request_id(),
         Some("logid-token-invalid-544"),
         "X-Tt-Logid must become request_id"
     );
 
     match &err {
         CoreError::Api(api) => {
+            assert!(
+                api.message.contains("tenant access token invalid"),
+                "business envelope msg must be preserved: {}",
+                api.message
+            );
             assert_eq!(
                 api.raw_code, 99991663,
                 "raw_code must preserve full 9-digit feishu code (no as u16 truncation)"
@@ -1154,12 +1109,7 @@ async fn request_typed_feishu_business_code_classifies_without_truncation() {
                 ErrorCode::TenantAccessTokenInvalid,
                 "production path must classify via ErrorCode::from_code without truncation"
             );
-            assert!(
-                api.message.contains("tenant access token invalid"),
-                "msg preserved: {}",
-                api.message
-            );
         }
-        other => panic!("expected CoreError::Api, got: {other:?}"),
+        other => panic!("expected CoreError::Api for business error, got: {other:?}"),
     }
 }


### PR DESCRIPTION
## Summary

- Fix Feishu error-code decode break: `ApiError.status: u16` → `raw_code: i32`; classify via `ErrorCode::from_code` without truncation.
- `Response::decode` passes `raw.code` as full i32; Display prints real code; document `RawResponse` dual-domain slot.
- Intermediate compile sync: retry matches `raw_code` range (#545 will switch to variant); `from_feishu_response` delegates to core `api_error` (#546 will delete).
- Review cleanup: merge near-duplicate decode/transport tests.

## Test plan

- [x] Unit: `decode_business_error_preserves_msg_and_classifies_raw_code` (99991663 → TenantAccessTokenInvalid)
- [x] Transport contract: `request_typed_feishu_business_error_classifies_and_attaches_context` (X-Tt-Logid + classification)
- [x] `cargo test --workspace --all-features`
- [x] clippy dual mode (during implement) + core/client after cleanup
- [ ] CI green on PR

Closes #544