### PR TITLE
docs(skills): close Feishu doc-fetch → implement → field-verify loop

### DIFF
--- a/.agents/skills/openlark-api-field-verify/SKILL.md
+++ b/.agents/skills/openlark-api-field-verify/SKILL.md
@@ -9,24 +9,26 @@ allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 ## 🧭 技能路由指南
 
 **本技能适用场景：**
-- 新增/重构飞书 API 后，需要核对请求体/响应体字段是否与官方文档一致
+- **实现前/后**读取飞书官方文档字段（本仓库唯一可靠的文档抓取入口）
+- 新增/重构飞书 API 后，核对请求体/响应体字段是否与官方文档一致
 - 怀疑某个 API 的字段是"推断"而非来自真实文档（如参照同族接口复制）
 - 用户级（user_access_token）接口的字段核对（这类接口字段常与应用级不同）
-- `fetch_docpath.py` 抓取失败（返回占位文本），需要替代方案
+- `fetch_docpath.py` 在线抓取失败（返回占位文本），需要替代方案
 
 **其他技能：**
-- 添加/重构 API 的实现规范 → `Skill(openlark-api)`
+- 添加/重构 API 的实现规范 → `Skill(openlark-api)`（读文档后回此技能核对，或实现时先来此抓取）
 - 统计 API 覆盖率/缺失清单 → `Skill(openlark-api-validation)`
 - 代码规范、风格一致性 → `Skill(openlark-code-standards)`
 
 ### 关键词触发映射
 
-- 字段核对、字段验证、字段不符、文档核对、核对请求字段、核对响应字段 → `openlark-api-field-verify`
+- 字段核对、字段验证、字段不符、文档核对、核对请求字段、核对响应字段、飞书文档、playwright 抓文档 → `openlark-api-field-verify`
 - 新增 API、重构 API、Builder、Request/Response → `openlark-api`
 - 覆盖率、缺失 API、CSV 对比 → `openlark-api-validation`
 
 ### 双向跳转规则
 
+- **`openlark-api` 需要读文档时必须来本技能**（勿用 `fetch_docpath.py` 在线抓取）
 - 若核对发现字段不符需要修正实现，转 `openlark-api` 落地修正
 - 若核对发现是 API 尚未实现，转 `openlark-api` 补齐
 - 若核对根源是覆盖率脚本误报，转 `openlark-api-validation`
@@ -59,27 +61,30 @@ allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 
 ### 第 1 步：找到正确的文档 URL
 
-**这是最易错的一步。** 飞书文档 URL 有两种路径格式，**不能混用**：
+**这是最易错的一步。** URL **唯一权威源**是 CSV 的 `fullPath`：
 
-| 文档类型 | URL 格式 | 说明 |
-|---------|---------|------|
-| 旧版/server-docs | `/document/server-docs/{project}-{version}/{resource}-{name}` | 用 `-` 连接，如 `approval-v4/task-pass` |
-| **新版/reference** | `/document/uAjLw4CM/ukTMukTMukTM/reference/{project}/{version}/{resource}/{name}` | 用 `/` 分层 |
+```text
+canonical_url = "https://open.feishu.cn" + fullPath
+```
 
-**判断方法：从 `api_list_export.csv` 的 `fullPath` 字段取真实路径**，不要自己拼：
+| 来源 | 是否可用 | 说明 |
+|------|---------|------|
+| `fullPath` | ✅ 唯一权威 | 原样拼接，不要改路径格式 |
+| `docPath` | ❌ 默认勿用 | 常与 `fullPath` 不一致（大量 server-docs vs 实际路径） |
+| 手拼 `/reference/...` 或 `/server-docs/...` | ❌ 禁止 | 易 404："The documentation could not be found." |
 
 ```bash
-# 从 CSV 查某个 API 的真实 fullPath（用 url 反查）
+# 从 CSV 用 api id 或 url 反查 fullPath
 python3 -c "
 import csv
 with open('api_list_export.csv', encoding='utf-8-sig') as f:
     for row in csv.DictReader(f):
-        if 'approval/v4/tasks/pass' in row['url']:
-            print(row['fullPath'])  # 真实路径，拼到 https://open.feishu.cn 后面
+        if row['id'] == '7642253323628383198' or 'approval/v4/tasks/pass' in row['url']:
+            print(row['fullPath'])
 "
 ```
 
-> ⚠️ 若用错路径格式，页面会显示 "The documentation could not be found."，**这不是抓取失败，是 URL 错了**。
+> ⚠️ 若用错路径，页面会显示 "The documentation could not be found."，**这不是抓取失败，是 URL 错了**。
 
 ### 第 2 步：用 playwright 渲染抓取
 
@@ -96,21 +101,28 @@ npx playwright install chromium  # 装匹配版本（约 170MB）
 #### 抓取单页
 
 ```bash
+# 推荐：按 CSV api-id（脚本内用 fullPath 拼 URL）
+node .agents/skills/openlark-api-field-verify/scripts/fetch_doc.js \
+  --from-csv 7642253323628383198 \
+  --out /tmp/doc_pass.txt
+
+# 或直接传完整 URL / fullPath
 node .agents/skills/openlark-api-field-verify/scripts/fetch_doc.js \
   "https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/approval-v4/task/pass" \
   /tmp/doc_pass.txt
 ```
 
