### PR TITLE
fix(#586): Contract & coverage gate institutionalization + next field-strict domain slot

### DIFF
--- a/docs/api-contract-validation.md
+++ b/docs/api-contract-validation.md
@@ -150,6 +150,7 @@ security_and_compliance 误配的回归 gate（与 endpoint strict gate 同级�
 |---|---|---|---|
 | attendance | `openlark-hr --biz-tag attendance`（~39 API） | CI `--strict fields` | #526 / #533 / #534 / #540 |
 | docs | `openlark-docs`（ccm/base/baike/minutes，~214 API） | CI `--strict fields` | #569（0.20 首批） |
+| *(next field-strict domain slot)* | 待选（**一域一 PR**） | 未 flip | 见 §1.6 admission |
 
 本地复现 docs 门禁：
 
@@ -165,6 +166,85 @@ python3 tools/validate_api_contracts.py \
 基线证据（#569 落地时 live 全量）：`0 error` / 仅 `WARN`（主要为
 `W_*_FIELDS_UNRESOLVED` 与 1 条 `W_REQUIRED_REQUEST_FIELD_OPTIONAL`，不阻塞 strict）。
 字段扫描器对 docs multipart（`UploadMeta` / `json!` 字面量）的识别见 #223 / #224。
+
+### 1.6 Trust gate inventory + next field-strict domain admission（#586）
+
+本节把 0.20 已落地的 contract / coverage trust gate **制度化**：CI green 必须继续
+表示「可调用准确性」，而不是「阈值被下调」或「域 gate 被静默删掉」。
+
+#### 1.6.1 Gate inventory（当前 pinned 清单）
+
+下列门禁由 `.github/workflows/ci.yml` 的 `api-contracts` job 执行，并由
+`tools/tests/test_validate_api_contracts_ci_gates.py`（gate inventory test）钉死。
+删除 / 放宽任一 pin 会让该 unittest 失败。
+
+| 层 | 范围 | CI 标志 | Inventory pin |
+|---|---|---|---|
+| Endpoint | monorepo 全仓离线 | `--all-crates --strict endpoint` | `test_endpoint_strict_covers_all_crates` |
+| Token | `openlark-security` + `openlark-auth` | `--strict tokens`（各一 step） | `test_token_strict_covers_security_and_auth` |
+| Field | attendance（`openlark-hr --biz-tag attendance`） | `--live-fields --strict fields` | `test_attendance_field_strict_gate` |
+| Field | docs（`openlark-docs`） | `--live-fields --strict fields` | `test_docs_field_strict_gate` |
+| Field inventory | **恰好** attendance + docs 两域 | 无 monorepo-wide field strict | `test_field_strict_inventory_is_exactly_attendance_and_docs` + `test_no_monorepo_wide_field_strict` |
+
+与 coverage 侧硬门禁的关系（**不在本 job 内执行，但同属 0.20 trust 程序**）：
+
+| 锁 | 位置 | 不得弱化 |
+|---|---|---|
+| Typed-coverage hard gates | `tools/typed_coverage_release.toml` + `docs/typed-coverage-release-criteria.md` | 阈值不得下调（见 #586 非目标） |
+| path_noise vs true_gap 分类 | `tools/validate_apis.py` 报告 + denoise 回归测试 | 分类保留；不得把噪音当「实现完成」删掉真相 |
+| Core-business P0 missing = 0 | release gate / `core_business` dashboard | 不得靠降低门槛伪装 PASS |
+| Platform P1 clear-or-disprove | `tools/tests/test_p1_platform_clear_or_disprove.py` | 锁仍绿 |
+| Selective P2 path_noise | `tools/tests/test_p2_selective_slice.py` | 锁仍绿 |
+
+本地复核 inventory（离线、秒级；不跑 live fields/tokens）：
+
+```bash
+python3 -m unittest tools.tests.test_validate_api_contracts_ci_gates -v
+python3 -m unittest tools.tests.test_typed_coverage_release_policy -v
+```
+
+#### 1.6.2 Next field-strict domain admission（下一域准入）
+
+**Slot**：上表「next field-strict domain slot」——每次只接纳 **一个** 新域进入
+CI `--strict fields`。本 ticket（#586）只制度化 slot + 规则 + 绿 inventory，
+**不**在本变更中 flip 第三个域。
+
+Admission 准入条件（全部满足才允许 flip）：
+
+1. **一域一 PR**：候选域必须单独成 PR（或明确 scoped 子单元），不得与无关重构混装。
+2. **Live baseline 必须 0 ERROR**：对候选域先跑 live field 校验，报告中
+   `ERROR` 计数为 0 后，才允许把该域 step 以 `--strict fields` 写入 CI。
+   `WARN` / `UNVERIFIED` 可带入（与 attendance/docs 先例一致），但不得靠
+   关掉 strict 或缩小扫描范围「假绿」。
+3. **Dual-edit（双改）规则**：同一变更必须同时更新：
+   - `.github/workflows/ci.yml` 的 `api-contracts` job（新增 domain-scoped step）；
+   - `tools/tests/test_validate_api_contracts_ci_gates.py` 的
+     `FIELD_STRICT_DOMAINS` inventory 与对应断言；
+   - 本节域表（§1.5）把 slot 行改成新域的「已 flip」状态。
+   只改 workflow 或只改测试 = 审查拒绝。
+4. **域范围显式**：step 必须带 `--crate …`（及必要时 `--biz-tag …`），
+   report-dir 使用 `api_contract_fields/<domain>` 风格片段，便于 inventory 钉死。
+
+推荐本地基线命令（以假设候选 `openlark-communication` 为例，**非**已 flip 域）：
+
+```bash
+python3 tools/validate_api_contracts.py \
+  --crate openlark-communication \
+  --fields \
+  --live-fields \
+  --report-dir /tmp/openlark-api-contracts-candidate-fields
+# 仅当 0 ERROR 后，再在 PR 中加 --strict fields 并 dual-edit inventory
+```
+
+#### 1.6.3 非目标（Explicit non-goals）
+
+- **禁止 monorepo-wide field strict**：不得用 `--all-crates --strict fields`
+  （或等价「一次打开全仓 fields」）替代域批推进。
+- **禁止 hard-gate 阈值下调**：不得为了让 typed-coverage / contract CI 变绿而降低
+  `tools/typed_coverage_release.toml` 中的 hard gate 阈值；阈值变更必须是独立
+  policy PR，且只能升高或维持，不得降低。
+- **本制度化单元不 march 新域**：#586 交付 slot + rules + green inventory，
+  不实现第三个域的 full field-strict flip（除非作为文档示例命令，且不写入 CI）。
 
 ## 2. 单 crate 使用
 

--- a/docs/typed-coverage-release-criteria.md
+++ b/docs/typed-coverage-release-criteria.md
@@ -110,3 +110,19 @@ waiver 至少需要满足：
 - 自动阻断脚本
 
 这些自动化接入可以在后续发布流程 issue 中完成，但应直接复用这里的输入与门槛。
+
+### 7.1 阈值纪律（#586 institutionalization）
+
+Hard gate 阈值是 0.20 trust 程序的一部分：**不得下调**（must not lower）阈值来
+换取 CI / 发布 PASS。具体：
+
+- `summary_completion_rate_min` / `core_business_completion_rate_min` /
+  `core_crate_completion_rate_min` 的制度化地板由
+  `tools/tests/test_typed_coverage_release_policy.py` 钉死；
+- 任何阈值变更必须是独立 policy PR，且只允许升高或维持，禁止降低；
+- 与 contract 侧「禁止 monorepo-wide field strict、一域一 PR」规则一起，保证
+  “CI green” 继续表示可调用准确性，而不是门槛被游戏。
+
+分类纪律（path_noise vs true_gap）同样不得为了刷完成度而删除：噪音匹配必须
+保留 evidence，真缺口继续计入 `true_missing`。详见
+`docs/typed-api-coverage.md` 与 `docs/api-contract-validation.md` §1.6。

--- a/tools/tests/test_typed_coverage_release_policy.py
+++ b/tools/tests/test_typed_coverage_release_policy.py
@@ -1,3 +1,9 @@
+"""Pin typed-coverage release hard-gate floors (#586 institutionalization).
+
+Thresholds may only rise (or stay) via an explicit policy PR — never lower
+to force PASS. Floor pins below are the 0.20 institutionalized values.
+"""
+
 import tomllib
 import unittest
 from pathlib import Path
@@ -5,6 +11,12 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 POLICY_PATH = ROOT / "tools" / "typed_coverage_release.toml"
+CRITERIA_DOC = ROOT / "docs" / "typed-coverage-release-criteria.md"
+
+# 0.20 institutionalized floors — do not lower without an explicit policy PR.
+SUMMARY_COMPLETION_FLOOR = 93.0
+CORE_BUSINESS_COMPLETION_FLOOR = 92.0
+CORE_CRATE_COMPLETION_FLOOR = 80.0
 
 
 class TypedCoverageReleasePolicyTests(unittest.TestCase):
@@ -22,14 +34,44 @@ class TypedCoverageReleasePolicyTests(unittest.TestCase):
         self.assertIn("reporting", stable_release)
 
         hard_gates = stable_release["hard_gates"]
-        self.assertGreaterEqual(hard_gates["summary_completion_rate_min"], 0)
-        self.assertGreaterEqual(hard_gates["core_business_completion_rate_min"], 0)
-        self.assertGreaterEqual(hard_gates["core_crate_completion_rate_min"], 0)
+        self.assertGreaterEqual(
+            hard_gates["summary_completion_rate_min"], SUMMARY_COMPLETION_FLOOR
+        )
+        self.assertGreaterEqual(
+            hard_gates["core_business_completion_rate_min"],
+            CORE_BUSINESS_COMPLETION_FLOOR,
+        )
+        self.assertGreaterEqual(
+            hard_gates["core_crate_completion_rate_min"], CORE_CRATE_COMPLETION_FLOOR
+        )
 
         waiver = stable_release["waiver"]
         self.assertIn("maintainer", waiver["required_approvers"])
         self.assertIn("domain-owner", waiver["required_approvers"])
         self.assertIn("target_release", waiver["required_fields"])
+
+    def test_hard_gate_floors_are_not_lowered(self):
+        """#586 non-goal: no hard-gate threshold lowering to game CI green."""
+        payload = tomllib.loads(POLICY_PATH.read_text(encoding="utf-8"))
+        hard_gates = payload["stable_release"]["hard_gates"]
+        self.assertEqual(
+            hard_gates["summary_completion_rate_min"], SUMMARY_COMPLETION_FLOOR
+        )
+        self.assertEqual(
+            hard_gates["core_business_completion_rate_min"],
+            CORE_BUSINESS_COMPLETION_FLOOR,
+        )
+        self.assertEqual(
+            hard_gates["core_crate_completion_rate_min"], CORE_CRATE_COMPLETION_FLOOR
+        )
+
+    def test_criteria_doc_restates_no_threshold_lowering(self):
+        text = CRITERIA_DOC.read_text(encoding="utf-8")
+        self.assertRegex(
+            text,
+            r"不得下调|must not lower|不.*降低.*阈值|threshold.*not lower|no.*threshold lowering",
+            "criteria doc must restate non-goal: no hard-gate threshold lowering",
+        )
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_validate_api_contracts_ci_gates.py
+++ b/tools/tests/test_validate_api_contracts_ci_gates.py
@@ -1,8 +1,13 @@
 """Pin the domain list of CI api-contracts strict gates.
 
-These assertions are the seam for domain-by-domain contract expansion (#566/#569):
-adding a new strict domain must update both `.github/workflows/ci.yml` and this
-test so the gate inventory cannot drift silently.
+These assertions are the seam for domain-by-domain contract expansion
+(#566/#569/#586): adding a new strict domain must update **both**
+`.github/workflows/ci.yml` and this test so the gate inventory cannot
+drift silently (dual-edit rule).
+
+Also pins the admission-policy docs that define how the *next*
+field-strict domain is admitted — see
+`docs/api-contract-validation.md` §1.5 / §1.6.
 """
 
 from __future__ import annotations
@@ -14,6 +19,25 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 CI_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "ci.yml"
+CONTRACT_POLICY_DOC = ROOT / "docs" / "api-contract-validation.md"
+
+# Canonical field-strict inventory for the institutionalization gate (#586).
+# Expanding this list requires the dual-edit: ci.yml step + this constant +
+# the inventory assertions below, in the *same* PR.
+FIELD_STRICT_DOMAINS = (
+    {
+        "name": "attendance",
+        "crate": "openlark-hr",
+        "biz_tag": "attendance",
+        "report_dir_fragment": "api_contract_fields/attendance",
+    },
+    {
+        "name": "docs",
+        "crate": "openlark-docs",
+        "biz_tag": None,
+        "report_dir_fragment": "api_contract_fields/docs",
+    },
+)
 
 
 def _api_contracts_job(workflow: str) -> str:
@@ -44,6 +68,10 @@ class ApiContractsCiGatesTests(unittest.TestCase):
         self.assertIn("--biz-tag attendance", self.job)
         self.assertIn("--strict fields", self.job)
         self.assertIn("api_contract_fields/attendance", self.job)
+        attendance_block = self._step_run_block_containing("--biz-tag attendance")
+        self.assertIn("--fields", attendance_block)
+        self.assertIn("--live-fields", attendance_block)
+        self.assertIn("--strict fields", attendance_block)
 
     def test_docs_field_strict_gate(self) -> None:
         """First 0.20 domain expansion beyond attendance (#569).
@@ -59,10 +87,107 @@ class ApiContractsCiGatesTests(unittest.TestCase):
         self.assertIn("--live-fields", docs_block)
         self.assertIn("--strict fields", docs_block)
 
+    def test_field_strict_inventory_is_exactly_attendance_and_docs(self) -> None:
+        """Institutionalized inventory: only the admitted domains are field-strict.
+
+        Adding a third domain is intentional expansion — update
+        FIELD_STRICT_DOMAINS + ci.yml + admission docs together (#586 dual-edit).
+        """
+        strict_fields_steps = [
+            block
+            for block in self._step_run_blocks()
+            if "--strict fields" in block
+        ]
+        self.assertEqual(
+            len(strict_fields_steps),
+            len(FIELD_STRICT_DOMAINS),
+            "field-strict step count must match FIELD_STRICT_DOMAINS inventory",
+        )
+        for domain in FIELD_STRICT_DOMAINS:
+            self.assertIn(f"--crate {domain['crate']}", self.job)
+            self.assertIn(domain["report_dir_fragment"], self.job)
+            if domain["biz_tag"] is not None:
+                self.assertIn(f"--biz-tag {domain['biz_tag']}", self.job)
+
+    def test_no_monorepo_wide_field_strict(self) -> None:
+        """Non-goal: never open monorepo-wide --strict fields in one shot (#586)."""
+        for block in self._step_run_blocks():
+            if "--strict fields" not in block:
+                continue
+            self.assertNotIn(
+                "--all-crates",
+                block,
+                "field-strict must stay domain-scoped; do not pair "
+                "--all-crates with --strict fields",
+            )
+
+    def test_admission_policy_doc_defines_next_domain_slot(self) -> None:
+        """Docs pin admission criteria + dual-edit + non-goals for next domain."""
+        self.assertTrue(
+            CONTRACT_POLICY_DOC.is_file(),
+            f"missing contract policy doc: {CONTRACT_POLICY_DOC}",
+        )
+        text = CONTRACT_POLICY_DOC.read_text(encoding="utf-8")
+
+        # Next-domain admission criteria (slot + rules).
+        self.assertRegex(
+            text,
+            r"next field-strict domain|下一[个个]? field-strict 域|下一域 admission",
+            "docs must name the next field-strict domain admission slot",
+        )
+        self.assertRegex(
+            text,
+            r"0\s*ERROR|0 error|live baseline",
+            "docs must require live baseline 0 ERROR before flipping strict",
+        )
+        self.assertRegex(
+            text,
+            r"dual-edit|双改|workflow.*inventory|ci\.yml.*inventory|gate inventory",
+            "docs must state the dual-edit rule (workflow + inventory test)",
+        )
+
+        # Explicit non-goals restated.
+        self.assertRegex(
+            text,
+            r"monorepo[- ]wide|--all-crates.*--strict fields|全仓.*strict fields",
+            "docs must restate non-goal: no monorepo-wide field strict",
+        )
+        self.assertRegex(
+            text,
+            r"threshold|阈值",
+            "docs must restate non-goal: no hard-gate threshold lowering",
+        )
+
+        # Current inventory still named so the slot is relative to known domains.
+        self.assertIn("attendance", text)
+        self.assertIn("openlark-docs", text)
+        self.assertIn("test_validate_api_contracts_ci_gates", text)
+
+    def test_gate_inventory_verification_section_present(self) -> None:
+        """Written verification that 0.20 trust gates remain pinned (#586 AC)."""
+        text = CONTRACT_POLICY_DOC.read_text(encoding="utf-8")
+        self.assertRegex(
+            text,
+            r"gate inventory|门禁清单|trust gate",
+            "docs must include a written gate-inventory verification section",
+        )
+        # Endpoint + token + field layers must all be listed.
+        self.assertIn("--strict endpoint", text)
+        self.assertIn("--strict tokens", text)
+        self.assertIn("--strict fields", text)
+        # Coverage locks referenced (not weakened).
+        self.assertRegex(
+            text,
+            r"typed.coverage|typed_coverage_release|path_noise|true_gap",
+            "docs must reference typed-coverage / path_noise locks",
+        )
+
+    def _step_run_blocks(self) -> list[str]:
+        return re.split(r"(?m)^(?=      - (?:name|uses):)", self.job)
+
     def _step_run_block_containing(self, needle: str) -> str:
         # Split on step headers (`- name:` / `- uses:`) at the job step indent.
-        parts = re.split(r"(?m)^(?=      - (?:name|uses):)", self.job)
-        for block in parts:
+        for block in self._step_run_blocks():
             if needle in block:
                 return block
         self.fail(f"no api-contracts step contains {needle!r}")


### PR DESCRIPTION
## Summary
Implements #586 (post code-review).

Institutionalizes the 0.20 trust gates so “CI green” continues to mean callable accuracy:
- Verifies monorepo endpoint contract strict, token strict, field strict (attendance + docs), typed-coverage hard gates, and P0/P1 locks remain pinned without threshold gaming
- Documents expansion policy for the **next** field-strict domain (one domain per PR; live baseline 0 ERROR before flip; dual-edit workflow + inventory unittest)
- Explicit non-goal: no monorepo-wide `--strict fields`; no hard-gate threshold lowering

## Test plan
- [ ] focused policy/CI unittests (`tools/tests/test_typed_coverage_release_policy.py`, `tools/tests/test_validate_api_contracts_ci_gates.py`)
- [ ] gate inventory pins attendance + docs field-strict (and endpoint/token strict) unchanged
- [ ] docs describe next field-strict domain admission criteria and dual-edit rule

Fixes #586