### PR TITLE
fix(#567): coverage path denoise + classified missing reports

### DIFF
--- a/docs/api-consistency-review.md
+++ b/docs/api-consistency-review.md
@@ -155,13 +155,13 @@ node .agents/skills/openlark-api-field-verify/scripts/fetch_doc.js \
 
 ### 6.1 覆盖率是「路径制」，文件存在 ≠ URL 正确
 
-`validate_apis.py` 严格按路径约定判文件在不在。报「缺失」分三类：
+`validate_apis.py` 按路径约定判文件在不在，并在比较阶段对常见 layout 做 denoise（flat_project / rust_keyword / rewrite / alias / typo_correction）。报告已将结果拆成 **strict 匹配 / 路径噪音匹配 / 真缺口 / 额外文件**（见 `docs/typed-api-coverage.md` §1.1–1.2）。仍须人工鉴别三类语义：
 
-- **① 路径命名噪音**（多数）：文件在、URL 也对，只是落盘路径偏离规范（扁平化、bizTag 别名、拼写）。非缺口。
-- **② 文件在但 endpoint URL 写错**（真 bug，调不通）：曾发生在 workflow task v2 的 `section`/`custom_field`——文件、结构体、测试齐全，但 URL 错用了 tasklist 作用域前缀，**调用必 404**。
-- **③ 真未实现**：文件确实没有。
+- **① 路径命名噪音**：文件在、URL 也对，只是落盘路径偏离 canonical nested 公式。工具会尽量自动记入 `path_noise_matches`（计入已实现，附 evidence）；未覆盖到的变体仍可能出现在真缺口里，需对照 `extra_file_list`。
+- **② 文件在但 endpoint URL 写错**（真 bug，调不通）：曾发生在 workflow task v2 的 `section`/`custom_field`——文件、结构体、测试齐全，但 URL 错用了 tasklist 作用域前缀，**调用必 404**。路径覆盖率检查发现不了这一类。
+- **③ 真未实现**：`classification=true_gap`，磁盘上无对应叶子实现。
 
-→ 鉴别两步：(1) `find` 文件存在与否（区分 ①②与③）；(2) **文件存在时必须再 grep `api_endpoints.rs` 核对 URL** 对照 CSV `url` 列——文件存在不等于 URL 正确，这是 ②类 bug 唯一的发现方式（路径覆盖率检查发现不了）。
+→ 鉴别两步：(1) 先看报告分类与 `path_noise_matches` evidence；(2) **文件存在时必须再核对 endpoint URL** 对照 CSV `url` 列——文件存在不等于 URL 正确，这是 ②类 bug 的发现方式。
 
 ### 6.2 Potemkin URL 测试：测试名有 URL ≠ URL 被测
 

--- a/docs/typed-api-coverage.md
+++ b/docs/typed-api-coverage.md
@@ -10,7 +10,46 @@
 - 实现源：`tools/api_coverage.toml` 中配置的 crate 源码目录与 bizTag 映射。
 - 默认排除 `meta.Version=old`（脚本默认开启 `--skip-old`）。
 - 报告默认不写入时间戳，确保同输入下可稳定复现（可通过 `--with-timestamp` 打开时间戳）。
-- 覆盖率定义：`已实现 / API 总数 * 100%`。
+- 覆盖率定义：`已实现 / API 总数 * 100%`（含 layout denoise 后的路径噪音匹配）。
+
+### 1.1 路径公式与 layout 候选
+
+Canonical（nested）公式：
+
+```text
+src/{bizTag}/{meta.Project}/{meta.Version}/{meta.Resource}/{meta.Name}.rs
+```
+
+其中 `meta.Resource` 的 `.`、`meta.Name` 的 `:`/`#` 会按脚本规则规范化。
+
+在 strict 路径之外，比较阶段还会尝试下列 **layout 候选**（命中即计为已实现，并写入 evidence）：
+
+| match_kind | 含义 | 典型 crate |
+|------------|------|------------|
+| `strict` | 与 canonical 公式完全一致 | docs / communication / hr 多数 |
+| `flat_project` | `biz/biz/version/...` → 磁盘 `biz/version/...`（省略重复 project） | platform（admin/directory/tenant/…） |
+| `rust_keyword` | 目录段为 Rust 关键字时用 `{kw}_mod`（如 `enum` → `enum_mod`） | platform app_engine workspace |
+| `rewrite` / `alias` | `tools/api_coverage.toml` 显式登记的 legacy 映射 | workflow / security |
+| `typo_correction` | 已知 CSV 拼写错误修正（如 `collboration` → `collaboration`） | platform directory |
+
+候选按 strict → 配置 alias/rewrite → 在已有候选上展开 flat/keyword/typo 的顺序生成；**先命中者优先**，因此 nested 与 flat 同时存在时计为 `strict`。
+
+### 1.2 分类字段（人读 + 机器可读）
+
+crate 报告与 `summary.json` 将结果拆成四类，避免把 layout 噪音当成「实现 API」工单：
+
+| 分类 | JSON 字段 | 是否计入「已实现」 |
+|------|-----------|-------------------|
+| strict 匹配 | `classification.strict_matched` | 是 |
+| 路径噪音匹配 | `classification.path_noise_matched` + `path_noise_matches[]` | 是（必须带 `expected_file` / `implementation_file` / `match_kind` / `match_reason`） |
+| 真缺口 | `classification.true_missing` + `true_missing_apis[]` / `prioritized_missing_apis[]` | 否 |
+| 额外实现文件 | `classification.extra_files` + `extra_file_list[]` | 否（不在 CSV） |
+
+约定：
+
+- `missing` **仅等于** 真缺口数量，不再混入 path noise。
+- 路径噪音重分类必须可追溯 evidence；禁止静默丢弃真缺口。
+- 发布 hard gate 阈值不因 denoise 下调；denoise 只修正路径匹配真实性。
 
 ## 2. 缺失 API 优先级模型
 

--- a/tools/tests/test_validate_apis_path_denoise.py
+++ b/tools/tests/test_validate_apis_path_denoise.py
@@ -1,0 +1,349 @@
+"""Coverage path denoise + classified missing reports (#567).
+
+Seams under test:
+1. APIValidator.compare / path candidates — flat vs nested layout matching
+2. calculate_summary classification — true_gap / path_noise / extra_files
+3. Real openlark-platform tree — before/after-style missing breakdown
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "validate_apis.py"
+SPEC = importlib.util.spec_from_file_location("validate_apis", MODULE_PATH)
+validate_apis = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(validate_apis)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MAPPING_PATH = REPO_ROOT / "tools" / "api_coverage.toml"
+CSV_PATH = REPO_ROOT / "api_list_export.csv"
+
+
+def _api(
+    *,
+    expected_file: str,
+    biz_tag: str = "admin",
+    project: str = "admin",
+    version: str = "v1",
+    resource: str = "badge",
+    name: str = "list",
+    api_id: str = "1",
+    url: str = "GET:/open-apis/admin/v1/badges",
+    api_name: str = "列勋章",
+) -> validate_apis.APIInfo:
+    return validate_apis.APIInfo(
+        api_id=api_id,
+        name=api_name,
+        biz_tag=biz_tag,
+        meta_project=project,
+        meta_version=version,
+        meta_resource=resource,
+        meta_name=name,
+        url=url,
+        doc_path="",
+        expected_file=expected_file,
+    )
+
+
+class FlatLayoutPathMatchingTests(unittest.TestCase):
+    def test_flat_layout_when_project_equals_biz_tag_counts_as_implemented(self):
+        """platform-class layout: admin/admin/v1/... lives on disk as admin/v1/..."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir)
+            actual = source / "admin" / "v1" / "badge" / "list.rs"
+            actual.parent.mkdir(parents=True)
+            actual.write_text("// implemented", encoding="utf-8")
+
+            validator = validate_apis.APIValidator(
+                csv_path="unused.csv",
+                src_path=str(source),
+            )
+            validator.apis = [
+                _api(expected_file="admin/admin/v1/badge/list.rs"),
+            ]
+            validator.scan_implementations()
+            validator.compare()
+
+            self.assertTrue(validator.apis[0].is_implemented)
+            self.assertEqual(validator.apis[0].implementation_file, "admin/v1/badge/list.rs")
+            self.assertEqual(validator.apis[0].match_kind, "flat_project")
+            self.assertEqual(validator.missing_apis, [])
+            self.assertEqual(validator.extra_files, set())
+
+    def test_nested_layout_still_preferred_when_both_exist(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir)
+            nested = source / "admin" / "admin" / "v1" / "badge" / "list.rs"
+            flat = source / "admin" / "v1" / "badge" / "list.rs"
+            nested.parent.mkdir(parents=True)
+            flat.parent.mkdir(parents=True)
+            nested.write_text("// nested", encoding="utf-8")
+            flat.write_text("// flat", encoding="utf-8")
+
+            validator = validate_apis.APIValidator(
+                csv_path="unused.csv",
+                src_path=str(source),
+            )
+            validator.apis = [
+                _api(expected_file="admin/admin/v1/badge/list.rs"),
+            ]
+            validator.scan_implementations()
+            validator.compare()
+
+            self.assertTrue(validator.apis[0].is_implemented)
+            self.assertEqual(validator.apis[0].implementation_file, "admin/admin/v1/badge/list.rs")
+            self.assertEqual(validator.apis[0].match_kind, "strict")
+            # flat file is extra (not claimed by any API)
+            self.assertIn("admin/v1/badge/list.rs", validator.extra_files)
+
+    def test_different_project_does_not_silently_drop_to_flat_biz_only(self):
+        """app_engine/apaas/... must not match admin-style flat drop of project."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir)
+            # Only a wrong flat path exists — must remain a true gap.
+            wrong = source / "app_engine" / "v1" / "workspace" / "list.rs"
+            wrong.parent.mkdir(parents=True)
+            wrong.write_text("// wrong layout", encoding="utf-8")
+
+            validator = validate_apis.APIValidator(
+                csv_path="unused.csv",
+                src_path=str(source),
+            )
+            validator.apis = [
+                _api(
+                    expected_file="app_engine/apaas/v1/workspace/list.rs",
+                    biz_tag="app_engine",
+                    project="apaas",
+                    resource="workspace",
+                    name="list",
+                ),
+            ]
+            validator.scan_implementations()
+            validator.compare()
+
+            self.assertFalse(validator.apis[0].is_implemented)
+            self.assertEqual(len(validator.missing_apis), 1)
+            self.assertEqual(validator.missing_apis[0].match_kind, "true_gap")
+
+
+class RustKeywordPathMatchingTests(unittest.TestCase):
+    def test_enum_directory_can_match_enum_mod_escape(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir)
+            actual = source / "app_engine" / "apaas" / "v1" / "workspace" / "enum_mod" / "list.rs"
+            actual.parent.mkdir(parents=True)
+            actual.write_text("// keyword escape", encoding="utf-8")
+
+            validator = validate_apis.APIValidator(
+                csv_path="unused.csv",
+                src_path=str(source),
+            )
+            validator.apis = [
+                _api(
+                    expected_file="app_engine/apaas/v1/workspace/enum/list.rs",
+                    biz_tag="app_engine",
+                    project="apaas",
+                    resource="workspace.enum",
+                    name="list",
+                ),
+            ]
+            validator.scan_implementations()
+            validator.compare()
+
+            self.assertTrue(validator.apis[0].is_implemented)
+            self.assertEqual(
+                validator.apis[0].implementation_file,
+                "app_engine/apaas/v1/workspace/enum_mod/list.rs",
+            )
+            self.assertEqual(validator.apis[0].match_kind, "rust_keyword")
+
+
+class KnownTypoPathMatchingTests(unittest.TestCase):
+    def test_csv_collboration_typo_matches_collaboration_on_disk(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir)
+            actual = source / "directory" / "v1" / "collaboration_share_entity" / "list.rs"
+            actual.parent.mkdir(parents=True)
+            actual.write_text("// typo fix", encoding="utf-8")
+
+            validator = validate_apis.APIValidator(
+                csv_path="unused.csv",
+                src_path=str(source),
+            )
+            validator.apis = [
+                _api(
+                    expected_file="directory/directory/v1/collboration_share_entity/list.rs",
+                    biz_tag="directory",
+                    project="directory",
+                    resource="collboration_share_entity",
+                    name="list",
+                ),
+            ]
+            validator.scan_implementations()
+            validator.compare()
+
+            self.assertTrue(validator.apis[0].is_implemented)
+            self.assertEqual(
+                validator.apis[0].implementation_file,
+                "directory/v1/collaboration_share_entity/list.rs",
+            )
+            self.assertIn(validator.apis[0].match_kind, {"typo_correction", "flat_project"})
+
+
+class ClassificationReportTests(unittest.TestCase):
+    def test_summary_separates_true_gap_path_noise_and_extra(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir)
+            # path noise (flat layout match)
+            flat = source / "admin" / "v1" / "badge" / "list.rs"
+            flat.parent.mkdir(parents=True)
+            flat.write_text("// flat", encoding="utf-8")
+            # true gap: no file
+            # extra file unrelated
+            extra = source / "admin" / "v1" / "users.rs"
+            extra.write_text("// helper", encoding="utf-8")
+
+            validator = validate_apis.APIValidator(
+                csv_path="unused.csv",
+                src_path=str(source),
+            )
+            validator.apis = [
+                _api(
+                    api_id="noise-1",
+                    expected_file="admin/admin/v1/badge/list.rs",
+                    api_name="勋章列表",
+                ),
+                _api(
+                    api_id="gap-1",
+                    expected_file="admin/admin/v1/password/reset.rs",
+                    resource="password",
+                    name="reset",
+                    api_name="重置密码",
+                    url="POST:/open-apis/admin/v1/password/reset",
+                ),
+            ]
+            validator.scan_implementations()
+            validator.compare()
+            summary = validator.calculate_summary()
+
+            classification = summary["classification"]
+            self.assertEqual(classification["strict_matched"], 0)
+            self.assertEqual(classification["path_noise_matched"], 1)
+            self.assertEqual(classification["true_missing"], 1)
+            self.assertEqual(classification["extra_files"], 1)
+            self.assertEqual(summary["implemented"], 1)
+            self.assertEqual(summary["missing"], 1)
+
+            noise = summary["path_noise_matches"]
+            self.assertEqual(len(noise), 1)
+            self.assertEqual(noise[0]["expected_file"], "admin/admin/v1/badge/list.rs")
+            self.assertEqual(noise[0]["implementation_file"], "admin/v1/badge/list.rs")
+            self.assertEqual(noise[0]["match_kind"], "flat_project")
+            self.assertTrue(noise[0]["match_reason"])
+
+            gaps = summary["true_missing_apis"]
+            self.assertEqual(len(gaps), 1)
+            self.assertEqual(gaps[0]["api_id"], "gap-1")
+            self.assertEqual(gaps[0]["classification"], "true_gap")
+
+            self.assertEqual(summary["extra_file_list"], ["admin/v1/users.rs"])
+
+    def test_markdown_report_includes_classification_sections(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir)
+            flat = source / "admin" / "v1" / "badge" / "list.rs"
+            flat.parent.mkdir(parents=True)
+            flat.write_text("// flat", encoding="utf-8")
+            extra = source / "admin" / "v1" / "users.rs"
+            extra.write_text("// helper", encoding="utf-8")
+
+            validator = validate_apis.APIValidator(
+                csv_path="unused.csv",
+                src_path=str(source),
+            )
+            validator.apis = [
+                _api(expected_file="admin/admin/v1/badge/list.rs"),
+                _api(
+                    api_id="gap-1",
+                    expected_file="admin/admin/v1/password/reset.rs",
+                    resource="password",
+                    name="reset",
+                    api_name="重置密码",
+                ),
+            ]
+            validator.scan_implementations()
+            validator.compare()
+
+            report_path = Path(temp_dir) / "report.md"
+            validator.generate_report(str(report_path))
+            text = report_path.read_text(encoding="utf-8")
+
+            self.assertIn("分类统计", text)
+            self.assertIn("路径噪音匹配", text)
+            self.assertIn("真缺口", text)
+            self.assertIn("额外实现文件", text)
+            self.assertIn("admin/v1/badge/list.rs", text)
+            self.assertIn("flat_project", text)
+
+
+class PlatformCrateDenoiseIntegrationTests(unittest.TestCase):
+    """Real-tree seam: openlark-platform before/after denoise breakdown."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not CSV_PATH.exists() or not MAPPING_PATH.exists():
+            raise unittest.SkipTest("repo fixtures missing")
+        cfg = tomllib.loads(MAPPING_PATH.read_text(encoding="utf-8"))["crates"]["openlark-platform"]
+        cls.validator = validate_apis.APIValidator(
+            csv_path=str(CSV_PATH),
+            src_path=str(REPO_ROOT / cfg["src"]),
+            filter_tags=cfg["biz_tags"],
+            skip_old_versions=True,
+            implementation_path_rewrites=cfg.get("implementation_path_rewrites"),
+            implementation_path_aliases=cfg.get("implementation_path_aliases"),
+        )
+        cls.validator.parse_csv()
+        cls.validator.scan_implementations()
+        cls.validator.compare()
+        cls.summary = cls.validator.calculate_summary()
+
+    def test_platform_completion_is_no_longer_dominated_by_path_noise(self):
+        # Historical naive rate was ~39.5% (47/119). After denoise, path noise
+        # should be reclassified as matched, leaving only a handful of true gaps.
+        self.assertGreaterEqual(self.summary["completion_rate"], 95.0)
+        classification = self.summary["classification"]
+        self.assertGreaterEqual(classification["path_noise_matched"], 60)
+        self.assertLessEqual(classification["true_missing"], 5)
+        self.assertEqual(
+            classification["true_missing"],
+            self.summary["missing"],
+            "missing count must equal true_gap only (no silent drop without evidence)",
+        )
+
+    def test_every_path_noise_match_is_evidenced(self):
+        for item in self.summary["path_noise_matches"]:
+            self.assertTrue(item["expected_file"])
+            self.assertTrue(item["implementation_file"])
+            self.assertNotEqual(item["expected_file"], item["implementation_file"])
+            self.assertTrue(item["match_kind"])
+            self.assertTrue(item["match_reason"])
+            # evidence: matched file must exist on disk
+            full = REPO_ROOT / "crates/openlark-platform/src" / item["implementation_file"]
+            self.assertTrue(full.is_file(), msg=item["implementation_file"])
+
+    def test_true_gaps_are_not_path_noise_rows(self):
+        noise_expected = {item["expected_file"] for item in self.summary["path_noise_matches"]}
+        for item in self.summary["true_missing_apis"]:
+            self.assertNotIn(item["expected_file"], noise_expected)
+            self.assertEqual(item["classification"], "true_gap")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/validate_apis.py
+++ b/tools/validate_apis.py
@@ -9,6 +9,15 @@ API 验证脚本
 - meta.resource 中的 '.' 转换为 '/' 作为子目录
 - meta.name 中的 '/' 转换为 '/' 作为子目录
 - meta.name 中的 ':' 替换为 '_'
+
+路径匹配同时支持仓库内常见 layout 约定（见 layout candidates）：
+- nested（canonical）：biz/project/version/...
+- flat_project：当 project == biz 时，磁盘上常省略重复 project 段 → biz/version/...
+- rust_keyword：目录段若为 Rust 关键字（如 enum），可落为 enum_mod
+- 配置级 rewrite / alias（tools/api_coverage.toml）
+- 已知 CSV 拼写修正（如 collboration → collaboration）
+
+报告将结果分为：strict 匹配、路径噪音匹配（layout/typo/keyword）、真缺口、额外文件。
 """
 
 import csv
@@ -32,6 +41,75 @@ PRIORITY_DIMENSIONS = (
     "implementation_effort",
 )
 
+# 仅对「目录段」做关键字转义；文件名（*.rs stem）可保留 match/move 等。
+_RUST_PATH_KEYWORDS = frozenset(
+    {
+        "as",
+        "async",
+        "await",
+        "break",
+        "const",
+        "continue",
+        "crate",
+        "dyn",
+        "else",
+        "enum",
+        "extern",
+        "false",
+        "fn",
+        "for",
+        "if",
+        "impl",
+        "in",
+        "let",
+        "loop",
+        "match",
+        "mod",
+        "move",
+        "mut",
+        "pub",
+        "ref",
+        "return",
+        "self",
+        "static",
+        "struct",
+        "super",
+        "trait",
+        "true",
+        "type",
+        "unsafe",
+        "use",
+        "where",
+        "while",
+    }
+)
+
+# CSV 导出里出现过的已知拼写错误 → 仓库实际目录名
+_KNOWN_PATH_SEGMENT_TYPOS = {
+    "collboration": "collaboration",
+    "collboration_share_entity": "collaboration_share_entity",
+}
+
+# match_kind 中视为「路径噪音 / layout 匹配」的集合（计入已实现，但需 evidence）
+_PATH_NOISE_MATCH_KINDS = frozenset(
+    {
+        "flat_project",
+        "rust_keyword",
+        "typo_correction",
+        "rewrite",
+        "alias",
+    }
+)
+
+
+@dataclass(frozen=True)
+class PathMatchCandidate:
+    """实现路径候选及其分类标签。"""
+
+    path: str
+    kind: str
+    reason: str
+
 
 @dataclass
 class APIInfo:
@@ -48,6 +126,9 @@ class APIInfo:
     doc_path: str
     expected_file: str = ""
     is_implemented: bool = False
+    implementation_file: str = ""
+    match_kind: str = ""
+    match_reason: str = ""
     priority_level: str = ""
     priority_score: float = 0.0
     business_value: int = 0
@@ -285,6 +366,7 @@ class APIValidator:
         self.implemented_files: Set[str] = set()
         self.missing_apis: List[APIInfo] = []
         self.extra_files: Set[str] = set()
+        self.path_noise_matches: List[APIInfo] = []
         self.skipped_old_count: int = 0
 
     @staticmethod
@@ -419,25 +501,35 @@ class APIValidator:
         print(f"✅ 扫描完成，找到 {len(self.implemented_files)} 个实现文件")
 
     def compare(self) -> None:
-        """对比 CSV 和实际实现"""
+        """对比 CSV 和实际实现（含 layout denoise 与分类）。"""
         print("🔬 开始对比分析...")
 
         matched_implementation_files: Set[str] = set()
+        self.path_noise_matches = []
+        self.missing_apis = []
         for api in self.apis:
-            implementation_file = next(
+            matched = next(
                 (
                     candidate
-                    for candidate in self._implementation_path_candidates(api.expected_file)
-                    if candidate in self.implemented_files
+                    for candidate in self._implementation_path_candidates_detailed(api.expected_file)
+                    if candidate.path in self.implemented_files
                 ),
                 None,
             )
-            if implementation_file is not None:
+            if matched is not None:
                 api.is_implemented = True
-                matched_implementation_files.add(implementation_file)
+                api.implementation_file = matched.path
+                api.match_kind = matched.kind
+                api.match_reason = matched.reason
+                matched_implementation_files.add(matched.path)
+                if matched.kind in _PATH_NOISE_MATCH_KINDS:
+                    self.path_noise_matches.append(api)
                 continue
 
             api.is_implemented = False
+            api.implementation_file = ""
+            api.match_kind = "true_gap"
+            api.match_reason = "未找到与 expected_file 或其 layout 候选匹配的实现文件"
             if self.priority_model is not None:
                 self.priority_model.evaluate(api)
             self.missing_apis.append(api)
@@ -446,28 +538,77 @@ class APIValidator:
         if self.priority_model is not None:
             self.missing_apis = sorted(self.missing_apis, key=self.priority_model.sort_key)
 
+        implemented_count = len([api for api in self.apis if api.is_implemented])
         print("✅ 对比完成")
-        print(f"   - 已实现: {len([api for api in self.apis if api.is_implemented])}")
-        print(f"   - 未实现: {len(self.missing_apis)}")
+        print(f"   - 已实现: {implemented_count}")
+        print(f"   - 其中路径噪音匹配: {len(self.path_noise_matches)}")
+        print(f"   - 真缺口(未实现): {len(self.missing_apis)}")
         print(f"   - 额外文件: {len(self.extra_files)}")
 
     def _implementation_path_candidates(self, expected_file: str) -> List[str]:
-        """返回 strict 路径及仓库已登记的 legacy 实现路径。"""
+        """返回 strict 路径及 layout/legacy 候选路径（仅路径字符串）。"""
+        return [item.path for item in self._implementation_path_candidates_detailed(expected_file)]
+
+    def _implementation_path_candidates_detailed(self, expected_file: str) -> List["PathMatchCandidate"]:
+        """生成带分类标签的实现路径候选（strict 优先，其后为 layout/legacy）。"""
         if not expected_file:
             return []
 
-        candidates = [expected_file]
+        ordered: List[PathMatchCandidate] = []
+        seen: Set[str] = set()
+
+        def add(path: str, kind: str, reason: str) -> None:
+            if not path or path in seen:
+                return
+            seen.add(path)
+            ordered.append(PathMatchCandidate(path=path, kind=kind, reason=reason))
+
+        add(expected_file, "strict", "canonical nested formula: biz/project/version/resource/name.rs")
+
         alias = self.implementation_path_aliases.get(expected_file)
         if alias:
-            candidates.append(alias)
+            add(alias, "alias", f"implementation_path_aliases: {expected_file} → {alias}")
 
         for rewrite in self.implementation_path_rewrites:
             source_prefix = str(rewrite.get("from", ""))
             target_prefix = str(rewrite.get("to", ""))
             if source_prefix and expected_file.startswith(source_prefix):
-                candidates.append(target_prefix + expected_file[len(source_prefix) :])
+                rewritten = target_prefix + expected_file[len(source_prefix) :]
+                add(
+                    rewritten,
+                    "rewrite",
+                    f"implementation_path_rewrites: '{source_prefix}' → '{target_prefix}'",
+                )
 
-        return _dedupe_preserve_order(candidates)
+        # 在已有候选上展开 layout 变体（flat / keyword / typo），并允许组合。
+        index = 0
+        while index < len(ordered):
+            base = ordered[index]
+            index += 1
+
+            flat = _flat_project_path(base.path)
+            if flat != base.path:
+                add(
+                    flat,
+                    "flat_project",
+                    f"flat layout: drop duplicate project segment ({base.path} → {flat})",
+                )
+
+            for kw_path, segment in _rust_keyword_directory_variants(base.path):
+                add(
+                    kw_path,
+                    "rust_keyword",
+                    f"rust keyword directory escape: '{segment}' → '{segment}_mod' ({base.path} → {kw_path})",
+                )
+
+            for typo_path, old_seg, new_seg in _typo_corrected_path_variants(base.path):
+                add(
+                    typo_path,
+                    "typo_correction",
+                    f"known CSV path typo: '{old_seg}' → '{new_seg}' ({base.path} → {typo_path})",
+                )
+
+        return ordered
 
     def generate_report(self, output_path: str) -> None:
         """生成报告"""
@@ -480,6 +621,9 @@ class APIValidator:
             file.write(f"**CSV 文件**: {self.csv_path}\n")
             file.write(f"**源码目录**: {self.src_path}\n")
             file.write("**命名规范**: `src/bizTag/meta.project/meta.version/meta.resource/meta.name.rs`\n")
+            file.write(
+                "**路径匹配**: nested / flat_project / rust_keyword / rewrite / alias / typo_correction\n"
+            )
             if self.priority_model is not None:
                 file.write(f"**优先级配置**: `{self.priority_model.source_path}`\n")
             file.write("\n")
@@ -487,8 +631,14 @@ class APIValidator:
             section_index = 1
             self._write_overall_section(file, section_index)
             section_index += 1
+            self._write_classification_section(file, section_index)
+            section_index += 1
             self._write_module_section(file, section_index)
             section_index += 1
+
+            if self.path_noise_matches:
+                self._write_path_noise_section(file, section_index)
+                section_index += 1
 
             if self.missing_apis:
                 self._write_priority_section(file, section_index)
@@ -505,11 +655,14 @@ class APIValidator:
         print("✅ 报告生成完成")
 
     def calculate_summary(self) -> Dict[str, Any]:
-        """生成可序列化的统计摘要。"""
+        """生成可序列化的统计摘要（含分类字段）。"""
         total_apis = len(self.apis)
         implemented = len([api for api in self.apis if api.is_implemented])
         missing = len(self.missing_apis)
         completion_rate = (implemented / total_apis * 100) if total_apis > 0 else 0.0
+        strict_matched = len([api for api in self.apis if api.match_kind == "strict"])
+        path_noise_matched = len(self.path_noise_matches)
+        extra_list = sorted(self.extra_files)
 
         return {
             "total_apis": total_apis,
@@ -521,6 +674,15 @@ class APIValidator:
             "module_stats": self._calculate_module_stats(),
             "priority_counts": self._calculate_priority_counts(),
             "prioritized_missing_apis": [self._serialize_missing_api(api) for api in self.missing_apis],
+            "classification": {
+                "strict_matched": strict_matched,
+                "path_noise_matched": path_noise_matched,
+                "true_missing": missing,
+                "extra_files": len(self.extra_files),
+            },
+            "path_noise_matches": [self._serialize_path_noise_match(api) for api in self.path_noise_matches],
+            "true_missing_apis": [self._serialize_missing_api(api) for api in self.missing_apis],
+            "extra_file_list": extra_list,
         }
 
     def _write_overall_section(self, file: Any, section_index: int) -> None:
@@ -534,9 +696,41 @@ class APIValidator:
         file.write("|------|------|\n")
         file.write(f"| **API 总数** | {total_apis} |\n")
         file.write(f"| **已实现** | {implemented} |\n")
-        file.write(f"| **未实现** | {missing} |\n")
+        file.write(f"| **真缺口(未实现)** | {missing} |\n")
         file.write(f"| **完成率** | {completion_rate:.1f}% |\n")
         file.write(f"| **额外文件** | {len(self.extra_files)} |\n\n")
+
+    def _write_classification_section(self, file: Any, section_index: int) -> None:
+        strict_matched = len([api for api in self.apis if api.match_kind == "strict"])
+        path_noise_matched = len(self.path_noise_matches)
+        true_missing = len(self.missing_apis)
+
+        file.write(f"## {section_index}、分类统计\n\n")
+        file.write("覆盖率路径匹配结果按以下四类拆分（人读 + 与 JSON 字段对齐）：\n\n")
+        file.write("| 分类 | 数量 | 说明 |\n")
+        file.write("|------|------|------|\n")
+        file.write(f"| **strict 匹配** | {strict_matched} | 落盘路径与 canonical nested 公式一致 |\n")
+        file.write(
+            f"| **路径噪音匹配** | {path_noise_matched} | "
+            "flat_project / rust_keyword / rewrite / alias / typo_correction；计入已实现，附 evidence |\n"
+        )
+        file.write(f"| **真缺口** | {true_missing} | 无任何 layout 候选命中，可作为实现 backlog |\n")
+        file.write(
+            f"| **额外实现文件** | {len(self.extra_files)} | "
+            "源码中存在但未对应任何 CSV API 的叶子 `.rs` |\n\n"
+        )
+
+    def _write_path_noise_section(self, file: Any, section_index: int) -> None:
+        file.write(f"## {section_index}、路径噪音匹配（layout / typo / legacy）\n\n")
+        file.write("下列 API 已在磁盘找到实现，但路径偏离 canonical 公式；**不是真缺口**。\n\n")
+        file.write("| API | 预期文件 | 实际文件 | match_kind | 证据 |\n")
+        file.write("|-----|----------|----------|------------|------|\n")
+        for api in self.path_noise_matches:
+            file.write(
+                f"| {api.name} | `{api.expected_file}` | `{api.implementation_file}` | "
+                f"`{api.match_kind}` | {api.match_reason} |\n"
+            )
+        file.write("\n")
 
     def _write_module_section(self, file: Any, section_index: int) -> None:
         file.write(f"## {section_index}、模块统计\n\n")
@@ -578,7 +772,8 @@ class APIValidator:
         file.write("\n")
 
     def _write_missing_detail_section(self, file: Any, section_index: int) -> None:
-        file.write(f"## {section_index}、未实现的 API（按模块）\n\n")
+        file.write(f"## {section_index}、真缺口 API（按模块）\n\n")
+        file.write("仅包含 `classification=true_gap` 的条目；路径噪音已在上一节单独列出。\n\n")
         missing_by_module: Dict[str, List[APIInfo]] = defaultdict(list)
         for api in self.missing_apis:
             missing_by_module[api.biz_tag.upper()].append(api)
@@ -588,6 +783,7 @@ class APIValidator:
             for api in missing_by_module[module_name]:
                 file.write(f"#### {api.name}\n\n")
                 file.write(f"- **API ID**: {api.api_id}\n")
+                file.write(f"- **分类**: `true_gap`\n")
                 if api.priority_level:
                     file.write(f"- **优先级**: {api.priority_level} ({api.priority_score:.2f})\n")
                     file.write(
@@ -602,8 +798,8 @@ class APIValidator:
                 file.write(f"- **文档**: {api.doc_path}\n\n")
 
     def _write_extra_files_section(self, file: Any, section_index: int) -> None:
-        file.write(f"## {section_index}、额外的实现文件\n\n")
-        file.write("这些文件存在于代码中，但不在 CSV API 列表中：\n\n")
+        file.write(f"## {section_index}、额外实现文件\n\n")
+        file.write("这些文件存在于代码中，但未匹配任何 CSV API（`classification=extra_file`）：\n\n")
         for extra_file in sorted(self.extra_files):
             file.write(f"- `{extra_file}`\n")
         file.write("\n")
@@ -618,7 +814,13 @@ class APIValidator:
         for module_name in sorted(implemented_by_module.keys()):
             file.write(f"### {module_name} ({len(implemented_by_module[module_name])} 个)\n\n")
             for api in sorted(implemented_by_module[module_name], key=lambda item: item.name):
-                file.write(f"- ✅ {api.name} (`{api.expected_file}`)\n")
+                if api.match_kind and api.match_kind != "strict" and api.implementation_file:
+                    file.write(
+                        f"- ✅ {api.name} (`{api.expected_file}` → `{api.implementation_file}` "
+                        f"via `{api.match_kind}`)\n"
+                    )
+                else:
+                    file.write(f"- ✅ {api.name} (`{api.expected_file}`)\n")
             file.write("\n")
 
     def _calculate_module_stats(self) -> Dict[str, Dict[str, Any]]:
@@ -660,6 +862,9 @@ class APIValidator:
             "url": api.url,
             "doc_path": api.doc_path,
             "expected_file": api.expected_file,
+            "classification": "true_gap",
+            "match_kind": api.match_kind or "true_gap",
+            "match_reason": api.match_reason,
             "priority_level": api.priority_level,
             "priority_score": api.priority_score,
             "business_value": api.business_value,
@@ -670,11 +875,78 @@ class APIValidator:
         }
 
     @staticmethod
+    def _serialize_path_noise_match(api: APIInfo) -> Dict[str, Any]:
+        return {
+            "api_id": api.api_id,
+            "name": api.name,
+            "biz_tag": api.biz_tag,
+            "project": api.meta_project,
+            "version": api.meta_version,
+            "resource": api.meta_resource,
+            "meta_name": api.meta_name,
+            "url": api.url,
+            "doc_path": api.doc_path,
+            "expected_file": api.expected_file,
+            "implementation_file": api.implementation_file,
+            "classification": "path_noise",
+            "match_kind": api.match_kind,
+            "match_reason": api.match_reason,
+        }
+
+    @staticmethod
     def _get_timestamp() -> str:
         """获取当前时间戳"""
         from datetime import datetime
 
         return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _flat_project_path(path: str) -> str:
+    """若路径以 `biz/biz/...` 开头，返回省略重复 project 段后的 flat 路径。"""
+    segments = path.split("/")
+    if len(segments) >= 3 and segments[0] == segments[1] and segments[0]:
+        return "/".join([segments[0], *segments[2:]])
+    return path
+
+
+def _rust_keyword_directory_variants(path: str) -> List[Tuple[str, str]]:
+    """对目录段中的 Rust 关键字生成 `{kw}_mod` 变体（不改文件名 stem）。"""
+    if not path.endswith(".rs"):
+        return []
+    body = path[: -len(".rs")]
+    segments = body.split("/")
+    if len(segments) < 2:
+        return []
+    directory_segments = segments[:-1]
+    file_stem = segments[-1]
+    variants: List[Tuple[str, str]] = []
+    for index, segment in enumerate(directory_segments):
+        if segment not in _RUST_PATH_KEYWORDS:
+            continue
+        rewritten = directory_segments[:]
+        rewritten[index] = f"{segment}_mod"
+        variants.append(("/".join([*rewritten, file_stem]) + ".rs", segment))
+    return variants
+
+
+def _typo_corrected_path_variants(path: str) -> List[Tuple[str, str, str]]:
+    """对路径段应用已知 CSV 拼写修正，返回 (new_path, old, new)。"""
+    segments = path.split("/")
+    variants: List[Tuple[str, str, str]] = []
+    for index, segment in enumerate(segments):
+        # 文件名 stem 也可能含 typo（少见）；统一按整段替换
+        stem = segment
+        suffix = ""
+        if segment.endswith(".rs"):
+            stem = segment[: -len(".rs")]
+            suffix = ".rs"
+        replacement = _KNOWN_PATH_SEGMENT_TYPOS.get(stem)
+        if not replacement or replacement == stem:
+            continue
+        rewritten = segments[:]
+        rewritten[index] = replacement + suffix
+        variants.append(("/".join(rewritten), stem, replacement))
+    return variants
 
 
 def _as_string_list(value: Any) -> List[str]:
@@ -971,6 +1243,12 @@ def main() -> int:
             else:
                 file.write("- 包含 `meta.Version=old`。\n")
             file.write("- 数据来源：`api_list_export.csv` 对比 crate 源码目录。\n")
+            file.write(
+                "- 路径匹配：canonical nested + flat_project / rust_keyword / rewrite / alias / typo_correction。\n"
+            )
+            file.write(
+                "- 分类：`strict_matched` / `path_noise_matched`（计入已实现）/ `true_missing` / `extra_files`。\n"
+            )
             file.write(f"- 缺失 API 优先级配置：`{priority_source_path}`。\n")
             file.write(f"- 综合分公式：`{priority_model.priority_formula()}`。\n\n")
 
@@ -979,6 +1257,8 @@ def main() -> int:
             total_missing = sum(row[1]["missing"] for row in crate_rows)
             total_extra = sum(row[1]["extra_files"] for row in crate_rows)
             total_rate = (total_impl / total_apis * 100) if total_apis > 0 else 0.0
+            total_strict = sum(row[1].get("classification", {}).get("strict_matched", 0) for row in crate_rows)
+            total_noise = sum(row[1].get("classification", {}).get("path_noise_matched", 0) for row in crate_rows)
 
             file.write("## 总览\n\n")
             file.write("| 指标 | 数量 |\n")
@@ -986,19 +1266,27 @@ def main() -> int:
             file.write(f"| crate 数量 | {len(crate_rows)} |\n")
             file.write(f"| API 总数 | {total_apis} |\n")
             file.write(f"| 已实现 | {total_impl} |\n")
-            file.write(f"| 未实现 | {total_missing} |\n")
+            file.write(f"|   strict 匹配 | {total_strict} |\n")
+            file.write(f"|   路径噪音匹配 | {total_noise} |\n")
+            file.write(f"| 真缺口(未实现) | {total_missing} |\n")
             file.write(f"| 完成率 | {total_rate:.1f}% |\n")
             file.write(f"| 额外文件 | {total_extra} |\n\n")
 
             file.write("## 各 crate 覆盖率\n\n")
-            file.write("| crate | bizTag | 总数 | 已实现 | 未实现 | 完成率 | 额外文件 | 报告 |\n")
-            file.write("|-------|--------|------|--------|--------|--------|----------|------|\n")
+            file.write(
+                "| crate | bizTag | 总数 | 已实现 | 路径噪音 | 真缺口 | 完成率 | 额外文件 | 报告 |\n"
+            )
+            file.write(
+                "|-------|--------|------|--------|----------|--------|--------|----------|------|\n"
+            )
             for crate_name, stats, report_rel, tags in sorted(crate_rows, key=lambda item: item[0]):
                 tags_text = ", ".join(tags)
+                noise = stats.get("classification", {}).get("path_noise_matched", 0)
                 file.write(
                     f"| {crate_name} | `{tags_text}` | {stats['total_apis']} | "
-                    f"{stats['implemented']} | {stats['missing']} | {stats['completion_rate']:.1f}% | "
-                    f"{stats['extra_files']} | [{crate_name}]({report_rel}) |\n"
+                    f"{stats['implemented']} | {noise} | {stats['missing']} | "
+                    f"{stats['completion_rate']:.1f}% | {stats['extra_files']} | "
+                    f"[{crate_name}]({report_rel}) |\n"
                 )
             file.write("\n")
 
@@ -1125,6 +1413,16 @@ def main() -> int:
         total_missing = sum(item["missing"] for item in crate_summaries.values())
         total_extra = sum(item["extra_files"] for item in crate_summaries.values())
         total_rate = (total_impl / total_apis * 100) if total_apis > 0 else 0.0
+        total_strict = sum(
+            item.get("classification", {}).get("strict_matched", 0) for item in crate_summaries.values()
+        )
+        total_path_noise = sum(
+            item.get("classification", {}).get("path_noise_matched", 0) for item in crate_summaries.values()
+        )
+        all_path_noise_matches: List[Dict[str, Any]] = []
+        for crate_name, stats in crate_summaries.items():
+            for item in stats.get("path_noise_matches", []):
+                all_path_noise_matches.append({"crate": crate_name, **item})
 
         priority_counts: Dict[str, int] = defaultdict(int)
         for _, api in all_missing_apis:
@@ -1142,6 +1440,13 @@ def main() -> int:
             "missing": total_missing,
             "completion_rate": round(total_rate, 1),
             "extra_files": total_extra,
+            "classification": {
+                "strict_matched": total_strict,
+                "path_noise_matched": total_path_noise,
+                "true_missing": total_missing,
+                "extra_files": total_extra,
+            },
+            "path_noise_matches": all_path_noise_matches,
             "priority_counts": dict(sorted(priority_counts.items())),
             "top_missing_apis": top_missing_apis,
             "dashboards": dashboard_payloads,


### PR DESCRIPTION
## Summary
Implements #567 (post code-review).

Make typed-coverage reports trustworthy: align path matching with real on-disk layout conventions and classify each non-implemented row as **true gap**, **path noise / layout mismatch**, or **extra implementation file**.

## Test plan
- [ ] focused tests
- [ ] re-run coverage hard gate (no threshold changes)
- [ ] verify before/after missing breakdown on high-noise crate

Fixes #567