### PR TITLE
fix: 恢复 Strict Evidence Gate 仅 Trusted 通过

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,34 +77,44 @@ jobs:
             --crate openlark-ai \
             --live-endpoints \
             --report-dir "$RUNNER_TEMP/api_contracts_live_monitor"
-      - name: Validate access-token types (security + auth regression gate, #511)
+      - name: Validate Trusted token Evidence inventory
+        run: |
+          python3 tools/validate_api_contracts.py \
+            --crate openlark-security \
+            --api-id 7321978105899122716 \
+            --tokens \
+            --strict tokens \
+            --report-dir "$RUNNER_TEMP/api_contract_tokens_strict/security"
+          python3 tools/validate_api_contracts.py \
+            --crate openlark-auth \
+            --api-id 7277403063290724380 \
+            --tokens \
+            --strict tokens \
+            --report-dir "$RUNNER_TEMP/api_contract_tokens_strict/auth"
+      - name: Monitor full token Evidence domains
         run: |
           python3 tools/validate_api_contracts.py \
             --crate openlark-security \
             --tokens \
-            --strict tokens \
             --report-dir "$RUNNER_TEMP/api_contract_tokens/security"
           python3 tools/validate_api_contracts.py \
             --crate openlark-auth \
             --tokens \
-            --strict tokens \
             --report-dir "$RUNNER_TEMP/api_contract_tokens/auth"
-      - name: Validate attendance fields (strict gate; #526/#533 防回归)
+      - name: Monitor attendance field Evidence
         run: |
           python3 tools/validate_api_contracts.py \
             --crate openlark-hr \
             --biz-tag attendance \
             --fields \
             --live-fields \
-            --strict fields \
             --report-dir "$RUNNER_TEMP/api_contract_fields/attendance"
-      - name: Validate docs fields (strict gate; #569 首个 0.20 域扩展)
+      - name: Monitor docs field Evidence
         run: |
           python3 tools/validate_api_contracts.py \
             --crate openlark-docs \
             --fields \
             --live-fields \
-            --strict fields \
             --report-dir "$RUNNER_TEMP/api_contract_fields/docs"
       - name: Upload API contract reports
         if: always()
@@ -114,6 +124,7 @@ jobs:
           path: |
             ${{ runner.temp }}/api_contracts
             ${{ runner.temp }}/api_contract_tokens
+            ${{ runner.temp }}/api_contract_tokens_strict
             ${{ runner.temp }}/api_contract_fields
           retention-days: 14
 

--- a/docs/api-contract-validation.md
+++ b/docs/api-contract-validation.md
@@ -36,10 +36,9 @@ python3 tools/validate_api_contracts.py --all-crates --strict endpoint
 CI 启用的 strict gate（`api-contracts` job）：
 
 - 全仓离线 endpoint strict（`--all-crates --strict endpoint`）
-- token 层：`openlark-security` + `openlark-auth`（见 §1.4）
-- field 层：`openlark-hr --biz-tag attendance`（#526/#533）与
-  `openlark-docs` 全 crate（#569，ccm/base/baike/minutes；0.20 首个域扩展）
-- live endpoint monitor：`openlark-ai --live-endpoints`，保留 fail-closed Evidence 状态但不作为全仓 strict gate
+- token strict：security/auth 各一个显式 Trusted API inventory（见 §1.4）
+- field live monitor：attendance 与 docs；field strict inventory 暂为空
+- live endpoint monitor：`openlark-ai --live-endpoints`，无 strict
 
 ### 1.2 Endpoint live 校验
 
@@ -112,6 +111,7 @@ acs / security_and_compliance 批量误配（误设 `App`/`app_access_token`）�
 ```bash
 python3 tools/validate_api_contracts.py \
   --crate openlark-security \
+  --api-id 7321978105899122716 \
   --tokens \
   --strict tokens \
   --report-dir /tmp/openlark-api-contracts-tokens
@@ -130,56 +130,53 @@ Token oracle 同样来自 Official Document Evidence `collect` seam。Structured
   按实际注入的 token 类型核对，而非 `none_access_token`——避免把「手动注入 user token」
   误判为 disjoint `ERROR`。真正无鉴权（声明 `None` 且无手动注入）对要求 token 的文档仍报 `ERROR`。
 
-与 live 校验一致，该维度访问网络。CI 对 `openlark-security` 与 `openlark-auth` 启用
-`--strict tokens`，作为 [#511](https://github.com/foxzool/openlark/issues/511) acs /
-security_and_compliance 误配的回归 gate（与 endpoint strict gate 同级；auth 覆盖 OIDC token
-端点）。全仓 live 核对因每个接口都要抓取详情 payload、调用量过大，未纳入 CI；其他 crate 用
-`just api-contract-tokens <crate>` 人工抽样。
+CI 的 token strict gate 只包含已证明 Structured Tokens Evidence 为 `Trusted` 的显式
+API inventory：`openlark-security/7321978105899122716` 与
+`openlark-auth/7277403063290724380`。两个 crate 的全量 token Evidence 仍以
+non-strict monitor 采集并上传报告；新增 strict API 必须先满足 §1.6 admission。
 
-### 1.5 Field strict 域扩展（attendance → docs）
+### 1.5 Field Evidence monitor 与 strict 准入
 
-字段 strict 按域推进，**禁止**一次 PR 把 monorepo 全量 `--strict fields` 打开。先验
-基线（0 `ERROR`），再 flip CI。
+Structured-only composition 当前无法让 attendance/docs 的 Request Fields 与 Response
+Fields 全部成为 `Trusted`；CI 不安装 Playwright，因此这两个域不能继续伪装成 strict
+pass。完整 live 采集保留为 monitor，field strict inventory 暂为空。
 
-| 域 | 范围 | 状态 | Issue |
+| 域 | 范围 | 当前状态 | Issue |
 |---|---|---|---|
-| attendance | `openlark-hr --biz-tag attendance`（~39 API） | CI `--strict fields` | #526 / #533 / #534 / #540 |
-| docs | `openlark-docs`（ccm/base/baike/minutes，~214 API） | CI `--strict fields` | #569（0.20 首批） |
+| attendance | `openlark-hr --biz-tag attendance`（~39 API） | live monitor；未进入 strict inventory | #526 / #533 / #534 / #540 |
+| docs | `openlark-docs`（ccm/base/baike/minutes，~214 API） | live monitor；未进入 strict inventory | #569 |
 | *(next field-strict domain slot)* | 待选（**一域一 PR**） | 未 flip | 见 §1.6 admission |
 
-本地复现 docs 门禁：
+本地复现 docs monitor：
 
 ```bash
 python3 tools/validate_api_contracts.py \
   --crate openlark-docs \
   --fields \
   --live-fields \
-  --strict fields \
   --report-dir /tmp/openlark-api-contracts-docs-fields
 ```
 
-基线证据（#569 落地时 live 全量）：`0 error` / 仅 `WARN`（主要为
-`W_*_FIELDS_UNRESOLVED` 与 1 条 `W_REQUIRED_REQUEST_FIELD_OPTIONAL`，不阻塞 strict）。
-字段扫描器对 docs multipart（`UploadMeta` / `json!` 字面量）的识别见 #223 / #224。
+monitor 的 `Incomplete` / `Unavailable` / `Rejected` 会保留在 JSON/Markdown 报告中。
+只有域内 requested dimensions 全部为 `Trusted`，且 comparison 为 0 `ERROR`，才允许
+加入 `--strict fields` inventory。
 
-### 1.6 Trust gate inventory + next field-strict domain admission（#586）
+### 1.6 Trust gate inventory + strict admission（#586 / #616）
 
-本节把 0.20 已落地的 contract / coverage trust gate **制度化**：CI green 必须继续
-表示「可调用准确性」，而不是「阈值被下调」或「域 gate 被静默删掉」。
+CI 必须明确区分 hard strict gate 与 live monitor；monitor 不得通过命名、参数或
+`continue-on-error` 伪装成 strict pass。清单由 `.github/workflows/ci.yml` 与
+`tools/tests/test_validate_api_contracts_ci_gates.py` 双改钉死。
 
 #### 1.6.1 Gate inventory（当前 pinned 清单）
 
-下列门禁由 `.github/workflows/ci.yml` 的 `api-contracts` job 执行，并由
-`tools/tests/test_validate_api_contracts_ci_gates.py`（gate inventory test）钉死。
-删除 / 放宽任一 pin 会让该 unittest 失败。
-
-| 层 | 范围 | CI 标志 | Inventory pin |
+| 层 | 范围 | CI 模式 | Inventory pin |
 |---|---|---|---|
-| Endpoint | monorepo 全仓离线 | `--all-crates --strict endpoint` | `test_endpoint_strict_covers_all_crates` |
-| Token | `openlark-security` + `openlark-auth` | `--strict tokens`（各一 step） | `test_token_strict_covers_security_and_auth` |
-| Field | attendance（`openlark-hr --biz-tag attendance`） | `--live-fields --strict fields` | `test_attendance_field_strict_gate` |
-| Field | docs（`openlark-docs`） | `--live-fields --strict fields` | `test_docs_field_strict_gate` |
-| Field inventory | **恰好** attendance + docs 两域 | 无 monorepo-wide field strict | `test_field_strict_inventory_is_exactly_attendance_and_docs` + `test_no_monorepo_wide_field_strict` |
+| Endpoint strict | monorepo 全仓离线 | `--all-crates --strict endpoint` | `test_endpoint_strict_covers_all_crates_offline` |
+| Endpoint monitor | `openlark-ai` live Structured | `--live-endpoints`，无 strict | `test_live_endpoint_monitor_uses_structured_only_cli_mode` |
+| Token strict | security/auth 各一个 Trusted API | `--api-id … --strict tokens` | `test_token_strict_uses_explicit_trusted_api_inventory` |
+| Token monitor | `openlark-security` + `openlark-auth` 全量 | `--tokens`，无 strict | `test_full_token_domains_remain_non_strict_monitors` |
+| Field strict | 空 inventory | 无 `--strict fields` | `test_field_strict_inventory_is_empty_until_trusted` |
+| Field monitor | attendance + docs | `--fields --live-fields`，无 strict | `test_field_monitor_inventory_is_exactly_attendance_and_docs` |
 
 与 coverage 侧硬门禁的关系（**不在本 job 内执行，但同属 0.20 trust 程序**）：
 
@@ -191,34 +188,28 @@ python3 tools/validate_api_contracts.py \
 | Platform P1 clear-or-disprove | `tools/tests/test_p1_platform_clear_or_disprove.py` | 锁仍绿 |
 | Selective P2 path_noise | `tools/tests/test_p2_selective_slice.py` | 锁仍绿 |
 
-本地复核 inventory（离线、秒级；不跑 live fields/tokens）：
+本地复核 inventory（离线、秒级；不跑 live monitors）：
 
 ```bash
 python3 -m unittest tools.tests.test_validate_api_contracts_ci_gates -v
 python3 -m unittest tools.tests.test_typed_coverage_release_policy -v
 ```
 
-#### 1.6.2 Next field-strict domain admission（下一域准入）
+#### 1.6.2 Strict Evidence admission（下一项准入）
 
-**Slot**：上表「next field-strict domain slot」——每次只接纳 **一个** 新域进入
-CI `--strict fields`。本 ticket（#586）只制度化 slot + 规则 + 绿 inventory，
-**不**在本变更中 flip 第三个域。
+每次只接纳一个显式 API inventory 项或一个完整 field 域。全部满足才允许 flip：
 
-Admission 准入条件（全部满足才允许 flip）：
-
-1. **一域一 PR**：候选域必须单独成 PR（或明确 scoped 子单元），不得与无关重构混装。
-2. **Live baseline 必须 0 ERROR**：对候选域先跑 live field 校验，报告中
-   `ERROR` 计数为 0 后，才允许把该域 step 以 `--strict fields` 写入 CI。
-   `WARN` / `UNVERIFIED` 可带入（与 attendance/docs 先例一致），但不得靠
-   关掉 strict 或缩小扫描范围「假绿」。
-3. **Dual-edit（双改）规则**：同一变更必须同时更新：
-   - `.github/workflows/ci.yml` 的 `api-contracts` job（新增 domain-scoped step）；
-   - `tools/tests/test_validate_api_contracts_ci_gates.py` 的
-     `FIELD_STRICT_DOMAINS` inventory 与对应断言；
-   - 本节域表（§1.5）把 slot 行改成新域的「已 flip」状态。
-   只改 workflow 或只改测试 = 审查拒绝。
-4. **域范围显式**：step 必须带 `--crate …`（及必要时 `--biz-tag …`），
-   report-dir 使用 `api_contract_fields/<domain>` 风格片段，便于 inventory 钉死。
+1. **Fresh Structured baseline**：CI composition 不安装 Playwright，也不得用 Recorded
+   Snapshot 冒充 fresh evidence。
+2. **Only Trusted**：候选范围内每个 requested Evidence Dimension 必须全部为
+   `Trusted`；`Incomplete`、`Unavailable`、`Rejected` 任一出现都不得进入 strict。
+3. **Comparison 0 ERROR**：Evidence Trusted 后，Rust comparison 必须为 0 `ERROR`。
+4. **完整范围**：field 域 admission 必须覆盖整个声明域，不得用 `--max-field-apis`
+   或单个 `--api-id` 冒充域级 strict。Token 可按显式 API inventory 逐项推进。
+5. **Dual-edit（双改）**：同一变更必须同时更新 workflow、gate inventory test 与本节
+   表格；只改一处即审查拒绝。
+6. **域范围显式**：step 必须带 `--crate`，必要时带 `--biz-tag` / `--api-id`，并使用
+   独立 report-dir。
 
 推荐本地基线命令（以假设候选 `openlark-communication` 为例，**非**已 flip 域）：
 
@@ -228,7 +219,7 @@ python3 tools/validate_api_contracts.py \
   --fields \
   --live-fields \
   --report-dir /tmp/openlark-api-contracts-candidate-fields
-# 仅当 0 ERROR 后，再在 PR 中加 --strict fields 并 dual-edit inventory
+# 仅当 requested Evidence 全 Trusted 且 0 ERROR，才可 dual-edit 加入 strict inventory
 ```
 
 #### 1.6.3 非目标（Explicit non-goals）
@@ -238,8 +229,8 @@ python3 tools/validate_api_contracts.py \
 - **禁止 hard-gate 阈值下调**：不得为了让 typed-coverage / contract CI 变绿而降低
   `tools/typed_coverage_release.toml` 中的 hard gate 阈值；阈值变更必须是独立
   policy PR，且只能升高或维持，不得降低。
-- **本制度化单元不 march 新域**：#586 交付 slot + rules + green inventory，
-  不实现第三个域的 full field-strict flip（除非作为文档示例命令，且不写入 CI）。
+- **本票不 march 新域**：#616 恢复 only-Trusted verdict 并重建诚实 inventory，
+  不把任何尚有 non-Trusted Evidence 的 field 域写回 strict。
 
 ## 2. 单 crate 使用
 
@@ -270,7 +261,7 @@ python3 tools/validate_api_contracts.py \
 | `WARN` | 实现缺失、解析不到或低噪声风险；endpoint strict 当前不因 warning 失败 |
 | `UNVERIFIED` | 官方详情或实现形态无法机器确认，需要人工判断 |
 
-Evidence 报告中，`Incomplete`、`Unavailable`、`Rejected` 均明确标记为 non-passing，并映射到既有 finding code。为保持既有 CLI 退出码用途，strict 仍以 `ERROR` 为主；真实 acquisition `Unavailable`（adapter/timeout/fetch/not-found）额外阻断，结构不完整或文档不健康继续以 `UNVERIFIED` 报告而不单独改变退出码。
+Evidence 报告中，`Incomplete`、`Unavailable`、`Rejected` 均明确标记为 non-passing，并映射到既有 finding code。只要命令请求了 `--strict endpoint|fields|tokens`，其实际采集的 requested Evidence Dimensions 必须全部为 `Trusted`；任一 non-Trusted 状态都返回非零。live strict 范围经 `--biz-tag` / `--api-id` 等过滤后若没有采集到 requested Evidence，同样 fail closed，防止空 inventory 误绿。未请求 live Evidence 的离线 endpoint strict 继续按既有 `ERROR` verdict 工作。
 
 常见 finding code：
 

--- a/tools/tests/test_validate_api_contracts_ci_gates.py
+++ b/tools/tests/test_validate_api_contracts_ci_gates.py
@@ -21,10 +21,17 @@ ROOT = Path(__file__).resolve().parents[2]
 CI_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "ci.yml"
 CONTRACT_POLICY_DOC = ROOT / "docs" / "api-contract-validation.md"
 
-# Canonical field-strict inventory for the institutionalization gate (#586).
-# Expanding this list requires the dual-edit: ci.yml step + this constant +
-# the inventory assertions below, in the *same* PR.
-FIELD_STRICT_DOMAINS = (
+# 仅列入已证明 live Structured Tokens Evidence 为 Trusted 的 API。
+TOKEN_STRICT_API_INVENTORY = {
+    "openlark-security": "7321978105899122716",
+    "openlark-auth": "7277403063290724380",
+}
+
+# Structured-only composition 尚无 request/response 双维度全 Trusted 的域。
+FIELD_STRICT_DOMAINS = ()
+
+# 原 strict 域继续完整采集并发布报告，但不得伪装为 strict pass。
+FIELD_EVIDENCE_MONITOR_DOMAINS = (
     {
         "name": "attendance",
         "crate": "openlark-hr",
@@ -64,56 +71,61 @@ class ApiContractsCiGatesTests(unittest.TestCase):
         self.assertIn("--crate openlark-ai", live_block)
         self.assertNotIn("--strict endpoint", live_block)
 
-    def test_token_strict_covers_security_and_auth(self) -> None:
-        self.assertIn("--crate openlark-security", self.job)
-        self.assertIn("--crate openlark-auth", self.job)
-        self.assertGreaterEqual(self.job.count("--strict tokens"), 2)
+    def test_token_strict_uses_explicit_trusted_api_inventory(self) -> None:
+        strict_block = self._step_run_block_containing(
+            "api_contract_tokens_strict"
+        )
+        self.assertEqual(strict_block.count("--strict tokens"), 2)
+        for crate, api_id in TOKEN_STRICT_API_INVENTORY.items():
+            self.assertIn(f"--crate {crate}", strict_block)
+            self.assertIn(f"--api-id {api_id}", strict_block)
 
-    def test_attendance_field_strict_gate(self) -> None:
-        self.assertIn("--crate openlark-hr", self.job)
-        self.assertIn("--biz-tag attendance", self.job)
-        self.assertIn("--strict fields", self.job)
-        self.assertIn("api_contract_fields/attendance", self.job)
+    def test_full_token_domains_remain_non_strict_monitors(self) -> None:
+        monitor = self._step_run_block_containing(
+            "api_contract_tokens/security"
+        )
+        self.assertIn("--crate openlark-security", monitor)
+        self.assertIn("--crate openlark-auth", monitor)
+        self.assertNotIn("--strict tokens", monitor)
+
+    def test_attendance_field_monitor_is_not_strict(self) -> None:
         attendance_block = self._step_run_block_containing("--biz-tag attendance")
+        self.assertIn("--crate openlark-hr", attendance_block)
         self.assertIn("--fields", attendance_block)
         self.assertIn("--live-fields", attendance_block)
-        self.assertIn("--strict fields", attendance_block)
+        self.assertNotIn("--strict fields", attendance_block)
+        self.assertIn("api_contract_fields/attendance", attendance_block)
 
-    def test_docs_field_strict_gate(self) -> None:
-        """First 0.20 domain expansion beyond attendance (#569).
-
-        openlark-docs (ccm/base/baike/minutes) must run live field validation
-        under --strict fields so required-body drift fails CI.
-        """
-        self.assertIn("--crate openlark-docs", self.job)
-        self.assertIn("api_contract_fields/docs", self.job)
-        # Require the docs step to enable strict fields (not a non-strict monitor).
+    def test_docs_field_monitor_is_not_strict(self) -> None:
         docs_block = self._step_run_block_containing("--crate openlark-docs")
         self.assertIn("--fields", docs_block)
         self.assertIn("--live-fields", docs_block)
-        self.assertIn("--strict fields", docs_block)
+        self.assertNotIn("--strict fields", docs_block)
+        self.assertIn("api_contract_fields/docs", docs_block)
 
-    def test_field_strict_inventory_is_exactly_attendance_and_docs(self) -> None:
-        """Institutionalized inventory: only the admitted domains are field-strict.
-
-        Adding a third domain is intentional expansion — update
-        FIELD_STRICT_DOMAINS + ci.yml + admission docs together (#586 dual-edit).
-        """
+    def test_field_strict_inventory_is_empty_until_trusted(self) -> None:
         strict_fields_steps = [
             block
             for block in self._step_run_blocks()
             if "--strict fields" in block
         ]
-        self.assertEqual(
-            len(strict_fields_steps),
-            len(FIELD_STRICT_DOMAINS),
-            "field-strict step count must match FIELD_STRICT_DOMAINS inventory",
-        )
-        for domain in FIELD_STRICT_DOMAINS:
-            self.assertIn(f"--crate {domain['crate']}", self.job)
-            self.assertIn(domain["report_dir_fragment"], self.job)
+        self.assertEqual(len(strict_fields_steps), len(FIELD_STRICT_DOMAINS))
+
+    def test_field_monitor_inventory_is_exactly_attendance_and_docs(self) -> None:
+        for domain in FIELD_EVIDENCE_MONITOR_DOMAINS:
+            block = self._step_run_block_containing(
+                f"--crate {domain['crate']}"
+            )
+            self.assertIn(domain["report_dir_fragment"], block)
+            self.assertNotIn("--strict fields", block)
             if domain["biz_tag"] is not None:
-                self.assertIn(f"--biz-tag {domain['biz_tag']}", self.job)
+                self.assertIn(f"--biz-tag {domain['biz_tag']}", block)
+
+    def test_monitors_do_not_masquerade_as_strict_or_hide_failures(self) -> None:
+        self.assertNotIn("continue-on-error", self.job)
+        self.assertNotIn("|| true", self.job)
+        self.assertNotIn("playwright", self.job.lower())
+        self.assertNotIn("recorded", self.job.lower())
 
     def test_no_monorepo_wide_field_strict(self) -> None:
         """Non-goal: never open monorepo-wide --strict fields in one shot (#586)."""

--- a/tools/tests/test_validate_api_contracts_compare.py
+++ b/tools/tests/test_validate_api_contracts_compare.py
@@ -4,6 +4,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from tools.api_contracts.compare import (
     compare_access_token_types,
@@ -12,6 +13,7 @@ from tools.api_contracts.compare import (
     compare_response_fields,
 )
 from tools.api_contracts.models import (
+    ContractFinding,
     ContractReport,
     DEFAULT_ACCESS_TOKEN_TYPES,
     ApiIdentity,
@@ -297,40 +299,138 @@ class ContractCompareTests(unittest.TestCase):
         )
         self.assertEqual(result.code, "U_OFFICIAL_DETAIL_FETCH_FAILED")
 
-    def test_strict_exit_blocks_only_unavailable_acquisition_failures(self):
+    def test_strict_runner_allows_only_trusted_evidence(self):
         import tools.validate_api_contracts as cli
 
-        report = ContractReport(
+        for status in (
+            EvidenceStatus.INCOMPLETE,
+            EvidenceStatus.UNAVAILABLE,
+            EvidenceStatus.REJECTED,
+        ):
+            with self.subTest(status=status):
+                report = ContractReport(
+                    "fixture",
+                    evidence=[
+                        {
+                            "api_id": "1",
+                            "dimensions": [
+                                {
+                                    "dimension": "request_fields",
+                                    "status": status.value,
+                                    "diagnostics": [],
+                                }
+                            ],
+                        }
+                    ],
+                )
+                live_fields = {"request_fields", "response_fields"}
+                self.assertEqual(
+                    cli._strict_exit_code(
+                        [report], {"fields"}, live_fields
+                    ),
+                    1,
+                )
+                self.assertEqual(
+                    cli._strict_exit_code([report], set(), live_fields), 0
+                )
+                self.assertEqual(
+                    cli._strict_exit_code(
+                        [report], {"tokens"}, live_fields
+                    ),
+                    0,
+                )
+
+        trusted = ContractReport(
             "fixture",
             evidence=[
                 {
                     "api_id": "1",
                     "dimensions": [
                         {
-                            "status": "incomplete",
-                            "diagnostics": [
-                                {"code": "structure_incomplete"}
-                            ],
+                            "dimension": "request_fields",
+                            "status": EvidenceStatus.TRUSTED.value,
+                            "diagnostics": [],
                         },
                         {
-                            "status": "rejected",
-                            "diagnostics": [
-                                {"code": "document_unhealthy"}
-                            ],
+                            "dimension": "response_fields",
+                            "status": EvidenceStatus.TRUSTED.value,
+                            "diagnostics": [],
                         },
                     ],
                 }
             ],
         )
-        self.assertFalse(cli._has_blocking_evidence_failure([report]))
+        live_fields = {"request_fields", "response_fields"}
+        self.assertEqual(
+            cli._strict_exit_code([trusted], {"fields"}, live_fields), 0
+        )
+        trusted.add(
+            ContractFinding(
+                severity="ERROR",
+                code="E_ENDPOINT_PATH_MISMATCH",
+                message="fixture drift",
+                api_id="1",
+                api_name="fixture",
+                expected_file="fixture.rs",
+                doc_path="",
+            )
+        )
+        self.assertEqual(
+            cli._strict_exit_code([trusted], {"fields"}, live_fields), 1
+        )
+        self.assertEqual(
+            cli._strict_exit_code(
+                [ContractReport("empty")], {"tokens"}, {"tokens"}
+            ),
+            1,
+        )
 
-        report.evidence[0]["dimensions"].append(
-            {
-                "status": "unavailable",
-                "diagnostics": [{"code": "acquisition_failed"}],
+    def test_runner_filters_catalog_to_explicit_api_inventory(self):
+        import tools.validate_api_contracts as cli
+
+        first = self._api()
+        second = ApiIdentity(
+            **{
+                **first.__dict__,
+                "api_id": "2",
+                "name": "Second API",
             }
         )
-        self.assertTrue(cli._has_blocking_evidence_failure([report]))
+
+        class RecordingCollector:
+            def __init__(self):
+                self.api_ids = []
+
+            def collect(self, api, dimensions, policy):
+                self.api_ids.append(api.api_id)
+                return _TrustedCollector().collect(
+                    api, dimensions, policy
+                )
+
+        collector = RecordingCollector()
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            mock.patch.object(
+                cli, "load_api_identities", return_value=[first, second]
+            ),
+            mock.patch.object(cli, "load_endpoint_constants", return_value={}),
+            mock.patch.object(cli, "load_enum_endpoints", return_value={}),
+            mock.patch.object(cli, "load_enum_methods", return_value={}),
+            mock.patch.object(cli, "scan_api_file", return_value=None),
+        ):
+            report = cli.validate_crate(
+                "fixture",
+                {"src": directory, "biz_tags": ["ai"]},
+                Path(directory) / "catalog.csv",
+                Path(directory) / "reports",
+                True,
+                collector,
+                tokens=True,
+                api_ids={"2"},
+            )
+
+        self.assertEqual(report.total_apis, 1)
+        self.assertEqual(collector.api_ids, ["2"])
 
 
 class ContractCliTests(unittest.TestCase):

--- a/tools/validate_api_contracts.py
+++ b/tools/validate_api_contracts.py
@@ -69,6 +69,11 @@ def parse_args() -> argparse.Namespace:
         action="append",
         help="进一步过滤到指定 bizTag（可多次传入）；覆盖 crate 的 biz_tags，用于子模块级 gate",
     )
+    parser.add_argument(
+        "--api-id",
+        action="append",
+        help="仅验证显式列入 gate inventory 的 API ID（可多次传入，需配合 --crate）",
+    )
     parser.add_argument("--report-dir", default="reports/api_contracts", help="Report directory")
     parser.add_argument("--include-old", dest="skip_old", action="store_false", help="Include meta.Version=old APIs")
     parser.add_argument("--skip-old", dest="skip_old", action="store_true", default=True, help="Skip old APIs")
@@ -135,11 +140,21 @@ def validate_crate(
     max_field_apis: int = 0,
     tokens: bool = False,
     biz_tag_filter: list[str] | None = None,
+    api_ids: set[str] | None = None,
 ) -> ContractReport:
     """核对一个 crate；官方事实只通过 collect seam 获取。"""
     src_path = Path(crate_config["src"])
     biz_tags = biz_tag_filter if biz_tag_filter else list(crate_config.get("biz_tags") or [])
     apis = load_api_identities(csv_path, filter_tags=biz_tags, skip_old_versions=skip_old)
+    if api_ids:
+        available_ids = {api.api_id for api in apis}
+        missing_ids = api_ids - available_ids
+        if missing_ids:
+            raise SystemExit(
+                "指定 API ID 不在当前 crate/catalog 范围内: "
+                + ", ".join(sorted(missing_ids))
+            )
+        apis = [api for api in apis if api.api_id in api_ids]
     constants = load_endpoint_constants(src_path)
     enum_endpoints = load_enum_endpoints(src_path, constants)
     enum_methods = load_enum_methods(src_path)
@@ -324,25 +339,44 @@ def _evidence_finding(api, dimension, evidence):
     )
 
 
-def _has_blocking_evidence_failure(reports: list[ContractReport]) -> bool:
-    """仅真实 acquisition 不可用阻断兼容的 strict CLI 退出码。"""
-    blocking_diagnostics = {
-        "snapshot_unavailable",
-        "adapter_unavailable",
-        "acquisition_timeout",
-        "acquisition_failed",
-        "document_not_found",
-    }
-    return any(
-        dimension["status"] == EvidenceStatus.UNAVAILABLE.value
-        and any(
-            diagnostic["code"] in blocking_diagnostics
-            for diagnostic in dimension["diagnostics"]
+def _strict_exit_code(
+    reports: list[ContractReport],
+    strict_categories: set[str],
+    live_dimensions: set[str],
+) -> int:
+    """Strict Evidence Gate：requested Evidence 只有 Trusted 才通过。"""
+    strict_dimensions = set()
+    if "endpoint" in strict_categories:
+        strict_dimensions.add(EvidenceDimension.ENDPOINT.value)
+    if "fields" in strict_categories:
+        strict_dimensions.update(
+            (
+                EvidenceDimension.REQUEST_FIELDS.value,
+                EvidenceDimension.RESPONSE_FIELDS.value,
+            )
         )
+    if "tokens" in strict_categories:
+        strict_dimensions.add(EvidenceDimension.TOKENS.value)
+    if not strict_dimensions:
+        return 0
+    required_strict_dimensions = strict_dimensions & live_dimensions
+    observed_dimensions = {
+        dimension["dimension"]
+        for report in reports
+        for api_evidence in report.evidence
+        for dimension in api_evidence["dimensions"]
+    }
+    if not required_strict_dimensions <= observed_dimensions:
+        return 1
+    has_nontrusted_evidence = any(
+        dimension["dimension"] in strict_dimensions
+        and dimension["status"] != EvidenceStatus.TRUSTED.value
         for report in reports
         for api_evidence in report.evidence
         for dimension in api_evidence["dimensions"]
     )
+    has_contract_error = any(report.error_count for report in reports)
+    return 1 if has_contract_error or has_nontrusted_evidence else 0
 
 
 def main() -> int:
@@ -358,6 +392,9 @@ def main() -> int:
     mapping = load_mapping(Path(args.mapping))
     if not args.all_crates and not args.crate_name:
         print("Specify --crate <name> or --all-crates", file=sys.stderr)
+        return 1
+    if args.api_id and not args.crate_name:
+        print("--api-id 必须配合 --crate 使用", file=sys.stderr)
         return 1
 
     if args.crate_name:
@@ -387,6 +424,7 @@ def main() -> int:
                 max_field_apis=args.max_field_apis,
                 tokens=args.tokens,
                 biz_tag_filter=args.biz_tag,
+                api_ids=set(args.api_id or []),
             )
             for crate_name in crate_names
         ]
@@ -401,12 +439,19 @@ def main() -> int:
     )
 
     strict_categories = {item.strip() for item in args.strict.split(",") if item.strip()}
-    blocking_evidence_failure = _has_blocking_evidence_failure(reports)
-    if strict_categories & {"endpoint", "fields", "tokens"} and (
-        total_errors or blocking_evidence_failure
-    ):
-        return 1
-    return 0
+    live_dimensions = set()
+    if args.live_endpoints:
+        live_dimensions.add(EvidenceDimension.ENDPOINT.value)
+    if args.fields:
+        live_dimensions.update(
+            (
+                EvidenceDimension.REQUEST_FIELDS.value,
+                EvidenceDimension.RESPONSE_FIELDS.value,
+            )
+        )
+    if args.tokens:
+        live_dimensions.add(EvidenceDimension.TOKENS.value)
+    return _strict_exit_code(reports, strict_categories, live_dimensions)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 摘要

- Strict Evidence Gate 仅允许实际请求的 Evidence Dimensions 全部为 `Trusted` 时通过
- `Incomplete`、`Unavailable`、`Rejected` 以及空 live strict inventory 均 fail closed
- 按 endpoint / fields / tokens 隔离 strict Evidence 维度，保留既有 contract `ERROR` 与 finding codes
- 新增 `--api-id` 显式 inventory，并将 CI 拆分为可信 API strict gates 与完整域 non-strict monitors
- 更新 CI inventory/admission policy 和回归测试

## 验证

- `python3 -m unittest discover -s tools/tests -p 'test_*.py'`：217 passed，2 skipped
- `cargo test --workspace --all-features`：6113 passed，162 ignored
- 全仓离线 endpoint strict：通过
- security/auth 显式 API token strict：通过
- 空 token strict inventory：确认退出码 1
- Standards/Spec 双轴 review 完成；空 inventory 误绿 finding 已修复并复核关闭

Closes #616