### PR TITLE
fix(verify): fail field-verify gate on doc fetch errors

### DIFF
--- a/.agents/skills/openlark-api-field-verify/SKILL.md
+++ b/.agents/skills/openlark-api-field-verify/SKILL.md
@@ -142,10 +142,12 @@ python3 tools/verify_api_fields.py --crate openlark-workflow
 python3 tools/verify_api_fields.py --crate openlark-workflow --fetch-docs
 
 # 单个 API 核对门禁（实现后必做）：抓文档对比
+# 抓取失败 / error / warning → 非 0 退出（禁止假绿）
 python3 tools/verify_api_fields.py --api-id 7642253323628383198 --fetch-docs
 ```
 
 工具自动完成路径解析、字段提取、文档抓取、差异对比，输出 `reports/api_field_verify/` 报告。
+`--fetch-docs` 模式下：文档抓取失败、内容过少/404、字段 error/warning 均记入报告并以非 0 退出；info 不阻断。
 设计文档见 `docs/superpowers/specs/2026-06-16-api-field-verify-tool-design.md`。
 
 ### 第 3 步：解析字段

--- a/.agents/skills/openlark-api/SKILL.md
+++ b/.agents/skills/openlark-api/SKILL.md
@@ -76,7 +76,7 @@ allowed-tools: Bash, Read, Grep, Glob, Edit
    - 涉及该 feature 的测试用 `#[cfg(test)]` 模块内 `#![cfg(feature = "...")]`（或模块级 `#[cfg(feature)]`）门控；
    - 若新增 `examples/` 示例，须在 `Cargo.toml [[example]]` 声明 `required-features`；
    - 跑 `just fmt && just lint && just test`，其中 `just lint` 须含 `--all-targets`（覆盖 examples + tests）；
-   - **字段核对（必做）**：`python3 tools/verify_api_fields.py --api-id <CSV的id> --fetch-docs`；`error`/`warning` 须清零（或按报告修正后再跑）。详细流程见 `Skill(openlark-api-field-verify)`。
+   - **字段核对（必做）**：`python3 tools/verify_api_fields.py --api-id <CSV的id> --fetch-docs`；进程须以 0 退出（抓取失败 / error / warning 均非 0）。详细流程见 `Skill(openlark-api-field-verify)`。
 
 ## 1. Feature Crate ↔ bizTag
 

--- a/tools/tests/test_verify_api_fields.py
+++ b/tools/tests/test_verify_api_fields.py
@@ -306,6 +306,30 @@ class TestParseDocFields(unittest.TestCase):
         self.assertTrue(req_map["instance_code"])
         self.assertFalse(req_map["comment"])
 
+    def test_parse_param_table_sparse_blank_lines_like_feishu_spa(self):
+        """飞书 SPA 在字段名与 Yes/No 之间插入多行空行时仍能解析，且不把 string 当字段。"""
+        section = (
+            "Parameter\n\nType\n\nRequired\n\nDescription\n\n\n\n"
+            "instance_code\n\n\n\nstring\n\n\n\nYes\n\n\n\n"
+            "Approval instance Code\n\n"
+            "Example value: \"81D31358\"\n\n\n\n\n"
+            "task_id\n\n\n\nstring\n\n\n\nYes\n\n\n\n"
+            "The approval task ID\n\n"
+            "form\n\n\n\nstring\n\n\n\nNo\n\n\n\n"
+            "Form data\n\n"
+            "comment\n\n\n\nstring\n\n\n\nNo\n\n\n\n"
+            "approval comment\n"
+        )
+        fields = verify_api_fields._parse_param_table(section)
+        names = [f.name for f in fields]
+        self.assertEqual(names, ["instance_code", "task_id", "form", "comment"])
+        self.assertNotIn("string", names)
+        req = {f.name: f.required for f in fields}
+        self.assertTrue(req["instance_code"])
+        self.assertTrue(req["task_id"])
+        self.assertFalse(req["form"])
+        self.assertFalse(req["comment"])
+
 
 class TestCompareFields(unittest.TestCase):
     def test_compare_finds_missing_and_extra(self):
@@ -322,6 +346,139 @@ class TestCompareFields(unittest.TestCase):
         self.assertIn("task_id", diff.missing)  # 文档有代码无
         self.assertIn("user_id", diff.extra)  # 代码有文档无
         self.assertIn("instance_code", diff.matched)