-脚本会 `waitUntil: 'networkidle'` + 多次延时 + 滚动触发懒加载，导出完整 `innerText`。正常应抓到 5000-8000 字符；若 < 500 字符，说明 URL 错或页面没渲染（回第 1 步检查 URL）。
+脚本会 `waitUntil: 'networkidle'` + 多次延时 + 滚动触发懒加载，导出完整 `innerText`。正常应抓到 5000-8000 字符；若 < 500 字符，说明 URL 错或页面没渲染（回第 1 步检查 URL）。**实现前抓取失败不得继续写字段。**
 
 #### 批量抓取
+
+传入 **完整 fullPath 或完整 URL**（勿再传「去掉前缀的短 path」——旧用法会错误拼到 `/reference/` 下）：
 
 ```bash
 node .agents/skills/openlark-api-field-verify/scripts/fetch_doc.js \
   --batch \
-  approval-v4/instance/add_cc \
-  approval-v4/instance/detail \
-  approval-v4/task/pass \
+  /document/uAjLw4CM/ukTMukTMukTM/reference/approval-v4/instance/add_cc \
+  /document/uAjLw4CM/ukTMukTMukTM/reference/approval-v4/task/pass \
   --out-dir /tmp/docs
 ```
 
@@ -129,8 +141,8 @@ python3 tools/verify_api_fields.py --crate openlark-workflow
 # 完整模式：抓飞书文档对比字段（慢，约 8 秒/API，默认跳过已缓存）
 python3 tools/verify_api_fields.py --crate openlark-workflow --fetch-docs
 
-# 单个 API 调试（只跑可疑模式检测，不抓文档）
-python3 tools/verify_api_fields.py --api-id 7642253323628383198
+# 单个 API 核对门禁（实现后必做）：抓文档对比
+python3 tools/verify_api_fields.py --api-id 7642253323628383198 --fetch-docs
 ```
 
 工具自动完成路径解析、字段提取、文档抓取、差异对比，输出 `reports/api_field_verify/` 报告。
@@ -200,23 +212,25 @@ awk '/^Response body example$/{p=1} /^Error code$/{p=0} p' doc_xxx.txt \
 
 ### scripts/fetch_doc.js
 
-playwright 渲染抓取脚本，两种用法：
-- 单页：`node fetch_doc.js <url> <out.txt>`
-- 批量：`node fetch_doc.js --batch <path1> <path2> ... --out-dir <dir>`
+playwright 渲染抓取脚本（本仓库读飞书文档的**唯一在线入口**）：
 
-脚本自动处理：`networkidle` 等待、滚动触发懒加载、导出 `innerText`。
+- 单页：`node fetch_doc.js <完整URL|fullPath> <out.txt>`
+- 按 CSV：`node fetch_doc.js --from-csv <api_id> --out <out.txt>`
+- 批量：`node fetch_doc.js --batch <fullPath|URL>... --out-dir <dir>`
+
+URL 解析规则：以 `http` 开头原样使用；以 `/` 开头则拼 `https://open.feishu.cn`；**禁止**手拼 `/reference/` 或 `/server-docs/` 前缀。
 
 > 依赖：`playwright` npm 包 + chromium。首次用前跑 `npx playwright install chromium`。
 
 ## 🚨 常见陷阱
 
-### 1. URL 路径格式错（最高频）
+### 1. URL 路径错误（最高频）
 
 症状：抓到的内容 < 500 字符，含 "The documentation could not be found."
 
-原因：用了 `server-docs/xxx-yyy` 格式，但接口实际在 `reference/xxx/yyy` 下。
+原因：用手拼了 `server-docs` / `reference` 前缀，或误用了 CSV `docPath`（常与 `fullPath` 不一致）。
 
-解决：**永远从 CSV 的 `fullPath` 取真实路径**，不要自己拼。reference 类（新版）文档用 `/` 分层，server-docs 类（旧版）用 `-` 连接。
+解决：**永远用 CSV `fullPath` 拼 `https://open.feishu.cn` + fullPath**，或 `--from-csv <api_id>`。
 
 ### 2. 响应 data 子字段在折叠区
 
@@ -268,6 +282,6 @@ playwright 渲染抓取脚本，两种用法：
 
 ## 🔗 相关技能
 
-- **添加/重构 API 实现**：`Skill(openlark-api)` —— 字段核对后，用它落地修正
-- **覆盖率验证**：`Skill(openlark-api-validation)` —— 核对文件落盘是否完整
+- **添加/重构 API 实现**：`Skill(openlark-api)` —— 实现前先用本技能抓文档；核对差异后回它落地修正；其 checklist 含本技能核对门禁
+- **覆盖率验证**：`Skill(openlark-api-validation)` —— 核对文件落盘是否完整（不管字段正确性）
 - **校验风格**：`Skill(openlark-validation-style)` —— `validate_required` vs `validate_required_list` 用法

