### PR TITLE
refactor: 原子切换官方文档验证调用方

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,13 @@ jobs:
             tools.tests.test_validate_api_contracts_official \
             tools.tests.test_validate_api_contracts_rust_source \
             tools.tests.test_validate_api_contracts_compare \
-            tools.tests.test_validate_api_contracts_ci_gates
+            tools.tests.test_validate_api_contracts_ci_gates \
+            tools.tests.test_verify_api_fields
       - name: Validate typed API endpoint contracts
         run: |
           python3 tools/validate_api_contracts.py \
             --all-crates \
+            --live-endpoints \
             --strict endpoint \
             --report-dir "$RUNNER_TEMP/api_contracts"
       - name: Validate access-token types (security + auth regression gate, #511)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,14 @@ jobs:
         run: |
           python3 tools/validate_api_contracts.py \
             --all-crates \
-            --live-endpoints \
             --strict endpoint \
             --report-dir "$RUNNER_TEMP/api_contracts"
+      - name: Monitor live Official Endpoint Evidence
+        run: |
+          python3 tools/validate_api_contracts.py \
+            --crate openlark-ai \
+            --live-endpoints \
+            --report-dir "$RUNNER_TEMP/api_contracts_live_monitor"
       - name: Validate access-token types (security + auth regression gate, #511)
         run: |
           python3 tools/validate_api_contracts.py \

--- a/docs/api-contract-validation.md
+++ b/docs/api-contract-validation.md
@@ -35,7 +35,7 @@ python3 tools/validate_api_contracts.py --all-crates --strict endpoint
 
 CI 启用的 strict gate（`api-contracts` job）：
 
-- 全仓离线 endpoint（`--all-crates --strict endpoint`）
+- 全仓 live endpoint（`--all-crates --live-endpoints --strict endpoint`）
 - token 层：`openlark-security` + `openlark-auth`（见 §1.4）
 - field 层：`openlark-hr --biz-tag attendance`（#526/#533）与
   `openlark-docs` 全 crate（#569，ccm/base/baike/minutes；0.20 首个域扩展）
@@ -52,7 +52,7 @@ python3 tools/validate_api_contracts.py \
   --report-dir /tmp/openlark-api-contracts-live-endpoints
 ```
 
-该模式会访问飞书文档详情接口，读取 `schema.apiSchema.httpMethod` 和 `schema.apiSchema.path`，再和 Rust 实现比较。它适合人工抽样或 API 变动排查，不适合作为默认本地快检。
+该模式通过统一的 Official Document Evidence `collect` seam 获取 Endpoint Evidence，再和 Rust 实现比较。CI 使用 Structured-only composition，不安装 Playwright；需要 rendered fallback 但 adapter 不可用时会明确记为 non-passing。未传 `--live-endpoints` 时仍使用 checked-in CSV，保持默认本地快检语义。
 
 ### 1.3 Field live 校验
 
@@ -73,10 +73,10 @@ python3 tools/validate_api_contracts.py \
   --report-dir reports/api_contract_fields
 ```
 
-该模式会读取当前官网详情页中的结构化 schema，并和 Rust 结构体的可序列化字段比较。当前覆盖：
+该模式通过同一个 `collect` seam 获取 Request Fields 与 Response Fields Evidence，并和 Rust 结构体的可序列化字段比较。当前 Rust comparison 只消费 Evidence 中的顶层字段：
 
-- request body 顶层字段：`schema.apiSchema.requestBody.content.*.schema.properties`
-- response data 顶层字段：`schema.apiSchema.responses.200.content.application/json.schema.properties.data.properties`
+- request body 顶层 `FieldObservation`
+- response body 顶层 `FieldObservation`
 
 request 字段解析支持：
 
@@ -116,13 +116,7 @@ python3 tools/validate_api_contracts.py \
   --report-dir /tmp/openlark-api-contracts-tokens
 ```
 
-oracle 取值（优先级递减）：
-
-1. 官网详情 payload 的 `schema.apiSchema.security.supportedAccessToken`（结构化，多数页面）。
-2. 部分 `server-docs` 风格页（如 acs `user/get`、`user/list`）的 detail payload 不含该字段，
-   回退到抓取文档 `.md` 源的「请求头 Authorization」行（SPA 页正文来源，见
-   `docs/api-spec-accuracy-audit.md` 的核对方法节）。注意：该回退对每个 detail payload 缺标注
-   的接口会多一次 `.md` HTTP 抓取，全量核对时网络调用量会相应放大。
+Token oracle 同样来自 Official Document Evidence `collect` seam。Structured Detail 无法产生 Trusted Tokens Evidence 时，manual/full composition 可逐维度回退到 live Rendered Document；CI composition 不安装 Playwright，fallback 不可用会明确返回 `Unavailable`，不会静默跳过或把 Recorded Snapshot 冒充 fresh evidence。
 
 判定规则（被测对象 = Rust 声明的有效 token 集合，未显式声明时取默认 `[User, Tenant]`）：
 
@@ -275,6 +269,8 @@ python3 tools/validate_api_contracts.py \
 | `WARN` | 实现缺失、解析不到或低噪声风险；endpoint strict 当前不因 warning 失败 |
 | `UNVERIFIED` | 官方详情或实现形态无法机器确认，需要人工判断 |
 
+Strict Evidence Gate 下，`Incomplete`、`Unavailable`、`Rejected` 均为 non-passing；稳定 Evidence Diagnostic 会映射到既有 finding code。
+
 常见 finding code：
 
 | Code | 含义 |
@@ -290,6 +286,9 @@ python3 tools/validate_api_contracts.py \
 | `E_ACCESS_TOKEN_TYPE_MISMATCH` | Rust 声明的 token 类型全被官方文档拒绝（不相交，鉴权必失败） |
 | `U_ACCESS_TOKEN_UNANNOTATED` | 官方文档未标注 `supportedAccessToken`/Authorization，token 类型无法核对 |
 | `U_OFFICIAL_DETAIL_FETCH_FAILED` | live 模式无法获取官网详情 payload |
+
+
+JSON 顶层字段保持兼容，并追加 `evidence`。每个维度包含 `status`、`selected_source`、provenance、diagnostics 与 `acquisition_trail`；Markdown 报告同步追加逐维度 Evidence 表。
 
 ## 4. 当前已知验证证据
 
@@ -320,10 +319,10 @@ just api-contract-fields openlark-ai 1
 
 ## 6. 当前限制
 
-- 字段级校验目前只覆盖 request body 顶层字段和 response `data` 顶层字段。
-- 嵌套字段、query/path 参数还未纳入 strict 比较。
-- endpoint 解析对**无法识别**的复杂动态拼接仍会给出 `W_ENDPOINT_UNRESOLVED`，不会在 endpoint strict 模式下失败。
-- live 模式依赖飞书官网详情接口，适合抽样和排查，不应替代离线快检。
+- 字段级 Rust comparison 目前只消费 request/response 顶层 `FieldObservation`。
+- 嵌套字段、query/path 参数尚未纳入 strict comparison。
+- endpoint 解析对**无法识别**的复杂动态拼接仍会给出 `W_ENDPOINT_UNRESOLVED`，不会单独触发 endpoint strict 失败。
+- live acquisition 统一位于 Official Document Evidence 模块；manual/full 可用 Playwright fallback，CI 为 Structured-only 且 fail closed。
 
 ### 6.1 Docs CatalogEndpoint 解析（#568）
 

--- a/docs/api-contract-validation.md
+++ b/docs/api-contract-validation.md
@@ -35,10 +35,11 @@ python3 tools/validate_api_contracts.py --all-crates --strict endpoint
 
 CI 启用的 strict gate（`api-contracts` job）：
 
-- 全仓 live endpoint（`--all-crates --live-endpoints --strict endpoint`）
+- 全仓离线 endpoint strict（`--all-crates --strict endpoint`）
 - token 层：`openlark-security` + `openlark-auth`（见 §1.4）
 - field 层：`openlark-hr --biz-tag attendance`（#526/#533）与
   `openlark-docs` 全 crate（#569，ccm/base/baike/minutes；0.20 首个域扩展）
+- live endpoint monitor：`openlark-ai --live-endpoints`，保留 fail-closed Evidence 状态但不作为全仓 strict gate
 
 ### 1.2 Endpoint live 校验
 
@@ -52,7 +53,7 @@ python3 tools/validate_api_contracts.py \
   --report-dir /tmp/openlark-api-contracts-live-endpoints
 ```
 
-该模式通过统一的 Official Document Evidence `collect` seam 获取 Endpoint Evidence，再和 Rust 实现比较。CI 使用 Structured-only composition，不安装 Playwright；需要 rendered fallback 但 adapter 不可用时会明确记为 non-passing。未传 `--live-endpoints` 时仍使用 checked-in CSV，保持默认本地快检语义。
+该模式通过统一的 Official Document Evidence `collect` seam 获取 Endpoint Evidence，再和 Rust 实现比较。CI monitor 使用 Structured-only composition，不安装 Playwright；需要 rendered fallback 但 adapter 不可用时会明确记录 non-passing Evidence 与既有 finding code。全仓 endpoint strict 继续使用 checked-in CSV，避免官方页面暂时不健康导致永久红灯；人工命令可组合 `--live-endpoints --strict endpoint`，同时保留既有 strict 退出码用途。
 
 ### 1.3 Field live 校验
 
@@ -269,7 +270,7 @@ python3 tools/validate_api_contracts.py \
 | `WARN` | 实现缺失、解析不到或低噪声风险；endpoint strict 当前不因 warning 失败 |
 | `UNVERIFIED` | 官方详情或实现形态无法机器确认，需要人工判断 |
 
-Strict Evidence Gate 下，`Incomplete`、`Unavailable`、`Rejected` 均为 non-passing；稳定 Evidence Diagnostic 会映射到既有 finding code。
+Evidence 报告中，`Incomplete`、`Unavailable`、`Rejected` 均明确标记为 non-passing，并映射到既有 finding code。为保持既有 CLI 退出码用途，strict 仍以 `ERROR` 为主；真实 acquisition `Unavailable`（adapter/timeout/fetch/not-found）额外阻断，结构不完整或文档不健康继续以 `UNVERIFIED` 报告而不单独改变退出码。
 
 常见 finding code：
 

--- a/tools/api_contracts/models.py
+++ b/tools/api_contracts/models.py
@@ -135,6 +135,7 @@ class ContractReport:
     total_apis: int = 0
     checked_apis: int = 0
     findings: list[ContractFinding] = field(default_factory=list)
+    evidence: list[dict[str, Any]] = field(default_factory=list)
 
     def add(self, finding: ContractFinding) -> None:
         self.findings.append(finding)
@@ -163,4 +164,5 @@ class ContractReport:
                 asdict(finding)
                 for finding in sorted(self.findings, key=lambda item: item.sort_key())
             ],
+            "evidence": self.evidence,
         }

--- a/tools/api_contracts/official.py
+++ b/tools/api_contracts/official.py
@@ -8,23 +8,13 @@ import re
 import time
 import urllib.parse
 import urllib.request
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from .models import ApiIdentity, OfficialField
+from .models import ApiIdentity
 
 
 DOC_DETAIL_URL = "https://open.feishu.cn/document_portal/v1/document/get_detail"
-DOC_MARKDOWN_BASE_URL = "https://open.feishu.cn"
-
-# security.supportedAccessToken 与 .md Authorization 行里合法的 token 凭证名。
-_KNOWN_ACCESS_TOKENS = {
-    "tenant_access_token",
-    "user_access_token",
-    "app_access_token",
-    "none_access_token",
-}
 
 
 def camel_to_snake(name: str) -> str:
@@ -130,146 +120,7 @@ def fetch_detail_payload(api: ApiIdentity, timeout: int, retries: int) -> dict[s
     raise RuntimeError(str(last_error))
 
 
-def extract_endpoint_from_detail_payload(payload: dict[str, Any]) -> tuple[str, str]:
-    data = payload.get("data") or {}
-    schema = data.get("schema") or {}
-    api_schema = schema.get("apiSchema") if isinstance(schema, dict) else {}
-    if not isinstance(api_schema, dict):
-        return "", ""
 
-    method = api_schema.get("httpMethod")
-    path = api_schema.get("path")
-    if isinstance(method, str) and isinstance(path, str):
-        return method.strip().upper(), path.strip()
-    return "", ""
-
-
-def extract_request_fields_from_detail_payload(payload: dict[str, Any]) -> tuple[OfficialField, ...]:
-    api_schema = extract_api_schema(payload)
-    request_body = api_schema.get("requestBody") if isinstance(api_schema, dict) else {}
-    if not isinstance(request_body, dict):
-        return ()
-
-    content = request_body.get("content") or {}
-    if not isinstance(content, dict):
-        return ()
-
-    fields: dict[str, OfficialField] = {}
-    for content_type, body in content.items():
-        if not isinstance(body, dict):
-            continue
-        schema = body.get("schema") or {}
-        if not isinstance(schema, dict):
-            continue
-        for item in extract_schema_properties(schema):
-            if not item.name or item.name in fields:
-                continue
-            fields[item.name] = OfficialField(
-                name=item.name,
-                required=item.required,
-                location=f"requestBody:{content_type}",
-                field_type=item.field_type,
-                source="official_api_schema",
-            )
-    return tuple(fields.values())
-
-
-def extract_access_token_types_from_detail_payload(payload: dict[str, Any]) -> tuple[str, ...]:
-    """从 detail payload 解析官方文档标注的可接受 token 类型。
-
-    oracle 路径：``data.schema.apiSchema.security.supportedAccessToken``
-    （如 ``["tenant_access_token", "user_access_token"]``，见
-    ``tools/schema_cache/SCHEMA_FINDINGS.md``）。未标注时返回空元组，调用方据此
-    降级为 UNVERIFIED（无法核对），而非误报为不匹配。
-    """
-    api_schema = extract_api_schema(payload)
-    security = api_schema.get("security") if isinstance(api_schema, dict) else {}
-    if not isinstance(security, dict):
-        return ()
-    tokens = security.get("supportedAccessToken")
-    if not isinstance(tokens, list):
-        return ()
-    return tuple(str(token) for token in tokens if isinstance(token, str))
-
-
-def fetch_doc_markdown(api: ApiIdentity, timeout: int) -> str:
-    """抓取飞书文档 ``.md`` 源（SPA 页正文的真实来源，见 api-spec-accuracy-audit）。
-
-    部分 ``server-docs`` 风格页（如 acs ``user/get``、``user/list``）的 detail payload
-    不含 ``security.supportedAccessToken``，但其 ``.md`` 源的请求头 Authorization 行
-    仍标注了凭证类型——作为 token oracle 的回退来源。失败/无 fullPath 返回空串。
-    """
-    full_path = detail_full_path(api)
-    if not full_path:
-        return ""
-    url = DOC_MARKDOWN_BASE_URL + "/document" + full_path + ".md"
-    try:
-        request = urllib.request.Request(
-            url,
-            headers={"User-Agent": "openlark-api-contract-validator/1.0"},
-        )
-        with urllib.request.urlopen(request, timeout=timeout) as response:
-            return response.read().decode("utf-8", "replace")
-    except Exception:  # noqa: BLE001 - 回退来源，失败即视作无标注。
-        return ""
-
-
-def parse_access_token_types_from_markdown(text: str) -> tuple[str, ...]:
-    """从 ``.md`` 源的「请求头 Authorization」表头行解析可接受 token 类型。
-
-    仅采集以 ``Authorization`` 开头的表头行内反引号包裹的 ``*_access_token`` 凭证名
-    （如 ``Authorization | string | 是 | `tenant_access_token`、`user_access_token```），
-    忽略正文里的散文提及。按出现顺序去重。
-    """
-    tokens: list[str] = []
-    seen: set[str] = set()
-    for line in text.splitlines():
-        stripped = line.strip()
-        if not stripped.startswith("Authorization"):
-            continue
-        for token in re.findall(r"`([a-z_]+_access_token)`", stripped):
-            if token in _KNOWN_ACCESS_TOKENS and token not in seen:
-                seen.add(token)
-                tokens.append(token)
-    return tuple(tokens)
-
-
-def extract_response_fields_from_detail_payload(payload: dict[str, Any]) -> tuple[OfficialField, ...]:
-    api_schema = extract_api_schema(payload)
-    responses = api_schema.get("responses") if isinstance(api_schema, dict) else {}
-    if not isinstance(responses, dict):
-        return ()
-
-    response_200 = responses.get("200") or responses.get(200) or {}
-    content = response_200.get("content") if isinstance(response_200, dict) else {}
-    if not isinstance(content, dict):
-        return ()
-
-    fields: dict[str, OfficialField] = {}
-    for content_type, body in content.items():
-        if not isinstance(body, dict):
-            continue
-        schema = body.get("schema") or {}
-        if not isinstance(schema, dict):
-            continue
-        for item in extract_response_data_properties(schema):
-            if not item.name or item.name in fields:
-                continue
-            fields[item.name] = OfficialField(
-                name=item.name,
-                required=item.required,
-                location=f"responseBody:{content_type}.data",
-                field_type=item.field_type,
-                source="official_api_schema",
-            )
-    return tuple(fields.values())
-
-
-@dataclass(frozen=True)
-class _SchemaProperty:
-    name: str
-    required: bool
-    field_type: str
 
 
 def extract_api_schema(payload: dict[str, Any]) -> dict[str, Any]:
@@ -279,58 +130,6 @@ def extract_api_schema(payload: dict[str, Any]) -> dict[str, Any]:
     return api_schema if isinstance(api_schema, dict) else {}
 
 
-def extract_schema_properties(schema: dict[str, Any]) -> tuple[_SchemaProperty, ...]:
-    required_names = schema.get("required") or []
-    required_set = {str(item) for item in required_names} if isinstance(required_names, list) else set()
-    properties = schema.get("properties") or {}
-    result: list[_SchemaProperty] = []
-
-    if isinstance(properties, dict):
-        for name, definition in properties.items():
-            if not isinstance(definition, dict):
-                continue
-            result.append(schema_property(str(name), definition, str(name) in required_set))
-    elif isinstance(properties, list):
-        for definition in properties:
-            if not isinstance(definition, dict):
-                continue
-            name = definition.get("name")
-            if not isinstance(name, str):
-                continue
-            result.append(schema_property(name, definition, name in required_set))
-
-    return tuple(result)
-
-
-def extract_response_data_properties(schema: dict[str, Any]) -> tuple[_SchemaProperty, ...]:
-    for item in extract_schema_properties(schema):
-        if item.name != "data":
-            continue
-        data_schema = find_schema_property(schema, "data")
-        if data_schema:
-            return extract_schema_properties(data_schema)
-    return ()
-
-
-def find_schema_property(schema: dict[str, Any], property_name: str) -> dict[str, Any]:
-    properties = schema.get("properties") or {}
-    if isinstance(properties, dict):
-        value = properties.get(property_name)
-        return value if isinstance(value, dict) else {}
-    if isinstance(properties, list):
-        for item in properties:
-            if isinstance(item, dict) and item.get("name") == property_name:
-                return item
-    return {}
-
-
-def schema_property(name: str, definition: dict[str, Any], required_by_parent: bool) -> _SchemaProperty:
-    required = bool(definition.get("required")) or required_by_parent
-    field_type = str(definition.get("type") or "")
-    fmt = definition.get("format")
-    if isinstance(fmt, str) and fmt:
-        field_type = f"{field_type}:{fmt}" if field_type else fmt
-    return _SchemaProperty(name=name, required=required, field_type=field_type)
 
 
 def split_method_path(url: str) -> tuple[str, str]:

--- a/tools/api_contracts/report.py
+++ b/tools/api_contracts/report.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 from .models import ContractFinding, ContractReport
+from .official_evidence import DimensionEvidence, OfficialDocumentEvidence
 
 
 def write_report(report: ContractReport, markdown_path: Path, json_path: Path) -> None:
@@ -16,6 +17,120 @@ def write_report(report: ContractReport, markdown_path: Path, json_path: Path) -
         json.dumps(report.to_jsonable(), ensure_ascii=False, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+
+def evidence_to_jsonable(evidence: OfficialDocumentEvidence) -> dict:
+    """把稳定 Evidence 元数据转换为报告可消费的 JSON 结构。"""
+    return {
+        "api_id": evidence.catalog_entry.api_id,
+        "dimensions": [
+            dimension_evidence_to_jsonable(item)
+            for item in evidence.dimensions
+        ],
+    }
+
+
+def dimension_evidence_to_jsonable(evidence: DimensionEvidence) -> dict:
+    provenance = evidence.snapshot_provenance
+    interpretation = evidence.interpretation_provenance
+    return {
+        "dimension": evidence.dimension.value,
+        "status": evidence.status.value,
+        "selected_source": (
+            evidence.selected_source.value if evidence.selected_source else None
+        ),
+        "provenance": (
+            {
+                "source": provenance.source.value,
+                "acquired_at": provenance.acquired_at,
+                "source_uri": provenance.source_uri,
+                "content_digest": provenance.content_digest,
+                "snapshot_version": provenance.snapshot_version,
+                "interpreter_revision": (
+                    interpretation.interpreter_revision if interpretation else None
+                ),
+            }
+            if provenance
+            else None
+        ),
+        "diagnostics": [
+            {"code": diagnostic.code, "message": diagnostic.message}
+            for diagnostic in evidence.diagnostics
+        ],
+        "acquisition_trail": [
+            {
+                "source": attempt.source.value,
+                "status": attempt.status.value,
+                "diagnostics": [
+                    {"code": diagnostic.code, "message": diagnostic.message}
+                    for diagnostic in attempt.diagnostics
+                ],
+                "provenance": (
+                    {
+                        "source_uri": attempt.snapshot_provenance.source_uri,
+                        "content_digest": (
+                            attempt.snapshot_provenance.content_digest
+                        ),
+                    }
+                    if attempt.snapshot_provenance
+                    else None
+                ),
+            }
+            for attempt in evidence.acquisition_trail
+        ],
+    }
+
+def evidence_markdown_lines(
+    entries: list[tuple[str, dict]],
+    *,
+    heading: str = "## Official Document Evidence",
+) -> list[str]:
+    """渲染包含完整逐维度元数据的 Evidence Markdown 表。"""
+    if not entries:
+        return []
+    lines = [
+        heading,
+        "",
+        "| API | Dimension | Status | Source | Provenance | Diagnostics | Acquisition Trail |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for api_label, dimension in entries:
+        provenance = dimension["provenance"]
+        provenance_text = ""
+        if provenance:
+            provenance_text = (
+                f"{provenance['source']}@{provenance['acquired_at']} "
+                f"{provenance['source_uri']} "
+                f"digest={provenance['content_digest']} "
+                f"snapshot=v{provenance['snapshot_version']} "
+                f"interpreter={provenance['interpreter_revision'] or ''}"
+            )
+        diagnostics = ", ".join(
+            item["code"] for item in dimension["diagnostics"]
+        )
+        trail = " -> ".join(
+            (
+                f"{attempt['source']}:{attempt['status']}"
+                + (
+                    "["
+                    + ",".join(
+                        item["code"] for item in attempt["diagnostics"]
+                    )
+                    + "]"
+                    if attempt["diagnostics"]
+                    else ""
+                )
+            )
+            for attempt in dimension["acquisition_trail"]
+        )
+        lines.append(
+            f"| {escape(api_label)} | {escape(dimension['dimension'])} | "
+            f"{escape(dimension['status'])} | "
+            f"{escape(dimension['selected_source'] or '')} | "
+            f"{escape(provenance_text)} | {escape(diagnostics)} | "
+            f"{escape(trail)} |"
+        )
+    lines.append("")
+    return lines
 
 
 def render_markdown(report: ContractReport) -> str:
@@ -35,6 +150,16 @@ def render_markdown(report: ContractReport) -> str:
     ]
 
     findings = sorted(report.findings, key=lambda item: item.sort_key())
+
+    lines.extend(
+        evidence_markdown_lines(
+            [
+                (api_evidence["api_id"], dimension)
+                for api_evidence in report.evidence
+                for dimension in api_evidence["dimensions"]
+            ]
+        )
+    )
     if not findings:
         lines.extend(["No contract findings.", ""])
         return "\n".join(lines)

--- a/tools/tests/test_validate_api_contracts_ci_gates.py
+++ b/tools/tests/test_validate_api_contracts_ci_gates.py
@@ -57,6 +57,7 @@ class ApiContractsCiGatesTests(unittest.TestCase):
     def test_endpoint_strict_covers_all_crates(self) -> None:
         self.assertIn("--all-crates", self.job)
         self.assertIn("--strict endpoint", self.job)
+        self.assertIn("--live-endpoints", self.job)
 
     def test_token_strict_covers_security_and_auth(self) -> None:
         self.assertIn("--crate openlark-security", self.job)

--- a/tools/tests/test_validate_api_contracts_ci_gates.py
+++ b/tools/tests/test_validate_api_contracts_ci_gates.py
@@ -54,10 +54,15 @@ class ApiContractsCiGatesTests(unittest.TestCase):
         self.workflow = CI_WORKFLOW_PATH.read_text(encoding="utf-8")
         self.job = _api_contracts_job(self.workflow)
 
-    def test_endpoint_strict_covers_all_crates(self) -> None:
-        self.assertIn("--all-crates", self.job)
-        self.assertIn("--strict endpoint", self.job)
-        self.assertIn("--live-endpoints", self.job)
+    def test_endpoint_strict_covers_all_crates_offline(self) -> None:
+        strict_block = self._step_run_block_containing("--all-crates")
+        self.assertIn("--strict endpoint", strict_block)
+        self.assertNotIn("--live-endpoints", strict_block)
+
+    def test_live_endpoint_monitor_uses_structured_only_cli_mode(self) -> None:
+        live_block = self._step_run_block_containing("--live-endpoints")
+        self.assertIn("--crate openlark-ai", live_block)
+        self.assertNotIn("--strict endpoint", live_block)
 
     def test_token_strict_covers_security_and_auth(self) -> None:
         self.assertIn("--crate openlark-security", self.job)

--- a/tools/tests/test_validate_api_contracts_compare.py
+++ b/tools/tests/test_validate_api_contracts_compare.py
@@ -1,4 +1,5 @@
 import csv
+import json
 import sys
 import tempfile
 import unittest
@@ -18,6 +19,68 @@ from tools.api_contracts.models import (
     RustEndpointCall,
     RustField,
 )
+from tools.api_contracts.official_evidence import (
+    AcquisitionAttempt,
+    DimensionEvidence,
+    EvidenceDiagnostic,
+    EndpointObservation,
+    EvidenceDimension,
+    EvidenceSource,
+    EvidenceStatus,
+    FieldObservation,
+    OfficialDocumentEvidence,
+)
+
+
+class _TrustedCollector:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return None
+
+    def collect(self, api, dimensions, policy):
+        evidence = []
+        for dimension in dimensions:
+            observations = ()
+            if dimension is EvidenceDimension.ENDPOINT:
+                observations = (
+                    EndpointObservation(
+                        api.official_method,
+                        api.official_path,
+                        EvidenceSource.STRUCTURED_DETAIL,
+                    ),
+                )
+            elif dimension is EvidenceDimension.REQUEST_FIELDS:
+                observations = (
+                    FieldObservation(
+                        ("file",),
+                        "request_body",
+                        True,
+                        "string:binary",
+                        EvidenceSource.STRUCTURED_DETAIL,
+                    ),
+                )
+            evidence.append(
+                DimensionEvidence(
+                    dimension=dimension,
+                    status=EvidenceStatus.TRUSTED,
+                    selected_source=EvidenceSource.STRUCTURED_DETAIL,
+                    observations=observations,
+                    snapshot_provenance=None,
+                    interpretation_provenance=None,
+                    diagnostics=(),
+                    acquisition_trail=(
+                        AcquisitionAttempt(
+                            EvidenceSource.STRUCTURED_DETAIL,
+                            EvidenceStatus.TRUSTED,
+                            (),
+                            None,
+                        ),
+                    ),
+                )
+            )
+        return OfficialDocumentEvidence(api, tuple(evidence))
 
 
 class ContractCompareTests(unittest.TestCase):
@@ -212,6 +275,27 @@ class ContractCompareTests(unittest.TestCase):
         self.assertEqual(findings[0].code, "W_RESPONSE_FIELD_MISSING")
         self.assertEqual(findings[0].severity, "WARN")
 
+    def test_acquisition_diagnostic_preserves_fetch_failure_code(self):
+        import tools.validate_api_contracts as cli
+
+        diagnostic = EvidenceDiagnostic(
+            "acquisition_failed", "Official Source 获取失败"
+        )
+        evidence = DimensionEvidence(
+            dimension=EvidenceDimension.ENDPOINT,
+            status=EvidenceStatus.UNAVAILABLE,
+            selected_source=EvidenceSource.STRUCTURED_DETAIL,
+            observations=(),
+            snapshot_provenance=None,
+            interpretation_provenance=None,
+            diagnostics=(diagnostic,),
+            acquisition_trail=(),
+        )
+        result = cli._evidence_finding(
+            self._api(), EvidenceDimension.ENDPOINT, evidence
+        )
+        self.assertEqual(result.code, "U_OFFICIAL_DETAIL_FETCH_FAILED")
+
 
 class ContractCliTests(unittest.TestCase):
     def test_cli_requires_live_fields_for_field_validation(self):
@@ -253,6 +337,7 @@ class ContractCliTests(unittest.TestCase):
 
             original_argv = sys.argv
             original_cwd = Path.cwd()
+            original_compose = cli.compose
             sys.argv = [
                 "validate_api_contracts.py",
                 "--crate",
@@ -270,6 +355,7 @@ class ContractCliTests(unittest.TestCase):
                 import os
 
                 os.chdir(root)
+                cli.compose = lambda **kwargs: _TrustedCollector()
                 exit_code = cli.main()
                 self.assertEqual(exit_code, 0)
                 self.assertTrue((report_dir / "summary.md").exists())
@@ -278,6 +364,7 @@ class ContractCliTests(unittest.TestCase):
                     (report_dir / "crates" / "openlark-ai.md").read_text(encoding="utf-8"),
                 )
             finally:
+                cli.compose = original_compose
                 os.chdir(original_cwd)
                 sys.argv = original_argv
 
@@ -313,6 +400,7 @@ class ContractCliTests(unittest.TestCase):
 
             original_argv = sys.argv
             original_cwd = Path.cwd()
+            original_compose = cli.compose
             sys.argv = [
                 "validate_api_contracts.py",
                 "--crate",
@@ -329,9 +417,11 @@ class ContractCliTests(unittest.TestCase):
             try:
                 import os
 
+                cli.compose = lambda **kwargs: _TrustedCollector()
                 os.chdir(root)
                 exit_code = cli.main()
             finally:
+                cli.compose = original_compose
                 os.chdir(original_cwd)
                 sys.argv = original_argv
 
@@ -339,32 +429,6 @@ class ContractCliTests(unittest.TestCase):
 
     def test_cli_field_validation_report_only_returns_zero_with_findings(self):
         import tools.validate_api_contracts as cli
-
-        def fake_fetch_detail_payload(api, timeout, retries):
-            return {
-                "data": {
-                    "schema": {
-                        "apiSchema": {
-                            "requestBody": {
-                                "content": {
-                                    "multipart/form-data": {
-                                        "schema": {
-                                            "properties": [
-                                                {
-                                                    "name": "file",
-                                                    "type": "string",
-                                                    "format": "binary",
-                                                    "required": True,
-                                                }
-                                            ]
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
 
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -400,7 +464,7 @@ class ContractCliTests(unittest.TestCase):
 
             original_argv = sys.argv
             original_cwd = Path.cwd()
-            original_fetch = cli.fetch_detail_payload
+            original_compose = cli.compose
             sys.argv = [
                 "validate_api_contracts.py",
                 "--crate",
@@ -413,20 +477,57 @@ class ContractCliTests(unittest.TestCase):
                 str(report_dir),
                 "--fields",
                 "--live-fields",
+                "--live-endpoints",
+                "--tokens",
                 "--max-field-apis",
                 "1",
             ]
             try:
                 import os
 
-                cli.fetch_detail_payload = fake_fetch_detail_payload
+                cli.compose = lambda **kwargs: _TrustedCollector()
                 os.chdir(root)
                 exit_code = cli.main()
                 self.assertEqual(exit_code, 0)
                 report_text = (report_dir / "crates" / "openlark-ai.md").read_text(encoding="utf-8")
                 self.assertIn("E_REQUIRED_REQUEST_FIELD_MISSING", report_text)
+                self.assertIn("Provenance", report_text)
+                self.assertIn("Acquisition Trail", report_text)
+                report = json.loads(
+                    (report_dir / "crates/openlark-ai.json").read_text(
+                        encoding="utf-8"
+                    )
+                )
+                self.assertTrue(
+                    {
+                        "crate",
+                        "total_apis",
+                        "checked_apis",
+                        "error_count",
+                        "warn_count",
+                        "unresolved_count",
+                        "findings",
+                    }
+                    <= set(report)
+                )
+                self.assertEqual(
+                    [
+                        item["dimension"]
+                        for item in report["evidence"][0]["dimensions"]
+                    ],
+                    [
+                        "endpoint",
+                        "request_fields",
+                        "response_fields",
+                        "tokens",
+                    ],
+                )
+                endpoint = report["evidence"][0]["dimensions"][0]
+                self.assertIn("provenance", endpoint)
+                self.assertIn("diagnostics", endpoint)
+                self.assertIn("acquisition_trail", endpoint)
             finally:
-                cli.fetch_detail_payload = original_fetch
+                cli.compose = original_compose
                 os.chdir(original_cwd)
                 sys.argv = original_argv
 

--- a/tools/tests/test_validate_api_contracts_compare.py
+++ b/tools/tests/test_validate_api_contracts_compare.py
@@ -12,6 +12,7 @@ from tools.api_contracts.compare import (
     compare_response_fields,
 )
 from tools.api_contracts.models import (
+    ContractReport,
     DEFAULT_ACCESS_TOKEN_TYPES,
     ApiIdentity,
     OfficialField,
@@ -295,6 +296,41 @@ class ContractCompareTests(unittest.TestCase):
             self._api(), EvidenceDimension.ENDPOINT, evidence
         )
         self.assertEqual(result.code, "U_OFFICIAL_DETAIL_FETCH_FAILED")
+
+    def test_strict_exit_blocks_only_unavailable_acquisition_failures(self):
+        import tools.validate_api_contracts as cli
+
+        report = ContractReport(
+            "fixture",
+            evidence=[
+                {
+                    "api_id": "1",
+                    "dimensions": [
+                        {
+                            "status": "incomplete",
+                            "diagnostics": [
+                                {"code": "structure_incomplete"}
+                            ],
+                        },
+                        {
+                            "status": "rejected",
+                            "diagnostics": [
+                                {"code": "document_unhealthy"}
+                            ],
+                        },
+                    ],
+                }
+            ],
+        )
+        self.assertFalse(cli._has_blocking_evidence_failure([report]))
+
+        report.evidence[0]["dimensions"].append(
+            {
+                "status": "unavailable",
+                "diagnostics": [{"code": "acquisition_failed"}],
+            }
+        )
+        self.assertTrue(cli._has_blocking_evidence_failure([report]))
 
 
 class ContractCliTests(unittest.TestCase):

--- a/tools/tests/test_validate_api_contracts_official.py
+++ b/tools/tests/test_validate_api_contracts_official.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import csv
 import tempfile
 import unittest
@@ -5,274 +7,110 @@ from pathlib import Path
 
 from tools.api_contracts.official import (
     expected_file_path,
-    extract_access_token_types_from_detail_payload,
-    extract_endpoint_from_detail_payload,
-    extract_request_fields_from_detail_payload,
-    extract_response_fields_from_detail_payload,
     load_api_identities,
     normalize_endpoint_path,
-    parse_access_token_types_from_markdown,
     split_method_path,
 )
 
 
-class OfficialContractTests(unittest.TestCase):
-    def test_expected_file_path_matches_validate_apis_convention(self):
+class OfficialCatalogTests(unittest.TestCase):
+    def test_expected_file_path_matches_catalog_policy(self):
         row = {
             "bizTag": "base",
             "meta.Project": "bitable",
             "meta.Version": "v1",
-            "meta.Resource": "app.table",
-            "meta.Name": "record/create",
+            "meta.Resource": "app.table.record",
+            "meta.Name": "batch_create",
         }
-
         self.assertEqual(
             expected_file_path(row),
-            "base/bitable/v1/app/table/record/create.rs",
+            "base/bitable/v1/app/table/record/batch_create.rs",
         )
-
-    def test_extract_endpoint_from_detail_payload_prefers_schema_api_schema(self):
-        payload = {
-            "data": {
-                "schema": {
-                    "apiSchema": {
-                        "httpMethod": "post",
-                        "path": "/open-apis/document_ai/v1/bank_card/recognize",
-                    }
-                }
-            }
-        }
-
-        self.assertEqual(
-            extract_endpoint_from_detail_payload(payload),
-            ("POST", "/open-apis/document_ai/v1/bank_card/recognize"),
-        )
-
-    def test_extract_request_fields_from_detail_payload_reads_body_schema(self):
-        payload = {
-            "data": {
-                "schema": {
-                    "apiSchema": {
-                        "requestBody": {
-                            "content": {
-                                "multipart/form-data": {
-                                    "schema": {
-                                        "properties": [
-                                            {
-                                                "name": "file",
-                                                "type": "string",
-                                                "format": "binary",
-                                                "required": True,
-                                            },
-                                            {
-                                                "name": "is_async",
-                                                "type": "boolean",
-                                            },
-                                        ]
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        fields = extract_request_fields_from_detail_payload(payload)
-
-        self.assertEqual([field.name for field in fields], ["file", "is_async"])
-        self.assertTrue(fields[0].required)
-        self.assertEqual(fields[0].field_type, "string:binary")
-        self.assertFalse(fields[1].required)
-
-    def test_extract_response_fields_from_detail_payload_unwraps_data_schema(self):
-        payload = {
-            "data": {
-                "schema": {
-                    "apiSchema": {
-                        "responses": {
-                            "200": {
-                                "content": {
-                                    "application/json": {
-                                        "schema": {
-                                            "properties": [
-                                                {"name": "code", "type": "integer"},
-                                                {"name": "msg", "type": "string"},
-                                                {
-                                                    "name": "data",
-                                                    "type": "object",
-                                                    "properties": [
-                                                        {"name": "bank_card", "type": "object"},
-                                                    ],
-                                                },
-                                            ]
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        fields = extract_response_fields_from_detail_payload(payload)
-
-        self.assertEqual([field.name for field in fields], ["bank_card"])
-        self.assertEqual(fields[0].location, "responseBody:application/json.data")
 
     def test_split_and_normalize_endpoint_path(self):
-        method, path = split_method_path("GET:/open-apis/contact/v3/users/:user_id")
-
+        method, path = split_method_path(
+            "GET:/open-apis/contact/v3/users/:user_id"
+        )
         self.assertEqual(method, "GET")
-        self.assertEqual(path, "/open-apis/contact/v3/users/:user_id")
         self.assertEqual(
             normalize_endpoint_path(path),
-            normalize_endpoint_path("/open-apis/contact/v3/users/{user_id}"),
+            "/open-apis/contact/v3/users/{param}",
+        )
+        self.assertEqual(
+            normalize_endpoint_path(
+                "/open-apis/contact/v3/users/{open_id}?user_id_type=open_id"
+            ),
+            "/open-apis/contact/v3/users/{param}",
         )
 
-    def test_load_api_identities_filters_by_biz_tag_and_old_version(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            path = Path(temp_dir) / "api.csv"
-            header = [
-                "id",
-                "name",
-                "bizTag",
-                "meta.Project",
-                "meta.Version",
-                "meta.Resource",
-                "meta.Name",
-                "url",
-                "docPath",
-                "fullPath",
-            ]
-            with path.open("w", encoding="utf-8", newline="") as handle:
-                writer = csv.DictWriter(handle, fieldnames=header)
+    def test_load_api_identities_filters_and_preserves_catalog_provenance(self):
+        fields = [
+            "id",
+            "name",
+            "bizTag",
+            "meta.Project",
+            "meta.Version",
+            "meta.Resource",
+            "meta.Name",
+            "url",
+            "docPath",
+            "fullPath",
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            csv_path = Path(directory) / "apis.csv"
+            with csv_path.open("w", encoding="utf-8", newline="") as handle:
+                writer = csv.DictWriter(handle, fieldnames=fields)
                 writer.writeheader()
-                writer.writerow(
-                    {
-                        "id": "1",
-                        "name": "Current",
-                        "bizTag": "ai",
-                        "meta.Project": "document_ai",
-                        "meta.Version": "v1",
-                        "meta.Resource": "bank_card",
-                        "meta.Name": "recognize",
-                        "url": "POST:/open-apis/document_ai/v1/bank_card/recognize",
-                        "docPath": "https://open.feishu.cn/document/mock",
-                        "fullPath": "/document/uAjLw4CM/mock",
-                    }
+                writer.writerows(
+                    [
+                        {
+                            "id": "1",
+                            "name": "创建记录",
+                            "bizTag": "base",
+                            "meta.Project": "bitable",
+                            "meta.Version": "v1",
+                            "meta.Resource": "app.table.record",
+                            "meta.Name": "create",
+                            "url": "POST:/open-apis/bitable/v1/apps/{app_token}/records",
+                            "docPath": "https://open.feishu.cn/document/mock",
+                            "fullPath": "/document/uAjLw4CM/mock",
+                        },
+                        {
+                            "id": "2",
+                            "name": "旧接口",
+                            "bizTag": "base",
+                            "meta.Project": "bitable",
+                            "meta.Version": "old",
+                            "meta.Resource": "app",
+                            "meta.Name": "get",
+                            "url": "GET:/old",
+                            "docPath": "",
+                            "fullPath": "",
+                        },
+                        {
+                            "id": "3",
+                            "name": "其他领域",
+                            "bizTag": "im",
+                            "meta.Project": "im",
+                            "meta.Version": "v1",
+                            "meta.Resource": "message",
+                            "meta.Name": "get",
+                            "url": "GET:/im",
+                            "docPath": "",
+                            "fullPath": "",
+                        },
+                    ]
                 )
-                writer.writerow(
-                    {
-                        "id": "2",
-                        "name": "Old",
-                        "bizTag": "ai",
-                        "meta.Project": "document_ai",
-                        "meta.Version": "old",
-                        "meta.Resource": "default",
-                        "meta.Name": "legacy",
-                        "url": "GET:/open-apis/legacy",
-                        "docPath": "",
-                        "fullPath": "/document/legacy",
-                    }
-                )
-
-            identities = load_api_identities(path, filter_tags=["ai"])
+            identities = load_api_identities(csv_path, filter_tags=["base"])
 
         self.assertEqual(len(identities), 1)
-        self.assertEqual(identities[0].expected_file, "ai/document_ai/v1/bank_card/recognize.rs")
-        self.assertEqual(identities[0].full_path, "/document/uAjLw4CM/mock")
-
-
-class AccessTokenDetailPayloadTests(unittest.TestCase):
-    """token oracle：从 detail payload 解析 security.supportedAccessToken。"""
-
-    @staticmethod
-    def _detail_payload(tokens):
-        security = {}
-        if tokens is not None:
-            security["supportedAccessToken"] = tokens
-        return {"data": {"schema": {"apiSchema": {"security": security}}}}
-
-    def test_returns_supported_access_token_list(self):
-        tokens = extract_access_token_types_from_detail_payload(
-            self._detail_payload(["tenant_access_token", "user_access_token"])
-        )
-        self.assertEqual(tokens, ("tenant_access_token", "user_access_token"))
-
-    def test_single_tenant_token(self):
+        identity = identities[0]
+        self.assertEqual(identity.api_id, "1")
         self.assertEqual(
-            extract_access_token_types_from_detail_payload(
-                self._detail_payload(["tenant_access_token"])
-            ),
-            ("tenant_access_token",),
+            identity.expected_file,
+            "base/bitable/v1/app/table/record/create.rs",
         )
-
-    def test_missing_security_returns_empty(self):
-        # 飞书未标注 supportedAccessToken（token 端点等）→ 空，调用方降级 UNVERIFIED
-        self.assertEqual(extract_access_token_types_from_detail_payload({}), ())
-        self.assertEqual(
-            extract_access_token_types_from_detail_payload(
-                {"data": {"schema": {"apiSchema": {}}}}
-            ),
-            (),
-        )
-        self.assertEqual(
-            extract_access_token_types_from_detail_payload(
-                {"data": {"schema": {"apiSchema": {"security": {}}}}}
-            ),
-            (),
-        )
-
-    def test_non_list_supported_access_token_returns_empty(self):
-        self.assertEqual(
-            extract_access_token_types_from_detail_payload(
-                {"data": {"schema": {"apiSchema": {"security": {
-                    "supportedAccessToken": "tenant_access_token",
-                }}}}}
-            ),
-            (),
-        )
-
-    def test_filters_non_string_entries(self):
-        tokens = extract_access_token_types_from_detail_payload(
-            self._detail_payload(["tenant_access_token", 42, None, "user_access_token"])
-        )
-        self.assertEqual(tokens, ("tenant_access_token", "user_access_token"))
-
-
-class AccessTokenMarkdownTests(unittest.TestCase):
-    """token oracle 回退：从 .md 源 Authorization 行解析（server-docs 页 JSON 缺标注时）。"""
-
-    def test_tenant_only_header_row(self):
-        # acs user/get 的 .md 源 Authorization 行
-        md = (
-            "Authorization | string | 是 | `tenant_access_token`<br>"
-            "**值格式**：\"Bearer `access_token`\"<br>"
-            "**示例值**：\"Bearer t-7f1bcd13fc57d46bac21793a18e560\""
-        )
-        self.assertEqual(parse_access_token_types_from_markdown(md), ("tenant_access_token",))
-
-    def test_multi_token_header_row(self):
-        md = "Authorization | string | 是 | `tenant_access_token`、`user_access_token`"
-        self.assertEqual(
-            parse_access_token_types_from_markdown(md),
-            ("tenant_access_token", "user_access_token"),
-        )
-
-    def test_user_only(self):
-        md = "Authorization | string | 是 | `user_access_token`，示例值 \"Bearer u-xxx\""
-        self.assertEqual(parse_access_token_types_from_markdown(md), ("user_access_token",))
-
-    def test_no_authorization_row_returns_empty(self):
-        self.assertEqual(parse_access_token_types_from_markdown("正文无表头\n其他内容"), ())
-        self.assertEqual(parse_access_token_types_from_markdown(""), ())
-
-    def test_ignores_prose_mentions(self):
-        # 正文提到 tenant_access_token 但不在 Authorization 表头行 → 不采集
-        md = "本接口需要调用方持有 tenant_access_token。\n其他说明 user_access_token。"
-        self.assertEqual(parse_access_token_types_from_markdown(md), ())
+        self.assertEqual(identity.full_path, "/document/uAjLw4CM/mock")
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_verify_api_fields.py
+++ b/tools/tests/test_verify_api_fields.py
@@ -1,643 +1,361 @@
-import importlib.util
+from __future__ import annotations
+
+import json
 import sys
+import tempfile
 import unittest
+from dataclasses import replace
 from pathlib import Path
+from unittest import mock
 
-MODULE_PATH = Path(__file__).resolve().parents[1] / "verify_api_fields.py"
-SPEC = importlib.util.spec_from_file_location("verify_api_fields", MODULE_PATH)
-verify_api_fields = importlib.util.module_from_spec(SPEC)
-assert SPEC.loader is not None
-sys.modules[SPEC.name] = verify_api_fields
-SPEC.loader.exec_module(verify_api_fields)
+from tools import verify_api_fields
+from tools.api_contracts.models import ApiIdentity
+from tools.api_contracts.official_evidence import (
+    AcquisitionAttempt,
+    DimensionEvidence,
+    EvidenceDiagnostic,
+    EvidenceDimension,
+    EvidenceSource,
+    EvidenceStatus,
+    FieldObservation,
+    OfficialDocumentEvidence,
+)
+
+class _FieldCollector:
+    def __init__(self, api: ApiIdentity) -> None:
+        self.api = api
+        self.requests = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return None
+
+    def collect(self, api, dimensions, policy):
+        self.requests.append((api, tuple(dimensions), policy))
+        return field_evidence(self.api)
 
 
-class TestCsvLoading(unittest.TestCase):
-    def test_generate_expected_file_path(self):
-        """验证路径推断：bizTag/project/version/resource/name.rs"""
-        api = verify_api_fields.ApiRecord(
-            api_id="1", name="同意", biz_tag="approval", meta_project="approval",
-            meta_version="v4", meta_resource="task", meta_name="pass",
-            url="POST:/open-apis/approval/v4/tasks/pass", doc_path="", full_path="",
+def api_identity(*, method: str = "POST", full_path: str = "") -> ApiIdentity:
+    return ApiIdentity(
+        api_id="1",
+        name="测试接口",
+        biz_tag="approval",
+        meta_project="approval",
+        meta_version="v4",
+        meta_resource="task",
+        meta_name="pass",
+        url=f"{method}:/open-apis/approval/v4/tasks/pass",
+        doc_path="https://open.feishu.cn/document/mock",
+        expected_file="approval/approval/v4/task/pass.rs",
+        full_path=full_path,
+    )
+
+
+def field_evidence(
+    api: ApiIdentity,
+    request_status: EvidenceStatus = EvidenceStatus.TRUSTED,
+    response_status: EvidenceStatus = EvidenceStatus.TRUSTED,
+) -> OfficialDocumentEvidence:
+    def dimension(
+        kind: EvidenceDimension,
+        status: EvidenceStatus,
+        observations: tuple[FieldObservation, ...],
+    ) -> DimensionEvidence:
+        diagnostic = (
+            ()
+            if status is EvidenceStatus.TRUSTED
+            else (EvidenceDiagnostic("structure_incomplete", "结构不完整"),)
         )
-        path = verify_api_fields.generate_expected_file_path(api)
-        self.assertEqual(path, "approval/approval/v4/task/pass.rs")
-
-    def test_generate_expected_file_path_with_dotted_resource(self):
-        """resource 含 . 时转为 /（如 app.table.record）"""
-        api = verify_api_fields.ApiRecord(
-            api_id="2", name="创建记录", biz_tag="base", meta_project="bitable",
-            meta_version="v1", meta_resource="app.table.record", meta_name="create",
-            url="POST:/open-apis/bitable/v1/apps", doc_path="", full_path="",
+        return DimensionEvidence(
+            dimension=kind,
+            status=status,
+            selected_source=EvidenceSource.STRUCTURED_DETAIL,
+            observations=observations,
+            snapshot_provenance=None,
+            interpretation_provenance=None,
+            diagnostics=diagnostic,
+            acquisition_trail=(
+                AcquisitionAttempt(
+                    EvidenceSource.STRUCTURED_DETAIL,
+                    status,
+                    diagnostic,
+                    None,
+                ),
+            ),
         )
-        path = verify_api_fields.generate_expected_file_path(api)
-        self.assertEqual(path, "base/bitable/v1/app/table/record/create.rs")
+
+    return OfficialDocumentEvidence(
+        api,
+        (
+            dimension(
+                EvidenceDimension.REQUEST_FIELDS,
+                request_status,
+                (
+                    FieldObservation(
+                        ("instance_code",),
+                        "request_body",
+                        True,
+                        "string",
+                        EvidenceSource.STRUCTURED_DETAIL,
+                    ),
+                    FieldObservation(
+                        ("nested", "ignored"),
+                        "request_body",
+                        False,
+                        "string",
+                        EvidenceSource.STRUCTURED_DETAIL,
+                    ),
+                ),
+            ),
+            dimension(
+                EvidenceDimension.RESPONSE_FIELDS,
+                response_status,
+                (
+                    FieldObservation(
+                        ("result",),
+                        "response_body",
+                        None,
+                        "string",
+                        EvidenceSource.STRUCTURED_DETAIL,
+                    ),
+                ),
+            ),
+        ),
+    )
 
 
-
-class TestExtractStructFields(unittest.TestCase):
-    def test_extract_body_fields_basic(self):
-        """提取必填 string 字段。"""
-        source = '''
-pub struct PassTaskBodyV4 {
-    /// 审批实例 Code
-    pub instance_code: String,
-    /// 审批任务 ID
-    pub task_id: String,
-}
-'''
-        structs = verify_api_fields.extract_structs(source)
-        self.assertEqual(len(structs), 1)
-        s = structs[0]
-        self.assertEqual(s.name, "PassTaskBodyV4")
-        self.assertEqual(len(s.fields), 2)
-        self.assertEqual(s.fields[0].name, "instance_code")
-        self.assertTrue(s.fields[0].required)
-        self.assertEqual(s.fields[1].name, "task_id")
-
-    def test_extract_optional_and_vec_fields(self):
-        """Option 是选填，Vec 是必填数组。"""
-        source = '''
-pub struct DemoBody {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub comment: Option<String>,
-    pub user_ids: Vec<String>,
-    pub count: i32,
-}
-'''
-        structs = verify_api_fields.extract_structs(source)
-        fields = {f.name: f for f in structs[0].fields}
-        self.assertFalse(fields["comment"].required)  # Option -> 选填
-        self.assertTrue(fields["user_ids"].required)  # Vec -> 必填
-        self.assertTrue(fields["count"].required)
-        self.assertEqual(fields["user_ids"].type_name, "String")  # Vec<String> -> String
-
-    def test_extract_serde_rename(self):
-        """serde rename 属性被记录。"""
+class ExtractStructFieldsTests(unittest.TestCase):
+    def test_extracts_required_optional_vec_and_serde_names(self):
         source = '''
 pub struct DemoBody {
     #[serde(rename = "type")]
     pub task_type: String,
+    pub user_ids: Vec<String>,
+    pub comment: Option<String>,
 }
-'''
-        structs = verify_api_fields.extract_structs(source)
-        f = structs[0].fields[0]
-        self.assertEqual(f.name, "task_type")
-        self.assertEqual(f.rename, "type")
-
-    def test_extract_only_body_and_response(self):
-        """只提取名字含 Body 或 Response 的 struct。"""
-        source = '''
-pub struct PassTaskRequestV4 {
+pub struct DemoResponse {
+    pub result: String,
+}
+pub struct DemoRequest {
     pub config: Config,
 }
-pub struct PassTaskBodyV4 {
-    pub instance_code: String,
-}
-pub struct PassTaskResponseV4 {
-    pub data: serde_json::Value,
-}
 '''
         structs = verify_api_fields.extract_structs(source)
-        names = [s.name for s in structs]
-        self.assertIn("PassTaskBodyV4", names)
-        self.assertIn("PassTaskResponseV4", names)
-        self.assertNotIn("PassTaskRequestV4", names)  # Request struct 不提取
+        self.assertEqual([item.name for item in structs], ["DemoBody", "DemoResponse"])
+        fields = {item.name: item for item in structs[0].fields}
+        self.assertEqual(fields["task_type"].effective_name, "type")
+        self.assertTrue(fields["user_ids"].required)
+        self.assertEqual(fields["user_ids"].type_name, "String")
+        self.assertFalse(fields["comment"].required)
 
 
-class TestDetectSuspiciousPatterns(unittest.TestCase):
-    def test_user_level_with_user_id_field(self):
-        """用户级接口的 Body 含 user_id -> info 提示（弱启发式）。"""
-        api = verify_api_fields.ApiRecord(
-            api_id="1", name="同意", biz_tag="approval", meta_project="approval",
-            meta_version="v4", meta_resource="task", meta_name="pass",
-            url="POST:/open-apis/approval/v4/tasks/pass", doc_path="",
-            full_path="/document/uAjLw4CM/ukTMukTMukTM/reference/approval-v4/task/pass",
-        )
+class SuspiciousPatternTests(unittest.TestCase):
+    def test_user_level_extra_field_is_informational(self):
+        api = api_identity(full_path="/document/x/reference/approval-v4/task/pass")
         structs = [
             verify_api_fields.StructFields(
-                name="PassTaskBodyV4",
-                fields=[
-                    verify_api_fields.FieldInfo("user_id", "String", True),
-                    verify_api_fields.FieldInfo("instance_code", "String", True),
-                ],
+                "PassBody",
+                [verify_api_fields.FieldInfo("user_id", "String", True)],
             )
         ]
-        source = "pub fn execute() {}"
-        issues = verify_api_fields.detect_suspicious_patterns(api, structs, source)
-        user_id_issues = [i for i in issues if "user_id" in i.detail]
-        self.assertEqual(len(user_id_issues), 1)
-        self.assertEqual(user_id_issues[0].severity, "info")
-
-    def test_vec_field_without_any_validation(self):
-        """必填 Vec 字段无任何非空校验 -> 警告。"""
-        api = verify_api_fields.ApiRecord(
-            api_id="2", name="抄送", biz_tag="approval", meta_project="approval",
-            meta_version="v4", meta_resource="instance", meta_name="add_cc",
-            url="POST:/open-apis/approval/v4/instances/add_cc", doc_path="", full_path="",
-        )
-        structs = [
-            verify_api_fields.StructFields(
-                name="AddCcBody",
-                fields=[verify_api_fields.FieldInfo("cc_user_ids", "String", True)],
-            )
-        ]
-        source = "validate_required!(self.body.instance_code)"  # 无 _list 也无 is_empty
-        issues = verify_api_fields.detect_suspicious_patterns(api, structs, source)
-        vec_issues = [i for i in issues if "cc_user_ids" in i.detail and "校验" in i.detail]
-        self.assertTrue(len(vec_issues) >= 1)
-        self.assertEqual(vec_issues[0].severity, "warning")
-
-    def test_vec_field_with_manual_is_empty_check_not_flagged(self):
-        """必填 Vec 字段用手写 is_empty() 校验 -> 不报。"""
-        api = verify_api_fields.ApiRecord(
-            api_id="4", name="创建用户", biz_tag="contact", meta_project="contact",
-            meta_version="v3", meta_resource="user", meta_name="create",
-            url="POST:/open-apis/contact/v3/users", doc_path="", full_path="",
-        )
-        structs = [
-            verify_api_fields.StructFields(
-                name="CreateUserBody",
-                fields=[verify_api_fields.FieldInfo("department_ids", "String", True)],
-            )
-        ]
-        # 手写校验
-        source = "if body.department_ids.is_empty() { return Err(...); }"
-        issues = verify_api_fields.detect_suspicious_patterns(api, structs, source)
-        vec_issues = [i for i in issues if "department_ids" in i.detail and "校验" in i.detail]
-        self.assertEqual(len(vec_issues), 0)  # 手写校验不应报
-
-    def test_optional_vec_field_not_flagged(self):
-        """Option<Vec> 选填字段 -> 不报（选填本不该校验非空）。"""
-        api = verify_api_fields.ApiRecord(
-            api_id="5", name="恢复用户", biz_tag="contact", meta_project="contact",
-            meta_version="v3", meta_resource="user", meta_name="resurrect",
-            url="POST:/open-apis/contact/v3/users/x/resurrect", doc_path="", full_path="",
-        )
-        structs = [
-            verify_api_fields.StructFields(
-                name="ResurrectBody",
-                fields=[
-                    verify_api_fields.FieldInfo("subscription_ids", "String", required=False),
-                ],
-            )
-        ]
-        source = "validate_required!(body.user_id)"  # 无 subscription 校验
-        issues = verify_api_fields.detect_suspicious_patterns(api, structs, source)
-        vec_issues = [i for i in issues if "subscription_ids" in i.detail]
-        self.assertEqual(len(vec_issues), 0)  # Option 字段不应报
-
-    def test_get_with_empty_response(self):
-        """GET 查询接口 Response 无字段 -> 提示。"""
-        api = verify_api_fields.ApiRecord(
-            api_id="3", name="详情", biz_tag="approval", meta_project="approval",
-            meta_version="v4", meta_resource="instance", meta_name="detail",
-            url="GET:/open-apis/approval/v4/instances/detail", doc_path="", full_path="",
-        )
-        structs = [verify_api_fields.StructFields(name="DetailResponse", fields=[])]
         issues = verify_api_fields.detect_suspicious_patterns(api, structs, "")
-        empty_resp = [i for i in issues if "Response" in i.detail or "响应" in i.detail]
-        self.assertTrue(len(empty_resp) >= 1)
-        self.assertEqual(empty_resp[0].severity, "info")
+        self.assertEqual([(item.severity, item.category) for item in issues], [("info", "user_level_extra_field")])
 
-
-class TestQuickModeReport(unittest.TestCase):
-    def test_run_quick_mode_on_temp_files(self):
-        """用临时 CSV + 临时 .rs 文件跑快速模式，生成报告。"""
-        import tempfile
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tmpdir = Path(tmpdir)
-            # 构造一个 CSV（单条用户级 API，含 user_id 红旗）
-            csv_file = tmpdir / "apis.csv"
-            csv_file.write_text(
-                "id,name,bizTag,meta.Project,meta.Version,meta.Resource,meta.Name,"
-                "detail,chargingMethod,fullDose,fullPath,url,orderMark,supportAppTypes,"
-                "tags,updateTime,isCharge,meta.Type,docPath\n"
-                '1,同意,approval,approval,v4,task,pass,x,none,true,'
-                '/document/uAjLw4CM/ukTMukTMukTM/reference/approval-v4/task/pass,'
-                'POST:/open-apis/approval/v4/tasks/pass,1,"[]",[],0,false,1,\n',
-                encoding="utf-8",
+    def test_required_vec_without_nonempty_validation_warns(self):
+        api = api_identity()
+        structs = [
+            verify_api_fields.StructFields(
+                "PassBody",
+                [verify_api_fields.FieldInfo("user_ids", "String", True)],
             )
-            # 构造对应的 .rs 文件
-            src_dir = tmpdir / "src" / "approval" / "approval" / "v4" / "task"
-            src_dir.mkdir(parents=True)
-            (src_dir / "pass.rs").write_text(
-                "pub struct PassTaskBodyV4 {\n"
-                "    pub user_id: String,\n"
-                "    pub instance_code: String,\n"
-                "}\n"
-                "pub struct PassTaskResponseV4 {}\n",
-                encoding="utf-8",
-            )
-            out_md = tmpdir / "report.md"
-            out_json = tmpdir / "summary.json"
-
-            report = verify_api_fields.run_quick_mode(
-                csv_path=csv_file,
-                src_root=tmpdir / "src",
-                output_md=out_md,
-                output_json=out_json,
-            )
-
-            # 报告应包含 user_id 警告
-            self.assertIn("user_id", report)
-            self.assertTrue(out_md.exists())
-            self.assertTrue(out_json.exists())
-            import json
-
-            data = json.loads(out_json.read_text(encoding="utf-8"))
-            self.assertEqual(data["total_apis"], 1)
-            self.assertGreaterEqual(data["apis_with_issues"], 1)
-
-
-class TestParseDocFields(unittest.TestCase):
-    def test_parse_request_body_fields(self):
-        """从文档文本提取 POST 请求体字段。"""
-        doc_text = (
-            "目录 Request Request body Request example Response\n"  # 导航（第1次）
-            "Request body\n"  # 正文标题（第2次）
-            "Parameter Type Required Description\n\n"
-            "instance_code\n\nstring\n\nYes\n\n审批实例 Code\n\n"
-            "task_id\n\nstring\n\nYes\n\n任务 ID\n\n"
-            "Request example\n"
-        )
-        fields = verify_api_fields.parse_doc_request_fields(doc_text, method="POST")
-        names = {f.name for f in fields}
-        self.assertIn("instance_code", names)
-        self.assertIn("task_id", names)
-        required_map = {f.name: f.required for f in fields}
-        self.assertTrue(required_map["instance_code"])
-
-    def test_parse_put_request_body_fields(self):
-        """PUT 接口与 POST 一样从 Request body 正文解析字段。"""
-        doc_text = (
-            "目录 Request Request body Request example Response\n"
-            "Request body\n"
-            "Parameter Type Required Description\n\n"
-            "user_id\n\nstring\n\nYes\n\n目标用户\n\n"
-            "password\n\nstring\n\nNo\n\n新密码\n\n"
-            "require_reset\n\nboolean\n\nNo\n\n下次登录重置\n\n"
-            "Request example\n"
-        )
-
-        fields = verify_api_fields.parse_doc_request_fields(doc_text, method="PUT")
-
-        self.assertEqual(
-            [(field.name, field.required) for field in fields],
-            [("user_id", True), ("password", False), ("require_reset", False)],
-        )
-
-    def test_parse_response_fields_from_example(self):
-        """从响应示例 JSON 提取响应字段名。"""
-        doc_text = (
-            'Response body example\n'
-            '{\n'
-            '    "code": 0,\n'
-            '    "data": {\n'
-            '        "definition_name": "请假",\n'
-            '        "status": "PENDING",\n'
-            '        "tasks": [{"id": "1"}]\n'
-            '    }\n'
-            '}\n'
-            'Error code\n'
-        )
-        fields = verify_api_fields.parse_doc_response_fields(doc_text)
-        self.assertIn("definition_name", fields)
-        self.assertIn("status", fields)
-        self.assertIn("tasks", fields)
-
-    def test_parse_param_table_skips_banned_words(self):
-        """_parse_param_table 跳过 parameter/type/required 等表头词。"""
-        section = (
-            "parameter\n\ntype\n\nrequired\n\n"  # 表头（应跳过）
-            "instance_code\n\nstring\n\nYes\n\n实例 Code\n\n"
-            "comment\n\nstring\n\nNo\n\n意见\n"
-        )
-        fields = verify_api_fields._parse_param_table(section)
-        names = {f.name for f in fields}
-        self.assertEqual(names, {"instance_code", "comment"})
-        # 确认表头词没被当成字段
-        self.assertNotIn("parameter", names)
-        self.assertNotIn("type", names)
-        self.assertNotIn("required", names)
-        # 必填性正确
-        req_map = {f.name: f.required for f in fields}
-        self.assertTrue(req_map["instance_code"])
-        self.assertFalse(req_map["comment"])
-
-    def test_parse_param_table_sparse_blank_lines_like_feishu_spa(self):
-        """飞书 SPA 在字段名与 Yes/No 之间插入多行空行时仍能解析，且不把 string 当字段。"""
-        section = (
-            "Parameter\n\nType\n\nRequired\n\nDescription\n\n\n\n"
-            "instance_code\n\n\n\nstring\n\n\n\nYes\n\n\n\n"
-            "Approval instance Code\n\n"
-            "Example value: \"81D31358\"\n\n\n\n\n"
-            "task_id\n\n\n\nstring\n\n\n\nYes\n\n\n\n"
-            "The approval task ID\n\n"
-            "form\n\n\n\nstring\n\n\n\nNo\n\n\n\n"
-            "Form data\n\n"
-            "comment\n\n\n\nstring\n\n\n\nNo\n\n\n\n"
-            "approval comment\n"
-        )
-        fields = verify_api_fields._parse_param_table(section)
-        names = [f.name for f in fields]
-        self.assertEqual(names, ["instance_code", "task_id", "form", "comment"])
-        self.assertNotIn("string", names)
-        req = {f.name: f.required for f in fields}
-        self.assertTrue(req["instance_code"])
-        self.assertTrue(req["task_id"])
-        self.assertFalse(req["form"])
-        self.assertFalse(req["comment"])
-
-
-class TestCompareFields(unittest.TestCase):
-    def test_compare_finds_missing_and_extra(self):
-        """对比代码字段与文档字段，找出缺失和多余。"""
-        code_fields = [
-            verify_api_fields.FieldInfo("instance_code", "String", True),
-            verify_api_fields.FieldInfo("user_id", "String", True),  # 多余
         ]
-        doc_fields = [
-            verify_api_fields.FieldInfo("instance_code", "String", True),
-            verify_api_fields.FieldInfo("task_id", "String", True),  # 代码缺失
-        ]
-        diff = verify_api_fields.compare_fields(code_fields, doc_fields)
-        self.assertIn("task_id", diff.missing)  # 文档有代码无
-        self.assertIn("user_id", diff.extra)  # 代码有文档无
-        self.assertIn("instance_code", diff.matched)
+        issues = verify_api_fields.detect_suspicious_patterns(api, structs, "")
+        self.assertIn("missing_list_validation", [item.category for item in issues])
 
-
-class TestDocFetchGate(unittest.TestCase):
-    """完整模式不得在抓取失败时假绿放行。"""
-
-    def test_validate_doc_text_rejects_thin_or_404(self):
-        self.assertIsNotNone(verify_api_fields._validate_doc_text(""))
-        self.assertIsNotNone(verify_api_fields._validate_doc_text("x" * 100))
-        self.assertIsNotNone(
-            verify_api_fields._validate_doc_text(
-                "The documentation could not be found.\n" + ("a" * 600)
+    def test_manual_nonempty_validation_suppresses_warning(self):
+        api = api_identity()
+        structs = [
+            verify_api_fields.StructFields(
+                "PassBody",
+                [verify_api_fields.FieldInfo("user_ids", "String", True)],
             )
+        ]
+        issues = verify_api_fields.detect_suspicious_patterns(
+            api, structs, "if self.user_ids.is_empty() { return Err(error); }"
         )
-        self.assertIsNone(verify_api_fields._validate_doc_text("正文内容" * 200))
+        self.assertNotIn("missing_list_validation", [item.category for item in issues])
 
-    def test_exit_code_error_and_warning_fail(self):
+    def test_empty_get_response_is_informational(self):
+        api = api_identity(method="GET")
+        structs = [verify_api_fields.StructFields("GetResponse", [])]
+        issues = verify_api_fields.detect_suspicious_patterns(api, structs, "")
+        self.assertEqual(issues[0].category, "empty_get_response")
+
+
+class ComparisonTests(unittest.TestCase):
+    def test_compare_fields_reports_missing_and_extra(self):
+        code = [
+            verify_api_fields.FieldInfo("instance_code", "String", True),
+            verify_api_fields.FieldInfo("extra", "String", False),
+        ]
+        official = [
+            verify_api_fields.FieldInfo("instance_code", "string", True),
+            verify_api_fields.FieldInfo("task_id", "string", True),
+        ]
+        diff = verify_api_fields.compare_fields(code, official)
+        self.assertEqual(diff.matched, ["instance_code"])
+        self.assertEqual(diff.missing, ["task_id"])
+        self.assertEqual(diff.extra, ["extra"])
+
+    def test_evidence_comparison_consumes_only_top_level_observations(self):
+        api = api_identity()
+        structs = [
+            verify_api_fields.StructFields(
+                "PassBody",
+                [verify_api_fields.FieldInfo("instance_code", "String", True)],
+            ),
+            verify_api_fields.StructFields(
+                "PassResponse",
+                [verify_api_fields.FieldInfo("result", "String", True)],
+            ),
+        ]
+        issues = []
+        verify_api_fields._compare_evidence_against_code(
+            structs, field_evidence(api), issues
+        )
+        self.assertEqual(issues, [])
+
+    def test_trusted_empty_request_evidence_preserves_nonpassing_semantics(self):
+        api = api_identity()
+        evidence = field_evidence(api)
+        evidence = OfficialDocumentEvidence(
+            api,
+            (
+                replace(evidence.dimensions[0], observations=()),
+                evidence.dimensions[1],
+            ),
+        )
+        issues = []
+        verify_api_fields._compare_evidence_against_code(
+            [
+                verify_api_fields.StructFields(
+                    "PassBody",
+                    [
+                        verify_api_fields.FieldInfo(
+                            "instance_code", "String", True
+                        )
+                    ],
+                )
+            ],
+            evidence,
+            issues,
+        )
+        self.assertEqual(issues[0].category, "doc_parse_empty")
+        self.assertEqual(verify_api_fields._exit_code_for_issues(issues), 1)
+
+    def test_incomplete_evidence_is_nonpassing_with_existing_code(self):
+        issues = []
+        verify_api_fields._compare_evidence_against_code(
+            [],
+            field_evidence(
+                api_identity(), request_status=EvidenceStatus.INCOMPLETE
+            ),
+            issues,
+        )
+        self.assertEqual(issues[0].category, "doc_parse_empty")
+        self.assertEqual(verify_api_fields._exit_code_for_issues(issues), 1)
+
+    def test_unavailable_evidence_maps_to_fetch_failure(self):
+        issues = []
+        verify_api_fields._compare_evidence_against_code(
+            [],
+            field_evidence(
+                api_identity(), response_status=EvidenceStatus.UNAVAILABLE
+            ),
+            issues,
+        )
+        self.assertEqual(issues[0].category, "doc_fetch_failed")
+        self.assertEqual(issues[0].severity, "error")
+
+    def test_info_does_not_fail_but_warning_and_error_do(self):
+        issue = verify_api_fields.FieldIssue
         self.assertEqual(verify_api_fields._exit_code_for_issues([]), 0)
-        self.assertEqual(
-            verify_api_fields._exit_code_for_issues(
-                [verify_api_fields.FieldIssue("info", "x", "tip")]
-            ),
-            0,
-        )
-        self.assertEqual(
-            verify_api_fields._exit_code_for_issues(
-                [verify_api_fields.FieldIssue("warning", "x", "warn")]
-            ),
-            1,
-        )
-        self.assertEqual(
-            verify_api_fields._exit_code_for_issues(
-                [verify_api_fields.FieldIssue("error", "doc_fetch_failed", "fail")]
-            ),
-            1,
-        )
+        self.assertEqual(verify_api_fields._exit_code_for_issues([issue("info", "x", "tip")]), 0)
+        self.assertEqual(verify_api_fields._exit_code_for_issues([issue("warning", "x", "warn")]), 1)
+        self.assertEqual(verify_api_fields._exit_code_for_issues([issue("error", "x", "error")]), 1)
 
-    def test_fetch_docs_failure_recorded_as_error_exit_1(self):
-        """--fetch-docs 时抓取失败必须记 error 且返回非 0（不再假绿）。"""
-        import tempfile
-        from unittest import mock
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tmpdir = Path(tmpdir)
-            src_root = tmpdir / "crates"
-            api_dir = (
-                src_root / "openlark-workflow" / "src" / "approval" / "approval" / "v4" / "task"
-            )
-            api_dir.mkdir(parents=True)
-            (api_dir / "pass.rs").write_text(
-                "pub struct PassTaskBodyV4 {\n"
+class FieldCliEvidenceTests(unittest.TestCase):
+    def test_single_full_cli_preserves_report_contract_and_adds_evidence(self):
+        api = api_identity()
+        collector = _FieldCollector(api)
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "crates/openlark-workflow/src" / api.expected_file
+            source.parent.mkdir(parents=True)
+            source.write_text(
+                "pub struct PassBody {\n"
                 "    pub instance_code: String,\n"
-                "    pub task_id: String,\n"
                 "}\n"
-                "pub struct PassTaskResponseV4 {}\n",
+                "pub struct PassResponse {\n"
+                "    pub result: String,\n"
+                "}\n",
                 encoding="utf-8",
             )
-            out_dir = tmpdir / "out"
-            api = verify_api_fields.ApiRecord(
-                api_id="999",
-                name="同意",
-                biz_tag="approval",
-                meta_project="approval",
-                meta_version="v4",
-                meta_resource="task",
-                meta_name="pass",
-                url="POST:/open-apis/approval/v4/tasks/pass",
-                doc_path="",
-                full_path="/document/uAjLw4CM/ukTMukTMukTM/reference/approval-v4/task/pass",
-            )
-            fake_fail = verify_api_fields.DocFetchResult(error="playwright missing")
-            with mock.patch.object(
-                verify_api_fields, "_fetch_single_doc", return_value=fake_fail
+            output = root / "reports"
+            argv = [
+                "verify_api_fields.py",
+                "--api-id",
+                api.api_id,
+                "--fetch-docs",
+                "--output-dir",
+                str(output),
+            ]
+            with (
+                mock.patch.object(sys, "argv", argv),
+                mock.patch.object(verify_api_fields, "REPO_ROOT", root),
+                mock.patch.object(
+                    verify_api_fields,
+                    "load_api_identities",
+                    return_value=[api],
+                ),
+                mock.patch.object(
+                    verify_api_fields,
+                    "compose_full",
+                    return_value=collector,
+                ),
             ):
-                code = verify_api_fields._run_single_api(
-                    "999", [api], src_root, out_dir, "api-999", fetch_docs=True
-                )
-            self.assertEqual(code, 1)
-            report = (out_dir / "api-999.md").read_text(encoding="utf-8")
-            self.assertIn("文档抓取失败", report)
-            self.assertIn("有问题 | 1", report)
+                exit_code = verify_api_fields.main()
 
-    def test_fetch_docs_success_compares_fields(self):
-        """抓取成功时对比字段，多余字段记 warning 并非 0 退出。"""
-        import tempfile
-        from unittest import mock
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tmpdir = Path(tmpdir)
-            src_root = tmpdir / "crates"
-            api_dir = (
-                src_root / "openlark-workflow" / "src" / "approval" / "approval" / "v4" / "task"
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(
+                collector.requests[0][1],
+                (
+                    EvidenceDimension.REQUEST_FIELDS,
+                    EvidenceDimension.RESPONSE_FIELDS,
+                ),
             )
-            api_dir.mkdir(parents=True)
-            (api_dir / "pass.rs").write_text(
-                "pub struct PassTaskBodyV4 {\n"
-                "    pub instance_code: String,\n"
-                "    pub task_id: String,\n"
-                "    pub user_id: String,\n"  # 文档没有 → extra
-                "}\n"
-                "pub struct PassTaskResponseV4 {}\n",
-                encoding="utf-8",
+            report = json.loads(
+                (output / "summary.json").read_text(encoding="utf-8")
             )
-            out_dir = tmpdir / "out"
-            api = verify_api_fields.ApiRecord(
-                api_id="998",
-                name="同意",
-                biz_tag="approval",
-                meta_project="approval",
-                meta_version="v4",
-                meta_resource="task",
-                meta_name="pass",
-                url="POST:/open-apis/approval/v4/tasks/pass",
-                doc_path="",
-                full_path="/document/uAjLw4CM/ukTMukTMukTM/reference/approval-v4/task/pass",
+            self.assertEqual(
+                set(report),
+                {"mode", "total_apis", "apis_with_issues", "apis"},
             )
-            # 伪造足够长的文档正文（含 Request body 段）
-            pad = "x" * 400
-            doc_text = (
-                f"{pad}\n目录 Request Request body Request example Response\n"
-                "Request body\n"
-                "instance_code\nstring\nYes\n实例\n"
-                "task_id\nstring\nYes\n任务\n"
-                "Request example\n"
-                f"{pad}\n"
+            self.assertEqual(report["apis"][0]["issues"], [])
+            markdown = (output / f"api-{api.api_id}.md").read_text(
+                encoding="utf-8"
             )
-            ok = verify_api_fields.DocFetchResult(text=doc_text)
-            with mock.patch.object(verify_api_fields, "_fetch_single_doc", return_value=ok):
-                code = verify_api_fields._run_single_api(
-                    "998", [api], src_root, out_dir, "api-998", fetch_docs=True
-                )
-            self.assertEqual(code, 1)  # extra_field warning
-            report = (out_dir / "api-998.md").read_text(encoding="utf-8")
-            self.assertIn("多余字段", report)
-
-    # --- issue #595：404 子串无锚点误伤 + 空解析假绿 ---
-
-    def test_validate_notfound_phrase_in_body_not_flagged(self):
-        """合法文档正文深处含 404 短语不应误判（issue #595 问题1）。
-
-        真实样本：错误码表/排障说明里合法出现「文档不存在」/
-        "the documentation could not be found"，在正文深处（数百行后）。
-        当前全文无锚点子串匹配会误判 -> _fetch_single_doc unlink 缓存 ->
-        每次 resume 重抓同一份有效文档又重判红（thrash）。
-        """
-        nav = "\n".join(f"nav {i}" for i in range(40))
-        body = "正常正文内容" * 200  # > MIN_DOC_CHARS
-        # 404 短语埋在正文深处（远超头部窗口）
-        doc = nav + "\n" + body + "\n若 文档不存在，请联系管理员。\n"
-        self.assertIsNone(verify_api_fields._validate_doc_text(doc))
-
-    def test_validate_notfound_phrase_in_head_still_flagged(self):
-        """404 短语出现在页面头部仍应判无效（真实 404 提示在导航后第 17 行）。"""
-        head = "\n".join([
-            "Customer Stories", "Documentation", "API Explorer", "CardKit",
-            "The documentation could not be found.",
-        ])
-        # 补足 >MIN_DOC_CHARS（模拟渲染较多导航的 404），短语仍在头部窗口内
-        doc = head + "\n" + "nav tail\n" * 60
-        self.assertIsNotNone(verify_api_fields._validate_doc_text(doc))
-
-    def test_compare_empty_doc_parse_records_warning(self):
-        """文档过 validate 但请求/响应字段均解析为空 -> 记 warning，禁止假绿（issue #595 问题2）。"""
-        api = verify_api_fields.ApiRecord(
-            api_id="1", name="查询", biz_tag="x", meta_project="x",
-            meta_version="v1", meta_resource="r", meta_name="q",
-            url="GET:/open-apis/x/v1/r/q", doc_path="",
-            full_path="/document/x/reference/x-v1/r/q",
-        )
-        structs = [verify_api_fields.StructFields(name="QResponse", fields=[])]
-        # >MIN_DOC_CHARS、无头部 404 短语、但无 Request body / Response body example 段
-        doc_text = "导航项内容\n" * 80
-        issues = []
-        verify_api_fields._compare_doc_against_code(api, structs, doc_text, issues)
-        empty = [i for i in issues if i.category == "doc_parse_empty"]
-        self.assertEqual(len(empty), 1)
-        self.assertEqual(empty[0].severity, "warning")
-
-    def test_compare_body_present_but_no_req_fields_single_warning(self):
-        """有 Body 实现但文档未解析出请求字段 -> 仅一条 doc_parse_empty（不与空解析检查重复）。"""
-        api = verify_api_fields.ApiRecord(
-            api_id="2", name="创建", biz_tag="x", meta_project="x",
-            meta_version="v1", meta_resource="r", meta_name="c",
-            url="POST:/open-apis/x/v1/r/c", doc_path="",
-            full_path="/document/x/reference/x-v1/r/c",
-        )
-        structs = [verify_api_fields.StructFields(
-            name="CBody", fields=[verify_api_fields.FieldInfo("foo", "String", True)],
-        )]
-        # 无 Request body 段 -> doc_req 空；无 Response body example -> doc_resp 空
-        doc_text = "导航项内容\n" * 80
-        issues = []
-        verify_api_fields._compare_doc_against_code(api, structs, doc_text, issues)
-        empty = [i for i in issues if i.category == "doc_parse_empty"]
-        self.assertEqual(len(empty), 1)  # 不重复
-
-    # --- issue #599：空解析 warning 对合法无字段 action API 假阳性 ---
-
-    def test_compare_fieldless_api_with_sections_not_failing(self):
-        """合法无字段 action API（doc 含标准段标题但段内无字段）-> 降为 info，不报 failing（issue #599）。
-
-        PR #598 的空解析 warning 对 envelope-only 响应的合法 API 假阳性（exit 1）。
-        修复：doc 含标准段标题（已渲染/结构正常）但字段空 -> 合法无字段 -> info（不阻断）。
-        """
-        api = verify_api_fields.ApiRecord(
-            api_id="3", name="操作", biz_tag="x", meta_project="x",
-            meta_version="v1", meta_resource="r", meta_name="act",
-            url="POST:/open-apis/x/v1/r/act", doc_path="",
-            full_path="/document/x/reference/x-v1/r/act",
-        )
-        # 无 Body struct；Response 无字段（操作型 / envelope-only API）
-        structs = [verify_api_fields.StructFields(name="ActResponse", fields=[])]
-        # doc 渲染了真实段：TOC + section 标题各一次（Response body example 共 2 次），
-        # 但 data:{} 无字段；不含 "Request body"（无请求体段）
-        doc_text = (
-            "The contents of this article\n"
-            "Response body example\n"  # TOC 导航项（第 1 次）
-            + "API intro padding content. " * 30
-            + "\nResponse body example\n"  # 真实 section 标题（第 2 次）
-            + '{\n  "code": 0,\n  "msg": "ok",\n  "data": {}\n}\n'
-            + "Error code\n"
-        )
-        issues = []
-        verify_api_fields._compare_doc_against_code(api, structs, doc_text, issues)
-        failing = [i for i in issues if i.severity in ("warning", "error")]
-        self.assertEqual(failing, [])  # 合法无字段 → 不阻断（最多一条 info）
-
-    def test_compare_unrendered_doc_without_sections_still_warning(self):
-        """缺标准段标题的未渲染文档 → 仍 warning，文案点明「缺标准段标题」（issue #599 反向分支）。"""
-        api = verify_api_fields.ApiRecord(
-            api_id="4", name="查询", biz_tag="x", meta_project="x",
-            meta_version="v1", meta_resource="r", meta_name="q",
-            url="GET:/open-apis/x/v1/r/q", doc_path="",
-            full_path="/document/x/reference/x-v1/r/q",
-        )
-        structs = [verify_api_fields.StructFields(name="QResponse", fields=[])]
-        # 未渲染 SPA 外壳：无任一标准段标题，且无字段
-        doc_text = "导航壳占位内容\n" * 80
-        issues = []
-        verify_api_fields._compare_doc_against_code(api, structs, doc_text, issues)
-        warns = [
-            i for i in issues
-            if i.category == "doc_parse_empty" and i.severity == "warning"
-        ]
-        self.assertEqual(len(warns), 1)
-        self.assertIn("缺标准段标题", warns[0].detail)  # 钉 #599 warning 分支文案
-
-    def test_compare_toc_only_shell_still_warning_not_false_green(self):
-        """部分渲染 shell（TOC 含段标题子串但 section bodies 未渲染）-> 仍 warning，不假绿。
-
-        回归保护：_doc_has_standard_sections 用子串时被 TOC 导航项误导（对抗验证发现），
-        未渲染 shell 误判 info -> exit 0 假绿（违背 #595）。改用 count>=2（TOC + 真实段
-        各一次）后修复：真实文档 Response body example 恒 2 次，TOC-only shell 仅 1 次。
-        """
-        api = verify_api_fields.ApiRecord(
-            api_id="5", name="操作", biz_tag="x", meta_project="x",
-            meta_version="v1", meta_resource="r", meta_name="act",
-            url="POST:/open-apis/x/v1/r/act", doc_path="",
-            full_path="/document/x/reference/x-v1/r/act",
-        )
-        structs = [verify_api_fields.StructFields(name="ActResponse", fields=[])]
-        # TOC-only shell：段标题仅在 TOC 出现 1 次，无 section bodies
-        doc_text = (
-            "The contents of this article\n"
-            "Request body\nQuery parameters\nResponse body example\n"  # TOC 导航项（各 1 次）
-            + "nav padding content line\n" * 80  # 凑长度，无真实 section body
-        )
-        issues = []
-        verify_api_fields._compare_doc_against_code(api, structs, doc_text, issues)
-        warns = [
-            i for i in issues
-            if i.category == "doc_parse_empty" and i.severity == "warning"
-        ]
-        self.assertEqual(len(warns), 1)  # TOC-only shell -> warning，不假绿
+            self.assertIn("Provenance", markdown)
+            self.assertIn("Acquisition Trail", markdown)
+            evidence = report["apis"][0]["evidence"][0]
+            self.assertEqual(evidence["status"], "trusted")
+            self.assertIn("provenance", evidence)
+            self.assertIn("diagnostics", evidence)
+            self.assertEqual(
+                evidence["acquisition_trail"][0]["status"], "trusted"
+            )
 
 
 if __name__ == "__main__":

--- a/tools/validate_api_contracts.py
+++ b/tools/validate_api_contracts.py
@@ -24,18 +24,18 @@ from tools.api_contracts.compare import (
     compare_response_fields,
     finding,
 )
-from tools.api_contracts.models import ContractReport
-from tools.api_contracts.official import (
-    extract_access_token_types_from_detail_payload,
-    extract_endpoint_from_detail_payload,
-    extract_request_fields_from_detail_payload,
-    extract_response_fields_from_detail_payload,
-    fetch_detail_payload,
-    fetch_doc_markdown,
-    load_api_identities,
-    parse_access_token_types_from_markdown,
+from tools.api_contracts.models import ContractReport, OfficialField
+from tools.api_contracts.official import load_api_identities
+from tools.api_contracts.official_evidence import (
+    EndpointObservation,
+    EvidenceDimension,
+    EvidenceStatus,
+    FieldObservation,
+    FreshOfficialPolicy,
+    TokenObservation,
+    compose,
 )
-from tools.api_contracts.report import write_report, write_summary
+from tools.api_contracts.report import evidence_to_jsonable, write_report, write_summary
 from tools.api_contracts.rust_source import (
     load_endpoint_constants,
     load_enum_endpoints,
@@ -129,14 +129,14 @@ def validate_crate(
     csv_path: Path,
     report_dir: Path,
     skip_old: bool,
+    collector,
     live_endpoints: bool = False,
     fields: bool = False,
-    field_timeout: int = 20,
-    field_retries: int = 1,
     max_field_apis: int = 0,
     tokens: bool = False,
     biz_tag_filter: list[str] | None = None,
 ) -> ContractReport:
+    """核对一个 crate；官方事实只通过 collect seam 获取。"""
     src_path = Path(crate_config["src"])
     biz_tags = biz_tag_filter if biz_tag_filter else list(crate_config.get("biz_tags") or [])
     apis = load_api_identities(csv_path, filter_tags=biz_tags, skip_old_versions=skip_old)
@@ -162,59 +162,111 @@ def validate_crate(
         )
         if rust_contract is not None:
             report.checked_apis += 1
-        detail_payload = None
+
+        should_check_fields = fields and (
+            not max_field_apis or field_checks < max_field_apis
+        )
+        dimensions = []
+        if live_endpoints:
+            dimensions.append(EvidenceDimension.ENDPOINT)
+        if should_check_fields:
+            dimensions.extend(
+                (
+                    EvidenceDimension.REQUEST_FIELDS,
+                    EvidenceDimension.RESPONSE_FIELDS,
+                )
+            )
+        if tokens:
+            dimensions.append(EvidenceDimension.TOKENS)
+        evidence = None
+        if dimensions:
+            evidence = collector.collect(
+                api, tuple(dimensions), FreshOfficialPolicy()
+            )
+            report.evidence.append(evidence_to_jsonable(evidence))
+
         endpoint_api = api
-        should_check_fields = fields and (not max_field_apis or field_checks < max_field_apis)
-        if live_endpoints or should_check_fields or tokens:
-            try:
-                detail_payload = fetch_detail_payload(api, timeout=field_timeout, retries=field_retries)
-            except Exception as exc:  # noqa: BLE001 - report and keep validating the remaining APIs.
+        if live_endpoints:
+            endpoint = evidence.for_dimension(EvidenceDimension.ENDPOINT)
+            if endpoint.status is EvidenceStatus.TRUSTED:
+                observation = next(
+                    (
+                        item
+                        for item in endpoint.observations
+                        if isinstance(item, EndpointObservation)
+                    ),
+                    None,
+                )
+                if observation is not None:
+                    endpoint_api = replace(
+                        api, url=f"{observation.method}:{observation.path}"
+                    )
+            else:
                 report.add(
-                    finding(
-                        "UNVERIFIED",
-                        "U_OFFICIAL_DETAIL_FETCH_FAILED",
-                        "Official detail payload could not be fetched.",
-                        api,
-                        official=str(exc),
+                    _evidence_finding(
+                        api, EvidenceDimension.ENDPOINT, endpoint
                     )
                 )
-            if live_endpoints and detail_payload is not None:
-                method, path = extract_endpoint_from_detail_payload(detail_payload)
-                if method and path:
-                    endpoint_api = replace(api, url=f"{method}:{path}")
-                else:
-                    report.add(
-                        finding(
-                            "UNVERIFIED",
-                            "U_LIVE_OFFICIAL_ENDPOINT_UNAVAILABLE",
-                            "Current official schema did not expose httpMethod/path.",
-                            api,
-                        )
-                    )
-
         for item in compare_endpoint(endpoint_api, rust_contract):
             report.add(item)
 
         if tokens:
-            # oracle：优先用 detail payload 的 security.supportedAccessToken；
-            # JSON 缺标注时（部分 server-docs 页）回退到 .md 源的 Authorization 行。
-            official_tokens = ()
-            if detail_payload is not None:
-                official_tokens = extract_access_token_types_from_detail_payload(detail_payload)
-            if not official_tokens:
-                markdown = fetch_doc_markdown(api, timeout=field_timeout)
-                official_tokens = parse_access_token_types_from_markdown(markdown)
-            for item in compare_access_token_types(api, official_tokens, rust_contract):
-                report.add(item)
+            token_evidence = evidence.for_dimension(EvidenceDimension.TOKENS)
+            if token_evidence.status is EvidenceStatus.TRUSTED:
+                official_tokens = tuple(
+                    item.token
+                    for item in token_evidence.observations
+                    if isinstance(item, TokenObservation)
+                )
+                for item in compare_access_token_types(
+                    api, official_tokens, rust_contract
+                ):
+                    report.add(item)
+            else:
+                report.add(
+                    _evidence_finding(
+                        api, EvidenceDimension.TOKENS, token_evidence
+                    )
+                )
 
-        if should_check_fields and detail_payload is not None:
+        if should_check_fields:
             field_checks += 1
-            request_fields = extract_request_fields_from_detail_payload(detail_payload)
-            for item in compare_request_fields(api, request_fields, rust_contract):
-                report.add(item)
-            response_fields = extract_response_fields_from_detail_payload(detail_payload)
-            for item in compare_response_fields(api, response_fields, rust_contract):
-                report.add(item)
+            request_evidence = evidence.for_dimension(
+                EvidenceDimension.REQUEST_FIELDS
+            )
+            response_evidence = evidence.for_dimension(
+                EvidenceDimension.RESPONSE_FIELDS
+            )
+            if request_evidence.status is EvidenceStatus.TRUSTED:
+                request_fields = _official_fields(request_evidence.observations)
+                for item in compare_request_fields(
+                    api, request_fields, rust_contract
+                ):
+                    report.add(item)
+            else:
+                report.add(
+                    _evidence_finding(
+                        api,
+                        EvidenceDimension.REQUEST_FIELDS,
+                        request_evidence,
+                    )
+                )
+            if response_evidence.status is EvidenceStatus.TRUSTED:
+                response_fields = _official_fields(
+                    response_evidence.observations
+                )
+                for item in compare_response_fields(
+                    api, response_fields, rust_contract
+                ):
+                    report.add(item)
+            else:
+                report.add(
+                    _evidence_finding(
+                        api,
+                        EvidenceDimension.RESPONSE_FIELDS,
+                        response_evidence,
+                    )
+                )
 
     write_report(
         report,
@@ -222,6 +274,54 @@ def validate_crate(
         report_dir / "crates" / f"{crate_name}.json",
     )
     return report
+
+
+def _official_fields(observations) -> tuple[OfficialField, ...]:
+    """当前 Rust comparison 只消费顶层字段，保持既有比较边界。"""
+    return tuple(
+        OfficialField(
+            name=item.path[0],
+            required=bool(item.required),
+            location=item.location or "",
+            field_type=item.field_type or "",
+            source=item.source.value,
+        )
+        for item in observations
+        if isinstance(item, FieldObservation) and len(item.path) == 1
+    )
+
+
+def _evidence_finding(api, dimension, evidence):
+    diagnostic_codes = {
+        diagnostic.code for diagnostic in evidence.diagnostics
+    }
+    acquisition_failure_codes = {
+        "snapshot_unavailable",
+        "adapter_unavailable",
+        "acquisition_timeout",
+        "acquisition_failed",
+        "document_not_found",
+        "document_unhealthy",
+    }
+    if diagnostic_codes & acquisition_failure_codes:
+        code = "U_OFFICIAL_DETAIL_FETCH_FAILED"
+    else:
+        code = {
+            EvidenceDimension.ENDPOINT: "U_LIVE_OFFICIAL_ENDPOINT_UNAVAILABLE",
+            EvidenceDimension.REQUEST_FIELDS: "U_OFFICIAL_DETAIL_FETCH_FAILED",
+            EvidenceDimension.RESPONSE_FIELDS: "U_OFFICIAL_DETAIL_FETCH_FAILED",
+            EvidenceDimension.TOKENS: "U_ACCESS_TOKEN_UNANNOTATED",
+        }[dimension]
+    diagnostics = ", ".join(
+        diagnostic.code for diagnostic in evidence.diagnostics
+    )
+    return finding(
+        "UNVERIFIED",
+        code,
+        "Official Document Evidence is not trusted.",
+        api,
+        official=f"{evidence.status.value}: {diagnostics}",
+    )
 
 
 def main() -> int:
@@ -248,23 +348,27 @@ def main() -> int:
         crate_names = sorted(mapping.keys())
 
     report_dir = Path(args.report_dir)
-    reports = [
-        validate_crate(
-            crate_name,
-            mapping[crate_name],
-            csv_path,
-            report_dir,
-            args.skip_old,
-            live_endpoints=args.live_endpoints,
-            fields=args.fields,
-            field_timeout=args.field_timeout,
-            field_retries=args.field_retries,
-            max_field_apis=args.max_field_apis,
-            tokens=args.tokens,
-            biz_tag_filter=args.biz_tag,
-        )
-        for crate_name in crate_names
-    ]
+    with compose(
+        snapshot_directory=report_dir / "official_evidence",
+        timeout_seconds=args.field_timeout,
+        retries=args.field_retries,
+    ) as collector:
+        reports = [
+            validate_crate(
+                crate_name,
+                mapping[crate_name],
+                csv_path,
+                report_dir,
+                args.skip_old,
+                collector,
+                live_endpoints=args.live_endpoints,
+                fields=args.fields,
+                max_field_apis=args.max_field_apis,
+                tokens=args.tokens,
+                biz_tag_filter=args.biz_tag,
+            )
+            for crate_name in crate_names
+        ]
     write_summary(reports, report_dir / "summary.md", report_dir / "summary.json")
 
     total_errors = sum(report.error_count for report in reports)
@@ -276,7 +380,15 @@ def main() -> int:
     )
 
     strict_categories = {item.strip() for item in args.strict.split(",") if item.strip()}
-    if strict_categories & {"endpoint", "fields", "tokens"} and total_errors:
+    nonpassing_evidence = any(
+        dimension["status"] != EvidenceStatus.TRUSTED.value
+        for report in reports
+        for api_evidence in report.evidence
+        for dimension in api_evidence["dimensions"]
+    )
+    if strict_categories & {"endpoint", "fields", "tokens"} and (
+        total_errors or nonpassing_evidence
+    ):
         return 1
     return 0
 

--- a/tools/validate_api_contracts.py
+++ b/tools/validate_api_contracts.py
@@ -324,6 +324,27 @@ def _evidence_finding(api, dimension, evidence):
     )
 
 
+def _has_blocking_evidence_failure(reports: list[ContractReport]) -> bool:
+    """仅真实 acquisition 不可用阻断兼容的 strict CLI 退出码。"""
+    blocking_diagnostics = {
+        "snapshot_unavailable",
+        "adapter_unavailable",
+        "acquisition_timeout",
+        "acquisition_failed",
+        "document_not_found",
+    }
+    return any(
+        dimension["status"] == EvidenceStatus.UNAVAILABLE.value
+        and any(
+            diagnostic["code"] in blocking_diagnostics
+            for diagnostic in dimension["diagnostics"]
+        )
+        for report in reports
+        for api_evidence in report.evidence
+        for dimension in api_evidence["dimensions"]
+    )
+
+
 def main() -> int:
     args = parse_args()
     if args.fields and not args.live_fields:
@@ -380,14 +401,9 @@ def main() -> int:
     )
 
     strict_categories = {item.strip() for item in args.strict.split(",") if item.strip()}
-    nonpassing_evidence = any(
-        dimension["status"] != EvidenceStatus.TRUSTED.value
-        for report in reports
-        for api_evidence in report.evidence
-        for dimension in api_evidence["dimensions"]
-    )
+    blocking_evidence_failure = _has_blocking_evidence_failure(reports)
     if strict_categories & {"endpoint", "fields", "tokens"} and (
-        total_errors or nonpassing_evidence
+        total_errors or blocking_evidence_failure
     ):
         return 1
     return 0

--- a/tools/verify_api_fields.py
+++ b/tools/verify_api_fields.py
@@ -11,15 +11,29 @@ API 字段核对工具：扫描代码字段、检测可疑模式、可选抓飞�
 from __future__ import annotations
 
 import argparse
-import csv
-import os
 import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.api_contracts.models import ApiIdentity
+from tools.api_contracts.official import load_api_identities
+from tools.api_contracts.official_evidence import (
+    EvidenceDimension,
+    EvidenceStatus,
+    FieldObservation,
+    PreferSnapshotPolicy,
+    compose_full,
+)
+from tools.api_contracts.report import (
+    evidence_markdown_lines,
+    evidence_to_jsonable,
+)
 DEFAULT_CSV = REPO_ROOT / "api_list_export.csv"
 
 
@@ -28,83 +42,6 @@ DEFAULT_CSV = REPO_ROOT / "api_list_export.csv"
 # ---------------------------------------------------------------------------
 
 
-@dataclass
-class ApiRecord:
-    """CSV 中一条 API 记录（只保留核对需要的字段）。"""
-
-    api_id: str
-    name: str
-    biz_tag: str
-    meta_project: str
-    meta_version: str
-    meta_resource: str
-    meta_name: str
-    url: str
-    doc_path: str
-    full_path: str
-
-    @property
-    def http_method(self) -> str:
-        return self.url.partition(":")[0].upper()
-
-    @property
-    def endpoint_path(self) -> str:
-        return self.url.partition(":")[2]
-
-    @property
-    def is_user_level(self) -> bool:
-        """用户级接口：文档 fullPath 含 /reference/（新版用户级路径标识）。"""
-        return "/reference/" in self.full_path
-
-
-# ---------------------------------------------------------------------------
-# 路径推断
-# ---------------------------------------------------------------------------
-
-
-def generate_expected_file_path(api: ApiRecord) -> str:
-    """根据 API 元信息推断 .rs 文件相对路径（移植自 validate_apis.py）。
-
-    规则：bizTag/project/version/resource/name.rs
-      - resource 的 . 转为 /
-      - name 的 : 转为 _
-    """
-    resource_path = api.meta_resource.replace(".", "/")
-    name_path = api.meta_name.replace(":", "_").rstrip("/")
-    return f"{api.biz_tag}/{api.meta_project}/{api.meta_version}/{resource_path}/{name_path}.rs"
-
-
-# ---------------------------------------------------------------------------
-# CSV 加载
-# ---------------------------------------------------------------------------
-
-
-def load_apis_from_csv(
-    csv_path: Path, filter_tags: Optional[List[str]] = None
-) -> List[ApiRecord]:
-    """从 CSV 加载 API 记录，可按 bizTag 过滤。跳过 old 版本。"""
-    apis: List[ApiRecord] = []
-    with open(csv_path, encoding="utf-8-sig", newline="") as f:
-        for row in csv.DictReader(f):
-            if filter_tags and row.get("bizTag", "") not in filter_tags:
-                continue
-            if row.get("meta.Version") == "old":
-                continue
-            apis.append(
-                ApiRecord(
-                    api_id=row["id"],
-                    name=row["name"],
-                    biz_tag=row["bizTag"],
-                    meta_project=row["meta.Project"],
-                    meta_version=row["meta.Version"],
-                    meta_resource=row["meta.Resource"],
-                    meta_name=row["meta.Name"],
-                    url=row["url"],
-                    doc_path=row.get("docPath", ""),
-                    full_path=row.get("fullPath", ""),
-                )
-            )
-    return apis
 
 
 # ---------------------------------------------------------------------------
@@ -228,7 +165,7 @@ class FieldIssue:
 
 
 def detect_suspicious_patterns(
-    api: ApiRecord, structs: List[StructFields], source: str
+    api: ApiIdentity, structs: List[StructFields], source: str
 ) -> List[FieldIssue]:
     """检测不抓文档就能发现的字段问题（三类红旗）。
 
@@ -246,7 +183,7 @@ def detect_suspicious_patterns(
     # 红旗 1：用户级接口含 user_id / approval_code
     # 注意：is_user_level 基于 /reference/ 路径，但 reference 也含管理员级接口，
     # 故降为 info 级提示，detail 说明"若用 tenant_token 则可忽略"。
-    if api.is_user_level:
+    if "/reference/" in api.full_path:
         for s in body_structs:
             for f in s.fields:
                 if f.name in ("user_id", "approval_code"):
@@ -292,7 +229,7 @@ def detect_suspicious_patterns(
                 )
 
     # 红旗 3：GET 查询接口 Response 为空
-    if api.http_method == "GET":
+    if api.official_method == "GET":
         resp_structs = [s for s in structs if "Response" in s.name]
         for s in resp_structs:
             if not s.fields:
@@ -319,11 +256,12 @@ def detect_suspicious_patterns(
 class ApiFieldReport:
     """单个 API 的核对结果。"""
 
-    api: ApiRecord
+    api: ApiIdentity
     file_path: str
     file_exists: bool
     structs: List[StructFields]
     issues: List[FieldIssue]
+    evidence: List[dict] = field(default_factory=list)
 
 
 def run_quick_mode(
@@ -334,11 +272,11 @@ def run_quick_mode(
     filter_tags: Optional[List[str]] = None,
 ) -> str:
     """快速模式：扫描代码字段 + 可疑模式检测，不抓文档。返回报告文本。"""
-    apis = load_apis_from_csv(csv_path, filter_tags)
+    apis = load_api_identities(csv_path, filter_tags)
     reports: List[ApiFieldReport] = []
 
     for api in apis:
-        rel_path = generate_expected_file_path(api)
+        rel_path = api.expected_file
         full_path = src_root / rel_path
         if not full_path.exists():
             reports.append(
@@ -417,6 +355,16 @@ def _render_report(reports: List[ApiFieldReport], mode: str) -> str:
             lines.append(f"- {r.api.name}: `{r.file_path}`")
         lines.append("")
 
+    lines.extend(
+        evidence_markdown_lines(
+            [
+                (report.api.name, dimension)
+                for report in reports
+                for dimension in report.evidence
+            ]
+        )
+    )
+
     return "\n".join(lines)
 
 
@@ -440,6 +388,7 @@ def _write_summary_json(reports: List[ApiFieldReport], path: Path, mode: str) ->
                     {"severity": i.severity, "category": i.category, "detail": i.detail}
                     for i in r.issues
                 ],
+                "evidence": r.evidence,
             }
             for r in reports
         ],
@@ -448,40 +397,6 @@ def _write_summary_json(reports: List[ApiFieldReport], path: Path, mode: str) ->
     path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
-# ---------------------------------------------------------------------------
-# 文档字段解析与对比（完整模式）
-# ---------------------------------------------------------------------------
-
-MIN_DOC_CHARS = 500  # 低于此视为抓取失败（URL 错或 SPA 未渲染）
-# 404 提示只在此头部窗口（行）内匹配：飞书 404 页面的错误提示在导航壳之后（实测第 17 行），
-# 而合法文档正文里出现「文档不存在」/"the documentation could not be found"（错误码表/排障说明）
-# 在数百行之后——全文匹配会误伤有效文档并 unlink 缓存，导致每次 resume 重抓重判红（thrash）。
-NOT_FOUND_HEAD_LINES = 30
-
-
-@dataclass
-class DocFetchResult:
-    """文档抓取结果。ok=False 时必须记 error，禁止假绿放行。"""
-
-    text: str = ""
-    error: Optional[str] = None  # None 表示成功
-
-    @property
-    def ok(self) -> bool:
-        return self.error is None
-
-
-def _validate_doc_text(text: str) -> Optional[str]:
-    """校验文档正文；返回错误原因，通过则返回 None。"""
-    if not text or not text.strip():
-        return "文档内容为空"
-    if len(text) < MIN_DOC_CHARS:
-        return f"文档内容过少（{len(text)} < {MIN_DOC_CHARS} 字符），可能 URL 错误或未渲染"
-    # 404 短语锚定到页面头部窗口（见 NOT_FOUND_HEAD_LINES），避免误伤正文深处合法出现
-    head_lower = "\n".join(text.split("\n")[:NOT_FOUND_HEAD_LINES]).lower()
-    if "the documentation could not be found" in head_lower or "文档不存在" in head_lower:
-        return "文档页面不存在（URL 可能错误）"
-    return None
 
 
 @dataclass
@@ -493,123 +408,6 @@ class FieldDiff:
     extra: List[str] = field(default_factory=list)  # 代码有、文档无
 
 
-# 标准 API 文档段标题（飞书 innerText）——判断文档是否已渲染/结构正常（issue #599）。
-# parse_doc_request_fields / parse_doc_response_fields 也以此定位段，集中定义避免漂移。
-SECTION_REQUEST_BODY = "Request body"
-SECTION_QUERY_PARAMS = "Query parameters"
-SECTION_RESPONSE_EXAMPLE = "Response body example"
-STANDARD_DOC_SECTIONS = (
-    SECTION_REQUEST_BODY,
-    SECTION_QUERY_PARAMS,
-    SECTION_RESPONSE_EXAMPLE,
-)
-
-
-def _doc_has_standard_sections(doc_text: str) -> bool:
-    """文档是否渲染了真实 API 段（区分 TOC 占位与未渲染 shell）。
-
-    飞书文档里段标题出现两次：per-article TOC 导航项 + 真实 section 标题。故
-    count >= 2 表示真实 section 已渲染；仅 1 次（只在 TOC）说明 section bodies 未
-    渲染（部分渲染 shell），应判未渲染而非合法无字段——避免子串匹配被 TOC 误导假绿
-    （issue #599 对抗验证发现；实测 "Response body example" 在 12 份真实文档恒为 2 次）。
-    """
-    return any(doc_text.count(section) >= 2 for section in STANDARD_DOC_SECTIONS)
-
-
-def parse_doc_request_fields(doc_text: str, method: str) -> List[FieldInfo]:
-    """从文档 innerText 提取请求体/查询参数字段。
-
-    POST/PUT/PATCH: Request body（第2次出现）→ Request example
-    GET/DELETE:     Query parameters → Request example
-    """
-    if method.upper() in {"POST", "PUT", "PATCH"}:
-        section = _extract_section(doc_text, SECTION_REQUEST_BODY, "Request example", occurrence=2)
-    else:
-        section = _extract_section(doc_text, SECTION_QUERY_PARAMS, "Request example", occurrence=1)
-    if not section:
-        return []
-    return _parse_param_table(section)
-
-
-def parse_doc_response_fields(doc_text: str) -> List[str]:
-    """从响应示例 JSON 提取字段名集合。
-
-    Response body 的 data 子字段在折叠区拿不到，从示例 JSON 反推。
-    返回 data 内部的字段名列表。
-    """
-    section = _extract_section(doc_text, SECTION_RESPONSE_EXAMPLE, "Error code", occurrence=1)
-    if not section:
-        return []
-    # 提取所有 "field": 的字段名（排除外层 code/msg/data）
-    names = re.findall(r'"([a-z_]+)"\s*:', section)
-    return [n for n in names if n not in ("code", "msg", "data")]
-
-
-def _extract_section(text: str, start: str, end: str, occurrence: int = 1) -> str:
-    """提取 start（第 occurrence 次出现）到 end 之间的文本。"""
-    parts = text.split(start)
-    if len(parts) <= occurrence:
-        return ""
-    chunk = start.join(parts[occurrence:])
-    end_idx = chunk.find(end)
-    if end_idx < 0:
-        return chunk
-    return chunk[:end_idx]
-
-
-def _parse_param_table(section: str) -> List[FieldInfo]:
-    """解析参数表（参数名/类型/必填交错成行）。
-
-    飞书 SPA innerText 常在参数名与 Yes/No 之间插入多行空行 + 类型行，
-    回看窗口需足够大；同时禁止把类型名（string/int/...）当成字段名。
-    """
-    lines = [l.strip() for l in section.split("\n")]
-    results: List[FieldInfo] = []
-    banned = {
-        "parameter", "type", "required", "description", "authorization",
-        "content", "value", "example", "facts", "scopes", "header",
-        # 类型名（勿当字段）
-        "string", "int", "integer", "boolean", "bool", "number", "float",
-        "double", "object", "array", "file", "binary", "map", "null",
-        "string[]", "int[]", "integer[]", "boolean[]", "number[]", "object[]",
-    }
-    type_line = re.compile(
-        r"^(string|int|integer|boolean|bool|number|float|double|object|array|"
-        r"file|binary|map|null)(\[\])?$",
-        re.I,
-    )
-    i = 0
-    while i < len(lines):
-        line = lines[i]
-        # 候选参数名：snake_case，非 banned / 非类型名
-        if (
-            re.fullmatch(r"[a-z][a-z0-9_]*", line)
-            and line not in banned
-            and not type_line.fullmatch(line)
-            and len(line) >= 2
-        ):
-            # 往后找 Yes/No（空行多时需更大窗口）
-            found = False
-            for j in range(i + 1, min(i + 16, len(lines))):
-                if lines[j] in ("Yes", "No"):
-                    required = lines[j] == "Yes"
-                    # 尝试取中间的类型行
-                    type_name = ""
-                    for k in range(i + 1, j):
-                        if type_line.fullmatch(lines[k]):
-                            type_name = lines[k]
-                            break
-                    results.append(
-                        FieldInfo(name=line, type_name=type_name, required=required)
-                    )
-                    i = j + 1
-                    found = True
-                    break
-            if not found:
-                i += 1
-        else:
-            i += 1
-    return results
 
 
 def compare_fields(
@@ -638,80 +436,111 @@ def _exit_code_for_issues(issues: List[FieldIssue]) -> int:
     return 0
 
 
-def _compare_doc_against_code(
-    api: ApiRecord,
+def _compare_evidence_against_code(
     structs: List[StructFields],
-    doc_text: str,
+    evidence,
     issues: List[FieldIssue],
 ) -> None:
-    """把文档字段对比结果追加到 issues（就地修改）。"""
-    doc_req = parse_doc_request_fields(doc_text, api.http_method)
-    code_body = next((s.fields for s in structs if "Body" in s.name), [])
-    parse_warned = False
-    if doc_req and code_body:
-        diff = compare_fields(code_body, doc_req)
-        if diff.missing:
-            issues.append(
-                FieldIssue(
-                    "error",
-                    "missing_field",
-                    f"请求体缺字段: {', '.join(diff.missing)}",
-                )
-            )
-        if diff.extra:
-            issues.append(
-                FieldIssue(
-                    "warning",
-                    "extra_field",
-                    f"请求体多余字段: {', '.join(diff.extra)}",
-                )
-            )
-    elif not doc_req and code_body:
-        # 有请求体实现但文档没解析出字段——通常是解析失败，记 warning 避免假绿
+    """消费顶层 Field Observations，保留既有 Rust comparison 语义。"""
+    request = evidence.for_dimension(EvidenceDimension.REQUEST_FIELDS)
+    response = evidence.for_dimension(EvidenceDimension.RESPONSE_FIELDS)
+    nonpassing = [
+        item
+        for item in (request, response)
+        if item.status is not EvidenceStatus.TRUSTED
+    ]
+    if nonpassing:
+        hard_failure = any(
+            item.status in (EvidenceStatus.UNAVAILABLE, EvidenceStatus.REJECTED)
+            for item in nonpassing
+        )
+        diagnostics = ", ".join(
+            diagnostic.code
+            for item in nonpassing
+            for diagnostic in item.diagnostics
+        )
         issues.append(
             FieldIssue(
-                "warning",
-                "doc_parse_empty",
-                "文档未解析到请求字段（可能页面结构变化或非标准请求段）",
+                "error" if hard_failure else "warning",
+                "doc_fetch_failed" if hard_failure else "doc_parse_empty",
+                "官方文档证据未通过 Strict Evidence Gate"
+                f"（{diagnostics or '无 diagnostic'}）",
             )
         )
-        parse_warned = True
 
-    doc_resp = parse_doc_response_fields(doc_text)
-    code_resp = next((s.fields for s in structs if "Response" in s.name), [])
-    if doc_resp and code_resp:
-        code_resp_names = {f.effective_name for f in code_resp}
-        missing_resp = sorted(set(doc_resp) - code_resp_names)
-        if missing_resp:
-            issues.append(
-                FieldIssue(
-                    "info",
-                    "missing_response_field",
-                    f"响应体可能缺字段: {', '.join(missing_resp)}",
-                )
+    if request.status is EvidenceStatus.TRUSTED:
+        doc_req = [
+            FieldInfo(
+                name=item.path[0],
+                type_name=item.field_type or "",
+                required=bool(item.required),
             )
-
-    # 文档正文已通过 _validate_doc_text 的基本校验（调用方契约，本函数不重校），
-    # 但请求/响应字段都解析为空。分两种情况（issue #599）：
-    # - 含标准段标题但段内无字段 → 合法无字段 action API，降为 info（不阻断）
-    # - 缺标准段标题 → 页面未渲染/结构异常，维持 warning 避免静默假绿（issue #595 问题2）
-    if not doc_req and not doc_resp and not parse_warned:
-        if _doc_has_standard_sections(doc_text):
-            issues.append(
-                FieldIssue(
-                    "info",
-                    "doc_parse_empty",
-                    "文档含标准段标题但请求/响应字段均空（可能为无字段的 action API）",
-                )
-            )
-        else:
+            for item in request.observations
+            if isinstance(item, FieldObservation)
+            and len(item.path) == 1
+            and item.location == "request_body"
+        ]
+        code_body = next(
+            (item.fields for item in structs if "Body" in item.name), []
+        )
+        if not doc_req and code_body:
             issues.append(
                 FieldIssue(
                     "warning",
                     "doc_parse_empty",
-                    "文档未解析到任何请求/响应字段且缺标准段标题（可能页面未渲染或结构异常）",
+                    "Trusted Evidence 未观察到请求字段，但 Rust 存在请求体字段",
                 )
             )
+        elif doc_req and code_body:
+            diff = compare_fields(code_body, doc_req)
+            if diff.missing:
+                issues.append(
+                    FieldIssue(
+                        "error",
+                        "missing_field",
+                        f"请求体缺字段: {', '.join(diff.missing)}",
+                    )
+                )
+            if diff.extra:
+                issues.append(
+                    FieldIssue(
+                        "warning",
+                        "extra_field",
+                        f"请求体多余字段: {', '.join(diff.extra)}",
+                    )
+                )
+
+    if response.status is EvidenceStatus.TRUSTED:
+        doc_response_names = {
+            item.path[0]
+            for item in response.observations
+            if isinstance(item, FieldObservation) and len(item.path) == 1
+        }
+        code_response = next(
+            (item.fields for item in structs if "Response" in item.name), []
+        )
+        if doc_response_names and code_response:
+            code_names = {item.effective_name for item in code_response}
+            missing = sorted(doc_response_names - code_names)
+            if missing:
+                issues.append(
+                    FieldIssue(
+                        "info",
+                        "missing_response_field",
+                        f"响应体可能缺字段: {', '.join(missing)}",
+                    )
+                )
+
+
+def _collect_field_evidence(collector, api: ApiIdentity):
+    return collector.collect(
+        api,
+        (
+            EvidenceDimension.REQUEST_FIELDS,
+            EvidenceDimension.RESPONSE_FIELDS,
+        ),
+        PreferSnapshotPolicy(),
+    )
 
 
 def main() -> int:
@@ -726,13 +555,34 @@ def main() -> int:
     csv_path = Path(args.csv)
     out_dir = Path(args.output_dir)
 
-    # 单 API 模式：按 id 过滤，src 根用 crates 目录（路径推断会定位到具体文件）
+    # 单 API 模式：按 id 过滤，src 根用 crates 目录。
     if args.api_id:
         src_root = REPO_ROOT / "crates"
         crate_label = f"api-{args.api_id}"
-        all_apis = load_apis_from_csv(csv_path)
+        all_apis = load_api_identities(csv_path)
+        if args.fetch_docs:
+            with compose_full(
+                snapshot_directory=out_dir / "official_evidence",
+                timeout_seconds=90,
+                retries=1,
+            ) as collector:
+                return _run_single_api(
+                    args.api_id,
+                    all_apis,
+                    src_root,
+                    out_dir,
+                    crate_label,
+                    True,
+                    collector,
+                )
         return _run_single_api(
-            args.api_id, all_apis, src_root, out_dir, crate_label, args.fetch_docs
+            args.api_id,
+            all_apis,
+            src_root,
+            out_dir,
+            crate_label,
+            False,
+            None,
         )
 
     # 确定 src 根目录和 bizTag 过滤
@@ -751,8 +601,20 @@ def main() -> int:
     print(f"🏷️  过滤 bizTag: {filter_tags or '(全部)'}")
 
     if args.fetch_docs:
-        print("🐌 完整模式（抓文档，默认跳过已缓存）")
-        return _run_full_mode(csv_path, src_root, out_dir, crate_label, filter_tags)
+        print("🐌 完整模式（通过 Official Document Evidence 收集）")
+        with compose_full(
+            snapshot_directory=out_dir / "official_evidence",
+            timeout_seconds=90,
+            retries=1,
+        ) as collector:
+            return _run_full_mode(
+                csv_path,
+                src_root,
+                out_dir,
+                crate_label,
+                filter_tags,
+                collector,
+            )
 
     # 快速模式
     print("⚡ 快速模式（代码自检）")
@@ -767,14 +629,22 @@ def main() -> int:
     return 0
 
 
-def _run_single_api(api_id, all_apis, src_root, out_dir, crate_label, fetch_docs) -> int:
+def _run_single_api(
+    api_id,
+    all_apis,
+    src_root,
+    out_dir,
+    crate_label,
+    fetch_docs,
+    collector,
+) -> int:
     """核对单个 API。--fetch-docs 时抓取失败或 error/warning 返回非 0。"""
     api = next((a for a in all_apis if a.api_id == api_id), None)
     if api is None:
         print(f"❌ CSV 中找不到 id={api_id} 的 API")
         return 1
     print(f"🔍 单 API 核对: {api.name} ({api.url})")
-    rel_path = generate_expected_file_path(api)
+    rel_path = api.expected_file
     # 单 API 模式：在所有 crate 的 src 目录下查找文件
     full_path = None
     for crate_dir in src_root.iterdir():
@@ -791,37 +661,26 @@ def _run_single_api(api_id, all_apis, src_root, out_dir, crate_label, fetch_docs
     structs = extract_structs(source)
     issues = detect_suspicious_patterns(api, structs, source)
 
-    # 完整模式：抓文档对比字段
     mode = "quick"
+    evidence_metadata = []
     if fetch_docs:
         mode = "full"
-        if not api.full_path:
-            issues.append(
-                FieldIssue(
-                    "error",
-                    "doc_fetch_failed",
-                    "CSV fullPath 为空，无法抓取官方文档",
-                )
-            )
-        else:
-            result = _fetch_single_doc(api, out_dir)
-            if not result.ok:
-                issues.append(
-                    FieldIssue(
-                        "error",
-                        "doc_fetch_failed",
-                        f"文档抓取失败: {result.error}",
-                    )
-                )
-            else:
-                _compare_doc_against_code(api, structs, result.text, issues)
+        evidence = _collect_field_evidence(collector, api)
+        evidence_metadata = evidence_to_jsonable(evidence)["dimensions"]
+        _compare_evidence_against_code(structs, evidence, issues)
 
     report = ApiFieldReport(
-        api=api, file_path=rel_path, file_exists=True, structs=structs, issues=issues,
+        api=api,
+        file_path=rel_path,
+        file_exists=True,
+        structs=structs,
+        issues=issues,
+        evidence=evidence_metadata,
     )
     md = _render_report([report], mode=mode)
     out_dir.mkdir(parents=True, exist_ok=True)
     (out_dir / f"{crate_label}.md").write_text(md, encoding="utf-8")
+    _write_summary_json([report], out_dir / "summary.json", mode=mode)
     if issues:
         print(f"⚠️ 发现 {len(issues)} 个问题:")
         for i in issues:
@@ -832,54 +691,6 @@ def _run_single_api(api_id, all_apis, src_root, out_dir, crate_label, fetch_docs
     return _exit_code_for_issues(issues) if fetch_docs else 0
 
 
-def _fetch_single_doc(api: ApiRecord, out_dir: Path) -> DocFetchResult:
-    """抓取单个 API 的文档（带缓存）。失败时 DocFetchResult.error 非空。"""
-    import subprocess
-
-    fetch_script = (
-        REPO_ROOT / ".agents" / "skills" / "openlark-api-field-verify" / "scripts" / "fetch_doc.js"
-    )
-    if not fetch_script.exists():
-        msg = f"找不到抓取脚本: {fetch_script}"
-        print(f"⚠️ {msg}")
-        return DocFetchResult(error=msg)
-    doc_cache = out_dir / "doc_cache"
-    doc_cache.mkdir(parents=True, exist_ok=True)
-    doc_file = doc_cache / f"{api.api_id}.txt"
-    if not doc_file.exists():
-        url = "https://open.feishu.cn" + api.full_path
-        print(f"📄 抓取文档: {url}")
-        try:
-            subprocess.run(
-                ["node", str(fetch_script), url, str(doc_file)],
-                check=True, capture_output=True, timeout=90, text=True,
-            )
-        except subprocess.CalledProcessError as e:
-            err_tail = (e.stderr or e.stdout or str(e))[-200:]
-            msg = f"fetch_doc.js 退出码 {e.returncode}: {err_tail}"
-            print(f"⚠️ 文档抓取失败: {msg}")
-            return DocFetchResult(error=msg)
-        except subprocess.TimeoutExpired:
-            msg = "fetch_doc.js 超时（90s）"
-            print(f"⚠️ 文档抓取失败: {msg}")
-            return DocFetchResult(error=msg)
-
-    if not doc_file.exists():
-        msg = "抓取完成但缓存文件未生成"
-        print(f"⚠️ 文档抓取失败: {msg}")
-        return DocFetchResult(error=msg)
-
-    text = doc_file.read_text(encoding="utf-8")
-    bad = _validate_doc_text(text)
-    if bad:
-        # 无效缓存不留着，避免下次 resume 假绿
-        try:
-            doc_file.unlink()
-        except OSError:
-            pass
-        print(f"⚠️ 文档内容无效: {bad}")
-        return DocFetchResult(text=text, error=bad)
-    return DocFetchResult(text=text)
 
 
 def _load_crate_tags(crate: str) -> Optional[List[str]]:
@@ -895,26 +706,23 @@ def _load_crate_tags(crate: str) -> Optional[List[str]]:
     return crate_cfg.get("biz_tags")
 
 
-def _run_full_mode(csv_path, src_root, out_dir, crate_label, filter_tags) -> int:
-    """完整模式：抓飞书文档对比字段（慢）。抓取失败或 error/warning 返回非 0。"""
+def _run_full_mode(
+    csv_path,
+    src_root,
+    out_dir,
+    crate_label,
+    filter_tags,
+    collector,
+) -> int:
+    """完整模式：复用同一个 collect 行为核对所有字段。"""
     import json
-    import subprocess
 
-    apis = load_apis_from_csv(csv_path, filter_tags)
-    fetch_script = (
-        REPO_ROOT / ".agents" / "skills" / "openlark-api-field-verify" / "scripts" / "fetch_doc.js"
-    )
-    if not fetch_script.exists():
-        print(f"❌ 找不到抓取脚本: {fetch_script}")
-        return 1
-
+    apis = load_api_identities(csv_path, filter_tags)
     reports: List[ApiFieldReport] = []
-    doc_cache = out_dir / "doc_cache"
-    doc_cache.mkdir(parents=True, exist_ok=True)
     failed: List[Tuple[str, str]] = []
 
     for idx, api in enumerate(apis, 1):
-        rel_path = generate_expected_file_path(api)
+        rel_path = api.expected_file
         full_path = src_root / rel_path
         if not full_path.exists():
             continue
@@ -922,61 +730,30 @@ def _run_full_mode(csv_path, src_root, out_dir, crate_label, filter_tags) -> int
         source = full_path.read_text(encoding="utf-8")
         structs = extract_structs(source)
         issues = detect_suspicious_patterns(api, structs, source)
-
-        # 抓文档
-        if not api.full_path:
-            err = "CSV fullPath 为空"
-            failed.append((api.api_id, err))
-            issues.append(FieldIssue("error", "doc_fetch_failed", f"文档抓取失败: {err}"))
-        else:
-            url = "https://open.feishu.cn" + api.full_path
-            doc_file = doc_cache / f"{api.api_id}.txt"
-            doc_text = ""
-            fetch_error: Optional[str] = None
-            if not doc_file.exists():  # 简单 resume：文件存在则跳过
-                try:
-                    subprocess.run(
-                        ["node", str(fetch_script), url, str(doc_file)],
-                        check=True, capture_output=True, timeout=90, text=True,
-                    )
-                except subprocess.CalledProcessError as e:
-                    err_tail = (e.stderr or e.stdout or str(e))[-200:]
-                    fetch_error = f"fetch_doc.js 退出码 {e.returncode}: {err_tail}"
-                except subprocess.TimeoutExpired:
-                    fetch_error = "fetch_doc.js 超时（90s）"
-                else:
-                    doc_text = (
-                        doc_file.read_text(encoding="utf-8") if doc_file.exists() else ""
-                    )
-            else:
-                doc_text = doc_file.read_text(encoding="utf-8")
-
-            if fetch_error is None:
-                bad = _validate_doc_text(doc_text)
-                if bad:
-                    fetch_error = bad
-                    if doc_file.exists():
-                        try:
-                            doc_file.unlink()
-                        except OSError:
-                            pass
-
-            if fetch_error:
-                failed.append((api.api_id, fetch_error[:200]))
-                issues.append(
-                    FieldIssue(
-                        "error",
-                        "doc_fetch_failed",
-                        f"文档抓取失败: {fetch_error}",
-                    )
-                )
-            else:
-                _compare_doc_against_code(api, structs, doc_text, issues)
+        evidence = _collect_field_evidence(collector, api)
+        dimensions = evidence_to_jsonable(evidence)["dimensions"]
+        _compare_evidence_against_code(structs, evidence, issues)
+        nonpassing = [
+            item
+            for item in evidence.dimensions
+            if item.status is not EvidenceStatus.TRUSTED
+        ]
+        if nonpassing:
+            diagnostics = ", ".join(
+                diagnostic.code
+                for item in nonpassing
+                for diagnostic in item.diagnostics
+            )
+            failed.append((api.api_id, diagnostics))
 
         reports.append(
             ApiFieldReport(
-                api=api, file_path=rel_path, file_exists=True,
-                structs=structs, issues=issues,
+                api=api,
+                file_path=rel_path,
+                file_exists=True,
+                structs=structs,
+                issues=issues,
+                evidence=dimensions,
             )
         )
         print(f"⏳ [{idx}/{len(apis)}] {api.name} ({len(issues)} 问题)")
@@ -987,17 +764,20 @@ def _run_full_mode(csv_path, src_root, out_dir, crate_label, filter_tags) -> int
     _write_summary_json(reports, out_dir / "summary.json", mode="full")
 
     if failed:
-        print(f"⚠️ {len(failed)} 个文档抓取失败，详见 failed.json")
+        print(f"⚠️ {len(failed)} 个官方文档证据未通过，详见 failed.json")
         (out_dir / "failed.json").write_text(
             json.dumps(failed, ensure_ascii=False, indent=2), encoding="utf-8"
         )
 
-    all_issues = [i for r in reports for i in r.issues]
+    all_issues = [issue for report in reports for issue in report.issues]
     exit_code = _exit_code_for_issues(all_issues)
     if exit_code == 0:
         print(f"✅ 报告: {out_dir / f'{crate_label}.md'}")
     else:
-        print(f"❌ 核对未通过（error/warning），报告: {out_dir / f'{crate_label}.md'}")
+        print(
+            f"❌ 核对未通过（error/warning），报告: "
+            f"{out_dir / f'{crate_label}.md'}"
+        )
     return exit_code
 
 


### PR DESCRIPTION
## 概要

- 字段核对 single/full 统一切换到 Official Document Evidence `collect` seam，并复用 canonical `ApiIdentity`
- API contract validator 的 Endpoint、Request Fields、Response Fields、Tokens 改为消费同一 Evidence 语义
- 删除调用方重复的抓取、缓存、健康判断、Catalog 解码、路径推断及低 seam parser/helper 测试
- 保持 CLI、退出码用途、finding codes 与 JSON 顶层字段兼容；追加逐维度 provenance、diagnostics 和 Acquisition Trail
- CI 保持全仓离线 endpoint strict gate，并增加 Structured-only live endpoint monitor；manual/full 保留 Playwright fallback
- Evidence 非 Trusted 状态继续完整报告；strict CLI 对真实 acquisition Unavailable 额外阻断，同时保持既有 ERROR 退出码用途

## 验证

- `python3 -m unittest discover -s tools/tests -p "test_*.py"`：213 passed，2 skipped
- `cargo test --workspace --all-features`：6113 passed，162 ignored
- CI live token/field strict commands本地复现通过
- Structured + Rendered live smoke：2 passed
- GitHub Actions：全部通过（含 api-contracts）
- 两轴 code review 已完成并修复全部 spec findings

Closes #611