+
+
+class TestDocFetchGate(unittest.TestCase):
+    """完整模式不得在抓取失败时假绿放行。"""
+
+    def test_validate_doc_text_rejects_thin_or_404(self):
+        self.assertIsNotNone(verify_api_fields._validate_doc_text(""))
+        self.assertIsNotNone(verify_api_fields._validate_doc_text("x" * 100))
+        self.assertIsNotNone(
+            verify_api_fields._validate_doc_text(
+                "The documentation could not be found.\n" + ("a" * 600)
+            )
+        )
+        self.assertIsNone(verify_api_fields._validate_doc_text("正文内容" * 200))
+
+    def test_exit_code_error_and_warning_fail(self):
+        self.assertEqual(verify_api_fields._exit_code_for_issues([]), 0)
+        self.assertEqual(
+            verify_api_fields._exit_code_for_issues(
+                [verify_api_fields.FieldIssue("info", "x", "tip")]
+            ),
+            0,
+        )
+        self.assertEqual(
+            verify_api_fields._exit_code_for_issues(
+                [verify_api_fields.FieldIssue("warning", "x", "warn")]
+            ),
+            1,
+        )
+        self.assertEqual(
+            verify_api_fields._exit_code_for_issues(
+                [verify_api_fields.FieldIssue("error", "doc_fetch_failed", "fail")]
+            ),
+            1,
+        )
+
+    def test_fetch_docs_failure_recorded_as_error_exit_1(self):
+        """--fetch-docs 时抓取失败必须记 error 且返回非 0（不再假绿）。"""
+        import tempfile
+        from unittest import mock
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            src_root = tmpdir / "crates"
+            api_dir = (
+                src_root / "openlark-workflow" / "src" / "approval" / "approval" / "v4" / "task"
+            )
+            api_dir.mkdir(parents=True)
+            (api_dir / "pass.rs").write_text(
+                "pub struct PassTaskBodyV4 {\n"
+                "    pub instance_code: String,\n"
+                "    pub task_id: String,\n"
+                "}\n"
+                "pub struct PassTaskResponseV4 {}\n",
+                encoding="utf-8",
+            )
+            out_dir = tmpdir / "out"
+            api = verify_api_fields.ApiRecord(
+                api_id="999",
+                name="同意",
+                biz_tag="approval",
+                meta_project="approval",
+                meta_version="v4",
+                meta_resource="task",
+                meta_name="pass",
+                url="POST:/open-apis/approval/v4/tasks/pass",
+                doc_path="",
+                full_path="/document/uAjLw4CM/ukTMukTMukTM/reference/approval-v4/task/pass",
+            )
+            fake_fail = verify_api_fields.DocFetchResult(error="playwright missing")
+            with mock.patch.object(
+                verify_api_fields, "_fetch_single_doc", return_value=fake_fail
+            ):
+                code = verify_api_fields._run_single_api(
+                    "999", [api], src_root, out_dir, "api-999", fetch_docs=True
+                )
+            self.assertEqual(code, 1)
+            report = (out_dir / "api-999.md").read_text(encoding="utf-8")
+            self.assertIn("文档抓取失败", report)
+            self.assertIn("有问题 | 1", report)
+
+    def test_fetch_docs_success_compares_fields(self):
+        """抓取成功时对比字段，多余字段记 warning 并非 0 退出。"""
+        import tempfile
+        from unittest import mock
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            src_root = tmpdir / "crates"
+            api_dir = (
+                src_root / "openlark-workflow" / "src" / "approval" / "approval" / "v4" / "task"
+            )
+            api_dir.mkdir(parents=True)
+            (api_dir / "pass.rs").write_text(
+                "pub struct PassTaskBodyV4 {\n"
+                "    pub instance_code: String,\n"
+                "    pub task_id: String,\n"
+                "    pub user_id: String,\n"  # 文档没有 → extra
+                "}\n"
+                "pub struct PassTaskResponseV4 {}\n",
+                encoding="utf-8",
+            )
+            out_dir = tmpdir / "out"
+            api = verify_api_fields.ApiRecord(
+                api_id="998",
+                name="同意",
+                biz_tag="approval",
+                meta_project="approval",
+                meta_version="v4",
+                meta_resource="task",
+                meta_name="pass",
+                url="POST:/open-apis/approval/v4/tasks/pass",
+                doc_path="",
+                full_path="/document/uAjLw4CM/ukTMukTMukTM/reference/approval-v4/task/pass",
+            )
+            # 伪造足够长的文档正文（含 Request body 段）
+            pad = "x" * 400
+            doc_text = (
+                f"{pad}\n目录 Request Request body Request example Response\n"
+                "Request body\n"
+                "instance_code\nstring\nYes\n实例\n"
+                "task_id\nstring\nYes\n任务\n"
+                "Request example\n"
+                f"{pad}\n"
+            )
+            ok = verify_api_fields.DocFetchResult(text=doc_text)
+            with mock.patch.object(verify_api_fields, "_fetch_single_doc", return_value=ok):
+                code = verify_api_fields._run_single_api(
+                    "998", [api], src_root, out_dir, "api-998", fetch_docs=True
+                )
+            self.assertEqual(code, 1)  # extra_field warning
+            report = (out_dir / "api-998.md").read_text(encoding="utf-8")
+            self.assertIn("多余字段", report)
 
 
 if __name__ == "__main__":