--- a/.agents/skills/openlark-api-field-verify/scripts/fetch_doc.js
+++ b/.agents/skills/openlark-api-field-verify/scripts/fetch_doc.js
@@ -7,50 +7,143 @@
  *
  * 依赖：playwright + chromium。首次用前跑：npx playwright install chromium
  *
- * 用法：
- *   单页：node fetch_doc.js <完整URL> <输出文件>
- *   批量：node fetch_doc.js --batch <path1> <path2> ... --out-dir <目录> [--base <基URL>]
+ * URL 权威源：api_list_export.csv 的 fullPath。
+ *   canonical = https://open.feishu.cn + fullPath
+ * 禁止手拼 /reference/ 或 /server-docs/ 前缀；不要默认用 docPath。
  *
- *   path 是 fullPath 去掉前导 /document 的部分，如 approval-v4/task/pass
- *   脚本会自动拼成 https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/<path>
+ * 用法：
+ *   单页：node fetch_doc.js <完整URL|fullPath> <输出文件>
+ *   CSV： node fetch_doc.js --from-csv <api_id> [--out <文件>] [--csv <路径>]
+ *   批量：node fetch_doc.js --batch <fullPath|URL>... --out-dir <目录>
  *
  * 示例：
  *   node fetch_doc.js \
  *     "https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/approval-v4/task/pass" \
  *     /tmp/doc_pass.txt
  *
- *   node fetch_doc.js --batch approval-v4/instance/add_cc approval-v4/task/pass --out-dir /tmp/docs
+ *   node fetch_doc.js --from-csv 7642253323628383198 --out /tmp/doc_pass.txt
+ *
+ *   node fetch_doc.js --batch \
+ *     /document/uAjLw4CM/ukTMukTMukTM/reference/approval-v4/task/pass \
+ *     --out-dir /tmp/docs
  */
 
 const fs = require('fs');
 const path = require('path');
+const { execSync } = require('child_process');
 
