### PR TITLE
fix(field-verify): guard fetch_doc.js outFile against URL misuse

### DIFF
--- a/.agents/skills/openlark-api-field-verify/scripts/fetch_doc.js
+++ b/.agents/skills/openlark-api-field-verify/scripts/fetch_doc.js
@@ -146,6 +146,18 @@ function outNameFromInput(input) {
 }
 
 /**
+ * 拒绝把 URL 当本地输出路径：path.resolve 会把 "https://" 折叠成 "https:/"，
+ * 配合 mkdirSync(recursive) 在 cwd 建出整棵 "https:/host/..." 垃圾目录树。
+ */
+function assertLocalOutFile(outFile) {
+  if (/^https?:\/\//i.test(outFile)) {
+    throw new Error(
+      `outFile 不能是 URL（得到 "${outFile}"）；请指定本地输出路径，如 /tmp/doc.txt`
+    );
+  }
+}
+
+/**
  * 渲染单个文档页面，导出 innerText
  * @param {import('playwright').Browser} browser
  * @param {string} url 完整 URL
@@ -206,6 +218,7 @@ async function main() {
     const csvPath = csvIdx >= 0 ? args[csvIdx + 1] : defaultCsvPath();
     const outFile =
       outIdx >= 0 ? args[outIdx + 1] : path.join('/tmp', `doc_${apiId}.txt`);
+    assertLocalOutFile(outFile);
 
     const fullPath = fullPathFromCsv(apiId, csvPath);
     const url = resolveUrl(fullPath);
@@ -276,6 +289,7 @@ async function main() {
     printUsage();
     process.exit(1);
   }
+  assertLocalOutFile(outFile);
   let url;
   try {
     url = resolveUrl(input);


### PR DESCRIPTION
## 背景

仓库根出现一棵 `https:/` 目录树（注意**单斜杠**），源自 2026-08-03 调试 #594 时手动跑 `fetch_doc.js` 误把完整 URL 当作 `<outFile>` 传入。该垃圾树存活 1 天才被清理。

## 根因

`fetch_doc.js` 单页/CSV 模式的 `fetchOne` 无条件执行：

```js
fs.mkdirSync(path.dirname(path.resolve(outFile)), { recursive: true });
fs.writeFileSync(outFile, text, "utf-8");
```

Node `path.resolve` 对结果 normalize，把 `https://` 折叠成 `https:/`（单斜杠）。于是误传的 URL 被当成相对路径，配合 `mkdirSync(recursive)` 在 cwd（仓库根）建出整棵 `https:/open.feishu.cn/.../<api>.txt` 目录树，写入飞书 SPA 的占位 innerText。

> 实测：`path.resolve("https://open.feishu.cn/a/b/pass")` → `<cwd>/https:/open.feishu.cn/a/b/pass`

`tools/verify_api_fields.py` 的调用是干净的（传 `<out_dir>/doc_cache/<api_id>.txt`），**非代码 bug**——本 PR 仅防御手动误用。

## 改动

新增 `assertLocalOutFile(outFile)` 守卫，在**单页 + CSV 两个手动入口、launch browser 之前**拦截：outFile 像协议 URL（`https?://`）则 `throw`，由 `main().catch` 统一打印 `❌ outFile 不能是 URL` 并 exit 1，不建任何目录。

批量模式的 outFile 由 `outNameFromInput` 自动构造成 `doc_*.txt`，不可能误传 URL，不加守卫（不臆测防御）。

## 验证

- `node --check` 语法 OK
- 单页模式误传 URL → `❌ outFile 不能是 URL` + exit 1 + **不建 `https:/`**
- CSV 模式 `--out <URL>` → 同上
- `--help` 正常（exit 0）