### PR TITLE
fix(verify): anchor 404 detection to doc head + flag empty doc parse

### DIFF
--- a/tools/tests/test_verify_api_fields.py
+++ b/tools/tests/test_verify_api_fields.py
@@ -480,6 +480,67 @@ class TestDocFetchGate(unittest.TestCase):
             report = (out_dir / "api-998.md").read_text(encoding="utf-8")
             self.assertIn("多余字段", report)
 
+    # --- issue #595：404 子串无锚点误伤 + 空解析假绿 ---
+
+    def test_validate_notfound_phrase_in_body_not_flagged(self):
+        """合法文档正文深处含 404 短语不应误判（issue #595 问题1）。
+
+        真实样本：错误码表/排障说明里合法出现「文档不存在」/
+        "the documentation could not be found"，在正文深处（数百行后）。
+        当前全文无锚点子串匹配会误判 -> _fetch_single_doc unlink 缓存 ->
+        每次 resume 重抓同一份有效文档又重判红（thrash）。
+        """
+        nav = "\n".join(f"nav {i}" for i in range(40))
+        body = "正常正文内容" * 200  # > MIN_DOC_CHARS
+        # 404 短语埋在正文深处（远超头部窗口）
+        doc = nav + "\n" + body + "\n若 文档不存在，请联系管理员。\n"
+        self.assertIsNone(verify_api_fields._validate_doc_text(doc))
+
+    def test_validate_notfound_phrase_in_head_still_flagged(self):
+        """404 短语出现在页面头部仍应判无效（真实 404 提示在导航后第 17 行）。"""
+        head = "\n".join([
+            "Customer Stories", "Documentation", "API Explorer", "CardKit",
+            "The documentation could not be found.",
+        ])
+        # 补足 >MIN_DOC_CHARS（模拟渲染较多导航的 404），短语仍在头部窗口内
+        doc = head + "\n" + "nav tail\n" * 60
+        self.assertIsNotNone(verify_api_fields._validate_doc_text(doc))
+
+    def test_compare_empty_doc_parse_records_warning(self):
+        """文档过 validate 但请求/响应字段均解析为空 -> 记 warning，禁止假绿（issue #595 问题2）。"""
+        api = verify_api_fields.ApiRecord(
+            api_id="1", name="查询", biz_tag="x", meta_project="x",
+            meta_version="v1", meta_resource="r", meta_name="q",
+            url="GET:/open-apis/x/v1/r/q", doc_path="",
+            full_path="/document/x/reference/x-v1/r/q",
+        )
+        structs = [verify_api_fields.StructFields(name="QResponse", fields=[])]
+        # >MIN_DOC_CHARS、无头部 404 短语、但无 Request body / Response body example 段
+        doc_text = "导航项内容\n" * 80
+        issues = []
+        verify_api_fields._compare_doc_against_code(api, structs, doc_text, issues)
+        empty = [i for i in issues if i.category == "doc_parse_empty"]
+        self.assertEqual(len(empty), 1)
+        self.assertEqual(empty[0].severity, "warning")
+
+    def test_compare_body_present_but_no_req_fields_single_warning(self):
+        """有 Body 实现但文档未解析出请求字段 -> 仅一条 doc_parse_empty（不与空解析检查重复）。"""
+        api = verify_api_fields.ApiRecord(
+            api_id="2", name="创建", biz_tag="x", meta_project="x",
+            meta_version="v1", meta_resource="r", meta_name="c",
+            url="POST:/open-apis/x/v1/r/c", doc_path="",
+            full_path="/document/x/reference/x-v1/r/c",
+        )
+        structs = [verify_api_fields.StructFields(
+            name="CBody", fields=[verify_api_fields.FieldInfo("foo", "String", True)],
+        )]
+        # 无 Request body 段 -> doc_req 空；无 Response body example -> doc_resp 空
+        doc_text = "导航项内容\n" * 80
+        issues = []
+        verify_api_fields._compare_doc_against_code(api, structs, doc_text, issues)
+        empty = [i for i in issues if i.category == "doc_parse_empty"]
+        self.assertEqual(len(empty), 1)  # 不重复
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/verify_api_fields.py
+++ b/tools/verify_api_fields.py
@@ -453,6 +453,10 @@ def _write_summary_json(reports: List[ApiFieldReport], path: Path, mode: str) ->
 # ---------------------------------------------------------------------------
 
 MIN_DOC_CHARS = 500  # 低于此视为抓取失败（URL 错或 SPA 未渲染）
