### PR TITLE
fix(#591): cut v0.20.0 tag and verify publish

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,9 +9,8 @@
 
 ## 当前发布窗口：0.20.0
 
-**状态：** 打包中 — workspace identity `0.20.0` + pre-release GO（#573 AC1–AC3）；annotated tag /
-stable GitHub Release / crates.io 为 **post-merge cut**（#573 AC4，同 0.19 #560 纪律；**no tag before GO**）。  
-#573 在 cut 验证前保持 open（packaging 用 `Refs #573`，勿 `Fixes`）。  
+**状态：** 已发布 — annotated tag `v0.20.0`、stable GitHub Release、crates.io `0.20.0`（#591）。  
+**Cut 记录：** [`docs/0.20.0_RELEASE_CUT.md`](docs/0.20.0_RELEASE_CUT.md)  
 **Sign-off：** [`docs/0.20.0_RELEASE_SIGNOFF.md`](docs/0.20.0_RELEASE_SIGNOFF.md)  
 **完整条目：** [`CHANGELOG.md` → `## [0.20.0]`](CHANGELOG.md)  
 **消费者升级：** [`docs/migration-guide.md` → OpenLark 0.20](docs/migration-guide.md)

--- a/docs/0.20.0_RELEASE_CUT.md
+++ b/docs/0.20.0_RELEASE_CUT.md
@@ -1,0 +1,130 @@
+# OpenLark 0.20.0 Release Cut
+
+| Field | Value |
+| --- | --- |
+| Version | `0.20.0` |
+| Cut date (UTC) | 2026-07-27 |
+| Tagged commit (peeled) | `063e50c4c0fc67b48aa219ac730f684e4e397c58` |
+| Annotated tag object | `dc1763cc1f0196c1271b68d07b3a043df921c7c7` |
+| Issue | #591 (parent #566 residual; continues deferred #573 AC4 after #580 packaging GO) |
+| Sign-off | [`docs/0.20.0_RELEASE_SIGNOFF.md`](./0.20.0_RELEASE_SIGNOFF.md) |
+| Decision | **SHIPPED** — tag, GitHub Release, and crates.io publish verified |
+
+This document is the in-repo reviewable record for cutting `v0.20.0` and verifying
+the release workflow. Publish was performed by `.github/workflows/release.yml` after
+the annotated tag was pushed.
+
+## 1. Pre-cut entry contract
+
+| Check | Result |
+| --- | --- |
+| `cargo metadata` openlark version | `0.20.0` |
+| Workspace publishable crate versions aligned | all `0.20.0` (except `openlark-capability-unique` publish=false) |
+| `CHANGELOG.md` has `## [0.20.0] - 2026-07-27` | yes |
+| Pre-release sign-off | GO (#573 packaging / #580; residual cut #591) |
+| Hard gates unchanged (`tools/typed_coverage_release.toml`) | 93.0 / 92.0 / 80.0 (no threshold changes) |
+| Main CI on tagged SHA (CI / Feature Matrix / Coverage / 质量门禁 / Security) | all success |
+| Existing `v0.20.0` tag | none (pre-cut) |
+
+Post-GO commits on main after packaging `a235df0423` are non-product rework only
+(catalog sync #581, ADR/docs #584/#586, CI policy #585/#589). Tag cut at main tip
+per issue guidance (“later main if only non-release docs/policy landed after GO”).
+
+## 2. Tag
+
+```bash
+git tag -a v0.20.0 -m "Release v0.20.0" 063e50c4c0fc67b48aa219ac730f684e4e397c58
+git push origin v0.20.0
+```
+
+| Property | Value |
+| --- | --- |
+| Tag name | `v0.20.0` |
+| Kind | annotated + GPG-signed (`tag.gpgsign=true`) |
+| Tagger | ZoOL \<zhooul@gmail.com\> |
+| Message | `Release v0.20.0` |
+| Points to | main tip after packaging GO + non-release docs/policy |
+
+## 3. Release workflow
+
+| Field | Value |
+| --- | --- |
+| Run | https://github.com/foxzool/openlark/actions/runs/30253325537 |
+| Overall | **success** |
+| Started (UTC) | 2026-07-27T09:17:45Z |
+| Finished (UTC) | 2026-07-27T09:51:19Z |
+
+| Job | Result |
+| --- | --- |
+| `validate` (fmt / clippy / test / public examples / doc) | success |
+| `github-release` | success |
+| `crates-io-release` | success |
+
+### Version match (crates-io-release)
+
+Workflow log:
+
+```
+Cargo (openlark) version: 0.20.0
+Tag version: 0.20.0
+✅ Version verification passed
+```
+
+## 4. GitHub Release
+
+| Field | Value |
+| --- | --- |
+| Name | Release v0.20.0 |
+| URL | https://github.com/foxzool/openlark/releases/tag/v0.20.0 |
+| Prerelease | **false** (stable) |
+| Draft | **false** |
+| Notes source | `CHANGELOG.md` `## [0.20.0]` section + quality-status appendix |
+
+## 5. crates.io publish
+
+Publish order from `scripts/publish-workspace.sh`. All 20 publishable crates reached
+`0.20.0` with no failures (no “already uploaded” roll-forward needed).
+
+| Crate | crates.io max version |
+| --- | --- |
+| openlark-core | 0.20.0 |
+| openlark-auth | 0.20.0 |
+| openlark-security | 0.20.0 |
+| openlark-communication | 0.20.0 |
+| openlark-cardkit | 0.20.0 |
+| openlark-webhook | 0.20.0 |
+| openlark-docs | 0.20.0 |
+| openlark-hr | 0.20.0 |
+| openlark-ai | 0.20.0 |
+| openlark-application | 0.20.0 |
+| openlark-platform | 0.20.0 |
+| openlark-meeting | 0.20.0 |
+| openlark-helpdesk | 0.20.0 |
+| openlark-mail | 0.20.0 |
+| openlark-bot | 0.20.0 |
+| openlark-workflow | 0.20.0 |
+| openlark-analytics | 0.20.0 |
+| openlark-user | 0.20.0 |
+| openlark-client | 0.20.0 |
+| openlark | 0.20.0 |
+
+Workflow closing line: `🎉 All crates published successfully!`
+
+## 6. Acceptance criteria mapping (#591)
+
+| Criterion | Status |
+| --- | --- |
+| Annotated tag `v0.20.0` on intended release commit | **PASS** |
+| Release workflow version match (Cargo == tag) | **PASS** |
+| GitHub Release stable (not prerelease) with usable notes | **PASS** |
+| Publishable workspace crates on crates.io at `0.20.0` | **PASS** (20/20) |
+| Publish failures triaged / rolled forward | **N/A** (zero failures) |
+| In-repo cut record documents SHA / tag / Release / crates.io | **PASS** (this file) |
+
+## 7. Residual notes
+
+- Tag was cut from main tip after #580 packaging GO, including post-GO catalog sync
+  and CI/docs institutionalization commits; workspace identity remains `0.20.0`.
+- Packaging GO tree base was `f8098960…`; packaging merge SHA `a235df0423` (#580).
+- `openlark-capability-unique` remains `publish = false` (internal trybuild helper).
+- Deferred #573 AC4 is satisfied by this cut; parent residual #591 is the ship ticket.

--- a/docs/0.20.0_RELEASE_SIGNOFF.md
+++ b/docs/0.20.0_RELEASE_SIGNOFF.md
@@ -9,8 +9,8 @@
 | Issue | #573 (parent #566; blocked by #567–#571 — all closed) |
 | Unit scope | **Packaging + pre-release GO only** (AC1–AC3). Does **not** cut tag or publish. |
 | Decision | **GO — allowed to tag `v0.20.0`** after this packaging lands on `main` |
-| Next step | Annotated tag + GitHub Release + crates.io publish (post-merge cut; no tag before GO) |
-| Issue close policy | Use `Refs #573` on packaging commits — **do not** `Fixes #573` until AC4 cut verifies |
+| Next step | Annotated tag + GitHub Release + crates.io publish — **done**, see [`0.20.0_RELEASE_CUT.md`](./0.20.0_RELEASE_CUT.md) (#591) |
+| Issue close policy | Packaging used `Refs #573`; cut verification is #591 / this cut record |
 
 This document is the in-repo reviewable record for the 0.20 pre-release
 compatibility + coverage gates. Transient machine artifacts under `reports/`


### PR DESCRIPTION
## Summary
Implements #591 (post code-review).

Records the v0.20.0 release cut and publish verification evidence in-repo after the packaging/GO path already on main.

## Test plan
- [ ] Confirm `docs/0.20.0_RELEASE_CUT.md` (or equivalent cut record) documents tag SHA / Release / crates.io evidence
- [ ] Confirm annotated tag `v0.20.0` and stable GitHub Release exist
- [ ] Confirm publishable workspace crates are on crates.io at `0.20.0` (or failures are triaged in the cut record)

Fixes #591