### PR TITLE
fix(#571): selective P2 slice (hr or helpdesk/mail true gaps)

### DIFF
--- a/docs/typed-api-coverage.md
+++ b/docs/typed-api-coverage.md
@@ -104,6 +104,29 @@ business_value × 0.50
 - **证据复现**：`python3 tools/validate_apis.py --crate openlark-platform` 后，platform `true_missing=0`、`priority_counts` 无 P1；回归锁在 `tools/tests/test_p1_platform_clear_or_disprove.py`。
 - **硬门禁**：未下调 `tools/typed_coverage_release.toml` 阈值；core-business P0 仍为 0。
 
+### 2.3 0.20 selective P2 slice（#571）
+
+0.19 签核时 workspace 真缺口含 **P2=89** 量级。#567 denoise 后，helpdesk / mail 尾部与 hr OKR v2 的「未实现」行被证明是 **path noise**（磁盘已有可调用 typed leaf），而非业务缺口。#571 只清这一小片（28 行），**不**以「清光全部 P2」为目标，也不下调 hard gate。
+
+| 范围 | 行数 | 机制 | 配置 |
+|------|-----:|------|------|
+| helpdesk FAQ 图像 | 1 | `alias`：`faq/faq_image.rs` → `faq/image.rs` | `[crates.openlark-helpdesk.implementation_path_aliases]` |
+| mail 撤回进度 / 撤回 | 2 | `alias`：`sent_message/*` → `message/recall/*` | `[crates.openlark-mail.implementation_path_aliases]` |
+| hr OKR v2 全套 | 25 | `rewrite`：`okr/okr/v2/okr/` → `okr/okr/v2/`（CSV resource `okr.*` 相对 project 冗余） | `[crates.openlark-hr] implementation_path_rewrites` |
+
+终端结论（复现命令）：
+
+```bash
+python3 tools/validate_apis.py --crate openlark-helpdesk  # true_missing=0, path_noise=1
+python3 tools/validate_apis.py --crate openlark-mail      # true_missing=0, path_noise=2
+python3 tools/validate_apis.py --crate openlark-hr        # true_missing=0, path_noise=25（OKR v2）
+python3 -m unittest tools.tests.test_p2_selective_slice -v
+```
+
+- **选型清单**：写在 issue #571 评论（coding 前），本表为仓库内 SSOT 摘要。
+- **硬门禁**：未改 `tools/typed_coverage_release.toml` 阈值；core-business P0 仍为 0。
+- **非目标**：platform/admin/acs 等其余 P2 尾、OKR 新功能实现（本片仅 reclassify 已存在 leaf）。
+
 ## 3. 报告产物
 
 执行批量模式后，会生成以下文件：

--- a/docs/typed-coverage-priorities/hr.md
+++ b/docs/typed-coverage-priorities/hr.md
@@ -2,47 +2,28 @@
 
 ## 当前结论
 
-基于当前覆盖率报告：
+基于当前覆盖率报告（#571 selective P2 之后）：
 
-- `reports/api_validation/crates/openlark-hr.md`
+- `python3 tools/validate_apis.py --crate openlark-hr`
 
 当前 `openlark-hr` 状态为：
 
-- API 总数：551
-- 已实现：546
-- 未实现：5
-- 完成率：99.1%
+- API 总数：583
+- 已实现：583（含 path noise 匹配）
+- 真缺口（未实现）：0
+- 完成率：100.0%
+- 路径噪音匹配：25（全部为 OKR v2 layout）
 
-所有缺口都集中在 `FEISHU_PEOPLE / CoreHR` 相关场景，因此 HR 域不需要重新做大范围排序，只需要按剩余 5 个缺口的频率和复杂度收敛。
+历史「CoreHR 最后 5 个缺口」与「OKR v2 25 个缺口」在 denoise 后均已清零：
 
-## 当前缺口优先级
-
-### P1：时间轴查询（优先先补）
-
-1. `feishu_people/corehr/v2/company/query_multi_timeline.rs`
-2. `feishu_people/corehr/v2/location/query_multi_timeline.rs`
-
-理由：
-
-- 都是查询型接口
-- 已被覆盖率模型判为 `P1`
-- 更适合作为 CoreHR 缺口治理的第一批收敛项
-
-### P2：流程与写操作（随后补齐）
-
-1. `feishu_people/corehr/v2/probation/edit.rs`
-2. `feishu_people/corehr/v2/process/query_flow_data_template/create.rs`
-3. `feishu_people/corehr/v2/process_start/create.rs`
-
-理由：
-
-- 都属于流程发起 / 模板 / 写操作路径
-- 请求体和语义约束更复杂
-- 频率低于时间轴查询类接口
+| 历史缺口族 | 终端结论 | 证据 |
+|------------|----------|------|
+| CoreHR 时间轴 / 流程（曾记 5 项） | 已在磁盘有 strict 实现（0.19 后） | 当前 `true_missing=0` |
+| OKR v2（25 项） | **path noise**：CSV resource `okr.*` vs 磁盘 `okr/okr/v2/*` | `implementation_path_rewrites` + `tools/tests/test_p2_selective_slice.py` |
 
 ## 默认频率顺序
 
-如果未来 HR 域再次出现新缺口，默认按以下顺序补齐：
+如果未来 HR 域再次出现**真缺口**，默认按以下顺序补齐：
 
 1. **组织与时间轴查询**
    - company / location / department / employee timeline
@@ -50,13 +31,10 @@
    - probation、入转调离等高频变更
 3. **流程模板与流程发起**
    - query_flow_data_template / process_start
-4. **其余尾部能力**
+4. **OKR / 绩效尾部能力**（仅当 CSV 新增且无 on-disk leaf）
+5. **其余尾部能力**
 
-## 阶段性实现建议
+## 说明
 
-| 阶段 | 范围 | 代表接口 |
-|------|------|----------|
-| P1 | CoreHR 时间轴查询 | `company/query_multi_timeline`, `location/query_multi_timeline` |
-| P2 | CoreHR 变更与流程 | `probation/edit`, `process/query_flow_data_template/create`, `process_start/create` |
-
-当前 HR 域的关键点不是“还有很多没做”，而是**把 CoreHR 最后 5 个缺口按低复杂度查询优先收口**。
+- 当前 HR 域的关键点不是「还有很多没做」，而是**保持 denoise 分类可信**，避免把 layout 噪音重新记成实现工单。
+- 详见 `docs/typed-api-coverage.md` §2.3（#571）。

--- a/tools/api_coverage.toml
+++ b/tools/api_coverage.toml
@@ -45,6 +45,12 @@ biz_tags = [
   "ehr",
 ]
 dashboard_groups = ["core_business"]
+# OKR v2 CSV resources are `okr.<sub>` → expected `okr/okr/v2/okr/<sub>/...`.
+# On-disk layout drops the redundant resource-prefix segment (project is already `okr`).
+# See #571 selective P2 slice / docs/typed-api-coverage.md §2.3.
+implementation_path_rewrites = [
+  { from = "okr/okr/v2/okr/", to = "okr/okr/v2/" },
+]
 
 [crates.openlark-security]
 src = "crates/openlark-security/src"
@@ -97,10 +103,19 @@ biz_tags = ["personal_settings"]
 [crates.openlark-mail]
 src = "crates/openlark-mail/src"
 biz_tags = ["mail"]
+# CSV uses meta.Resource=sent_message; on-disk layout nests under message/recall/
+# (matches Feishu URL /messages/:id/recall). See #571 selective P2 slice.
+[crates.openlark-mail.implementation_path_aliases]
+"mail/mail/v1/user_mailbox/sent_message/get_recall_detail.rs" = "mail/mail/v1/user_mailbox/message/recall/get_recall_detail.rs"
+"mail/mail/v1/user_mailbox/sent_message/recall.rs" = "mail/mail/v1/user_mailbox/message/recall/recall.rs"
 
 [crates.openlark-helpdesk]
 src = "crates/openlark-helpdesk/src"
 biz_tags = ["helpdesk"]
+# CSV meta.Name=faq_image → expected faq_image.rs; leaf is image.rs (docPath faq_image).
+# See #571 selective P2 slice.
+[crates.openlark-helpdesk.implementation_path_aliases]
+"helpdesk/helpdesk/v1/faq/faq_image.rs" = "helpdesk/helpdesk/v1/faq/image.rs"
 
 [crates.openlark-application]
 src = "crates/openlark-application/src"

--- a/tools/tests/test_p2_selective_slice.py
+++ b/tools/tests/test_p2_selective_slice.py
@@ -1,0 +1,246 @@
+"""0.20 selective P2 slice: helpdesk / mail / hr-OKR true-gap reclassification (#571).
+
+Seams under test:
+1. Typed coverage classification for the denoise-informed P2 selection list
+   — each chosen row must be path_noise (alias/rewrite), never true_gap.
+2. Crate-level true_missing after denoise:
+   - openlark-helpdesk: 0
+   - openlark-mail: 0
+   - openlark-hr OKR v2 expected_files: none remain in true_missing
+3. On-disk implementation leaves for those rows — still present and callable
+   at the evidenced alias/rewrite paths (public Builder modules).
+
+Selection list was written on #571 before coding. Scope is a small value-sorted
+slice (not all ~89 workspace P2s). Hard gates are not lowered.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import tomllib
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "validate_apis.py"
+SPEC = importlib.util.spec_from_file_location("validate_apis", MODULE_PATH)
+validate_apis = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(validate_apis)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MAPPING_PATH = REPO_ROOT / "tools" / "api_coverage.toml"
+CSV_PATH = REPO_ROOT / "api_list_export.csv"
+
+# Denoise-informed selection (#571): helpdesk + mail exact aliases.
+HELPDESK_MAIL_P2_SLICE: dict[str, dict[str, str]] = {
+    "helpdesk/helpdesk/v1/faq/faq_image.rs": {
+        "crate": "openlark-helpdesk",
+        "name": "获取知识库图像",
+        "implementation_file": "helpdesk/helpdesk/v1/faq/image.rs",
+        "match_kind": "alias",
+        "outcome": "noise",
+    },
+    "mail/mail/v1/user_mailbox/sent_message/get_recall_detail.rs": {
+        "crate": "openlark-mail",
+        "name": "获取邮件撤回进度",
+        "implementation_file": (
+            "mail/mail/v1/user_mailbox/message/recall/get_recall_detail.rs"
+        ),
+        "match_kind": "alias",
+        "outcome": "noise",
+    },
+    "mail/mail/v1/user_mailbox/sent_message/recall.rs": {
+        "crate": "openlark-mail",
+        "name": "撤回已发送邮件",
+        "implementation_file": "mail/mail/v1/user_mailbox/message/recall/recall.rs",
+        "match_kind": "alias",
+        "outcome": "noise",
+    },
+}
+
+# HR OKR v2: CSV resource is `okr.<sub>` → expected `okr/okr/v2/okr/<sub>/...`,
+# on-disk layout drops the redundant resource-prefix segment.
+OKR_V2_EXPECTED_PREFIX = "okr/okr/v2/okr/"
+OKR_V2_IMPLEMENTATION_PREFIX = "okr/okr/v2/"
+
+
+def _load_crate_validator(crate_name: str) -> validate_apis.APIValidator:
+    cfg = tomllib.loads(MAPPING_PATH.read_text(encoding="utf-8"))["crates"][crate_name]
+    priority_model = validate_apis.PriorityModel.from_path(
+        str(REPO_ROOT / "tools" / "api_priority.toml")
+    )
+    validator = validate_apis.APIValidator(
+        csv_path=str(CSV_PATH),
+        src_path=str(REPO_ROOT / cfg["src"]),
+        filter_tags=cfg["biz_tags"],
+        skip_old_versions=True,
+        priority_model=priority_model,
+        implementation_path_rewrites=cfg.get("implementation_path_rewrites"),
+        implementation_path_aliases=cfg.get("implementation_path_aliases"),
+    )
+    validator.parse_csv()
+    validator.scan_implementations()
+    validator.compare()
+    return validator
+
+
+def _assert_callable_leaf(test: unittest.TestCase, leaf: Path) -> None:
+    test.assertTrue(leaf.is_file(), msg=str(leaf))
+    text = leaf.read_text(encoding="utf-8")
+    # Callable typed API markers (Builder + execute + Transport).
+    # Some OKR leaves use `pub struct Request` + module-level Builder pattern.
+    test.assertTrue(
+        "RequestBuilder" in text or "async fn execute" in text,
+        msg=f"missing execute/builder seam in {leaf}",
+    )
+    test.assertIn("async fn execute", text)
+    test.assertIn("Transport::request_typed", text)
+
+
+class HelpdeskMailP2SliceTests(unittest.TestCase):
+    """Real-tree seam: helpdesk/mail selected P2s are path noise over shipped leaves."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not CSV_PATH.exists() or not MAPPING_PATH.exists():
+            raise unittest.SkipTest("repo fixtures missing")
+        cls.validators: dict[str, validate_apis.APIValidator] = {}
+        cls.summaries: dict[str, dict] = {}
+        cls.by_expected: dict[str, dict[str, validate_apis.APIInfo]] = {}
+        cls.noise_by_expected: dict[str, dict[str, dict]] = {}
+        for crate_name in ("openlark-helpdesk", "openlark-mail"):
+            validator = _load_crate_validator(crate_name)
+            summary = validator.calculate_summary()
+            cls.validators[crate_name] = validator
+            cls.summaries[crate_name] = summary
+            cls.by_expected[crate_name] = {
+                api.expected_file: api for api in validator.apis
+            }
+            cls.noise_by_expected[crate_name] = {
+                item["expected_file"]: item
+                for item in summary.get("path_noise_matches", [])
+            }
+
+    def test_selection_list_has_three_helpdesk_mail_rows(self):
+        self.assertEqual(len(HELPDESK_MAIL_P2_SLICE), 3)
+
+    def test_each_helpdesk_mail_row_is_path_noise_with_evidence(self):
+        for expected, meta in HELPDESK_MAIL_P2_SLICE.items():
+            with self.subTest(expected=expected):
+                crate = meta["crate"]
+                api = self.by_expected[crate].get(expected)
+                self.assertIsNotNone(
+                    api,
+                    f"CSV no longer lists {expected}; update selection map if catalog moved",
+                )
+                assert api is not None
+                self.assertTrue(
+                    api.is_implemented,
+                    f"{meta['name']} still true-missing under denoise",
+                )
+
+                noise = self.noise_by_expected[crate].get(expected)
+                self.assertIsNotNone(
+                    noise,
+                    f"{expected} matched strict or missing path_noise evidence",
+                )
+                assert noise is not None
+                self.assertEqual(noise["implementation_file"], meta["implementation_file"])
+                self.assertEqual(noise["match_kind"], meta["match_kind"])
+                self.assertTrue(noise["match_reason"])
+
+                src = REPO_ROOT / tomllib.loads(MAPPING_PATH.read_text(encoding="utf-8"))[
+                    "crates"
+                ][crate]["src"]
+                _assert_callable_leaf(self, src / meta["implementation_file"])
+
+    def test_helpdesk_and_mail_true_missing_are_zero(self):
+        for crate_name in ("openlark-helpdesk", "openlark-mail"):
+            with self.subTest(crate=crate_name):
+                summary = self.summaries[crate_name]
+                self.assertEqual(summary["classification"]["true_missing"], 0)
+                self.assertEqual(summary["missing"], 0)
+                self.assertEqual(summary["completion_rate"], 100.0)
+
+    def test_no_deferred_outcomes_in_helpdesk_mail_slice(self):
+        for meta in HELPDESK_MAIL_P2_SLICE.values():
+            self.assertEqual(meta["outcome"], "noise")
+
+
+class HrOkrV2P2SliceTests(unittest.TestCase):
+    """Real-tree seam: all OKR v2 CSV rows reclassify via rewrite to on-disk layout."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not CSV_PATH.exists() or not MAPPING_PATH.exists():
+            raise unittest.SkipTest("repo fixtures missing")
+        cls.validator = _load_crate_validator("openlark-hr")
+        cls.summary = cls.validator.calculate_summary()
+        cls.okr_v2_apis = [
+            api
+            for api in cls.validator.apis
+            if api.expected_file.startswith(OKR_V2_EXPECTED_PREFIX)
+        ]
+        cls.noise_by_expected = {
+            item["expected_file"]: item
+            for item in cls.summary.get("path_noise_matches", [])
+        }
+        cls.true_missing = {
+            item["expected_file"] for item in cls.summary.get("true_missing_apis", [])
+        }
+        cls.hr_src = REPO_ROOT / "crates" / "openlark-hr" / "src"
+
+    def test_okr_v2_slice_has_twenty_five_csv_rows(self):
+        # Catalog lock: selective slice covers the full OKR v2 gap set from 0.19/0.20 reports.
+        self.assertEqual(len(self.okr_v2_apis), 25)
+
+    def test_each_okr_v2_row_is_path_noise_via_rewrite(self):
+        for api in self.okr_v2_apis:
+            with self.subTest(expected=api.expected_file):
+                self.assertTrue(
+                    api.is_implemented,
+                    f"{api.name} still true-missing under denoise",
+                )
+                noise = self.noise_by_expected.get(api.expected_file)
+                self.assertIsNotNone(noise, f"missing path_noise evidence for {api.name}")
+                assert noise is not None
+                self.assertEqual(noise["match_kind"], "rewrite")
+                expected_impl = OKR_V2_IMPLEMENTATION_PREFIX + api.expected_file[
+                    len(OKR_V2_EXPECTED_PREFIX) :
+                ]
+                self.assertEqual(noise["implementation_file"], expected_impl)
+                self.assertTrue(noise["match_reason"])
+                _assert_callable_leaf(self, self.hr_src / expected_impl)
+
+    def test_no_okr_v2_rows_remain_in_true_missing(self):
+        for api in self.okr_v2_apis:
+            self.assertNotIn(api.expected_file, self.true_missing)
+
+    def test_hr_true_missing_excludes_okr_v2_and_is_not_inflated(self):
+        # After reclassification, OKR v2 must not contribute to true_missing.
+        # Other HR modules may still have gaps in the future; assert only the slice.
+        remaining_okr = [
+            path for path in self.true_missing if path.startswith("okr/")
+        ]
+        self.assertEqual(remaining_okr, [])
+        # Slice closed 25 historical OKR gaps; overall true_missing must drop accordingly.
+        self.assertEqual(
+            self.summary["classification"]["true_missing"],
+            len(self.true_missing),
+        )
+        self.assertLessEqual(self.summary["classification"]["true_missing"], 0)
+
+
+class SelectiveSliceScopeGuardTests(unittest.TestCase):
+    """Scope guard: this unit is a slice, not full-workspace P2 clearance."""
+
+    def test_selection_is_bounded(self):
+        # helpdesk/mail exact rows + OKR v2 set (25) = 28; never "all 89 P2".
+        total = len(HELPDESK_MAIL_P2_SLICE) + 25
+        self.assertEqual(total, 28)
+        self.assertLess(total, 89)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements #571 (post code-review).

Reclassify helpdesk/mail/hr-OKR P2 path noise so the selective P2 slice closes true gaps with evidence rather than threshold gaming.

## Test plan
- [ ] focused tests
- [ ] workspace/tests green for touched crates

Fixes #571