### PR TITLE
fix(#572): optional thin high-frequency helper (docs/IM/workflow)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **workflow：高频 `create_task` helper（#572）**：
+  新增 `WorkflowTaskCreate` 输入类型与 `WorkflowService::create_task`，在既有
+  typed `CreateTaskRequest` 之上固化常见创建字段（标题/描述/截止/优先级/执行者/清单等），
+  返回业务 `CreateTaskResponse`。不新增 feature、不引入 registry 或双客户端栈。
+  覆盖：builder unit test、wiremock e2e、helper snapshot、`workflow_api_example` /
+  `communication_workflows` 示例，以及 helper 边界文档。
+
 - **ci(api-contracts)：docs 域 field strict gate（#569，0.20 首个 contract 域扩展）**：
   在 attendance field-monitor → strict（#534/#540）之后，将 live field 校验扩展到
   `openlark-docs`（ccm/base/baike/minutes，~214 API）并以 `--strict fields` 接入 CI

--- a/crates/openlark-workflow/src/lib.rs
+++ b/crates/openlark-workflow/src/lib.rs
@@ -15,8 +15,8 @@
 //!
 //! ```rust,no_run
 //! use openlark_workflow::{
-//!     ApprovalTaskAction, ApprovalTaskQuery, WorkflowService, WorkflowTaskListQuery,
-//!     WorkflowTaskMutation,
+//!     ApprovalTaskAction, ApprovalTaskQuery, WorkflowService, WorkflowTaskCreate,
+//!     WorkflowTaskListQuery, WorkflowTaskMutation,
 //! };
 //! use openlark_core::config::Config;
 //!
@@ -28,6 +28,15 @@
 //!
 //! let workflow_service = WorkflowService::new(config);
 //!
+//! // 创建任务
+//! let created = workflow_service
+//!     .create_task(
+//!         WorkflowTaskCreate::new("完成项目文档")
+//!             .priority(3)
+//!             .tasklist_guid("tasklist_guid"),
+//!     )
+//!     .await?;
+//!
 //! // 列取任务清单中的任务
 //! let tasks = workflow_service
 //!     .list_tasks_all(WorkflowTaskListQuery::for_tasklist("tasklist_guid"))
@@ -36,7 +45,7 @@
 //! // 更新任务
 //! let result = workflow_service
 //!     .mutate_task(
-//!         "task_guid",
+//!         &created.task_guid,
 //!         WorkflowTaskMutation::new()
 //!             .summary("完成项目文档")
 //!             .priority(3),
@@ -99,8 +108,8 @@ pub mod prelude;
 
 // 重新导出核心服务
 pub use service::{
-    ApprovalTaskAction, ApprovalTaskQuery, WorkflowService, WorkflowTaskListQuery,
-    WorkflowTaskMutation,
+    ApprovalTaskAction, ApprovalTaskQuery, WorkflowService, WorkflowTaskCreate,
+    WorkflowTaskListQuery, WorkflowTaskMutation,
 };
 
 // 重新导出 approval v4 用户级接口类型（用户态，需 user_access_token）

--- a/crates/openlark-workflow/src/prelude.rs
+++ b/crates/openlark-workflow/src/prelude.rs
@@ -3,7 +3,7 @@
 //! 这个模块重新导出了使用 workflow / approval helper 时最常需要的类型。
 
 pub use crate::{
-    ApprovalTaskAction, ApprovalTaskQuery, WorkflowService, WorkflowTaskListQuery,
-    WorkflowTaskMutation,
+    ApprovalTaskAction, ApprovalTaskQuery, WorkflowService, WorkflowTaskCreate,
+    WorkflowTaskListQuery, WorkflowTaskMutation,
 };
 pub use openlark_core::{SDKResult, config::Config};

--- a/crates/openlark-workflow/src/service.rs
+++ b/crates/openlark-workflow/src/service.rs
@@ -102,6 +102,106 @@ impl WorkflowTaskListQuery {
     }
 }
 