+# 404 提示只在此头部窗口（行）内匹配：飞书 404 页面的错误提示在导航壳之后（实测第 17 行），
+# 而合法文档正文里出现「文档不存在」/"the documentation could not be found"（错误码表/排障说明）
+# 在数百行之后——全文匹配会误伤有效文档并 unlink 缓存，导致每次 resume 重抓重判红（thrash）。
+NOT_FOUND_HEAD_LINES = 30
 
 
 @dataclass
@@ -473,8 +477,9 @@ def _validate_doc_text(text: str) -> Optional[str]:
         return "文档内容为空"
     if len(text) < MIN_DOC_CHARS:
         return f"文档内容过少（{len(text)} < {MIN_DOC_CHARS} 字符），可能 URL 错误或未渲染"
-    lower = text.lower()
-    if "the documentation could not be found" in lower or "文档不存在" in text:
+    # 404 短语锚定到页面头部窗口（见 NOT_FOUND_HEAD_LINES），避免误伤正文深处合法出现
+    head_lower = "\n".join(text.split("\n")[:NOT_FOUND_HEAD_LINES]).lower()
+    if "the documentation could not be found" in head_lower or "文档不存在" in head_lower:
         return "文档页面不存在（URL 可能错误）"
     return None
 
@@ -619,6 +624,7 @@ def _compare_doc_against_code(
     """把文档字段对比结果追加到 issues（就地修改）。"""
     doc_req = parse_doc_request_fields(doc_text, api.http_method)
     code_body = next((s.fields for s in structs if "Body" in s.name), [])
+    parse_warned = False
     if doc_req and code_body:
         diff = compare_fields(code_body, doc_req)
         if diff.missing:
@@ -646,6 +652,7 @@ def _compare_doc_against_code(
                 "文档未解析到请求字段（可能页面结构变化或非 POST/GET 标准段）",
             )
         )
+        parse_warned = True
 
     doc_resp = parse_doc_response_fields(doc_text)
     code_resp = next((s.fields for s in structs if "Response" in s.name), [])
@@ -660,6 +667,18 @@ def _compare_doc_against_code(
                     f"响应体可能缺字段: {', '.join(missing_resp)}",
                 )
             )
+
+    # 文档正文已通过 _validate_doc_text 的基本校验（调用方契约，本函数不重校），
+    # 但请求/响应字段都解析为空——通常是页面未渲染/结构异常。
+    # 记 warning 避免静默假绿（issue #595 问题2）。
+    if not doc_req and not doc_resp and not parse_warned:
+        issues.append(
+            FieldIssue(
+                "warning",
+                "doc_parse_empty",
+                "文档未解析到任何请求/响应字段（可能页面未渲染或结构异常）",
+            )
+        )
 
 
 def main() -> int:


### PR DESCRIPTION
Closes #595.

## 背景

PR #594 review 时发现的两个非阻断质量项，都在 `tools/verify_api_fields.py`（人工/agent 字段核对门禁，不在 CI）。

## 问题 1：404 子串无锚点误伤 + 缓存 thrash

`_validate_doc_text` 对全文做无锚点子串匹配「文档不存在」/「the documentation could not be found」。合法文档正文（错误码表/排障说明）若含此类短语会被误判 404 → `doc_file.unlink()` 清缓存 → 每次 resume 重抓同一份有效文档又重判红，**缓存永不收敛**。

**实证（抓真实页面）**：
- 真实 404 innerText：提示在**第 17 行**（导航壳后），共 285 字符
- 合法文档正文短语：在 **382 / 399 / 433 / 741 行**（错误码表，深处）

**修复**：404 检查锚定到前 `NOT_FOUND_HEAD_LINES=30` 行——覆盖 404 提示（17 行）+ 余量，远低于正文（380+），不再误伤。

## 问题 2：GET + 无 Body 空解析假绿

文档抓取成功（过 validate）但请求/响应字段均解析为空（未渲染 SPA 外壳）时，`_compare_doc_against_code` 不产生任何 issue → 若 `detect_suspicious_patterns` 也无命中 → exit 0 假绿，与 #594「禁止假绿」相悖。

**修复**：末尾 `not doc_req and not doc_resp` → 记 `doc_parse_empty` **warning**（复用现有 category；warning 触发 exit 1）。`parse_warned` flag 防与现有「有 Body 但无请求字段」分支重复计。

## 验证

- TDD：4 个复现测试（红，正对应两 bug）→ 绿
- 单文件 25 全绿、全套 `tools/tests` 207 全绿、py_compile 通过
- /code-review 双轴：Standards 0 硬违反，Spec 完全符合、无 scope creep