--- a/tools/verify_api_fields.py
+++ b/tools/verify_api_fields.py
@@ -452,6 +452,32 @@ def _write_summary_json(reports: List[ApiFieldReport], path: Path, mode: str) ->
 # 文档字段解析与对比（完整模式）
 # ---------------------------------------------------------------------------
 
+MIN_DOC_CHARS = 500  # 低于此视为抓取失败（URL 错或 SPA 未渲染）
+
+
+@dataclass
+class DocFetchResult:
+    """文档抓取结果。ok=False 时必须记 error，禁止假绿放行。"""
+
+    text: str = ""
+    error: Optional[str] = None  # None 表示成功
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+
+def _validate_doc_text(text: str) -> Optional[str]:
+    """校验文档正文；返回错误原因，通过则返回 None。"""
+    if not text or not text.strip():
+        return "文档内容为空"
+    if len(text) < MIN_DOC_CHARS:
+        return f"文档内容过少（{len(text)} < {MIN_DOC_CHARS} 字符），可能 URL 错误或未渲染"
+    lower = text.lower()
+    if "the documentation could not be found" in lower or "文档不存在" in text:
+        return "文档页面不存在（URL 可能错误）"
+    return None
+
 
 @dataclass
 class FieldDiff:
@@ -504,26 +530,54 @@ def _extract_section(text: str, start: str, end: str, occurrence: int = 1) -> st
 
 
 def _parse_param_table(section: str) -> List[FieldInfo]:
-    """解析参数表（参数名/类型/必填交错成行）。"""
+    """解析参数表（参数名/类型/必填交错成行）。
+
+    飞书 SPA innerText 常在参数名与 Yes/No 之间插入多行空行 + 类型行，
+    回看窗口需足够大；同时禁止把类型名（string/int/...）当成字段名。
+    """
     lines = [l.strip() for l in section.split("\n")]
     results: List[FieldInfo] = []
     banned = {
         "parameter", "type", "required", "description", "authorization",
-        "content", "value", "example",
+        "content", "value", "example", "facts", "scopes", "header",
+        # 类型名（勿当字段）
+        "string", "int", "integer", "boolean", "bool", "number", "float",
+        "double", "object", "array", "file", "binary", "map", "null",
+        "string[]", "int[]", "integer[]", "boolean[]", "number[]", "object[]",
     }
+    type_line = re.compile(
+        r"^(string|int|integer|boolean|bool|number|float|double|object|array|"
+        r"file|binary|map|null)(\[\])?$",
+        re.I,
+    )
     i = 0
     while i < len(lines):
         line = lines[i]
-        # 候选参数名：snake_case，非 banned 词
-        if re.fullmatch(r"[a-z][a-z0-9_]*", line) and line not in banned and len(line) >= 2:
-            # 往后找 Yes/No
-            for j in range(i + 1, min(i + 8, len(lines))):
+        # 候选参数名：snake_case，非 banned / 非类型名
+        if (
+            re.fullmatch(r"[a-z][a-z0-9_]*", line)
+            and line not in banned
+            and not type_line.fullmatch(line)
+            and len(line) >= 2
+        ):
+            # 往后找 Yes/No（空行多时需更大窗口）
+            found = False
+            for j in range(i + 1, min(i + 16, len(lines))):
                 if lines[j] in ("Yes", "No"):
                     required = lines[j] == "Yes"