+/// 任务创建 helper。
+///
+/// 只覆盖高频创建字段（标题、描述、截止、优先级、执行者、所属清单等），
+/// 不试图替代完整 typed `CreateTaskRequest`（自定义字段 / 子任务 / 重复规则等仍走 typed API）。
+#[derive(Debug, Clone, PartialEq)]
+pub struct WorkflowTaskCreate {
+    /// 任务标题（必填）。
+    pub summary: String,
+    /// 任务描述。
+    pub description: Option<String>,
+    /// 开始时间。
+    pub start: Option<String>,
+    /// 截止时间。
+    pub due: Option<String>,
+    /// 优先级。
+    pub priority: Option<i32>,
+    /// 执行者。
+    pub assignee: Option<String>,
+    /// 任务清单 GUID。
+    pub tasklist_guid: Option<String>,
+    /// 分组 GUID。
+    pub section_guid: Option<String>,
+    /// 关注者。
+    pub followers: Option<Vec<String>>,
+    /// 提醒时间。
+    pub remind_time: Option<String>,
+}
+
+impl WorkflowTaskCreate {
+    /// 以必填标题创建任务描述。
+    pub fn new(summary: impl Into<String>) -> Self {
+        Self {
+            summary: summary.into(),
+            description: None,
+            start: None,
+            due: None,
+            priority: None,
+            assignee: None,
+            tasklist_guid: None,
+            section_guid: None,
+            followers: None,
+            remind_time: None,
+        }
+    }
+
+    /// 设置任务描述。
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// 设置开始时间。
+    pub fn start(mut self, start: impl Into<String>) -> Self {
+        self.start = Some(start.into());
+        self
+    }
+
+    /// 设置截止时间。
+    pub fn due(mut self, due: impl Into<String>) -> Self {
+        self.due = Some(due.into());
+        self
+    }
+
+    /// 设置优先级。
+    pub fn priority(mut self, priority: i32) -> Self {
+        self.priority = Some(priority);
+        self
+    }
+
+    /// 设置执行者。
+    pub fn assignee(mut self, assignee: impl Into<String>) -> Self {
+        self.assignee = Some(assignee.into());
+        self
+    }
+
+    /// 设置任务清单 GUID。
+    pub fn tasklist_guid(mut self, tasklist_guid: impl Into<String>) -> Self {
+        self.tasklist_guid = Some(tasklist_guid.into());
+        self
+    }
+
+    /// 设置分组 GUID。
+    pub fn section_guid(mut self, section_guid: impl Into<String>) -> Self {
+        self.section_guid = Some(section_guid.into());
+        self
+    }
+
+    /// 设置关注者列表。
+    pub fn followers(mut self, followers: Vec<String>) -> Self {
+        self.followers = Some(followers);
+        self
+    }
+
+    /// 设置提醒时间。
+    pub fn remind_time(mut self, remind_time: impl Into<String>) -> Self {
+        self.remind_time = Some(remind_time.into());
+        self
+    }
+}
+
 /// 任务变更 helper。
 ///
 /// 只覆盖高频可变字段，不试图替代完整 typed request。
@@ -356,6 +456,49 @@ impl WorkflowService {
         Ok(items)
     }
 
