### PR TITLE
fix(#559): release/0.19 pre-release sign-off (compatibility + coverage gates)

### DIFF
--- a/docs/0.19.0_RELEASE_SIGNOFF.md
+++ b/docs/0.19.0_RELEASE_SIGNOFF.md
@@ -1,0 +1,210 @@
+# OpenLark 0.19.0 Pre-release Sign-off
+
+| Field | Value |
+| --- | --- |
+| Version | `0.19.0` |
+| Sign-off date (UTC) | 2026-07-26 |
+| Tree base SHA | `fd979074dd1592779827f8e22a1df974fb05ee7e` |
+| Issue | #559 (parent #555; blocked by #558 — closed) |
+| Decision | **GO — allowed to tag `v0.19.0`** |
+| Next ticket | #560 (cut tag + verify publish) |
+
+This document is the in-repo reviewable record for the 0.19 pre-release
+compatibility + coverage gates. Transient machine artifacts under `reports/`
+are gitignored; key numbers and checklist conclusions are frozen here.
+
+## 1. Pre-release compatibility verification
+
+Command:
+
+```bash
+bash scripts/check-pre-release-compatibility.sh
+```
+
+Result on this tree: **GREEN**
+
+| Step | Result |
+| --- | --- |
+| Compatibility policy docs present | PASS |
+| `cargo fmt --all -- --check` | PASS |
+| `cargo clippy --workspace --all-targets --all-features -- -Dwarnings -A missing_docs` | PASS |
+| `cargo test --workspace --all-features` | PASS |
+| `bash scripts/check-public-examples.sh` | PASS |
+| Feature combo `essential` (`--lib`) | PASS |
+| Feature combo `enterprise` (`--lib`) | PASS |
+| Feature combo `communication,websocket` (`--lib`) | PASS |
+| Typed API coverage regenerate (`tools/validate_apis.py --all-crates`) | PASS |
+| Typed coverage release gate (`tools/check_typed_coverage_release.py`) | **PASS** |
+| Endpoint contracts (`validate_api_contracts.py --strict endpoint`) | PASS (0 errors / 321 warnings) |
+| Crate quality status (`tools/release_quality_status.py`) | PASS (regenerated) |
+
+Reviewable local artifact paths (regenerated; not committed):
+
+- `reports/pre_release_compatibility/summary.md`
+- `reports/pre_release_compatibility/typed_coverage_release_gate.md`
+- `reports/pre_release_compatibility/release_quality_status.md`
+- `reports/pre_release_compatibility/api_contracts/`
+- `reports/api_validation/summary.json` / `summary.md`
+- `reports/api_validation/dashboards/core_business.json` / `core_business.md`
+
+## 2. Typed coverage release gate
+
+Policy: `tools/typed_coverage_release.toml` (thresholds **not** lowered).
+
+| Hard gate | Threshold | Observed | Result |
+| --- | ---: | ---: | --- |
+| Workspace `summary.completion_rate` | ≥ 93.0% | **93.9%** (1530 / 1630) | PASS |
+| Core-business dashboard completion | ≥ 92.0% | **97.8%** | PASS |
+| Each core-business crate completion | ≥ 80.0% | min = openlark-hr **95.7%** | PASS |
+
+Core-business crate breakdown:
+
+| Crate | Completion | Missing |
+| --- | ---: | ---: |
+| openlark-hr | 95.7% | 25 (all P2) |
+| openlark-communication | 100.0% | 0 |
+| openlark-docs | 100.0% | 0 |
+| openlark-security | 100.0% | 0 |
+| openlark-workflow | 100.0% | 0 |
+
+Waiver signals:
+
+- Core-business P0 missing: **0** → no waiver required
+- Remaining gaps are non-core / lower priority (platform P1/P2/P3 tail, hr P2, helpdesk/mail P2)
+
+**Gate status: PASS**
+
+## 3. Regenerated quality artifacts (summary freeze)
+
+### 3.1 Coverage summary (workspace)
+
+| Metric | Value |
+| --- | ---: |
+| Crates in typed coverage map | 16 |
+| API total (skip-old) | 1630 |
+| Implemented | 1530 |
+| Missing | 100 |
+| Completion rate | 93.9% |
+| Priority counts (missing) | P1=7, P2=89, P3=4 |
+
+### 3.2 Crate-level quality status (release-note fragment)
+
+Regenerated via `python3 tools/release_quality_status.py`. Snapshot:
+
+| crate | typed coverage | 剩余缺口 | contract tests | snapshot tests | 备注 |
+|------|----------------|----------|----------------|----------------|------|
+| `openlark` | n/a | n/a | no | no | 非 typed API 覆盖统计对象 |
+| `openlark-core` | n/a | n/a | yes | no | 非 typed API 覆盖统计对象 |
+| `openlark-client` | n/a | n/a | yes | no | 非 typed API 覆盖统计对象 |
+| `openlark-capability-unique` | n/a | n/a | no | no | 非 typed API 覆盖统计对象 |
+| `openlark-auth` | 100.0% | 0 | no | no | 无 typed API 缺口 |
+| `openlark-security` | 100.0% | 0 | no | no | 无 typed API 缺口 |
+| `openlark-communication` | 100.0% | 0 | yes | yes | 无 typed API 缺口 |
+| `openlark-cardkit` | 100.0% | 0 | no | no | 无 typed API 缺口 |
+| `openlark-webhook` | n/a | n/a | no | no | 非 typed API 覆盖统计对象 |
+| `openlark-docs` | 100.0% | 0 | yes | yes | 无 typed API 缺口 |
+| `openlark-hr` | 95.7% | 25 | yes | no | 缺口：P2=25 |
+| `openlark-ai` | 100.0% | 0 | no | no | 无 typed API 缺口 |
+| `openlark-workflow` | 100.0% | 0 | yes | yes | 无 typed API 缺口 |
+| `openlark-application` | 100.0% | 0 | yes | no | 无 typed API 缺口 |
+| `openlark-platform` | 39.5% | 72 | yes | no | 缺口：P1=7, P2=61, P3=4 |
+| `openlark-meeting` | 100.0% | 0 | yes | no | 无 typed API 缺口 |
+| `openlark-helpdesk` | 98.0% | 1 | yes | no | 缺口：P2=1 |
+| `openlark-mail` | 98.1% | 2 | yes | no | 缺口：P2=2 |
+| `openlark-bot` | 100.0% | 0 | no | no | 无 typed API 缺口 |
+| `openlark-analytics` | 100.0% | 0 | yes | no | 无 typed API 缺口 |
+| `openlark-user` | 100.0% | 0 | yes | no | 无 typed API 缺口 |
+
+Notes:
+
+- `openlark-platform` low coverage is **not** a hard-gate failure (not a core-business dashboard member under current policy).
+- Residual gaps do not block 0.19 under stable thresholds.
+
+## 4. API compatibility release checklist
+
+Walked against `docs/api-compatibility-release-checklist.md` on this tree.
+
+### A. Public surface inventory
+
+- [x] Public surface for 0.19 identified: entrypoints, typed APIs, helpers, features, re-exports
+- [x] Changes map to policy docs:
+  - `docs/PUBLIC_API_STABILITY_POLICY.md`
+  - `docs/TYPED_API_SEMVER_RULES.md`
+  - `docs/HELPER_SEMVER_RULES.md`
+  - `docs/PUBLIC_REEXPORT_POLICY.md`
+
+### B. Breaking / non-breaking 判定
+
+- [x] Breaking changes recorded in `CHANGELOG.md` `## [0.19.0]` (ADR-0002 / 0003 / 0004, registry removal, hire `common_models` re-export removal, attendance schema alignment, dead seam cleanup)
+- [x] Typed API changes judged under `docs/TYPED_API_SEMVER_RULES.md`
+- [x] Helper / convenience changes judged under `docs/HELPER_SEMVER_RULES.md`
+- [x] Re-export / legacy entrypoint changes judged under `docs/PUBLIC_REEXPORT_POLICY.md`
+- [x] Behavior-only candidates reviewed via CHANGELOG migration tables (e.g. `ApiError` field semantics, retry predicate via `ErrorCode`)
+
+### C. Deprecation / support / migration
+
+- [x] Removed / deprecated paths have replacements in `docs/migration-guide.md` (**OpenLark 0.19** section)
+- [x] Support / removal narrative aligned with `docs/DEPRECATED_API_SUPPORT_POLICY.md`
+- [x] Before/after examples present for `raw_code`, registry, `WsClientError`, hire `common_models`
+- [x] Legacy entrypoint notes present (`docs/legacy-entrypoint-migration-notes.md`)
+
+### D. Release note / changelog completeness
+
+- [x] Dated `## [0.19.0] - 2026-07-26` section present (content freeze #557, date filled #558)
+- [x] Breaking / migration content identifiable for release extraction by `.github/workflows/release.yml`
+- [x] Crate-level quality status regenerated (section 3.2); release workflow will attach via `tools/release_quality_status.py`
+- [x] Categories align with `docs/changelog-compatibility-categories.md` intent (breaking + migration first)
+
+### E. Evidence / verification
+
+- [x] Pre-release compatibility script executed green (section 1)
+- [x] Artifacts regenerated and reviewed (section 1–3)
+- [x] Public examples compile-check green
+- [x] Common feature combinations green
+- [x] Typed coverage + quality status regenerated and reviewed
+
+## 5. Version / tag preconditions
+
+| Check | Result |
+| --- | --- |
+| Workspace / publishable package identity `0.19.0` (`cargo metadata`) | PASS |
+| README / Agents / primary surfaces show `0.19.0` | PASS (from #558) |
+| `CHANGELOG` dated `## [0.19.0]` | PASS |
+| Local / remote `v0.19.0` tag absent | PASS (tag is #560) |
+
+## 6. Decision
+
+### GO — allowed to tag `v0.19.0`
+
+Rationale:
+
+1. Pre-release compatibility verification is fully green with reviewable artifacts.
+2. Typed coverage stable-release gate is **PASS** without threshold changes and without waiver.
+3. Coverage summary, core-business dashboard, and crate quality status were regenerated on this tree.
+4. API compatibility checklist walked; breaking + migration docs are complete for the 0.19 window.
+5. No open out-of-unit blockers (#558 closed). Tagging remains deferred to #560.
+
+### Residual non-blocking risks
+
+- `openlark-platform` typed coverage 39.5% (72 missing) — outside hard gates; track post-0.19.
+- Endpoint contract strict mode reports 321 warnings (no errors) — mostly missing-impl / non-core tails.
+- Tag + crates.io publish still owned by #560; this ticket does **not** create `v0.19.0`.
+
+## 7. How to re-run
+
+```bash
+# Full gate (fmt + clippy + test + examples + features + coverage + contracts + quality)
+bash scripts/check-pre-release-compatibility.sh
+
+# Coverage + gate only
+python3 tools/validate_apis.py --all-crates
+python3 tools/check_typed_coverage_release.py
+python3 tools/release_quality_status.py --output reports/pre_release_compatibility/release_quality_status.md
+```
+
+References:
+
+- `docs/pre-release-compatibility-workflow.md`
+- `docs/api-compatibility-release-checklist.md`
+- `docs/typed-coverage-release-criteria.md`
+- `tools/typed_coverage_release.toml`

--- a/tools/tests/test_release_signoff_019.py
+++ b/tools/tests/test_release_signoff_019.py
@@ -1,0 +1,57 @@
+"""Assert the 0.19.0 pre-release sign-off record meets acceptance seams (#559)."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SIGNOFF_PATH = ROOT / "docs" / "0.19.0_RELEASE_SIGNOFF.md"
+
+
+class ReleaseSignoff019Tests(unittest.TestCase):
+    def test_signoff_document_exists(self) -> None:
+        self.assertTrue(
+            SIGNOFF_PATH.is_file(),
+            f"missing sign-off record: {SIGNOFF_PATH}",
+        )
+
+    def test_signoff_records_go_decision_and_gate_pass(self) -> None:
+        text = SIGNOFF_PATH.read_text(encoding="utf-8")
+
+        self.assertIn("0.19.0", text)
+        self.assertRegex(
+            text,
+            r"\*\*GO\b|Decision\s*\|\s*\*\*GO",
+            "sign-off must record an explicit GO decision for tagging",
+        )
+        self.assertIn("PASS", text)
+        self.assertIn("allowed to tag", text)
+        self.assertIn("#559", text)
+        self.assertIn("tools/typed_coverage_release.toml", text)
+        self.assertIn("docs/api-compatibility-release-checklist.md", text)
+
+        # Frozen metrics from the gate on the 0.19 tree (do not lower thresholds).
+        self.assertRegex(text, r"93\.9%")
+        self.assertRegex(text, r"97\.8%")
+
+        # Base tree SHA is a full 40-char hex so reviewers can pin the sign-off.
+        self.assertRegex(
+            text,
+            r"\b[0-9a-f]{40}\b",
+            "sign-off must pin a full base SHA",
+        )
+
+        # Checklist sections A–E must be walked (checked boxes present).
+        checked = len(re.findall(r"- \[x\]", text, flags=re.IGNORECASE))
+        self.assertGreaterEqual(
+            checked,
+            15,
+            "API compatibility checklist should be walked with [x] marks",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements #559 (post code-review).

Pre-release sign-off for 0.19.0: compatibility verification, typed coverage release gate, quality artifacts, and API compatibility checklist with explicit go/no-go for tagging.

## Test plan
- [ ] focused tests
- [ ] verify release sign-off artifacts on branch

Fixes #559