-                    results.append(FieldInfo(name=line, type_name="", required=required))
+                    # 尝试取中间的类型行
+                    type_name = ""
+                    for k in range(i + 1, j):
+                        if type_line.fullmatch(lines[k]):
+                            type_name = lines[k]
+                            break
+                    results.append(
+                        FieldInfo(name=line, type_name=type_name, required=required)
+                    )
                     i = j + 1
+                    found = True
                     break
-            else:
+            if not found:
                 i += 1
         else:
             i += 1
@@ -548,6 +602,66 @@ def compare_fields(
 # ---------------------------------------------------------------------------
 
 
+def _exit_code_for_issues(issues: List[FieldIssue]) -> int:
+    """完整模式门禁：error/warning 导致非 0；info 不阻断。"""
+    for i in issues:
+        if i.severity in ("error", "warning"):
+            return 1
+    return 0
+
+
+def _compare_doc_against_code(
+    api: ApiRecord,
+    structs: List[StructFields],
+    doc_text: str,
+    issues: List[FieldIssue],
+) -> None:
+    """把文档字段对比结果追加到 issues（就地修改）。"""
+    doc_req = parse_doc_request_fields(doc_text, api.http_method)
+    code_body = next((s.fields for s in structs if "Body" in s.name), [])
+    if doc_req and code_body:
+        diff = compare_fields(code_body, doc_req)
+        if diff.missing:
+            issues.append(
+                FieldIssue(
+                    "error",
+                    "missing_field",
+                    f"请求体缺字段: {', '.join(diff.missing)}",
+                )
+            )
+        if diff.extra:
+            issues.append(
+                FieldIssue(
+                    "warning",
+                    "extra_field",
+                    f"请求体多余字段: {', '.join(diff.extra)}",
+                )
+            )
+    elif not doc_req and code_body:
+        # 有请求体实现但文档没解析出字段——通常是解析失败，记 warning 避免假绿
+        issues.append(
+            FieldIssue(
+                "warning",
+                "doc_parse_empty",
+                "文档未解析到请求字段（可能页面结构变化或非 POST/GET 标准段）",
+            )
+        )
+
+    doc_resp = parse_doc_response_fields(doc_text)
+    code_resp = next((s.fields for s in structs if "Response" in s.name), [])
+    if doc_resp and code_resp:
+        code_resp_names = {f.effective_name for f in code_resp}
+        missing_resp = sorted(set(doc_resp) - code_resp_names)
+        if missing_resp:
+            issues.append(
+                FieldIssue(
+                    "info",
+                    "missing_response_field",
+                    f"响应体可能缺字段: {', '.join(missing_resp)}",
+                )
+            )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="API 字段核对工具")
     parser.add_argument("--csv", default=str(DEFAULT_CSV), help="API 清单 CSV 路径")
@@ -564,11 +678,10 @@ def main() -> int:
     if args.api_id:
         src_root = REPO_ROOT / "crates"
         crate_label = f"api-{args.api_id}"
-        # 自定义过滤：只保留指定 id 的 API
         all_apis = load_apis_from_csv(csv_path)
-        filter_tags = None  # 由 _filter_by_id 处理
-        _run_single_api(args.api_id, all_apis, src_root, out_dir, crate_label, args.fetch_docs)
-        return 0
+        return _run_single_api(
+            args.api_id, all_apis, src_root, out_dir, crate_label, args.fetch_docs
+        )
 
     # 确定 src 根目录和 bizTag 过滤
     if args.crate:
@@ -602,60 +715,54 @@ def main() -> int:
     return 0
 
 
-def _run_single_api(api_id, all_apis, src_root, out_dir, crate_label, fetch_docs):
-    """核对单个 API（调试用）。"""
+def _run_single_api(api_id, all_apis, src_root, out_dir, crate_label, fetch_docs) -> int:
+    """核对单个 API。--fetch-docs 时抓取失败或 error/warning 返回非 0。"""
     api = next((a for a in all_apis if a.api_id == api_id), None)
     if api is None:
         print(f"❌ CSV 中找不到 id={api_id} 的 API")
