### PR TITLE
refactor: 接入 Live Structured Detail 与 Snapshot 复用

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,69 @@
+# OpenLark API Contract
+
+This context defines the language used to compare OpenLark's typed Rust contracts with authoritative Feishu/Lark documentation.
+
+## Language
+
+**Catalog Entry**:
+The authoritative identity and metadata for one Feishu/Lark operation and its official document. Official Document Evidence is always produced for exactly one Catalog Entry.
+_Avoid_: API record, CSV row
+
+**Official Document Evidence**:
+Normalized observations derived from the authoritative official document for a Catalog entry, including provenance, document health, and confidence. It excludes the Rust contract comparison and any pass/fail verdict.
+_Avoid_: fetched document, page text, verification result
+
+**Official Document Snapshot**:
+An immutable capture of an official document together with its acquisition provenance. It is input to document-health assessment and interpretation, and is not Official Document Evidence until those checks succeed.
+_Avoid_: cache file, page text, evidence
+
+**Recorded Snapshot**:
+A versioned, immutable Official Document Snapshot fixture containing the raw official representation and acquisition provenance for offline evidence production. It never stores parsed Evidence.
+_Avoid_: expected Evidence, inline mock response
+
+**Trusted Evidence**:
+Official Document Evidence whose provenance and document health are established and whose relevant structure was interpreted successfully. It may legitimately contain no fields.
+_Avoid_: successful fetch, non-empty evidence
+
+**Incomplete Evidence**:
+Official Document Evidence from an authoritative, healthy document whose relevant structure could not be interpreted completely. Its partial observations may support diagnostic findings, but cannot establish a match or passing verdict.
+_Avoid_: parse warning, empty result
+
+**Unavailable Evidence**:
+The state in which no official document snapshot could be acquired for a Catalog entry.
+_Avoid_: missing fields, empty evidence
+
+**Rejected Evidence**:
+An acquired document snapshot that fails provenance or document-health requirements and therefore cannot serve as Official Document Evidence.
+_Avoid_: fetch error, incomplete evidence
+
+**Strict Evidence Gate**:
+A verification mode in which only Trusted Evidence can support a passing verdict. Incomplete, Unavailable, and Rejected Evidence are always non-passing, even when they still provide diagnostic information.
+_Avoid_: no errors found, warning-only pass
+
+**Evidence Acquisition Policy**:
+The caller-declared requirement for acquiring an Official Document Snapshot: fresh from the official source, preferably from a provenance-matching snapshot, or exclusively from a designated recorded snapshot. The policy does not alter the resulting Evidence Status.
+_Avoid_: cache mode, global TTL
+
+**Official Evidence Source**:
+The official representation actually used to produce Official Document Evidence. Structured Detail is primary; Rendered Document is a fallback when the primary source cannot produce Trusted Evidence for the requested dimension, and observations from different sources are never silently merged.
+_Avoid_: blended evidence, source-agnostic fields
+
+**Evidence Dimension**:
+An independently assessed category of official contract knowledge: Endpoint, Request Fields, Response Fields, or Tokens. Each dimension has its own Evidence Status, provenance, and observations.
+_Avoid_: document-wide status, validation category
+
+**Field Observation**:
+A normalized request or response field identified by its canonical hierarchical path, location, requiredness, type, and Official Evidence Source. Attributes not established by the source remain unknown rather than inferred.
+_Avoid_: flat field name, guessed field
+
+**Evidence Provenance**:
+The reproducibility record for Official Document Evidence. Snapshot provenance identifies the Catalog entry, actual source, acquisition time, and content digest; interpretation provenance identifies the snapshot digest, interpreter revision, and Evidence Dimension.
+_Avoid_: source URL only, report timestamp
+
+**Acquisition Trail**:
+The ordered record of source attempts made while obtaining an Evidence Dimension. A successful fallback may produce Trusted Evidence while retaining failed primary attempts for diagnosis; only the selected source contributes observations.
+_Avoid_: merged evidence, discarded fallback reason
+
+**Evidence Diagnostic**:
+A stable, source-agnostic reason attached to an Evidence Status or Acquisition Trail entry. It describes evidence production and is distinct from caller-specific finding codes and comparison verdicts.
+_Avoid_: finding code, error message, verdict

