### PR TITLE
fix(#547): docs(changelog): 0.19 迁移项 + 全仓回归验证

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (Breaking — 目标 0.19)
 
-- **core/client：删除死映射 `ErrorCode::from_feishu_code` 与 `from_feishu_response`（#546，ADR-0004）**：
-  三条飞书码映射路径收敛为一条——`ErrorCode::from_code(raw_code)`（经 `api_error` / `ApiError.raw_code` 接通，不截断）。
-  删除 `ErrorCode::from_feishu_code(i32) → Option`（`from_code` 飞书臂的子集复刻）及
-  `openlark_client::error::from_feishu_response`（测试外零调用）。
-  **迁移**：改用 `ErrorCode::from_code(code)`（未知 → `Unknown` 而非 `None`）或
-  core / client `api_error(raw_code, endpoint, message, request_id)`。
+- **core/client：飞书错误码解码断裂修复 —— `ApiError.raw_code` + 映射收敛（#544/#545/#546，ADR-0004）**：
+  生产路径曾把飞书 9 位业务码（如 `99991663`）`as u16` 截断后再分类，导致 `ErrorCode` 恒为
+  `Unknown`，`Display` 输出垃圾码。本批接通 `ErrorCode::from_code(raw_code)` 单路径，并收敛
+  三条并行映射。与 ADR-0002（`apply_app_ticket` 收口）/ ADR-0003（`WsClientError` 收并）同属
+  0.19 breaking 窗口；条目各自独立、不重复。
+  - **`ApiError.status: u16` 移除，`raw_code: i32` 新增**（#544）：字段语义从「截断后的假 HTTP
+    status」改为「原始错误码」（飞书 body `code` 或 HTTP 非 2xx 合成 status；与 `RawResponse.code`
+    同为双域共槽）。`code: ErrorCode` / `endpoint` / `message` / `source` / `ctx` 保留。
+    `Display` 打印 `raw_code`。`Response::decode` 传 `raw.code` 原值，去掉 `as u16`。
+  - **构造器签名 `u16` → `i32`**（#544）：自由函数 `api_error`、`CoreError::api` /
+    `CoreError::api_error`、client 转发壳 `openlark_client::error::api_error`、prelude 宏
+    `api_err!`、`ErrorBuilder::status(u16)` → `ErrorBuilder::raw_code(i32)` 同步改收完整
+    `i32`，经 `ErrorCode::from_code(raw_code)` 不截断分类。
+  - **retry 谓词切 `ErrorCode` variant**（#545，行为等价回归）：`CoreError::is_retryable` /
+    `retry_delay` 对 `Api` 不再匹配 `raw_code` 数值范围，改 `self.code().is_retryable()`
+    （覆盖 `TooManyRequests` + 5xx 族）。延迟公式保持 `1 << attempt.min(5)` 秒，**不**换成
+    `suggested_retry_delay`（后者对 429 固定 60s）。HTTP 合成 429/5xx 仍可重试；飞书业务码
+    仍不可重试。
+  - **删除死映射**（#546）：`ErrorCode::from_feishu_code(i32) → Option`（`from_code` 飞书臂的
+    子集复刻）与 `openlark_client::error::from_feishu_response`（测试外零调用，内含第三份
+    category→status magic）。三条路径收敛为一条：`ErrorCode::from_code(raw_code)`。
+  - **迁移（before → after）**：
+
+    ```rust
+    // 1) 读字段：status → raw_code / code
+    // before
+    if let CoreError::Api(api) = &err {
+        let _ = api.status; // u16 截断垃圾（99991663 → 49263）
+    }
+    // after
+    if let CoreError::Api(api) = &err {
+        let raw = api.raw_code;                 // i32 原样：99991663
+        let kind = api.code;                    // ErrorCode::TenantAccessTokenInvalid
+        assert_eq!(kind, ErrorCode::TenantAccessTokenInvalid);
+        let _ = raw;
+    }
+
+    // 2) 构造：api_error / CoreError::api* / api_err! 参数 u16 → i32（勿再 as u16）
+    // before
+    let _ = api_error(99991663u32 as u16, "/open-apis/...", "token invalid", None);
+    // after
+    let _ = api_error(99991663, "/open-apis/...", "token invalid", None);
+
+    // 3) ErrorBuilder：.status(u16) → .raw_code(i32)
+    // before
+    let _ = ErrorBuilder::new(BuilderKind::Api).status(404).message("not found").build();
+    // after
+    let _ = ErrorBuilder::new(BuilderKind::Api).raw_code(404).message("not found").build();
+
+    // 4) from_feishu_code 删除 → from_code（未知为 Unknown，非 None）
+    // before
+    // let opt: Option<ErrorCode> = ErrorCode::from_feishu_code(code);
+    // after
+    let kind = ErrorCode::from_code(code); // 未知 → ErrorCode::Unknown
+
+    // 5) from_feishu_response 删除 → core/client api_error 或 CoreError::Api
+    // before
+    // let err = openlark_client::error::from_feishu_response(...);
+    // after
+    let err = openlark_core::error::api_error(raw_code, endpoint, message, request_id);
+    ```
 
 - **hr/attendance：`user_daily_shift` 族 3 API 字段对齐飞书官网 schema（#533）**：
   `batch_create`（`shifts`→`user_daily_shifts`[{group_id,shift_id,month,user_id,day_no,is_clear_schedule}]，加可选 `operator_id`）、

--- a/docs/adr/0004-feishu-error-code-decode-break.md
+++ b/docs/adr/0004-feishu-error-code-decode-break.md
@@ -1,7 +1,7 @@
 # ADR: 飞书错误码解码断裂修复（ApiError 承载 raw_code + 映射收敛）
 
-- **状态**: Proposed（2026-07-25 `/improve-codebase-architecture` → `/grilling` 达成共识，待实施）
-- **日期**: 2026-07-26
+- **状态**: Accepted（2026-07-26 全部落地：#543 ADR → #544 raw_code → #545 retry → #546 映射收敛 → #547 CHANGELOG/回归；见文末「执行记录」）
+- **日期**: 2026-07-26（决策）/ 2026-07-26（执行完成）
 - **决策者**: 架构评审 + 用户 grilling 共识
 - **来源**: 架构评审候选 1（error 解码断裂使 ErrorCode 分类在生产路径失效）+ grilling 三项决策；父 spec #542；本 ADR 为 #543
 - **breaking 窗口**: 目标 0.19，与 ADR-0002/0003 同批。公开 breaking：`ApiError.status: u16` 移除、`raw_code: i32` 新增；自由函数 `api_error` 与相关构造器签名 `u16 → i32`；`ErrorCode::from_feishu_code` 与 `openlark_client::error::from_feishu_response` 删除。`code: ErrorCode` / `endpoint` / `message` / `source` / `ctx` 字段保留。
@@ -143,4 +143,22 @@ SDK 使用者调用飞书 API 失败时拿到 `CoreError::Api`，但**无法区�
 
 ## 执行记录
 
-_待 #544–#547 落地后由 #547 补齐各 ticket commit 与验证结果。_
+ADR-0004 各阶段已落地（PR 链 #548 → #549 → #550 → #551 → #547，TDD；与 ADR-0002/0003 同批 0.19 窗口，CHANGELOG 条目各自独立、不重复）：
+
+| 阶段 | ticket / PR | commit | 产出 |
+|------|-------------|--------|------|
+| ADR | #543 / #548 | `c236add865936258e1eaae2d6cc0a4a784e61813` | 本文件：背景 / 三项决策 / 理由 / 后果 / 非目标 / 迁移路径 / 遵循 |
+| ApiError + decode | #544 / #549 | `5982eea16225458ad683cdf6855fa3dcce0565fa` | `ApiError.status: u16` → `raw_code: i32`；`api_error` / `CoreError::api*` / ErrorBuilder / prelude / client 转发壳签名 `u16→i32`；`Response::decode` 去 `as u16`；Display 打 `raw_code`；共槽注释；中间态 retry 先按 `raw_code` 范围（行为等价）。TDD：transport contract + decode 单元（`99991663 → TenantAccessTokenInvalid` + `raw_code` 原样 + `request_id` 透传） |
+| retry 判定 | #545 / #550 | `6acbbc21819ad78d6ebeb526c9389a55e51b7d97` | `is_retryable` / `retry_delay` 谓词切 `ErrorCode` variant（`api.code.is_retryable()` / 非 Network 统一 `self.code().is_retryable()`）；延迟公式保持 `1 << attempt.min(5)`；合成 429 可重试 + 飞书业务码不可重试回归 |
+| 映射收敛删除 | #546 / #551 | `ac51bb21a1ba22f4594f612374810ac010ce0183` | 删 `ErrorCode::from_feishu_code` + `from_feishu_response` 及其测试；全仓源码无残留；`ARCHITECTURE.md`「错误码对齐与优先级」改写为 `from_code` 单路径 + `raw_code` 语义；CHANGELOG 初稿条目 |
+| CHANGELOG + 回归 | #547 / 本提交 | （本提交 SHA） | CHANGELOG 0.19 breaking 迁移表覆盖 Breaking 清单全部行（字段移除/新增、`api_error`/`CoreError::api*`/ErrorBuilder/prelude 签名、两处删除）+ before/after 示例；与 ADR-0002/0003 同节并列；本 ADR 状态 → Accepted + 本执行记录；`just check-all` 等价验证 |
+
+验证（#547 本地全绿；#544–#546 各自合入时已独立全绿）：
+- `cargo test --workspace --all-features`（全 `0 failed`，含 transport contract / decode / retry seam）；
+- `cargo fmt --check`（workspace）；
+- `cargo clippy --workspace --all-targets --all-features -- -Dwarnings` 与 `--no-default-features` 两模式均 clean；
+- `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc --workspace --all-features --no-deps`（无断链）；
+- `cargo machete`（workspace，无 unused dep）。
+- msrv 未单独跑：本批 #547 无依赖变更、lockfile 未动，不触发 msrv 门控（#551 若涉及 machete 清点已在其 PR 同步）。
+
+**Breaking（目标 0.19，与 ADR-0002/0003 同批）**：见上文「负面 / Breaking 清单」全部行；CHANGELOG Unreleased `### Changed (Breaking — 目标 0.19)` 下 ADR-0004 综合条目（#544/#545/#546）含 before/after 迁移示例。


### PR DESCRIPTION
## Summary
Implements #547 (post code-review).

## Test plan
- [ ] focused tests

Fixes #547