-        return
+        return 1
     print(f"🔍 单 API 核对: {api.name} ({api.url})")
     rel_path = generate_expected_file_path(api)
     # 单 API 模式：在所有 crate 的 src 目录下查找文件
     full_path = None
     for crate_dir in src_root.iterdir():
+        if not crate_dir.is_dir():
+            continue
         candidate = crate_dir / "src" / rel_path
         if candidate.exists():
             full_path = candidate
             break
     if full_path is None:
         print(f"❌ 文件不存在（在所有 crate 中查找）: {rel_path}")
-        return
+        return 1
     source = full_path.read_text(encoding="utf-8")
     structs = extract_structs(source)
     issues = detect_suspicious_patterns(api, structs, source)
 
     # 完整模式：抓文档对比字段
     mode = "quick"
-    if fetch_docs and api.full_path:
+    if fetch_docs:
         mode = "full"
-        doc_text = _fetch_single_doc(api, out_dir)
-        if doc_text:
-            # 对比请求体字段
-            doc_req = parse_doc_request_fields(doc_text, api.http_method)
-            code_body = next((s.fields for s in structs if "Body" in s.name), [])
-            if doc_req and code_body:
-                diff = compare_fields(code_body, doc_req)
-                if diff.missing:
-                    issues.append(
-                        FieldIssue("error", "missing_field",
-                                   f"请求体缺字段: {', '.join(diff.missing)}")
+        if not api.full_path:
+            issues.append(
+                FieldIssue(
+                    "error",
+                    "doc_fetch_failed",
+                    "CSV fullPath 为空，无法抓取官方文档",
+                )
+            )
+        else:
+            result = _fetch_single_doc(api, out_dir)
+            if not result.ok:
+                issues.append(
+                    FieldIssue(
+                        "error",
+                        "doc_fetch_failed",
+                        f"文档抓取失败: {result.error}",
                     )
-                if diff.extra:
-                    issues.append(
-                        FieldIssue("warning", "extra_field",
-                                   f"请求体多余字段: {', '.join(diff.extra)}")
-                    )
-            # 对比响应体字段
-            doc_resp = parse_doc_response_fields(doc_text)
-            code_resp = next((s.fields for s in structs if "Response" in s.name), [])
-            if doc_resp and code_resp:
-                code_resp_names = {f.effective_name for f in code_resp}
-                missing_resp = sorted(set(doc_resp) - code_resp_names)
-                if missing_resp:
-                    issues.append(
-                        FieldIssue("info", "missing_response_field",
-                                   f"响应体可能缺字段: {', '.join(missing_resp)}")
-                    )
+                )
+            else:
+                _compare_doc_against_code(api, structs, result.text, issues)
 
     report = ApiFieldReport(
         api=api, file_path=rel_path, file_exists=True, structs=structs, issues=issues,
@@ -668,20 +775,22 @@ def _run_single_api(api_id, all_apis, src_root, out_dir, crate_label, fetch_docs
         for i in issues:
             print(f"  [{i.severity}] {i.detail}")
     else:
-        print("✅ 无可疑模式")
+        print("✅ 字段核对通过" if fetch_docs else "✅ 无可疑模式")
     print(f"📄 报告: {out_dir / f'{crate_label}.md'}")
+    return _exit_code_for_issues(issues) if fetch_docs else 0
 
 
-def _fetch_single_doc(api: ApiRecord, out_dir: Path) -> str:
-    """抓取单个 API 的文档（带缓存）。返回文档文本，失败返回空串。"""
+def _fetch_single_doc(api: ApiRecord, out_dir: Path) -> DocFetchResult:
+    """抓取单个 API 的文档（带缓存）。失败时 DocFetchResult.error 非空。"""
     import subprocess
 
     fetch_script = (
         REPO_ROOT / ".agents" / "skills" / "openlark-api-field-verify" / "scripts" / "fetch_doc.js"
     )
     if not fetch_script.exists():
-        print(f"⚠️ 找不到抓取脚本: {fetch_script}")
-        return ""
+        msg = f"找不到抓取脚本: {fetch_script}"
+        print(f"⚠️ {msg}")
+        return DocFetchResult(error=msg)
     doc_cache = out_dir / "doc_cache"
     doc_cache.mkdir(parents=True, exist_ok=True)
     doc_file = doc_cache / f"{api.api_id}.txt"
@@ -691,12 +800,34 @@ def _fetch_single_doc(api: ApiRecord, out_dir: Path) -> str:
         try:
             subprocess.run(
                 ["node", str(fetch_script), url, str(doc_file)],
-                check=True, capture_output=True, timeout=90,
+                check=True, capture_output=True, timeout=90, text=True,
             )
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
-            print("⚠️ 文档抓取失败")
-            return ""
-    return doc_file.read_text(encoding="utf-8") if doc_file.exists() else ""
+        except subprocess.CalledProcessError as e:
+            err_tail = (e.stderr or e.stdout or str(e))[-200:]
+            msg = f"fetch_doc.js 退出码 {e.returncode}: {err_tail}"
+            print(f"⚠️ 文档抓取失败: {msg}")
+            return DocFetchResult(error=msg)
+        except subprocess.TimeoutExpired:
+            msg = "fetch_doc.js 超时（90s）"
+            print(f"⚠️ 文档抓取失败: {msg}")
+            return DocFetchResult(error=msg)
+
+    if not doc_file.exists():
+        msg = "抓取完成但缓存文件未生成"
+        print(f"⚠️ 文档抓取失败: {msg}")
+        return DocFetchResult(error=msg)
+
+    text = doc_file.read_text(encoding="utf-8")
+    bad = _validate_doc_text(text)
+    if bad:
+        # 无效缓存不留着，避免下次 resume 假绿
+        try:
+            doc_file.unlink()
+        except OSError:
+            pass
+        print(f"⚠️ 文档内容无效: {bad}")
+        return DocFetchResult(text=text, error=bad)
+    return DocFetchResult(text=text)
 
 
 def _load_crate_tags(crate: str) -> Optional[List[str]]:
@@ -712,8 +843,8 @@ def _load_crate_tags(crate: str) -> Optional[List[str]]:
     return crate_cfg.get("biz_tags")
 
 
-def _run_full_mode(csv_path, src_root, out_dir, crate_label, filter_tags):
-    """完整模式：抓飞书文档对比字段（慢）。"""
+def _run_full_mode(csv_path, src_root, out_dir, crate_label, filter_tags) -> int:
+    """完整模式：抓飞书文档对比字段（慢）。抓取失败或 error/warning 返回非 0。"""
     import json
     import subprocess
 
@@ -741,18 +872,26 @@ def _run_full_mode(csv_path, src_root, out_dir, crate_label, filter_tags):
         issues = detect_suspicious_patterns(api, structs, source)
 
         # 抓文档
-        doc_text = ""
-        if api.full_path:
+        if not api.full_path:
+            err = "CSV fullPath 为空"
+            failed.append((api.api_id, err))
+            issues.append(FieldIssue("error", "doc_fetch_failed", f"文档抓取失败: {err}"))
+        else:
             url = "https://open.feishu.cn" + api.full_path
             doc_file = doc_cache / f"{api.api_id}.txt"
+            doc_text = ""
+            fetch_error: Optional[str] = None
             if not doc_file.exists():  # 简单 resume：文件存在则跳过
                 try:
                     subprocess.run(
                         ["node", str(fetch_script), url, str(doc_file)],
-                        check=True, capture_output=True, timeout=90,
+                        check=True, capture_output=True, timeout=90, text=True,
                     )
-                except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-                    failed.append((api.api_id, str(e)[:80]))
+                except subprocess.CalledProcessError as e:
+                    err_tail = (e.stderr or e.stdout or str(e))[-200:]
+                    fetch_error = f"fetch_doc.js 退出码 {e.returncode}: {err_tail}"
+                except subprocess.TimeoutExpired:
+                    fetch_error = "fetch_doc.js 超时（90s）"
                 else:
                     doc_text = (
                         doc_file.read_text(encoding="utf-8") if doc_file.exists() else ""
@@ -760,41 +899,27 @@ def _run_full_mode(csv_path, src_root, out_dir, crate_label, filter_tags):
             else:
                 doc_text = doc_file.read_text(encoding="utf-8")
 
-            # 对比请求体字段
-            if doc_text:
-                doc_req = parse_doc_request_fields(doc_text, api.http_method)
-                code_body = next((s.fields for s in structs if "Body" in s.name), [])
-                if doc_req and code_body:
-                    diff = compare_fields(code_body, doc_req)
-                    if diff.missing:
-                        issues.append(
-                            FieldIssue(
-                                "error", "missing_field",
-                                f"请求体缺字段: {', '.join(diff.missing)}",
-                            )
-                        )
-                    if diff.extra:
-                        issues.append(
-                            FieldIssue(
-                                "warning", "extra_field",
-                                f"请求体多余字段: {', '.join(diff.extra)}",
-                            )
-                        )
+            if fetch_error is None:
+                bad = _validate_doc_text(doc_text)
+                if bad:
+                    fetch_error = bad
+                    if doc_file.exists():
+                        try:
+                            doc_file.unlink()
+                        except OSError:
+                            pass
 
-                # 对比响应体字段（文档示例 vs 代码 Response struct）
-                doc_resp = parse_doc_response_fields(doc_text)
-                code_resp = next((s.fields for s in structs if "Response" in s.name), [])
-                if doc_resp and code_resp:
-                    code_resp_names = {f.effective_name for f in code_resp}
-                    doc_resp_set = set(doc_resp)
-                    missing_resp = sorted(doc_resp_set - code_resp_names)
-                    if missing_resp:
-                        issues.append(
-                            FieldIssue(
-                                "info", "missing_response_field",
-                                f"响应体可能缺字段: {', '.join(missing_resp)}",
-                            )
-                        )
+            if fetch_error:
+                failed.append((api.api_id, fetch_error[:200]))
+                issues.append(
+                    FieldIssue(
+                        "error",
+                        "doc_fetch_failed",
+                        f"文档抓取失败: {fetch_error}",
+                    )
+                )
+            else:
+                _compare_doc_against_code(api, structs, doc_text, issues)
 
         reports.append(
             ApiFieldReport(
@@ -814,8 +939,14 @@ def _run_full_mode(csv_path, src_root, out_dir, crate_label, filter_tags):
         (out_dir / "failed.json").write_text(
             json.dumps(failed, ensure_ascii=False, indent=2), encoding="utf-8"
         )
-    print(f"✅ 报告: {out_dir / f'{crate_label}.md'}")
-    return 0
+
+    all_issues = [i for r in reports for i in r.issues]
+    exit_code = _exit_code_for_issues(all_issues)
+    if exit_code == 0:
+        print(f"✅ 报告: {out_dir / f'{crate_label}.md'}")
+    else:
+        print(f"❌ 核对未通过（error/warning），报告: {out_dir / f'{crate_label}.md'}")
+    return exit_code
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# 概要

修复 `--fetch-docs` 字段核对门禁假绿：文档抓取失败/内容过少/404 记为 error 并以非 0 退出；同时修正飞书 SPA 参数表解析（多空行窗口 + 禁止把 `string` 等类型名当成字段）。error/warning 阻断，info 不阻断。

## 变更类型

- [x] 🐛 修复
- [ ] ✨ 新功能
- [x] 📚 文档 / 格式
- [ ] 🔧 构建 / CI
- [ ] 💥 破坏性改动

## 关联 Issue（可选）

Fixes #

## 验证

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`
- [x] 其它说明：
  - `python3 -m unittest tools.tests.test_verify_api_fields`（21 passed，含假绿回归与稀疏空行解析）
  - `python3 tools/verify_api_fields.py --api-id 7642253323628383198 --fetch-docs` → 字段核对通过，exit 0
  - 无 Rust 代码变更

## 备注（可选）

- `tools/verify_api_fields.py`：`DocFetchResult`、内容校验、完整模式非 0 退出
- 技能文档同步说明门禁 exit code 语义
- 报告目录 `/reports/` 仍被 gitignore，不入库

<details>
<summary>维护者检查（如适用）</summary>

- [ ] 更新 CHANGELOG
- [ ] 评估版本号调整
- [ ] 安全影响评估
- [ ] 更新 API 文档

</details>

Made with [Cursor](https://cursor.com)