--- a/docs/adr/0005-official-document-evidence-module.md
+++ b/docs/adr/0005-official-document-evidence-module.md
@@ -1,0 +1,58 @@
+# ADR: 官方文档证据集中为深模块
+
+- **状态**: Accepted
+- **日期**: 2026-08-11
+- **决策者**: 架构评审 + 用户 grilling 共识
+- **来源**: `/improve-codebase-architecture` 的 Official Document Evidence 候选
+
+## 背景
+
+官方飞书文档的获取、缓存、健康判定、结构解释与字段提取目前横跨 `tools/verify_api_fields.py`、`tools/api_contracts/official.py` 和 Playwright 脚本。单 API 与全量字段核对还分别实现抓取流程，使调用方必须理解文件缓存、页面长度、404 文本、section 结构和解析顺序等细节。连续修复曾分别处理抓取失败假绿、404 误判、空解析假绿、合法无字段假阳性和目录文本假绿，说明这些规则缺少一个可测试的职责边界。
+
+## 决策
+
+在 `tools/api_contracts/official_evidence/` 建立 Official Document Evidence 深模块。它以现有 `ApiIdentity` 表达的单个 Catalog Entry 为输入，隐藏官方来源获取、原始快照缓存、文档健康判定、结构解释、字段标准化和 provenance；输出按 Evidence Dimension 划分的不可变证据。Rust 合约比较、finding code、通过判定、批量调度、并发、进度和报告仍由调用方负责。
+
+外部 interface 采用组合入口加单一 `collect()` 行为。调用方声明需要的维度和 Evidence Acquisition Policy；timeout/retry 等运行参数在 composition root 配置。Structured Detail、Rendered Document、Recorded Snapshot 与 snapshot store 是模块内部的 ports，生产环境可复用 HTTP 或浏览器生命周期，但调用方不能指定 parser、直接选择来源或混合 observation。
+
+每个 Endpoint、Request Fields、Response Fields、Tokens 维度独立返回以下状态、provenance、observations、diagnostics 和 Acquisition Trail：
+
+- `Trusted`：来源和健康已建立，相关结构解释成功；空 observations 是合法证据。
+- `Incomplete`：权威且健康的文档只能被部分解释；保留诊断观察，但不能证明匹配。
+- `Unavailable`：未能取得官方文档快照。
+- `Rejected`：已取得的快照不满足来源或健康要求。
+
+Strict Evidence Gate 下只有 `Trusted` 可以支持通过。若所有来源均非 Trusted，选择最有信息量的单一结果：`Incomplete` 优先于 `Rejected`，`Rejected` 优先于 `Unavailable`；同状态优先 Structured Detail。所有尝试保留在 Acquisition Trail，但 observations 只来自最终选定的一个来源。
+
+Structured Detail 是首选来源；仅当某个请求维度无法获得 Trusted Evidence 时，才尝试 Rendered Document。回退成功可以产生 Trusted Evidence，同时保留首选来源的失败诊断。不同来源的 observations 不得静默合并。
+
+缓存只保存不可变的原始 Official Document Snapshot，每次使用时重新执行健康判定和解释。快照 provenance 包含 Catalog Entry、实际来源、获取时间和内容摘要；解释 provenance 包含快照摘要、解释器 revision 和 Evidence Dimension。`Rejected` 快照被移除，`Unavailable` 不缓存。Recorded Snapshot 是带版本的原始 fixture，包含来源类型、Catalog identity、获取 provenance 和原始 structured/rendered 内容，绝不保存解析后的 Evidence。
+
+Field Observation 使用规范化的层级路径，并携带 location、requiredness、type 和来源；来源未证明的属性保持 unknown，不作推断。当前比较器可以暂时只消费顶层字段。
+
+预期的官方来源结果，例如网络超时、文档不存在、内容不健康或结构暂不支持，转换为 Evidence 状态并记录稳定、来源无关的 Evidence Diagnostic。无效 Evidence Request、snapshot-store I/O 失败、adapter 契约或内部 invariant 违例、解释器缺陷直接中止，不得伪装成证据不完整。
+
+## 迁移与兼容性
+
+字段核对与 API contract 验证两个调用方在同一批改造中切换到新模块，同时删除重复的抓取、缓存、健康检查、Catalog record/CSV loader、简化路径公式和针对旧内部 helper 的测试。现有 CLI 参数、退出码用途、finding codes 与 JSON 顶层结构保持不变；调用方将 Evidence Diagnostic 映射到既有 finding codes，并在报告中追加 Evidence 状态、provenance 和 trail。
+
+CI 本批不安装 Playwright。模块测试使用 Recorded Snapshot；CI 的 live composition 仅提供 Structured Detail，若所需 rendered fallback 不可用，则记录 `Unavailable` 并严格失败。人工及 full composition 可使用 live Playwright。Recorded Snapshot 不得充当 fresh acquisition 的隐式回退。
+
+验收必须覆盖：
+
+1. Recorded Snapshot 驱动的 interface matrix，包括四种状态、合法零字段、逐维度回退、层级字段和缓存 policy；
+2. 本地 adapter contracts，包括临时 snapshot store、HTTP mock 和 Playwright subprocess 失败；
+3. 至少一个 live Structured Detail 与一个 live Rendered Document smoke；
+4. 两个现有 CLI 的代表性端到端命令。
+
+## 理由
+
+该边界把反复变化的官方文档规则集中到一个可替换、可录制且可通过公共行为测试的模块。证据获取与业务裁决分离，使失败来源、证据置信度和“合法空字段”不再被压成同一个空集合；内部 ports 保留真实 HTTP、浏览器和离线 fixture 的替换能力，同时不把扩展机制暴露给调用方。
+
+## 非目标
+
+- 不把 Rust contract comparison、通用 validation run policy 或 `--strict` category isolation 纳入本模块。
+- 不在本次工作中完成完整 Catalog provenance/path policy 深化；只复用现有 `ApiIdentity` 并删除字段核对侧重复实现。
+- 不设计 batch API、parser registry、source override、跨来源 observation 合并或自动 verdict。
+- 不改变 Playwright 作为 rendered production adapter，也不改变已批准的 Python 正则与结构解析技术选择。
+

--- a/tools/api_contracts/official_evidence/__init__.py
+++ b/tools/api_contracts/official_evidence/__init__.py
@@ -3,11 +3,20 @@
 from __future__ import annotations
 
 import hashlib
+import http.client
 import json
+import os
 import re
-from dataclasses import dataclass
-from datetime import datetime
+import socket
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 from enum import Enum
+from pathlib import Path
 from typing import Any, Iterable
 
 from ..models import ApiIdentity