+    /// 使用 helper 风格创建任务（高频字段）。
+    ///
+    /// 在 typed `CreateTaskRequest` 之上固化常见创建动作，返回业务结果
+    /// `CreateTaskResponse`，而不是底层响应壳。
+    #[cfg(feature = "v2")]
+    pub async fn create_task(
+        &self,
+        create: WorkflowTaskCreate,
+    ) -> SDKResult<crate::v2::task::models::CreateTaskResponse> {
+        use crate::v2::task::create::CreateTaskRequest;
+
+        let mut request = CreateTaskRequest::new(self.config.clone()).summary(create.summary);
+        if let Some(description) = create.description {
+            request = request.description(description);
+        }
+        if let Some(start) = create.start {
+            request = request.start(start);
+        }
+        if let Some(due) = create.due {
+            request = request.due(due);
+        }
+        if let Some(priority) = create.priority {
+            request = request.priority(priority);
+        }
+        if let Some(assignee) = create.assignee {
+            request = request.assignee(assignee);
+        }
+        if let Some(tasklist_guid) = create.tasklist_guid {
+            request = request.tasklist_guid(tasklist_guid);
+        }
+        if let Some(section_guid) = create.section_guid {
+            request = request.section_guid(section_guid);
+        }
+        if let Some(followers) = create.followers {
+            request = request.followers(followers);
+        }
+        if let Some(remind_time) = create.remind_time {
+            request = request.remind_time(remind_time);
+        }
+
+        request.execute().await
+    }
+
     /// 使用 helper 风格更新任务高频字段。
     #[cfg(feature = "v2")]
     pub async fn mutate_task(
@@ -575,6 +718,37 @@ mod tests {
     }
 
     #[test]
+    fn test_task_create_builder() {
+        let create = WorkflowTaskCreate::new("编写 release notes")
+            .description("补齐 0.20 create_task helper")
+            .due("2026-08-01T18:00:00Z")
+            .start("2026-07-27T09:00:00Z")
+            .priority(2)
+            .assignee("ou_owner")
+            .tasklist_guid("tasklist_abc")
+            .section_guid("section_xyz")
+            .followers(vec!["ou_follower".to_string()])
+            .remind_time("2026-07-31T09:00:00Z");
+
+        assert_eq!(create.summary, "编写 release notes");
+        assert_eq!(
+            create.description.as_deref(),
+            Some("补齐 0.20 create_task helper")
+        );
+        assert_eq!(create.due.as_deref(), Some("2026-08-01T18:00:00Z"));
+        assert_eq!(create.start.as_deref(), Some("2026-07-27T09:00:00Z"));
+        assert_eq!(create.priority, Some(2));
+        assert_eq!(create.assignee.as_deref(), Some("ou_owner"));
+        assert_eq!(create.tasklist_guid.as_deref(), Some("tasklist_abc"));
+        assert_eq!(create.section_guid.as_deref(), Some("section_xyz"));
+        assert_eq!(
+            create.followers,
+            Some(vec!["ou_follower".to_string()])
+        );
+        assert_eq!(create.remind_time.as_deref(), Some("2026-07-31T09:00:00Z"));
+    }
+
+    #[test]
     fn test_approval_task_query_builder() {
         let query = ApprovalTaskQuery::new("ou_xxx", "1")
             .user_id_type("open_id")
@@ -605,6 +779,70 @@ mod tests {
         assert_eq!(action.user_id_type.as_deref(), Some("open_id"));
         assert_eq!(action.comment.as_deref(), Some("已确认"));
         assert_eq!(action.form.as_deref(), Some("[{}]"));
+    }
+
+    /// #572：create_task helper 透传高频字段并返回业务 CreateTaskResponse。
+    #[cfg(feature = "v2")]
+    #[tokio::test]
+    async fn test_create_task_helper_posts_high_frequency_fields() {
+        use wiremock::matchers::{body_partial_json, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/open-apis/task/v2/tasks"))
+            .and(body_partial_json(json!({
+                "summary": "编写 release notes",
+                "description": "补齐 0.20 create_task helper",
+                "priority": 2,
+                "assignee": "ou_owner",
+                "tasklist_guid": "tasklist_abc"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": {
+                    "task_guid": "task_created_001",
+                    "summary": "编写 release notes",
+                    "description": "补齐 0.20 create_task helper",
+                    "status": "todo",
+                    "tasklist_guid": "tasklist_abc",
+                    "section_guid": null,
+                    "created_at": "2026-07-27T00:00:00Z",
+                    "updated_at": "2026-07-27T00:00:00Z"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let service = WorkflowService::new(
+            Config::builder()
+                .app_id("ci_app_id")
+                .app_secret("ci_app_secret")
+                .base_url(server.uri())
+                .enable_token_cache(false)
+                .build(),
+        );
+
+        let response = service
+            .create_task(
+                WorkflowTaskCreate::new("编写 release notes")
+                    .description("补齐 0.20 create_task helper")
+                    .priority(2)
+                    .assignee("ou_owner")
+                    .tasklist_guid("tasklist_abc"),
+            )
+            .await
+            .expect("create_task 应在飞书成功响应时返回业务结果");
+
+        assert_eq!(response.task_guid, "task_created_001");
+        assert_eq!(response.summary, "编写 release notes");
+        assert_eq!(response.status, "todo");
+        assert_eq!(response.tasklist_guid.as_deref(), Some("tasklist_abc"));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].url.path(), "/open-apis/task/v2/tasks");
     }
 
     /// #350：approve/reject/resubmit 成功时返回 `Ok(())`，不再伪造恒真 `success`。

--- a/crates/openlark-workflow/src/service.rs
+++ b/crates/openlark-workflow/src/service.rs
@@ -741,10 +741,7 @@ mod tests {
         assert_eq!(create.assignee.as_deref(), Some("ou_owner"));
         assert_eq!(create.tasklist_guid.as_deref(), Some("tasklist_abc"));
         assert_eq!(create.section_guid.as_deref(), Some("section_xyz"));
-        assert_eq!(
-            create.followers,
-            Some(vec!["ou_follower".to_string()])
-        );
+        assert_eq!(create.followers, Some(vec!["ou_follower".to_string()]));
         assert_eq!(create.remind_time.as_deref(), Some("2026-07-31T09:00:00Z"));
     }
 

--- a/crates/openlark-workflow/tests/helper_snapshots.rs
+++ b/crates/openlark-workflow/tests/helper_snapshots.rs
@@ -3,7 +3,8 @@
 
 use insta::assert_json_snapshot;
 use openlark_workflow::{
-    ApprovalTaskAction, ApprovalTaskQuery, WorkflowTaskListQuery, WorkflowTaskMutation,
+    ApprovalTaskAction, ApprovalTaskQuery, WorkflowTaskCreate, WorkflowTaskListQuery,
+    WorkflowTaskMutation,
 };
 use serde_json::json;
 
@@ -15,6 +16,16 @@ fn workflow_helper_outputs_snapshot() {
         .sort(json!([{ "field": "updated_at", "order": "desc" }]))
         .user_type("open_id")
         .page_size(50);
+    let create = WorkflowTaskCreate::new("编写 release notes")
+        .description("补齐 0.20 create_task helper")
+        .start("2026-07-27T09:00:00Z")
+        .due("2026-08-01T18:00:00Z")
+        .priority(2)
+        .assignee("ou_owner")
+        .tasklist_guid("tasklist_abc")
+        .section_guid("section_xyz")
+        .followers(vec!["ou_follower".to_string()])
+        .remind_time("2026-07-31T09:00:00Z");
     let mutation = WorkflowTaskMutation::new()
         .summary("完成项目文档")
         .description("补齐 helper 快照测试")
@@ -43,6 +54,18 @@ fn workflow_helper_outputs_snapshot() {
                 "sort": list_query.sort,
                 "user_type": list_query.user_type,
                 "page_size": list_query.page_size,
+            },
+            "workflow_task_create": {
+                "summary": create.summary,
+                "description": create.description,
+                "start": create.start,
+                "due": create.due,
+                "priority": create.priority,
+                "assignee": create.assignee,
+                "tasklist_guid": create.tasklist_guid,
+                "section_guid": create.section_guid,
+                "followers": create.followers,
+                "remind_time": create.remind_time,
             },
             "workflow_task_mutation": {
                 "summary": mutation.summary,

--- a/crates/openlark-workflow/tests/snapshots/helper_snapshots__workflow_helper_outputs.snap
+++ b/crates/openlark-workflow/tests/snapshots/helper_snapshots__workflow_helper_outputs.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/openlark-workflow/tests/helper_snapshots.rs
-expression: "json!({\n    \"workflow_task_list_query\":\n    {\n        \"tasklist_guid\": list_query.tasklist_guid, \"section_guid\":\n        list_query.section_guid, \"filter\": list_query.filter, \"sort\":\n        list_query.sort, \"user_type\": list_query.user_type, \"page_size\":\n        list_query.page_size,\n    }, \"workflow_task_mutation\":\n    {\n        \"summary\": mutation.summary, \"description\": mutation.description,\n        \"due\": mutation.due, \"priority\": mutation.priority, \"assignee\":\n        mutation.assignee, \"status\": mutation.status,\n    }, \"approval_task_query\":\n    {\n        \"user_id\": approval_query.user_id, \"topic\": approval_query.topic,\n        \"user_id_type\": approval_query.user_id_type, \"status\":\n        approval_query.status, \"instance_code\": approval_query.instance_code,\n        \"page_size\": approval_query.page_size,\n    }, \"approval_task_action\":\n    {\n        \"approval_code\": approval_action.approval_code, \"instance_code\":\n        approval_action.instance_code, \"user_id\": approval_action.user_id,\n        \"task_id\": approval_action.task_id, \"user_id_type\":\n        approval_action.user_id_type, \"comment\": approval_action.comment,\n        \"form\": approval_action.form,\n    }\n})"
+expression: "json!({\n    \"workflow_task_list_query\":\n    {\n        \"tasklist_guid\": list_query.tasklist_guid, \"section_guid\":\n        list_query.section_guid, \"filter\": list_query.filter, \"sort\":\n        list_query.sort, \"user_type\": list_query.user_type, \"page_size\":\n        list_query.page_size,\n    }, \"workflow_task_create\":\n    {\n        \"summary\": create.summary, \"description\": create.description, \"start\":\n        create.start, \"due\": create.due, \"priority\": create.priority,\n        \"assignee\": create.assignee, \"tasklist_guid\": create.tasklist_guid,\n        \"section_guid\": create.section_guid, \"followers\": create.followers,\n        \"remind_time\": create.remind_time,\n    }, \"workflow_task_mutation\":\n    {\n        \"summary\": mutation.summary, \"description\": mutation.description,\n        \"due\": mutation.due, \"priority\": mutation.priority, \"assignee\":\n        mutation.assignee, \"status\": mutation.status,\n    }, \"approval_task_query\":\n    {\n        \"user_id\": approval_query.user_id, \"topic\": approval_query.topic,\n        \"user_id_type\": approval_query.user_id_type, \"status\":\n        approval_query.status, \"instance_code\": approval_query.instance_code,\n        \"page_size\": approval_query.page_size,\n    }, \"approval_task_action\":\n    {\n        \"approval_code\": approval_action.approval_code, \"instance_code\":\n        approval_action.instance_code, \"user_id\": approval_action.user_id,\n        \"task_id\": approval_action.task_id, \"user_id_type\":\n        approval_action.user_id_type, \"comment\": approval_action.comment,\n        \"form\": approval_action.form,\n    }\n})"
 ---
 {
   "approval_task_action": {
@@ -19,6 +19,20 @@ expression: "json!({\n    \"workflow_task_list_query\":\n    {\n        \"taskli
     "topic": "1",
     "user_id": "ou_xxx",
     "user_id_type": "open_id"
+  },
+  "workflow_task_create": {
+    "assignee": "ou_owner",
+    "description": "补齐 0.20 create_task helper",
+    "due": "2026-08-01T18:00:00Z",
+    "followers": [
+      "ou_follower"
+    ],
+    "priority": 2,
+    "remind_time": "2026-07-31T09:00:00Z",
+    "section_guid": "section_xyz",
+    "start": "2026-07-27T09:00:00Z",
+    "summary": "编写 release notes",
+    "tasklist_guid": "tasklist_abc"
   },
   "workflow_task_list_query": {
     "filter": "{\"status\":\"Todo\"}",

--- a/crates/openlark-workflow/tests/workflow_contract_models.rs
+++ b/crates/openlark-workflow/tests/workflow_contract_models.rs
@@ -8,7 +8,8 @@ use openlark_workflow::v2::custom_field::{
 use openlark_workflow::v2::task::{CreateTaskBody, ListTasksResponse};
 use openlark_workflow::v2::tasklist::{CreateTasklistBody, ListTasklistsResponse, TasklistIcon};
 use openlark_workflow::{
-    ApprovalTaskAction, ApprovalTaskQuery, WorkflowTaskListQuery, WorkflowTaskMutation,
+    ApprovalTaskAction, ApprovalTaskQuery, WorkflowTaskCreate, WorkflowTaskListQuery,
+    WorkflowTaskMutation,
 };
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -45,6 +46,32 @@ fn workflow_helper_models_preserve_builder_contracts() {
             sort: Some(json!([{ "field": "updated_at", "order": "desc" }])),
             user_type: Some("open_id".to_string()),
             page_size: Some(50),
+        }
+    );
+
+    let create = WorkflowTaskCreate::new("编写 release notes")
+        .description("补齐 create_task helper")
+        .start("2026-07-27T09:00:00Z")
+        .due("2026-08-01T18:00:00Z")
+        .priority(2)
+        .assignee("ou_owner")
+        .tasklist_guid("tasklist_abc")
+        .section_guid("section_xyz")
+        .followers(vec!["ou_follower".to_string()])
+        .remind_time("2026-07-31T09:00:00Z");
+    assert_eq!(
+        create,
+        WorkflowTaskCreate {
+            summary: "编写 release notes".to_string(),
+            description: Some("补齐 create_task helper".to_string()),
+            start: Some("2026-07-27T09:00:00Z".to_string()),
+            due: Some("2026-08-01T18:00:00Z".to_string()),
+            priority: Some(2),
+            assignee: Some("ou_owner".to_string()),
+            tasklist_guid: Some("tasklist_abc".to_string()),
+            section_guid: Some("section_xyz".to_string()),
+            followers: Some(vec!["ou_follower".to_string()]),
+            remind_time: Some("2026-07-31T09:00:00Z".to_string()),
         }
     );
 

--- a/docs/communication-workflow-helper-boundaries.md
+++ b/docs/communication-workflow-helper-boundaries.md
@@ -94,8 +94,10 @@
 
 - **任务流 helper**：
   - `WorkflowTaskListQuery`
+  - `WorkflowTaskCreate`
   - `WorkflowTaskMutation`
   - `list_tasks_all`
+  - `create_task`
   - `mutate_task`
   - `complete_task`
   - `reopen_task`
@@ -176,7 +178,7 @@
 
 | 能力 | 应留层级 | 原因 |
 |------|----------|------|
-| list/mutate/complete/reopen task | helper | 典型任务流动作 |
+| create/list/mutate/complete/reopen task | helper | 典型任务流动作 |
 | query/approve/reject/resubmit approval task | helper | 高频审批动作，但必须保留官方必填字段 |
 | approval instance/comment/external instance 深度能力 | typed API | 契约复杂、频率相对低 |
 

--- a/docs/helper-snapshot-scope.md
+++ b/docs/helper-snapshot-scope.md
@@ -35,6 +35,7 @@
 ### Workflow
 
 - `WorkflowTaskListQuery`
+- `WorkflowTaskCreate`
 - `WorkflowTaskMutation`
 - `ApprovalTaskQuery`
 - `ApprovalTaskAction`

--- a/examples/01_getting_started/communication_workflows.rs
+++ b/examples/01_getting_started/communication_workflows.rs
@@ -11,7 +11,8 @@
 
 use open_lark::prelude::*;
 use open_lark::workflow::{
-    ApprovalTaskAction, ApprovalTaskQuery, WorkflowTaskListQuery, WorkflowTaskMutation,
+    ApprovalTaskAction, ApprovalTaskQuery, WorkflowTaskCreate, WorkflowTaskListQuery,
+    WorkflowTaskMutation,
 };
 
 #[tokio::main]
@@ -91,6 +92,22 @@ async fn workflow_execution_flow(
     if let Ok(tasklist_guid) = std::env::var("OPENLARK_WORKFLOW_TASKLIST_GUID")
         && !tasklist_guid.trim().is_empty()
     {
+        if std::env::var("OPENLARK_WORKFLOW_CREATE_TASK")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+        {
+            let created = client
+                .workflow
+                .create_task(
+                    WorkflowTaskCreate::new("通过 helper 创建任务")
+                        .description("communication_workflows 示例")
+                        .priority(3)
+                        .tasklist_guid(&tasklist_guid),
+                )
+                .await?;
+            println!("任务创建完成: {}", created.task_guid);
+        }
+
         let tasks = client
             .workflow
             .list_tasks_all(

--- a/examples/docs/configuration.md
+++ b/examples/docs/configuration.md
@@ -66,13 +66,14 @@ cargo run --example websocket_echo_bot --features "communication,websocket"
 ## 说明
 
 - `client_setup` 默认只演示客户端初始化；当你提供 `OPENLARK_USER_SEARCH_NAME` / `OPENLARK_CHAT_SEARCH_NAME` 时，才会额外触发 user/chat lookup helper。
-- `communication_workflows` 会串起“查人/查群 -> 发消息”和“列任务 -> 更新任务 -> 处理审批”两类任务流。
+- `communication_workflows` 会串起“查人/查群 -> 发消息”和“创建/列任务 -> 更新任务 -> 处理审批”两类任务流。
 - `docs_helpers` 会按你是否提供相关 token，分别演示文件夹遍历、Drive 上传/下载、sheet 查找、批量读范围与多维表格读取；如需启用分片下载/批量写入演示，再额外设置 `OPENLARK_DOWNLOAD_RANGE_DEMO=1` / `OPENLARK_SHEETS_WRITE_DEMO=1`。
 - `docs_workflows` 会以任务流方式串起 Drive 文件流转、Spreadsheet 周报处理，以及 Wiki / Bitable 巡检流程。
 - `websocket_echo_bot` 需要额外完成飞书事件订阅和长连接配置。
 
 ## 风险提示
 
-- `communication_workflows` 在环境变量完整时，会执行真实的消息发送、任务更新和审批动作。
+- `communication_workflows` 在环境变量完整时，会执行真实的消息发送、任务创建/更新和审批动作；
+  任务创建需额外设置 `OPENLARK_WORKFLOW_CREATE_TASK=1`（与 `OPENLARK_WORKFLOW_TASKLIST_GUID` 联用）。
 - `workflow_api_example` 使用的是可编译的占位参数示例，适合先验证 helper 调用结构。
 - 如果你只想验证示例可编译，请不要设置这些动作相关环境变量，或保持其值为空。

--- a/examples/workflow_api_example.rs
+++ b/examples/workflow_api_example.rs
@@ -4,8 +4,8 @@
 
 use open_lark::CoreConfig;
 use open_lark::workflow::{
-    ApprovalTaskAction, ApprovalTaskQuery, WorkflowService, WorkflowTaskListQuery,
-    WorkflowTaskMutation,
+    ApprovalTaskAction, ApprovalTaskQuery, WorkflowService, WorkflowTaskCreate,
+    WorkflowTaskListQuery, WorkflowTaskMutation,
 };
 
 #[tokio::main]
@@ -17,6 +17,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build();
 
     let workflow_service = WorkflowService::new(config);
+
+    let created = workflow_service
+        .create_task(
+            WorkflowTaskCreate::new("完成项目文档")
+                .description("编写并完成 OpenLark SDK 的工作流模块文档")
+                .priority(3)
+                .tasklist_guid("tasklist_guid"),
+        )
+        .await?;
+    println!("任务创建成功: {}", created.task_guid);
 
     let tasks = workflow_service
         .list_tasks_all(
@@ -30,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = workflow_service
         .mutate_task(
-            "task_guid",
+            &created.task_guid,
             WorkflowTaskMutation::new()
                 .summary("完成项目文档")
                 .description("编写并完成 OpenLark SDK 的工作流模块文档")


### PR DESCRIPTION
## Summary
Implements #572 (post code-review).

Adds optional thin high-frequency helper for workflow (`create_task` over typed `CreateTaskRequest`).

## Test plan
- [ ] focused tests
- [ ] helper snapshots / contract models

Fixes #572