-// 尝试加载 playwright（不依赖个人本机绝对路径）
-// 1) 优先用当前 NODE_PATH / 本地已装的 playwright
-// 2) 失败则查 npm 全局 node_modules 根（等价于 npx 全局缓存解析到的位置）
-// 这样在任何机器上都能跑，不写死作者本机的 npx 缓存路径。
-let chromium;
-try {
-  ({ chromium } = require('playwright'));
-} catch (e) {
-  let resolved = null;
+const DOC_BASE = 'https://open.feishu.cn';
+
+/** 懒加载 playwright，便于 --help / CSV 解析在未安装时也能跑。 */
+function loadChromium() {
   try {
-    const { execSync } = require('child_process');
-    const globalRoot = execSync('npm root -g', { encoding: 'utf8' }).trim();
-    resolved = require('path').join(globalRoot, 'playwright');
-    ({ chromium } = require(resolved));
-  } catch (e2) {
-    resolved = null;
-  }
-  if (!chromium) {
-    console.error('❌ 找不到 playwright 模块。请先安装：npm i -g playwright && npx playwright install chromium');
-    process.exit(1);
+    return require('playwright').chromium;
+  } catch (e) {
+    try {
+      const globalRoot = execSync('npm root -g', { encoding: 'utf8' }).trim();
+      return require(path.join(globalRoot, 'playwright')).chromium;
+    } catch (e2) {
+      console.error(
+        '❌ 找不到 playwright 模块。请先安装：npm i -g playwright && npx playwright install chromium'
+      );
+      process.exit(1);
+    }
   }
 }
 
-const DOC_BASE = 'https://open.feishu.cn';
-// reference 类文档的公共前缀
-const REFERENCE_PREFIX = '/document/uAjLw4CM/ukTMukTMukTM/reference/';
+/**
+ * 将输入解析为完整文档 URL。
+ * - 已是 http(s) URL → 原样
+ * - 以 / 开头的 fullPath → DOC_BASE + path
+ * - 其他 → 报错（禁止短 path 自动拼 /reference/）
+ */
+function resolveUrl(input) {
+  const s = (input || '').trim();
+  if (!s) {
+    throw new Error('空 URL/fullPath');
+  }
+  if (/^https?:\/\//i.test(s)) {
+    return s;
+  }
+  if (s.startsWith('/')) {
+    return DOC_BASE + s;
+  }
+  throw new Error(
+    `非法路径 "${s}"：请传完整 URL 或 CSV fullPath（以 / 开头）。` +
+      '禁止传短 path（如 approval-v4/task/pass）——旧用法会错误拼到 /reference/ 下。'
+  );
+}
+
+/**
+ * 从 api_list_export.csv 按 id 取 fullPath。
+ */
+function fullPathFromCsv(apiId, csvPath) {
+  const text = fs.readFileSync(csvPath, 'utf8');
+  // 去掉 UTF-8 BOM
+  const raw = text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+  const lines = raw.split(/\r?\n/).filter((l) => l.length > 0);
+  if (lines.length < 2) {
+    throw new Error(`CSV 无数据: ${csvPath}`);
+  }
+  const headers = parseCsvLine(lines[0]);
+  const idIdx = headers.indexOf('id');
+  const fpIdx = headers.indexOf('fullPath');
+  if (idIdx < 0 || fpIdx < 0) {
+    throw new Error('CSV 缺少 id 或 fullPath 列');
+  }
+  for (let i = 1; i < lines.length; i++) {
+    const cols = parseCsvLine(lines[i]);
+    if (cols[idIdx] === apiId) {
+      const fp = cols[fpIdx];
+      if (!fp) {
+        throw new Error(`api_id=${apiId} 的 fullPath 为空`);
+      }
+      return fp;
+    }
+  }
+  throw new Error(`CSV 中找不到 id=${apiId}`);
+}
+
+/** 简易 CSV 行解析（支持引号字段）。 */
+function parseCsvLine(line) {
+  const out = [];
+  let cur = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (line[i + 1] === '"') {
+          cur += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        cur += ch;
+      }
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ',') {
+      out.push(cur);
+      cur = '';
+    } else {
+      cur += ch;
+    }
+  }
+  out.push(cur);
+  return out;
+}
+
+function defaultCsvPath() {
+  // scripts → openlark-api-field-verify → skills → .agents → repo root
+  return path.resolve(__dirname, '../../../../api_list_export.csv');
+}
+
+function outNameFromInput(input) {
+  const s = input.replace(/^https?:\/\/[^/]+/i, '');
+  return 'doc_' + s.replace(/^\//, '').replace(/\//g, '_') + '.txt';
+}
 
 /**
  * 渲染单个文档页面，导出 innerText
@@ -73,43 +166,99 @@ async function fetchOne(browser, url, outFile) {
     await page.waitForTimeout(500);
 
     const text = await page.evaluate(() => document.body.innerText);
+    fs.mkdirSync(path.dirname(path.resolve(outFile)), { recursive: true });
     fs.writeFileSync(outFile, text, 'utf-8');
 
     // 简单健康检查：内容太少说明可能 URL 错或没渲染
     const flag = text.length < 500 ? '⚠️ 内容过少，检查 URL 是否正确' : '✅';
     console.log(`${flag} ${path.basename(outFile)}: ${text.length} chars`);
+    console.log(`   url: ${url}`);
     return text.length;
   } finally {
     await page.close();
   }
 }
 
+function printUsage() {
+  console.error(`用法:
+  node fetch_doc.js <完整URL|fullPath> <输出文件>
+  node fetch_doc.js --from-csv <api_id> [--out <文件>] [--csv <路径>]
+  node fetch_doc.js --batch <fullPath|URL>... --out-dir <目录>`);
+}
+
 async function main() {
   const args = process.argv.slice(2);
 
-  if (args[0] === '--batch') {
-    // 批量模式
-    const outDirIdx = args.indexOf('--out-dir');
-    const baseIdx = args.indexOf('--base');
-    const outDir = outDirIdx >= 0 ? args[outDirIdx + 1] : '/tmp/feishu-docs';
-    const basePath = baseIdx >= 0 ? args[baseIdx + 1] : DOC_BASE + REFERENCE_PREFIX;
+  if (args.length === 0 || args[0] === '-h' || args[0] === '--help') {
+    printUsage();
+    process.exit(args.length === 0 ? 1 : 0);
+  }
 
-    const paths = args.slice(1).filter(
-      (a, i) => a !== '--out-dir' && a !== '--base' && args[i + 1] !== '--out-dir' && args[i + 1] !== '--base' && !a.startsWith('--')
-    );
+  if (args[0] === '--from-csv') {
+    const apiId = args[1];
+    if (!apiId || apiId.startsWith('--')) {
+      console.error('❌ --from-csv 需要 <api_id>');
+      printUsage();
+      process.exit(1);
+    }
+    const outIdx = args.indexOf('--out');
+    const csvIdx = args.indexOf('--csv');
+    const csvPath = csvIdx >= 0 ? args[csvIdx + 1] : defaultCsvPath();
+    const outFile =
+      outIdx >= 0 ? args[outIdx + 1] : path.join('/tmp', `doc_${apiId}.txt`);
+
+    const fullPath = fullPathFromCsv(apiId, csvPath);
+    const url = resolveUrl(fullPath);
+    console.log(`📄 api_id=${apiId} fullPath=${fullPath}`);
+
+    const chromium = loadChromium();
+    const browser = await chromium.launch({ headless: true });
+    try {
+      await fetchOne(browser, url, outFile);
+    } finally {
+      await browser.close();
+    }
+    return;
+  }
+
+  if (args[0] === '--batch') {
+    const outDirIdx = args.indexOf('--out-dir');
+    const outDir = outDirIdx >= 0 ? args[outDirIdx + 1] : '/tmp/feishu-docs';
+
+    const paths = [];
+    for (let i = 1; i < args.length; i++) {
+      const a = args[i];
+      if (a === '--out-dir') {
+        i++; // skip value
+        continue;
+      }
+      if (a.startsWith('--')) {
+        console.error(`❌ 未知选项: ${a}`);
+        printUsage();
+        process.exit(1);
+      }
+      paths.push(a);
+    }
 
     if (paths.length === 0) {
-      console.error('用法: node fetch_doc.js --batch <path1> <path2> ... --out-dir <目录>');
+      console.error('❌ --batch 需要至少一个 fullPath 或完整 URL');
+      printUsage();
       process.exit(1);
     }
 
     fs.mkdirSync(outDir, { recursive: true });
+    const chromium = loadChromium();
     const browser = await chromium.launch({ headless: true });
     console.log(`📥 批量抓取 ${paths.length} 个文档到 ${outDir}`);
     for (const p of paths) {
-      const url = basePath + p;
-      const name = p.replace(/\//g, '_');
-      const outFile = path.join(outDir, `doc_${name}.txt`);
+      let url;
+      try {
+        url = resolveUrl(p);
+      } catch (e) {
+        console.log(`❌ ${p}: ${e.message}`);
+        continue;
+      }
+      const outFile = path.join(outDir, outNameFromInput(p));
       try {
         await fetchOne(browser, url, outFile);
       } catch (e) {
@@ -118,19 +267,28 @@ async function main() {
     }
     await browser.close();
     console.log('✅ 批量完成');
-  } else {
-    // 单页模式
-    const [url, outFile] = args;
-    if (!url || !outFile) {
-      console.error('用法: node fetch_doc.js <完整URL> <输出文件>');
-      process.exit(1);
-    }
-    const browser = await chromium.launch({ headless: true });
-    try {
-      await fetchOne(browser, url, outFile);
-    } finally {
-      await browser.close();
-    }
+    return;
+  }
+
+  // 单页模式
+  const [input, outFile] = args;
+  if (!input || !outFile || input.startsWith('--')) {
+    printUsage();
+    process.exit(1);
+  }
+  let url;
+  try {
+    url = resolveUrl(input);
+  } catch (e) {
+    console.error(`❌ ${e.message}`);
+    process.exit(1);
+  }
+  const chromium = loadChromium();
+  const browser = await chromium.launch({ headless: true });
+  try {
+    await fetchOne(browser, url, outFile);
+  } finally {
+    await browser.close();
   }
 }
 

--- a/.agents/skills/openlark-api-validation/SKILL.md
+++ b/.agents/skills/openlark-api-validation/SKILL.md
@@ -17,11 +17,13 @@ allowed-tools: Bash, Read, Edit, Write
 **其他技能：**
 - 项目级规范体检（架构/API/导出/校验一体）→ `Skill(openlark-code-standards)`
 - 新增/重构具体 API → `Skill(openlark-api)`
+- 字段正确性核对（文档 vs 代码）→ `Skill(openlark-api-field-verify)`
 - 审查整体架构与公共 API 收敛 → `Skill(openlark-design-review)`
 
 ### 关键词触发映射
 
 - 覆盖率、缺失 API、实现数量、CSV 对比、验证脚本、报告 → `openlark-api-validation`
+- 字段核对、文档字段、playwright → `openlark-api-field-verify`
 - 新增 API、重构 API、Builder、Request/Response、mod.rs 导出 → `openlark-api`
 - 代码规范、规范检查、风格一致性、体检 → `openlark-code-standards`
 - 架构设计、public API、收敛方案、feature gating、兼容策略 → `openlark-design-review`
@@ -29,6 +31,7 @@ allowed-tools: Bash, Read, Edit, Write
 
 ### 双向跳转规则
 
+- 本技能只回答「文件在不在」；若要核对字段是否与飞书文档一致，转 `openlark-api-field-verify`。
 - 若发现缺失 API 的根因是架构分层/范式混乱，转 `openlark-design-review`。
 - 若发现问题是具体 API 尚未实现，转 `openlark-api` 落地实现。
 - 若需要把覆盖率问题归因到全仓规范一致性，转 `openlark-code-standards`。

--- a/.agents/skills/openlark-api/SKILL.md
+++ b/.agents/skills/openlark-api/SKILL.md
@@ -16,13 +16,16 @@ allowed-tools: Bash, Read, Grep, Glob, Edit
 - 需要了解端点规范、RequestOption 约定、Service 链式调用
 
 **其他技能：**
+- 字段核对 / 抓飞书文档（playwright）→ `Skill(openlark-api-field-verify)`（**读文档唯一入口**）
 - 项目级规范体检（架构/API/导出/校验一体）→ `Skill(openlark-code-standards)`
 - 审查整体设计规范 → `Skill(openlark-design-review)`
 - 统一 `validate()` 写法 → `Skill(openlark-validation-style)`
+- 覆盖率（文件在不在）→ `Skill(openlark-api-validation)`
 
 ### 关键词触发映射
 
 - 新增 API、重构 API、Builder、Request/Response、mod.rs 导出、RequestOption → `openlark-api`
+- 字段核对、文档抓取、playwright、飞书文档字段 → `openlark-api-field-verify`
 - 代码规范、规范检查、风格一致性、体检 → `openlark-code-standards`
 - 架构设计、public API、收敛方案、feature gating、兼容策略 → `openlark-design-review`
 - validate、必填校验、validate_required、空白字符串、校验聚合 → `openlark-validation-style`
@@ -30,13 +33,15 @@ allowed-tools: Bash, Read, Grep, Glob, Edit
 
 ### 双向跳转规则
 
+- **读文档 / 字段核对**：一律转 `openlark-api-field-verify`（勿用本技能下的 `fetch_docpath.py` 在线抓取）。
+- 实现完成后必须跑字段核对门禁（见 §0 步骤 8 / §4）；差异修正仍在本技能落地。
 - 若实现问题本质是架构范式冲突（Request/Service 边界），转 `openlark-design-review`。
 - 若实现前需要先做全仓规范体检，先跑 `openlark-code-standards`。
 - 若实现完成后要核验覆盖率与缺失清单，转 `openlark-api-validation`。
 
 ---
 
-本文件只保留"可执行的最小流程"，标准示例与 docPath 抓取能力见 `references/` 与 `scripts/`。
+本文件只保留"可执行的最小流程"。标准示例见 `references/`；**官方文档抓取**见 `Skill(openlark-api-field-verify)`。
 
 ## 🔒 核心契约（所有 crate 必须遵守，不可违反）
 
@@ -57,19 +62,21 @@ allowed-tools: Bash, Read, Grep, Glob, Edit
 
 ## 0. 快速工作流（新增一个 API）
 
-1) **定位 API**：在 `./api_list_export.csv` 拿到 `bizTag`、`meta.Project`、`meta.Version`、`meta.Resource`、`meta.Name`
-   - 若有 `docPath`，用脚本抓取请求/响应体定义（见 §4）
-2) **选 crate**：根据 bizTag 选择 feature crate（见 §1）
-3) **定路径**：`crates/{crate}/src/{bizTag}/{project}/{version}/{resource...}/{name}.rs`
-4) **写代码**：`Body/Response` + Builder（`execute/send`）+ 端点常量/enum
+1) **定位 API**：在 `./api_list_export.csv` 拿到 `id`、`bizTag`、`meta.*`、**`fullPath`**
+   - URL 权威源是 `fullPath`（拼 `https://open.feishu.cn` + `fullPath`）。**不要**用手拼路径，也**不要**默认用 `docPath`（常与 `fullPath` 不一致）。
+2) **读文档（门禁）**：用 playwright 抓取（见 §5）。产出文件 `<500` 字符 = 失败，**禁止**继续实现或推断字段。
+3) **选 crate**：根据 bizTag 选择 feature crate（见 §1）
+4) **定路径**：`crates/{crate}/src/{bizTag}/{project}/{version}/{resource...}/{name}.rs`
+5) **写代码**：按抓取到的真实字段写 `Body/Response` + Builder（`execute/send`）+ 端点常量/enum
    - **必须支持 RequestOption**：用于 `user_access_token` / `tenant_key` / 自定义 header
-5) **补导出**：在 `mod.rs` 中 `pub mod ...` / `pub use ...`
-6) **补链路**：在约定入口补齐链式调用（默认 `service.rs`，但 `openlark-docs` 例外，见 §2）
-7) **验证**：
+6) **补导出**：在 `mod.rs` 中 `pub mod ...` / `pub use ...`
+7) **补链路**：在约定入口补齐链式调用（默认 `service.rs`，但 `openlark-docs` 例外，见 §2）
+8) **验证（含字段核对门禁）**：
    - 新增 API 所属 crate feature 已在 `Cargo.toml [features]` 声明；
    - 涉及该 feature 的测试用 `#[cfg(test)]` 模块内 `#![cfg(feature = "...")]`（或模块级 `#[cfg(feature)]`）门控；
    - 若新增 `examples/` 示例，须在 `Cargo.toml [[example]]` 声明 `required-features`；
-   - 跑 `just fmt && just lint && just test`，其中 `just lint` 须含 `--all-targets`（覆盖 examples + tests）。
+   - 跑 `just fmt && just lint && just test`，其中 `just lint` 须含 `--all-targets`（覆盖 examples + tests）；
+   - **字段核对（必做）**：`python3 tools/verify_api_fields.py --api-id <CSV的id> --fetch-docs`；`error`/`warning` 须清零（或按报告修正后再跑）。详细流程见 `Skill(openlark-api-field-verify)`。
 
 ## 1. Feature Crate ↔ bizTag
 
@@ -248,6 +255,7 @@ impl {Name}Request {
 ## 4. 提交前检查清单
 
 - [ ] 落盘路径正确（与同模块现有结构一致）
+- [ ] **已用 playwright 按 `fullPath` 抓取文档**（产出 ≥500 字符）；字段来自真实文档，非同族推断
 - [ ] Request/Response 字段对齐官方文档（含 `serde(rename)`）
 - [ ] **核心契约 1**：`config: Config`（owned），未用 `Arc<Config>`
 - [ ] **核心契约 2**：`R` 是响应 data 内容类型，未在外面再包 `XxxResponse{data}`
@@ -258,15 +266,36 @@ impl {Name}Request {
 - [ ] `mod.rs` 已导出；`service.rs`/链式入口已补
 - [ ] 新增 feature 已在 `Cargo.toml [features]` 声明；测试/示例的 `#[cfg(feature)]` 与 `[[example]] required-features` 已补
 - [ ] `just fmt && just lint --all-targets && just test` 通过
+- [ ] **字段核对门禁**：`python3 tools/verify_api_fields.py --api-id <id> --fetch-docs` 无未处理的 error/warning
 
-## 5. docPath 网页读取
+## 5. 官方文档读取（唯一入口）
+
+飞书文档是 **SPA**，禁止用本目录 `scripts/fetch_docpath.py` 做在线抓取（常返回空壳）。统一走 field-verify 的 playwright 脚本，**URL 只用 CSV `fullPath`**：
 
 ```bash
-python3 .agents/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --format md --out /tmp/doc.md
+# 从 CSV 取 fullPath / id 后：
+FULL_PATH="$(python3 -c "
+import csv
+with open('api_list_export.csv', encoding='utf-8-sig') as f:
+    for row in csv.DictReader(f):
+        if row['id'] == '<API_ID>':
+            print(row['fullPath']); break
+")"
+
+node .agents/skills/openlark-api-field-verify/scripts/fetch_doc.js \
+  "https://open.feishu.cn${FULL_PATH}" \
+  "/tmp/doc_<API_ID>.txt"
+
+# 或按 api-id 直接抓（脚本内读 CSV）：
+node .agents/skills/openlark-api-field-verify/scripts/fetch_doc.js \
+  --from-csv <API_ID> --out /tmp/doc_<API_ID>.txt
 ```
+
+抓取后按 `Skill(openlark-api-field-verify)` 解析 Request/Response 字段再写代码。离线已有 HTML 时，才可用 `fetch_docpath.py --html-file` 作解析兜底。
 
 ## 6. References
 
 - 目录规范与反查：`references/file-layout.md`
 - CSV 映射规则：`references/csv-mapping.md`
 - 标准示例（照抄结构）：`references/standard-example.md`
+- 字段核对与文档抓取：`Skill(openlark-api-field-verify)`

--- a/.agents/skills/openlark-api/references/README.md
+++ b/.agents/skills/openlark-api/references/README.md
@@ -1,6 +1,6 @@
 # OpenLark API Skill References
 
-`SKILL.md` 已压缩为 200 行速查，本目录用于“按需加载”。
+`SKILL.md` 已压缩为速查，本目录用于“按需加载”。
 
 ## 文件说明
 
@@ -8,9 +8,31 @@
 - `file-layout.md`：落盘路径口径、目录反查方法
 - `csv-mapping.md`：`api_list_export.csv` 的最小提取规则（method/path + 落盘信息）
 
-## docPath 抓取脚本
+## 官方文档抓取（唯一在线入口）
 
-- 在线抓取（需要网络）：`python3 .agents/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --format md --out /tmp/doc.md`
-- 离线解析（无网络/受限环境）：先把页面保存为 HTML，再用 `--html-file` 解析：
-  - `python3 .agents/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --html-file /path/to/page.html --format md --out /tmp/doc.md`
-  - 或直接从 stdin 输入 HTML：`cat /path/to/page.html | python3 .agents/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --stdin --format md`
+飞书文档是 SPA。**在线抓取必须用 playwright**：
+
+```bash
+# 推荐：按 CSV api-id（脚本内用 fullPath）
+node .agents/skills/openlark-api-field-verify/scripts/fetch_doc.js \
+  --from-csv <API_ID> --out /tmp/doc.txt
+
+# 或：https://open.feishu.cn + CSV fullPath
+node .agents/skills/openlark-api-field-verify/scripts/fetch_doc.js \
+  "https://open.feishu.cn${FULL_PATH}" /tmp/doc.txt
+```
+
+完整流程与字段解析见 `Skill(openlark-api-field-verify)`。实现后核对门禁：
+
+```bash
+python3 tools/verify_api_fields.py --api-id <API_ID> --fetch-docs
+```
+
+## 离线 HTML 解析（deprecated 脚本，仅兜底）
+
+`scripts/fetch_docpath.py` **禁止用于在线抓取**（SPA 常返回空壳）。仅当已有本地 HTML 时：
+
+```bash
+python3 .agents/skills/openlark-api/scripts/fetch_docpath.py unused \
+  --html-file /path/to/page.html --format md --out /tmp/doc.md
+```

--- a/.agents/skills/openlark-api/scripts/fetch_docpath.py
+++ b/.agents/skills/openlark-api/scripts/fetch_docpath.py
@@ -1,18 +1,17 @@
 #!/usr/bin/env python3
 """
-抓取飞书开放平台 docPath 网页并提取“可能有用”的 API 定义信息（请求/响应/示例 JSON/字段表等）。
+[DEPRECATED — 在线抓取请改用 openlark-api-field-verify/scripts/fetch_doc.js]
 
-目标：
-- 尽量用 stdlib（无需额外依赖）
-- 输出可直接粘贴到上下文的 Markdown，辅助生成 Rust Request/Response 字段
+飞书开放平台文档是 SPA，本脚本用 stdlib HTTP 抓 HTML，**在线模式对新接口常返回空壳/占位**，
+无法可靠提取字段表。
 
-用法：
-  python3 .agents/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --format md --out /tmp/doc.md
-  python3 .agents/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --format json
+唯一可靠的在线入口：
+  node .agents/skills/openlark-api-field-verify/scripts/fetch_doc.js --from-csv <api_id> --out /tmp/doc.txt
+  # URL = https://open.feishu.cn + CSV fullPath（不要用手拼 / 默认 docPath）
 
-离线模式（无网络/受限环境）：
-  python3 .agents/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --html-file /path/to/page.html --format md
-  cat /path/to/page.html | python3 .agents/skills/openlark-api/scripts/fetch_docpath.py "<docPath>" --stdin --format md
+本脚本仅保留离线用途：已有 HTML 文件时解析为 Markdown/JSON：
+  python3 .agents/skills/openlark-api/scripts/fetch_docpath.py unused --html-file /path/to/page.html --format md
+  cat page.html | python3 .agents/skills/openlark-api/scripts/fetch_docpath.py unused --stdin --format md
 """
 
 from __future__ import annotations
@@ -275,8 +274,13 @@ def to_markdown(data: Extracted) -> str:
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
-    p = argparse.ArgumentParser(description="Fetch and extract useful parts from a docPath page.")
-    p.add_argument("url", nargs="?", help="docPath URL（离线模式可省略）")
+    p = argparse.ArgumentParser(
+        description=(
+            "[DEPRECATED online] Parse Feishu doc HTML offline. "
+            "For live fetch use openlark-api-field-verify/scripts/fetch_doc.js"
+        )
+    )
+    p.add_argument("url", nargs="?", help="docPath URL（在线已弃用；离线模式可省略）")
     p.add_argument("--timeout", type=int, default=20)
     p.add_argument("--max-code-blocks", type=int, default=12)
     p.add_argument("--max-text-chars", type=int, default=12000)
@@ -302,6 +306,13 @@ def main(argv: list[str]) -> int:
     else:
         if not args.url:
             raise SystemExit("缺少 docPath URL：请提供 <docPath>，或使用 --html-file/--stdin 进入离线模式")
+        print(
+            "⚠️  DEPRECATED: 在线抓取请改用\n"
+            "  node .agents/skills/openlark-api-field-verify/scripts/fetch_doc.js "
+            "--from-csv <api_id> --out /tmp/doc.txt\n"
+            "本脚本对 SPA 常返回空壳，结果不可靠。",
+            file=sys.stderr,
+        )
         html = fetch_html(args.url, timeout=args.timeout)
         url = args.url
 


### PR DESCRIPTION
# 概要

打通「飞书官网读文档 → 写实现 → 字段核对」闭环：实现技能统一走 playwright + CSV `fullPath`，弃用易抓空的在线 `fetch_docpath.py`，并在 checklist 强制 `verify_api_fields --fetch-docs` 门禁。避免 Agent 推断字段后才事后核对。

## 变更类型

- [ ] 🐛 修复
- [ ] ✨ 新功能
- [x] 📚 文档 / 格式
- [ ] 🔧 构建 / CI
- [ ] 💥 破坏性改动

## 关联 Issue（可选）

Fixes #

## 验证

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`
- [x] 其它说明：对 `fetch_doc.js` 做了无网络冒烟（`--help`、拒绝短 path、CSV `fullPath` 解析、`resolveUrl`）；`fetch_docpath.py` 在线模式会打印 DEPRECATED 警告。本次仅改 agent skills/脚本，无 Rust 代码变更。

## 备注（可选）

**主要改动**
- `openlark-api`：读文档改走 field-verify；工作流加抓取/核对门禁；与 field-verify 互跳
- `openlark-api-field-verify`：明确为唯一文档源；URL 只用 `fullPath`
- `fetch_doc.js`：新增 `--from-csv`；批量接受完整 fullPath/URL；拒绝短 path；playwright 懒加载
- `fetch_docpath.py`：在线弃用警告，仅保留离线 HTML 解析

<details>
<summary>维护者检查（如适用）</summary>

- [ ] 更新 CHANGELOG
- [ ] 评估版本号调整
- [ ] 安全影响评估
- [ ] 更新 API 文档

</details>

Made with [Cursor](https://cursor.com)