@@ -15,6 +24,7 @@ from ..models import ApiIdentity
 
 __all__ = [
     "AcquisitionAttempt",
+    "AdapterContractError",
     "DimensionEvidence",
     "EndpointObservation",
     "EvidenceDiagnostic",
@@ -23,19 +33,27 @@ __all__ = [
     "EvidenceSource",
     "EvidenceStatus",
     "FieldObservation",
+    "FreshOfficialPolicy",
     "InterpretationProvenance",
     "InterpreterError",
     "InvalidEvidenceRequest",
     "OfficialDocumentEvidence",
+    "PreferSnapshotPolicy",
     "RecordedOnlyPolicy",
     "RecordedSnapshot",
     "SnapshotInvariantError",
     "SnapshotProvenance",
+    "SnapshotStoreError",
     "TokenObservation",
     "collect",
+    "compose",
 ]
 
 _INTERPRETER_REVISION = "official-evidence/1"
+
+_STRUCTURED_DETAIL_URL = (
+    "https://open.feishu.cn/document_portal/v1/document/get_detail"
+)
 
 
 class EvidenceDimension(str, Enum):
@@ -71,6 +89,14 @@ class SnapshotInvariantError(EvidenceError):
 
 class InterpreterError(EvidenceError):
     """解释器发生非预期缺陷。"""
+
+
+class SnapshotStoreError(EvidenceError):
+    """Snapshot store 无法维持持久化契约。"""
+
+
+class AdapterContractError(EvidenceError):
+    """Live source adapter 返回了违反契约的结果。"""
 
 
 @dataclass(frozen=True)
@@ -246,6 +272,16 @@ class RecordedOnlyPolicy:
 
 
 @dataclass(frozen=True)
+class FreshOfficialPolicy:
+    """必须从当前 Official Source 获取新快照。"""
+
+
+@dataclass(frozen=True)
+class PreferSnapshotPolicy:
+    """优先复用 provenance 匹配的持久快照，否则获取新快照。"""
+
+
+@dataclass(frozen=True)
 class _Candidate:
     status: EvidenceStatus
     source: EvidenceSource
@@ -254,75 +290,485 @@ class _Candidate:
     snapshot: RecordedSnapshot | None
 
 
+@dataclass(frozen=True)
+class _AcquisitionResult:
+    snapshot: RecordedSnapshot | None
+    failure: _Candidate | None
+
+
+class _StructuredDetailAdapter:
+    def __init__(self, base_url: str, timeout_seconds: float, retries: int) -> None:
+        self._base_url = base_url
+        self._timeout_seconds = timeout_seconds
+        self._retries = retries
+
+    def acquire(self, catalog_entry: ApiIdentity) -> _AcquisitionResult:
+        full_path = _detail_full_path(catalog_entry)
+        if not full_path:
+            raise InvalidEvidenceRequest("Catalog Entry 缺少 Structured Detail fullPath")
+        separator = "&" if "?" in self._base_url else "?"
+        url = (
+            self._base_url
+            + separator
+            + urllib.parse.urlencode({"fullPath": full_path})
+        )
+        last_error: Exception | None = None
+        for attempt in range(self._retries + 1):
+            try:
+                request = urllib.request.Request(
+                    url,
+                    headers={"User-Agent": "openlark-official-evidence/1.0"},
+                )
+                with urllib.request.urlopen(
+                    request,
+                    timeout=self._timeout_seconds,
+                ) as response:
+                    raw_bytes = response.read()
+                    source_uri = response.geturl()
+                raw = raw_bytes.decode("utf-8", "replace")
+                return _AcquisitionResult(
+                    snapshot=_raw_structured_snapshot(
+                        catalog_entry,
+                        source_uri,
+                        raw,
+                    ),
+                    failure=None,
+                )
+            except urllib.error.HTTPError as error:
+                status = error.code
+                error.close()
+                if status == 404:
+                    return _AcquisitionResult(
+                        snapshot=None,
+                        failure=_unavailable(
+                            EvidenceSource.STRUCTURED_DETAIL,
+                            "document_not_found",
+                        ),
+                    )
+                last_error = error
+            except (TimeoutError, socket.timeout) as error:
+                last_error = error
+            except urllib.error.URLError as error:
+                last_error = error
+            except (OSError, http.client.HTTPException) as error:
+                last_error = error
+            if attempt < self._retries:
+                time.sleep(min(2**attempt, 8))
+        code = (
+            "acquisition_timeout"
+            if _is_timeout(last_error)
+            else "acquisition_failed"
+        )
+        return _AcquisitionResult(
+            snapshot=None,
+            failure=_unavailable(EvidenceSource.STRUCTURED_DETAIL, code),
+        )
+
+
+class _SnapshotStore:
+    def __init__(self, directory: Path) -> None:
+        self._directory = directory
+
+    def load(
+        self,
+        catalog_entry: ApiIdentity,
+        source: EvidenceSource,
+    ) -> RecordedSnapshot | None:
+        source_directory = self._source_directory(catalog_entry, source)
+        try:
+            if not source_directory.exists():
+                return None
+            snapshots = tuple(
+                self._read(path)
+                for path in source_directory.iterdir()
+                if path.is_file() and path.suffix == ".json"
+            )
+        except SnapshotStoreError:
+            raise
+        except OSError as error:
+            raise SnapshotStoreError("读取 Official Snapshot store 失败") from error
+        matching = tuple(
+            snapshot
+            for snapshot in snapshots
+            if snapshot.catalog_entry == catalog_entry
+            and snapshot.source_kind is source
+        )
+        if len(matching) != len(snapshots):
+            raise SnapshotStoreError("Snapshot store provenance 与存储路径不匹配")
+        return max(matching, key=_snapshot_time) if matching else None
+
+    def save(self, snapshot: RecordedSnapshot) -> None:
+        _validate_snapshot(snapshot)
+        source_directory = self._source_directory(
+            snapshot.catalog_entry,
+            snapshot.source_kind,
+        )
+        path = source_directory / f"{_snapshot_key(snapshot)}.json"
+        record = {
+            "version": snapshot.version,
+            "source_kind": snapshot.source_kind.value,
+            "catalog_entry": asdict(snapshot.catalog_entry),
+            "acquired_at": snapshot.acquired_at,
+            "source_uri": snapshot.source_uri,
+            "content_digest": snapshot.content_digest,
+            "raw_representation": snapshot.raw_representation,
+        }
+        serialized = json.dumps(
+            record,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        try:
+            source_directory.mkdir(parents=True, exist_ok=True)
+        except OSError as error:
+            raise SnapshotStoreError(
+                "创建 Official Snapshot store 目录失败"
+            ) from error
+        temporary_path: Path | None = None
+        try:
+            descriptor, temporary_name = tempfile.mkstemp(
+                dir=source_directory,
+                prefix=".snapshot-",
+            )
+            temporary_path = Path(temporary_name)
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                handle.write(serialized)
+                handle.flush()
+                os.fsync(handle.fileno())
+            try:
+                os.link(temporary_path, path)
+            except FileExistsError:
+                if path.read_text(encoding="utf-8") != serialized:
+                    raise SnapshotStoreError(
+                        "不可变 Official Snapshot 写入发生键冲突"
+                    )
+        except SnapshotStoreError:
+            raise
+        except OSError as error:
+            raise SnapshotStoreError(
+                "写入 Official Snapshot store 失败"
+            ) from error
+        finally:
+            if temporary_path is not None:
+                try:
+                    temporary_path.unlink(missing_ok=True)
+                except OSError as error:
+                    raise SnapshotStoreError(
+                        "清理 Official Snapshot 临时文件失败"
+                    ) from error
+
+    def remove(self, snapshot: RecordedSnapshot) -> None:
+        path = self._source_directory(
+            snapshot.catalog_entry,
+            snapshot.source_kind,
+        ) / f"{_snapshot_key(snapshot)}.json"
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as error:
+            raise SnapshotStoreError("淘汰 Rejected Official Snapshot 失败") from error
+
+    def _source_directory(
+        self,
+        catalog_entry: ApiIdentity,
+        source: EvidenceSource,
+    ) -> Path:
+        identity = json.dumps(
+            asdict(catalog_entry),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        identity_key = hashlib.sha256(identity.encode("utf-8")).hexdigest()
+        return self._directory / identity_key / source.value
+
+    @staticmethod
+    def _read(path: Path) -> RecordedSnapshot:
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(record, dict):
+                raise ValueError("snapshot record is not an object")
+            snapshot = RecordedSnapshot(
+                version=record["version"],
+                source_kind=EvidenceSource(record["source_kind"]),
+                catalog_entry=ApiIdentity(**record["catalog_entry"]),
+                acquired_at=record["acquired_at"],
+                source_uri=record["source_uri"],
+                content_digest=record["content_digest"],
+                raw_representation=record["raw_representation"],
+            )
+            _validate_snapshot(snapshot)
+            return snapshot
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+            raise SnapshotStoreError("Official Snapshot store 记录损坏") from error
+        except OSError as error:
+            raise SnapshotStoreError("读取 Official Snapshot store 失败") from error
+
+
+class _OfficialEvidenceCollector:
+    """绑定 live adapters 与 snapshot store 的 Evidence composition。"""
+
+    def __init__(
+        self,
+        structured_detail: _StructuredDetailAdapter,
+        snapshot_store: _SnapshotStore,
+    ) -> None:
+        self._structured_detail = structured_detail
+        self._snapshot_store = snapshot_store
+
+    def collect(
+        self,
+        catalog_entry: ApiIdentity,
+        dimensions: Iterable[EvidenceDimension],
+        policy: FreshOfficialPolicy | PreferSnapshotPolicy | RecordedOnlyPolicy,
+    ) -> OfficialDocumentEvidence:
+        requested = _requested_dimensions(catalog_entry, dimensions)
+        if isinstance(policy, RecordedOnlyPolicy):
+            _validate_recorded_policy(catalog_entry, policy)
+            return _collect_from_snapshots(
+                catalog_entry,
+                requested,
+                policy.snapshots,
+            )
+        if not isinstance(policy, (FreshOfficialPolicy, PreferSnapshotPolicy)):
+            raise InvalidEvidenceRequest("不支持的 Evidence Acquisition Policy")
+        if isinstance(policy, PreferSnapshotPolicy):
+            cached = self._snapshot_store.load(
+                catalog_entry,
+                EvidenceSource.STRUCTURED_DETAIL,
+            )
+            if cached is not None:
+                result = _collect_from_snapshots(
+                    catalog_entry,
+                    requested,
+                    (cached,),
+                )
+                if not _structured_rejected(result):
+                    return result
+                self._snapshot_store.remove(cached)
+        acquisition = self._structured_detail.acquire(catalog_entry)
+        if not isinstance(acquisition, _AcquisitionResult):
+            raise AdapterContractError(
+                "Structured Detail adapter 返回了无效 acquisition result"
+            )
+        if acquisition.snapshot is None:
+            if acquisition.failure is None:
+                raise AdapterContractError(
+                    "Structured Detail adapter 未返回 snapshot 或 failure"
+                )
+            return _collect_from_candidate(
+                catalog_entry,
+                requested,
+                acquisition.failure,
+            )
+        if acquisition.failure is not None:
+            raise AdapterContractError(
+                "Structured Detail adapter 同时返回 snapshot 与 failure"
+            )
+        snapshot = acquisition.snapshot
+        if (
+            snapshot.catalog_entry != catalog_entry
+            or snapshot.source_kind is not EvidenceSource.STRUCTURED_DETAIL
+        ):
+            raise AdapterContractError(
+                "Structured Detail snapshot provenance 与请求不匹配"
+            )
+        self._snapshot_store.save(snapshot)
+        result = _collect_from_snapshots(
+            catalog_entry,
+            requested,
+            (snapshot,),
+        )
+        if _structured_rejected(result):
+            self._snapshot_store.remove(snapshot)
+        return result
+
+
+def compose(
+    *,
+    snapshot_directory: Path,
+    timeout_seconds: float,
+    retries: int,
+    structured_detail_url: str = _STRUCTURED_DETAIL_URL,
+) -> _OfficialEvidenceCollector:
+    """在 composition root 配置 live transport 与 snapshot store。"""
+    if not isinstance(snapshot_directory, Path):
+        raise TypeError("snapshot_directory 必须是 pathlib.Path")
+    if not isinstance(timeout_seconds, (int, float)) or timeout_seconds <= 0:
+        raise ValueError("timeout_seconds 必须大于零")
+    if not isinstance(retries, int) or isinstance(retries, bool) or retries < 0:
+        raise ValueError("retries 必须是非负整数")
+    if not isinstance(structured_detail_url, str) or not structured_detail_url:
+        raise ValueError("structured_detail_url 不能为空")
+    return _OfficialEvidenceCollector(
+        _StructuredDetailAdapter(
+            structured_detail_url,
+            float(timeout_seconds),
+            retries,
+        ),
+        _SnapshotStore(snapshot_directory),
+    )
+
+
 def collect(
     catalog_entry: ApiIdentity,
     dimensions: Iterable[EvidenceDimension],
     policy: RecordedOnlyPolicy,
 ) -> OfficialDocumentEvidence:
-    """只通过 Recorded Snapshots 为一个 Catalog Entry 收集所需维度。"""
+    """通过统一 collect seam 解释版本化 Recorded Snapshots。"""
+    requested = _requested_dimensions(catalog_entry, dimensions)
+    if not isinstance(policy, RecordedOnlyPolicy):
+        raise InvalidEvidenceRequest(
+            "live acquisition policy 必须通过 compose() 配置"
+        )
+    _validate_recorded_policy(catalog_entry, policy)
+    return _collect_from_snapshots(
+        catalog_entry,
+        requested,
+        policy.snapshots,
+    )
+
+
+def _requested_dimensions(
+    catalog_entry: ApiIdentity,
+    dimensions: Iterable[EvidenceDimension],
+) -> tuple[EvidenceDimension, ...]:
+    if not isinstance(catalog_entry, ApiIdentity):
+        raise InvalidEvidenceRequest("catalog_entry 必须是 ApiIdentity")
     try:
         requested = tuple(dimensions)
     except TypeError as error:
         raise InvalidEvidenceRequest("Evidence Dimensions 必须可迭代") from error
-    _validate_request(catalog_entry, requested, policy)
-    snapshots = {snapshot.source_kind: snapshot for snapshot in policy.snapshots}
-    results = tuple(
-        _collect_dimension(dimension, snapshots)
-        for dimension in requested
-    )
-    return OfficialDocumentEvidence(catalog_entry=catalog_entry, dimensions=results)
+    if not requested or any(
+        not isinstance(item, EvidenceDimension)
+        for item in requested
+    ):
+        raise InvalidEvidenceRequest("至少请求一个有效 Evidence Dimension")
+    if len(set(requested)) != len(requested):
+        raise InvalidEvidenceRequest("Evidence Dimensions 不得重复")
+    return requested
 
 
-def _validate_request(
+def _validate_recorded_policy(
     catalog_entry: ApiIdentity,
-    dimensions: tuple[EvidenceDimension, ...],
     policy: RecordedOnlyPolicy,
 ) -> None:
-    if not isinstance(catalog_entry, ApiIdentity):
-        raise InvalidEvidenceRequest("catalog_entry 必须是 ApiIdentity")
-    if not isinstance(policy, RecordedOnlyPolicy):
-        raise InvalidEvidenceRequest("仅支持 recorded-only acquisition policy")
-    if not dimensions or any(not isinstance(item, EvidenceDimension) for item in dimensions):
-        raise InvalidEvidenceRequest("至少请求一个有效 Evidence Dimension")
-    if len(set(dimensions)) != len(dimensions):
-        raise InvalidEvidenceRequest("Evidence Dimensions 不得重复")
     if not isinstance(policy.snapshots, tuple):
-        raise SnapshotInvariantError("Recorded-only policy 必须保存不可变 snapshot 序列")
-    if any(not isinstance(snapshot, RecordedSnapshot) for snapshot in policy.snapshots):
+        raise SnapshotInvariantError(
+            "Recorded-only policy 必须保存不可变 snapshot 序列"
+        )
+    if any(
+        not isinstance(snapshot, RecordedSnapshot)
+        for snapshot in policy.snapshots
+    ):
         raise SnapshotInvariantError("Recorded-only policy 包含无效 snapshot")
-    if any(snapshot.catalog_entry != catalog_entry for snapshot in policy.snapshots):
-        raise InvalidEvidenceRequest("Recorded Snapshot 与 Catalog Entry 不匹配")
+    if any(
+        snapshot.catalog_entry != catalog_entry
+        for snapshot in policy.snapshots
+    ):
+        raise InvalidEvidenceRequest(
+            "Recorded Snapshot 与 Catalog Entry 不匹配"
+        )
     sources = [snapshot.source_kind for snapshot in policy.snapshots]
-    if any(not isinstance(source, EvidenceSource) for source in sources):
-        raise SnapshotInvariantError("Recorded Snapshot source kind 无效")
     if len(set(sources)) != len(sources):
-        raise InvalidEvidenceRequest("每种 Official Evidence Source 最多一个 Recorded Snapshot")
+        raise InvalidEvidenceRequest(
+            "每种 Official Evidence Source 最多一个 Recorded Snapshot"
+        )
     for snapshot in policy.snapshots:
-        if snapshot.version != 1:
-            raise SnapshotInvariantError("不支持的 Recorded Snapshot version")
-        if not isinstance(snapshot.raw_representation, str):
-            raise SnapshotInvariantError("Recorded Snapshot 原始表示必须是字符串")
-        if not isinstance(snapshot.acquired_at, str):
-            raise SnapshotInvariantError("Recorded Snapshot acquisition time 无效")
-        try:
-            acquired_at = datetime.fromisoformat(snapshot.acquired_at.replace("Z", "+00:00"))
-        except ValueError as error:
-            raise SnapshotInvariantError("Recorded Snapshot acquisition time 无效") from error
-        if acquired_at.tzinfo is None:
-            raise SnapshotInvariantError("Recorded Snapshot acquisition time 必须包含时区")
-        if not isinstance(snapshot.source_uri, str) or not snapshot.source_uri.strip():
-            raise SnapshotInvariantError("Recorded Snapshot source URI 不能为空")
-        digest = hashlib.sha256(snapshot.raw_representation.encode("utf-8")).hexdigest()
-        if digest != snapshot.content_digest:
-            raise SnapshotInvariantError("Recorded Snapshot content digest 不匹配")
+        _validate_snapshot(snapshot)
+
+
+def _validate_snapshot(snapshot: RecordedSnapshot) -> None:
+    if not isinstance(snapshot.catalog_entry, ApiIdentity):
+        raise SnapshotInvariantError("Official Snapshot Catalog Entry 无效")
+    if not isinstance(snapshot.source_kind, EvidenceSource):
+        raise SnapshotInvariantError("Official Snapshot source kind 无效")
+    if snapshot.version != 1:
+        raise SnapshotInvariantError("不支持的 Official Snapshot version")
+    if not isinstance(snapshot.raw_representation, str):
+        raise SnapshotInvariantError("Official Snapshot 原始表示必须是字符串")
+    if not isinstance(snapshot.acquired_at, str):
+        raise SnapshotInvariantError("Official Snapshot acquisition time 无效")
+    try:
+        acquired_at = datetime.fromisoformat(
+            snapshot.acquired_at.replace("Z", "+00:00")
+        )
+    except ValueError as error:
+        raise SnapshotInvariantError(
+            "Official Snapshot acquisition time 无效"
+        ) from error
+    if acquired_at.tzinfo is None:
+        raise SnapshotInvariantError(
+            "Official Snapshot acquisition time 必须包含时区"
+        )
+    if (
+        not isinstance(snapshot.source_uri, str)
+        or not snapshot.source_uri.strip()
+    ):
+        raise SnapshotInvariantError("Official Snapshot source URI 不能为空")
+    digest = hashlib.sha256(
+        snapshot.raw_representation.encode("utf-8")
+    ).hexdigest()
+    if digest != snapshot.content_digest:
+        raise SnapshotInvariantError(
+            "Official Snapshot content digest 不匹配"
+        )
+
+
+def _collect_from_snapshots(
+    catalog_entry: ApiIdentity,
+    dimensions: tuple[EvidenceDimension, ...],
+    snapshots: tuple[RecordedSnapshot, ...],
+) -> OfficialDocumentEvidence:
+    by_source = {snapshot.source_kind: snapshot for snapshot in snapshots}
+    results = tuple(
+        _collect_dimension(dimension, by_source)
+        for dimension in dimensions
+    )
+    return OfficialDocumentEvidence(
+        catalog_entry=catalog_entry,
+        dimensions=results,
+    )
+
+
+def _collect_from_candidate(
+    catalog_entry: ApiIdentity,
+    dimensions: tuple[EvidenceDimension, ...],
+    structured: _Candidate,
+) -> OfficialDocumentEvidence:
+    results = tuple(
+        _collect_dimension(
+            dimension,
+            {},
+            structured_candidate=structured,
+        )
+        for dimension in dimensions
+    )
+    return OfficialDocumentEvidence(
+        catalog_entry=catalog_entry,
+        dimensions=results,
+    )
+
+
+def _structured_rejected(evidence: OfficialDocumentEvidence) -> bool:
+    return any(
+        dimension.acquisition_trail
+        and dimension.acquisition_trail[0].source
+        is EvidenceSource.STRUCTURED_DETAIL
+        and dimension.acquisition_trail[0].status
+        is EvidenceStatus.REJECTED
+        for dimension in evidence.dimensions
+    )
 
 
 def _collect_dimension(
     dimension: EvidenceDimension,
     snapshots: dict[EvidenceSource, RecordedSnapshot],
+    *,
+    structured_candidate: _Candidate | None = None,
 ) -> DimensionEvidence:
     structured_snapshot = snapshots.get(EvidenceSource.STRUCTURED_DETAIL)
-    structured = (
+    structured = structured_candidate or (
         _interpret_snapshot(structured_snapshot, dimension)
         if structured_snapshot is not None
         else _unavailable(EvidenceSource.STRUCTURED_DETAIL)
@@ -685,9 +1131,66 @@ def _normalize_endpoint(path: str) -> str:
     return normalized.rstrip("/") or "/"
 
 
+def _detail_full_path(catalog_entry: ApiIdentity) -> str:
+    full_path = catalog_entry.full_path.strip()
+    if full_path.startswith("/document/"):
+        return full_path.removeprefix("/document")
+    if full_path == "/document":
+        return ""
+    return full_path
+
+
+def _now_iso8601() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _raw_structured_snapshot(
+    catalog_entry: ApiIdentity,
+    source_uri: str,
+    raw: str,
+) -> RecordedSnapshot:
+    return RecordedSnapshot._create(
+        version=1,
+        source_kind=EvidenceSource.STRUCTURED_DETAIL,
+        catalog_entry=catalog_entry,
+        acquired_at=_now_iso8601(),
+        source_uri=source_uri,
+        raw_representation=raw,
+    )
+
+
+def _is_timeout(error: Exception | None) -> bool:
+    if isinstance(error, (TimeoutError, socket.timeout)):
+        return True
+    return (
+        isinstance(error, urllib.error.URLError)
+        and isinstance(error.reason, (TimeoutError, socket.timeout))
+    )
+
+
+def _snapshot_time(snapshot: RecordedSnapshot) -> datetime:
+    return datetime.fromisoformat(
+        snapshot.acquired_at.replace("Z", "+00:00")
+    )
+
+
+def _snapshot_key(snapshot: RecordedSnapshot) -> str:
+    identity = "\0".join(
+        (
+            snapshot.source_uri,
+            snapshot.acquired_at,
+            snapshot.content_digest,
+        )
+    )
+    return hashlib.sha256(identity.encode("utf-8")).hexdigest()
+
+
 def _diagnostic(code: str) -> EvidenceDiagnostic:
     messages = {
         "snapshot_unavailable": "未提供可用的 Recorded Snapshot",
+        "acquisition_timeout": "Official Source 获取超时",
+        "acquisition_failed": "Official Source 获取失败",
+        "document_not_found": "Official Source 未找到对应文档",
         "document_unhealthy": "原始官方文档表示未通过健康检查",
         "structure_incomplete": "相关官方文档结构无法完整解释",
         "structure_unsupported": "相关官方文档结构暂不受解释器支持",
@@ -695,12 +1198,15 @@ def _diagnostic(code: str) -> EvidenceDiagnostic:
     return EvidenceDiagnostic(code=code, message=messages[code])
 
 
-def _unavailable(source: EvidenceSource) -> _Candidate:
+def _unavailable(
+    source: EvidenceSource,
+    code: str = "snapshot_unavailable",
+) -> _Candidate:
     return _Candidate(
         status=EvidenceStatus.UNAVAILABLE,
         source=source,
         observations=(),
-        diagnostics=(_diagnostic("snapshot_unavailable"),),
+        diagnostics=(_diagnostic(code),),
         snapshot=None,
     )
 

--- a/tools/tests/test_official_evidence_live.py
+++ b/tools/tests/test_official_evidence_live.py
@@ -1,0 +1,391 @@
+import json
+import os
+import tempfile
+import threading
+import time
+import unittest
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+from tools.api_contracts.models import ApiIdentity
+from tools.api_contracts.official_evidence import (
+    AdapterContractError,
+    EvidenceDimension,
+    EvidenceSource,
+    EvidenceStatus,
+    FreshOfficialPolicy,
+    PreferSnapshotPolicy,
+    SnapshotStoreError,
+    compose,
+)
+
+
+class _ResponseServer(ThreadingHTTPServer):
+    response_status = 200
+    response_body = b"{}"
+    response_delay = 0.0
+    declared_length = None
+    requests = 0
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.server.requests += 1
+        if self.server.response_delay:
+            time.sleep(self.server.response_delay)
+        self.send_response(self.server.response_status)
+        self.send_header("Content-Type", "application/json")
+        if self.server.declared_length is not None:
+            self.send_header(
+                "Content-Length",
+                str(self.server.declared_length),
+            )
+        self.end_headers()
+        try:
+            self.wfile.write(self.server.response_body)
+        except BrokenPipeError:
+            pass
+
+    def log_message(self, format, *args):
+        pass
+
+
+@contextmanager
+def detail_server(
+    payload=None,
+    *,
+    status=200,
+    body=None,
+    delay=0.0,
+    declared_length=None,
+):
+    server = _ResponseServer(("127.0.0.1", 0), _Handler)
+    server.response_status = status
+    server.response_body = (
+        body
+        if body is not None
+        else json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    )
+    server.response_delay = delay
+    server.declared_length = declared_length
+    server.requests = 0
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server, f"http://127.0.0.1:{server.server_port}/detail"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+def structured_payload(*, path="/open-apis/bitable/v1/apps/:app_token/records"):
+    return {
+        "data": {
+            "schema": {
+                "apiSchema": {
+                    "httpMethod": "POST",
+                    "path": path,
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": ["record"],
+                                    "properties": {
+                                        "record": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {"type": "string"}
+                                            },
+                                        }
+                                    },
+                                }
+                            }
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "properties": {
+                                            "data": {
+                                                "properties": {
+                                                    "record_id": {"type": "string"}
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "security": {
+                        "supportedAccessToken": ["tenant_access_token"]
+                    },
+                }
+            }
+        }
+    }
+
+
+class LiveOfficialEvidenceCollectTests(unittest.TestCase):
+    def setUp(self):
+        self.api = ApiIdentity(
+            api_id="42",
+            name="创建记录",
+            biz_tag="base",
+            meta_project="bitable",
+            meta_version="v1",
+            meta_resource="app.table.record",
+            meta_name="create",
+            url="POST:/open-apis/bitable/v1/apps/{app_token}/records",
+            doc_path="https://open.feishu.cn/document/mock",
+            expected_file="base/bitable/v1/app/table/record/create.rs",
+            full_path="/document/uAjLw4CM/mock",
+        )
+        self.dimensions = tuple(EvidenceDimension)
+
+    def test_live_structured_detail_collects_every_dimension_and_reuses_snapshot(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with detail_server(structured_payload()) as (server, url):
+                collector = compose(
+                    snapshot_directory=Path(directory),
+                    structured_detail_url=url,
+                    timeout_seconds=1,
+                    retries=0,
+                )
+                fresh = collector.collect(
+                    self.api, self.dimensions, FreshOfficialPolicy()
+                )
+
+                self.assertEqual(server.requests, 1)
+                for dimension in self.dimensions:
+                    evidence = fresh.for_dimension(dimension)
+                    self.assertEqual(evidence.status, EvidenceStatus.TRUSTED)
+                    self.assertEqual(
+                        evidence.selected_source, EvidenceSource.STRUCTURED_DETAIL
+                    )
+                    self.assertEqual(
+                        evidence.snapshot_provenance.source_uri,
+                        f"{url}?fullPath=%2FuAjLw4CM%2Fmock",
+                    )
+                    self.assertEqual(
+                        evidence.interpretation_provenance.dimension, dimension
+                    )
+
+                cached = collector.collect(
+                    self.api, self.dimensions, PreferSnapshotPolicy()
+                )
+                self.assertEqual(server.requests, 1)
+                for dimension in self.dimensions:
+                    current = cached.for_dimension(dimension)
+                    previous = fresh.for_dimension(dimension)
+                    self.assertEqual(current.status, previous.status)
+                    self.assertEqual(
+                        current.snapshot_provenance.content_digest,
+                        previous.snapshot_provenance.content_digest,
+                    )
+                    self.assertIsNot(
+                        current.interpretation_provenance,
+                        previous.interpretation_provenance,
+                    )
+
+    def test_fresh_policy_never_succeeds_from_an_existing_snapshot(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with detail_server(structured_payload()) as (server, url):
+                collector = compose(
+                    snapshot_directory=Path(directory),
+                    structured_detail_url=url,
+                    timeout_seconds=0.05,
+                    retries=0,
+                )
+                trusted = collector.collect(
+                    self.api,
+                    (EvidenceDimension.ENDPOINT,),
+                    FreshOfficialPolicy(),
+                ).for_dimension(EvidenceDimension.ENDPOINT)
+                self.assertEqual(trusted.status, EvidenceStatus.TRUSTED)
+
+            fresh = collector.collect(
+                self.api,
+                (EvidenceDimension.ENDPOINT,),
+                FreshOfficialPolicy(),
+            ).for_dimension(EvidenceDimension.ENDPOINT)
+            self.assertEqual(fresh.status, EvidenceStatus.UNAVAILABLE)
+            self.assertEqual(fresh.diagnostics[0].code, "acquisition_failed")
+
+            cached = collector.collect(
+                self.api,
+                (EvidenceDimension.ENDPOINT,),
+                PreferSnapshotPolicy(),
+            ).for_dimension(EvidenceDimension.ENDPOINT)
+            self.assertEqual(cached.status, EvidenceStatus.TRUSTED)
+
+    def test_timeout_not_found_and_unhealthy_content_are_observable(self):
+        cases = (
+            ({"delay": 0.15}, "acquisition_timeout", EvidenceStatus.UNAVAILABLE),
+            ({"status": 404, "payload": {}}, "document_not_found", EvidenceStatus.UNAVAILABLE),
+            ({"body": b"not-json"}, "document_unhealthy", EvidenceStatus.REJECTED),
+            (
+                {"body": b"{}", "declared_length": 20},
+                "acquisition_failed",
+                EvidenceStatus.UNAVAILABLE,
+            ),
+        )
+        for server_options, diagnostic, status in cases:
+            with self.subTest(diagnostic=diagnostic), tempfile.TemporaryDirectory() as directory:
+                payload = server_options.pop("payload", structured_payload())
+                with detail_server(payload, **server_options) as (_, url):
+                    evidence = compose(
+                        snapshot_directory=Path(directory),
+                        structured_detail_url=url,
+                        timeout_seconds=0.03,
+                        retries=0,
+                    ).collect(
+                        self.api,
+                        (EvidenceDimension.ENDPOINT,),
+                        FreshOfficialPolicy(),
+                    ).for_dimension(EvidenceDimension.ENDPOINT)
+                self.assertEqual(evidence.status, status)
+                self.assertEqual(evidence.diagnostics[0].code, diagnostic)
+                self.assertEqual(evidence.acquisition_trail[0].status, status)
+
+    def test_store_is_immutable_reinterprets_and_evicts_rejected_snapshots(self):
+        with tempfile.TemporaryDirectory() as directory:
+            snapshot_directory = Path(directory)
+            first = structured_payload(path="/open-apis/first")
+            second = structured_payload(path="/open-apis/second")
+            with detail_server(first) as (server, url):
+                collector = compose(
+                    snapshot_directory=snapshot_directory,
+                    structured_detail_url=url,
+                    timeout_seconds=1,
+                    retries=0,
+                )
+                collector.collect(
+                    self.api, (EvidenceDimension.ENDPOINT,), FreshOfficialPolicy()
+                )
+                original_files = tuple(snapshot_directory.rglob("*.json"))
+                self.assertEqual(len(original_files), 1)
+                original_bytes = original_files[0].read_bytes()
+                original_record = json.loads(
+                    original_bytes.decode("utf-8")
+                )
+                self.assertEqual(
+                    original_record["raw_representation"],
+                    json.dumps(first, ensure_ascii=False),
+                )
+
+                server.response_body = json.dumps(second).encode("utf-8")
+                collector.collect(
+                    self.api, (EvidenceDimension.ENDPOINT,), FreshOfficialPolicy()
+                )
+                self.assertEqual(original_files[0].read_bytes(), original_bytes)
+                self.assertEqual(len(tuple(snapshot_directory.rglob("*.json"))), 2)
+
+                latest = collector.collect(
+                    self.api,
+                    (EvidenceDimension.ENDPOINT,),
+                    PreferSnapshotPolicy(),
+                ).for_dimension(EvidenceDimension.ENDPOINT)
+                self.assertEqual(latest.observations[0].path, "/open-apis/second")
+
+                server.response_body = b"not-json"
+                rejected = collector.collect(
+                    self.api, (EvidenceDimension.ENDPOINT,), FreshOfficialPolicy()
+                ).for_dimension(EvidenceDimension.ENDPOINT)
+                self.assertEqual(rejected.status, EvidenceStatus.REJECTED)
+                self.assertEqual(len(tuple(snapshot_directory.rglob("*.json"))), 2)
+
+                server.response_status = 503
+                unavailable = collector.collect(
+                    self.api, (EvidenceDimension.ENDPOINT,), FreshOfficialPolicy()
+                ).for_dimension(EvidenceDimension.ENDPOINT)
+                self.assertEqual(unavailable.status, EvidenceStatus.UNAVAILABLE)
+                self.assertEqual(len(tuple(snapshot_directory.rglob("*.json"))), 2)
+
+    def test_store_io_and_http_adapter_contract_failures_abort(self):
+        with tempfile.TemporaryDirectory() as directory:
+            store_file = Path(directory) / "not-a-directory"
+            store_file.write_text("occupied", encoding="utf-8")
+            with detail_server(structured_payload()) as (_, url):
+                collector = compose(
+                    snapshot_directory=store_file,
+                    structured_detail_url=url,
+                    timeout_seconds=1,
+                    retries=0,
+                )
+                with self.assertRaises(SnapshotStoreError):
+                    collector.collect(
+                        self.api,
+                        (EvidenceDimension.ENDPOINT,),
+                        FreshOfficialPolicy(),
+                    )
+
+            with detail_server(body=b"[]") as (_, url):
+                collector = compose(
+                    snapshot_directory=Path(directory) / "snapshots",
+                    structured_detail_url=url,
+                    timeout_seconds=1,
+                    retries=0,
+                )
+                rejected = collector.collect(
+                    self.api,
+                    (EvidenceDimension.ENDPOINT,),
+                    FreshOfficialPolicy(),
+                ).for_dimension(EvidenceDimension.ENDPOINT)
+                self.assertEqual(rejected.status, EvidenceStatus.REJECTED)
+                self.assertEqual(
+                    rejected.diagnostics[0].code,
+                    "document_unhealthy",
+                )
+
+            class BrokenAdapter:
+                def acquire(self, catalog_entry):
+                    return object()
+
+            collector._structured_detail = BrokenAdapter()
+            with self.assertRaises(AdapterContractError):
+                collector.collect(
+                    self.api,
+                    (EvidenceDimension.ENDPOINT,),
+                    FreshOfficialPolicy(),
+                )
+
+
+@unittest.skipUnless(
+    os.environ.get("OPENLARK_LIVE_STRUCTURED_DETAIL") == "1",
+    "需要显式启用 live Structured Detail smoke",
+)
+class LiveStructuredDetailSmokeTests(unittest.TestCase):
+    def test_live_collect_returns_trusted_endpoint(self):
+        api = ApiIdentity(
+            api_id="6960166873968574467",
+            name="获取多维表格元数据",
+            biz_tag="base",
+            meta_project="bitable",
+            meta_version="v1",
+            meta_resource="app",
+            meta_name="get",
+            url="GET:/open-apis/bitable/v1/apps/{app_token}",
+            doc_path="https://open.feishu.cn/document/server-docs/docs/bitable-v1/app/get",
+            expected_file="base/bitable/v1/app/get.rs",
+            full_path="/document/uAjLw4CM/ukTMukTMukTM/reference/bitable-v1/app/get",
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            evidence = compose(
+                snapshot_directory=Path(directory),
+                timeout_seconds=10,
+                retries=1,
+            ).collect(
+                api,
+                (EvidenceDimension.ENDPOINT,),
+                FreshOfficialPolicy(),
+            ).for_dimension(EvidenceDimension.ENDPOINT)
+        self.assertEqual(evidence.status, EvidenceStatus.TRUSTED, evidence)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更

- 通过统一 `collect()` seam 接入 live Structured Detail
- 新增 fresh、prefer provenance-matching snapshot、recorded-only acquisition policies
- 在 composition root 配置 timeout/retry，隐藏 HTTP adapter 与 snapshot store
- 以原始响应保存不可变 snapshot，并在每次读取时重新执行健康判定与解释
- 完整记录 snapshot/interpretation provenance、diagnostics 与 acquisition trail
- Rejected snapshot 自动淘汰，Unavailable 不持久化，fresh policy 不读取缓存
- 覆盖 Endpoint、Request Fields、Response Fields、Tokens 四个 Evidence dimensions
- 增加本地 HTTP、临时 snapshot store 和显式 live Structured Detail smoke contracts
- 提交 OpenLark API Contract 上下文与 ADR-0005

## 验证

- `python3 -m unittest discover -s tools/tests -p 'test_*.py'`：230 passed，1 skipped
- `cargo test --workspace --all-features`：6113 passed，162 ignored
- `OPENLARK_LIVE_STRUCTURED_DETAIL=1 python3 -m unittest tools.tests.test_official_evidence_live.LiveStructuredDetailSmokeTests`：1 passed

Closes #609