### PR TITLE
fix(tools): harden API field verify gate (#618–#624)

### DIFF
--- a/.agents/skills/openlark-api-field-verify/SKILL.md
+++ b/.agents/skills/openlark-api-field-verify/SKILL.md
@@ -138,10 +138,15 @@ python3 tools/verify_api_fields.py
 # 快速模式：单个 crate
 python3 tools/verify_api_fields.py --crate openlark-workflow
 
-# 完整模式：抓飞书文档对比字段（慢，约 8 秒/API，默认跳过已缓存）
+# 完整模式：抓飞书文档对比字段（慢，约 8 秒/API）
+# 批量模式默认复用未超龄 Official Evidence 快照（--max-age 天，默认 30）
 python3 tools/verify_api_fields.py --crate openlark-workflow --fetch-docs
 
-# 单个 API 核对门禁（实现后必做）：抓文档对比
+# 强制忽略快照重抓 / 自定义超龄阈值
+python3 tools/verify_api_fields.py --crate openlark-workflow --fetch-docs --force-refresh
+python3 tools/verify_api_fields.py --crate openlark-workflow --fetch-docs --max-age 7
+
+# 单个 API 核对门禁（实现后必做）：默认 Fresh 重抓（单页约 8 秒）
 # 抓取失败 / error / warning → 非 0 退出（禁止假绿）
 python3 tools/verify_api_fields.py --api-id 7642253323628383198 --fetch-docs
 ```
@@ -149,6 +154,19 @@ python3 tools/verify_api_fields.py --api-id 7642253323628383198 --fetch-docs
 工具自动完成路径解析、字段提取、文档抓取、差异对比，输出 `reports/api_field_verify/` 报告。
 `--fetch-docs` 模式下：文档抓取失败、内容过少/404、字段 error/warning 均记入报告并以非 0 退出；info 不阻断。
 设计文档见 `docs/superpowers/specs/2026-06-16-api-field-verify-tool-design.md`。
+
+### 工具核对边界
+
+门禁通过 ≠ 字段完全正确。自动化覆盖有限，以下边界需知情：
+
+1. **嵌套结构盲区**：请求体只对比「第一个名字含 Body 的 struct」；嵌套子对象的独立 struct（通常不叫 `*Body`）不参与对比。文档 innerText 拍平后嵌套子字段可能被当成顶层参数，误报/漏报方向不定。响应侧只做「示例字段名集合差」，字段在错误层级也算存在。
+2. **响应体是弱保证**：`missing_response_field` 仅 info 不阻断；代码多余的响应字段完全不检测。响应体完整性需人工比对 Response body example。
+3. **人工核对项**（门禁不覆盖）：
+   - 数组上限（如 `cc_user_ids` ≤20）——无法从 innerText 结构化解析
+   - 嵌套子结构字段与层级（见上）
+   - 响应体字段完整性与类型（见上）
+
+> 类型与必填性已纳入 `compare_fields()` 自动对比（文档 Yes+代码 Option → error；类型映射不匹配 → warning）；不再需要人工逐项核对这两类。
 
 ### 第 3 步：解析字段
 
@@ -169,7 +187,7 @@ Query parameters ... Request example 之间
 **Response body 的 data 子字段**：
 - 外层只有 `code/msg/data`
 - `data` 的子字段在折叠的 "Show sublists" 里，innerText 拿不到
-- **改从 Response body example 的 JSON 提取字段名**：`grep -oE '"[a-z_]+"\s*:' doc.txt | sort -u`
+- **改从 Response body example 的 JSON 提取字段名**：`grep -oE '"[a-z][a-z0-9_]*"\s*:' doc.txt | sort -u`
 
 #### 解析辅助命令
 
@@ -179,9 +197,9 @@ awk '/^Request body$/{c++; if(c==2){p=1; next}} /^Request example$/{p=0} p' doc_
   | grep -E "^[a-z_]+$|^(Yes|No)$|^(string|int|boolean|string\[\]|object|-)$" \
   | grep -vE "^(parameter|type|required|description)$"
 
-# 提取响应示例里的所有字段名（用于完整建模响应体）
+# 提取响应示例里的所有字段名（用于完整建模响应体；含 i18n_name/md5/s3_key 等数字字符）
 awk '/^Response body example$/{p=1} /^Error code$/{p=0} p' doc_xxx.txt \
-  | grep -oE '"[a-z_]+"\s*:' | tr -d '":' | sort -u
+  | grep -oE '"[a-z][a-z0-9_]*"\s*:' | tr -d '":' | sort -u
 
 # 确认 POST 响应的 data 是否空对象（决定 Response struct 是否留空）
 awk '/^Response body example$/{p=1} /^Error code$/{p=0} p' doc_xxx.txt \
@@ -240,7 +258,7 @@ URL 解析规则：以 `http` 开头原样使用；以 `/` 开头则拼 `https:/
 
 原因：data 的子字段在 "Show sublists" 折叠区，innerText 拿不到。
 
-解决：从 **Response body example 的 JSON** 提取字段名（`grep -oE '"[a-z_]+"\s*:'`），示例里出现的字段就是真实字段。
+解决：从 **Response body example 的 JSON** 提取字段名（`grep -oE '"[a-z][a-z0-9_]*"\s*:'`），示例里出现的字段就是真实字段。
 
 ### 3. playwright 版本不匹配
 

--- a/.agents/skills/openlark-api-field-verify/scripts/fetch_doc.js
+++ b/.agents/skills/openlark-api-field-verify/scripts/fetch_doc.js
@@ -34,6 +34,13 @@ const { execSync } = require('child_process');
 
 const DOC_BASE = 'https://open.feishu.cn';
 
+/** 与 verify_api_fields / official_evidence 解析锚点对齐的英文段标题。 */
+const STANDARD_DOC_SECTIONS = [
+  'Request body',
+  'Query parameters',
+  'Response body example',
+];
+
 /** 懒加载 playwright，便于 --help / CSV 解析在未安装时也能跑。 */
 function loadChromium() {
   try {
@@ -48,6 +55,30 @@ function loadChromium() {
       );
       process.exit(1);
     }
+  }
+}
+
+/**
+ * 固定英文 locale，避免飞书按地区渲染中文段标题导致下游解析归零。
+ * @param {import('playwright').Browser} browser
+ */
+async function newEnglishContext(browser) {
+  return browser.newContext({
+    locale: 'en-US',
+    extraHTTPHeaders: {
+      'Accept-Language': 'en-US,en',
+    },
+  });
+}
+
+/** 抓取内容若缺少英文标准段标题，提示可能落到了非英文页。 */
+function warnIfMissingEnglishSections(text, outFile) {
+  const hasSection = STANDARD_DOC_SECTIONS.some((section) => text.includes(section));
+  if (!hasSection) {
+    console.warn(
+      `⚠️ ${path.basename(outFile)}: 未检测到英文标准段标题` +
+        `（${STANDARD_DOC_SECTIONS.join(' / ')}），页面可能非英文，解析可能失败`
+    );
   }
 }
 
@@ -159,12 +190,12 @@ function assertLocalOutFile(outFile) {
 
 /**
  * 渲染单个文档页面，导出 innerText
- * @param {import('playwright').Browser} browser
+ * @param {import('playwright').BrowserContext} context 已固定 en-US 的 context
  * @param {string} url 完整 URL
  * @param {string} outFile 输出文件路径
  */
-async function fetchOne(browser, url, outFile) {
-  const page = await browser.newPage();
+async function fetchOne(context, url, outFile) {
+  const page = await context.newPage();
   try {
     await page.goto(url, { waitUntil: 'networkidle', timeout: 60000 });
     // SPA 需要额外等待内容渲染
@@ -185,6 +216,7 @@ async function fetchOne(browser, url, outFile) {
     const flag = text.length < 500 ? '⚠️ 内容过少，检查 URL 是否正确' : '✅';
     console.log(`${flag} ${path.basename(outFile)}: ${text.length} chars`);
     console.log(`   url: ${url}`);
+    warnIfMissingEnglishSections(text, outFile);
     return text.length;
   } finally {
     await page.close();
@@ -226,9 +258,11 @@ async function main() {
 
     const chromium = loadChromium();
     const browser = await chromium.launch({ headless: true });
+    const context = await newEnglishContext(browser);
     try {
-      await fetchOne(browser, url, outFile);
+      await fetchOne(context, url, outFile);
     } finally {
+      await context.close();
       await browser.close();
     }
     return;
@@ -262,6 +296,7 @@ async function main() {
     fs.mkdirSync(outDir, { recursive: true });
     const chromium = loadChromium();
     const browser = await chromium.launch({ headless: true });
+    const context = await newEnglishContext(browser);
     console.log(`📥 批量抓取 ${paths.length} 个文档到 ${outDir}`);
     for (const p of paths) {
       let url;
@@ -273,11 +308,12 @@ async function main() {
       }
       const outFile = path.join(outDir, outNameFromInput(p));
       try {
-        await fetchOne(browser, url, outFile);
+        await fetchOne(context, url, outFile);
       } catch (e) {
         console.log(`❌ ${p}: ${e.message}`);
       }
     }
+    await context.close();
     await browser.close();
     console.log('✅ 批量完成');
     return;
@@ -299,9 +335,11 @@ async function main() {
   }
   const chromium = loadChromium();
   const browser = await chromium.launch({ headless: true });
+  const context = await newEnglishContext(browser);
   try {
-    await fetchOne(browser, url, outFile);
+    await fetchOne(context, url, outFile);
   } finally {
+    await context.close();
     await browser.close();
   }
 }

--- a/.agents/skills/openlark-api/SKILL.md
+++ b/.agents/skills/openlark-api/SKILL.md
@@ -76,7 +76,7 @@ allowed-tools: Bash, Read, Grep, Glob, Edit
    - 涉及该 feature 的测试用 `#[cfg(test)]` 模块内 `#![cfg(feature = "...")]`（或模块级 `#[cfg(feature)]`）门控；
    - 若新增 `examples/` 示例，须在 `Cargo.toml [[example]]` 声明 `required-features`；
    - 跑 `just fmt && just lint && just test`，其中 `just lint` 须含 `--all-targets`（覆盖 examples + tests）；
-   - **字段核对（必做）**：`python3 tools/verify_api_fields.py --api-id <CSV的id> --fetch-docs`；进程须以 0 退出（抓取失败 / error / warning 均非 0）。详细流程见 `Skill(openlark-api-field-verify)`。
+   - **字段核对（必做）**：`python3 tools/verify_api_fields.py --api-id <CSV的id> --fetch-docs`；进程须以 0 退出（抓取失败 / error / warning 均非 0）。详细流程见 `Skill(openlark-api-field-verify)`。**门禁通过不覆盖嵌套结构与响应体完整性**，见 field-verify 技能「工具核对边界」。
 
 ## 1. Feature Crate ↔ bizTag
 
@@ -266,7 +266,7 @@ impl {Name}Request {
 - [ ] `mod.rs` 已导出；`service.rs`/链式入口已补
 - [ ] 新增 feature 已在 `Cargo.toml [features]` 声明；测试/示例的 `#[cfg(feature)]` 与 `[[example]] required-features` 已补
 - [ ] `just fmt && just lint --all-targets && just test` 通过
-- [ ] **字段核对门禁**：`python3 tools/verify_api_fields.py --api-id <id> --fetch-docs` 无未处理的 error/warning
+- [ ] **字段核对门禁**：`python3 tools/verify_api_fields.py --api-id <id> --fetch-docs` 无未处理的 error/warning（门禁通过不覆盖嵌套结构与响应体完整性，见 field-verify 技能「工具核对边界」）
 
 ## 5. 官方文档读取（唯一入口）
 

--- a/.github/workflows/api-field-verify-full.yml
+++ b/.github/workflows/api-field-verify-full.yml
@@ -1,0 +1,90 @@
+name: API Field Verify (Full)
+
+on:
+  workflow_dispatch:
+    inputs:
+      crate:
+        description: '可选 crate（如 openlark-workflow）；留空=全仓'
+        required: false
+        type: string
+        default: ''
+      force_refresh:
+        description: '强制忽略 Official Evidence 快照重抓'
+        required: false
+        type: boolean
+        default: false
+      max_age:
+        description: '快照最大年龄（天），仅在未 force_refresh 时生效'
+        required: false
+        type: string
+        default: '30'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: api-field-verify-full-${{ github.event.inputs.crate || 'all' }}
+  cancel-in-progress: false
+
+jobs:
+  full:
+    name: Full-mode field verify
+    runs-on: ubuntu-latest
+    # 全仓完整模式可能极慢；单 crate 通常可接受
+    timeout-minutes: 360
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Playwright Chromium
+        run: |
+          npm install -g playwright
+          npx playwright install --with-deps chromium
+
+      - name: Run full-mode verify
+        id: verify
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          mkdir -p reports/api_field_verify
+
+          args=(--fetch-docs --output-dir reports/api_field_verify --max-age "${{ inputs.max_age }}")
+          if [[ -n "${{ inputs.crate }}" ]]; then
+            args+=(--crate "${{ inputs.crate }}")
+          fi
+          if [[ "${{ inputs.force_refresh }}" == "true" ]]; then
+            args+=(--force-refresh)
+          fi
+
+          echo "Running: python3 tools/verify_api_fields.py ${args[*]}"
+          set +e
+          python3 tools/verify_api_fields.py "${args[@]}"
+          status=$?
+          set -e
+          echo "exit_code=${status}" >> "$GITHUB_OUTPUT"
+          exit "${status}"
+
+      - name: Upload field-verify artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-field-verify-full
+          path: reports/api_field_verify/
+          retention-days: 30
+
+      - name: Fail job if verify reported error/warning
+        if: steps.verify.outcome == 'failure'
+        run: |
+          echo "Full-mode verify exited non-zero (error/warning or tool failure)."
+          echo "See uploaded artifact reports/api_field_verify/ for details."
+          exit 1

--- a/.github/workflows/api-field-verify-weekly.yml
+++ b/.github/workflows/api-field-verify-weekly.yml
@@ -1,0 +1,162 @@
+name: API Field Verify (Weekly Quick)
+
+on:
+  schedule:
+    # 每周一 11:00（Asia/Shanghai）跑全仓快速自检
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: api-field-verify-weekly
+  cancel-in-progress: false
+
+jobs:
+  quick:
+    name: Quick-mode field self-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run verify_api_fields unit tests
+        run: |
+          python3 -m unittest tools.tests.test_verify_api_fields
+
+      - name: Run quick-mode full-repo scan
+        id: scan
+        run: |
+          set -euo pipefail
+          mkdir -p reports/api_field_verify
+          # 快速模式恒 exit 0；工具崩溃才失败本 step
+          python3 tools/verify_api_fields.py --output-dir reports/api_field_verify
+
+          python3 <<'PY'
+          import json
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          summary_path = Path("reports/api_field_verify/summary.json")
+          if not summary_path.exists():
+              raise SystemExit("missing summary.json after quick scan")
+
+          summary = json.loads(summary_path.read_text(encoding="utf-8"))
+          blocking = []
+          for api in summary.get("apis", []):
+              for issue in api.get("issues", []):
+                  if issue.get("severity") in ("error", "warning"):
+                      blocking.append(
+                          {
+                              "id": api.get("id"),
+                              "name": api.get("name"),
+                              "file": api.get("file"),
+                              "severity": issue.get("severity"),
+                              "category": issue.get("category"),
+                              "detail": issue.get("detail"),
+                          }
+                      )
+
+          Path("reports/api_field_verify/blocking.json").write_text(
+              json.dumps(blocking, ensure_ascii=False, indent=2),
+              encoding="utf-8",
+          )
+
+          lines = [
+              "<!-- api-field-verify-weekly-tracking -->",
+              "",
+              "# API 字段核对（快速模式）发现可疑模式",
+              "",
+              f"- 运行时间（UTC）: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M')}",
+              f"- 模式: `{summary.get('mode', 'quick')}`",
+              f"- 核对 API 数: {summary.get('total_apis', 0)}",
+              f"- 有问题 API 数: {summary.get('apis_with_issues', 0)}",
+              f"- error/warning 条数: {len(blocking)}",
+              "",
+              "本 issue 由 `.github/workflows/api-field-verify-weekly.yml` 自动维护。",
+              "快速模式**不抓文档**，仅代码自检 + 可疑模式；完整模式请手动触发 `API Field Verify (Full)`。",
+              "",
+          ]
+          if blocking:
+              lines.extend(
+                  [
+                      "## 问题列表",
+                      "",
+                      "| 严重度 | API | 文件 | 类别 | 详情 |",
+                      "|--------|-----|------|------|------|",
+                  ]
+              )
+              for item in blocking[:200]:
+                  detail = (item.get("detail") or "").replace("|", "\\|")
+                  lines.append(
+                      f"| {item.get('severity')} | {item.get('name')} "
+                      f"(`{item.get('id')}`) | `{item.get('file')}` | "
+                      f"{item.get('category')} | {detail} |"
+                  )
+              if len(blocking) > 200:
+                  lines.append("")
+                  lines.append(f"> 仅展示前 200 条，共 {len(blocking)} 条。")
+          else:
+              lines.append("当前无 error/warning。")
+
+          Path("reports/api_field_verify/findings.md").write_text(
+              "\n".join(lines) + "\n", encoding="utf-8"
+          )
+          print(len(blocking))
+          PY
+
+          BLOCKING_COUNT="$(python3 -c '
+          import json
+          from pathlib import Path
+          print(len(json.loads(Path("reports/api_field_verify/blocking.json").read_text(encoding="utf-8"))))
+          ')"
+          echo "blocking_count=${BLOCKING_COUNT}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload quick-mode artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-field-verify-weekly
+          path: reports/api_field_verify/
+          retention-days: 14
+
+      - name: Open or update tracking issue
+        if: steps.scan.outputs.blocking_count != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          title="API 字段核对（快速模式）发现可疑模式"
+          body_file="reports/api_field_verify/findings.md"
+
+          existing="$(
+            gh issue list \
+              --state open \
+              --search "\"${title}\" in:title" \
+              --json number,title \
+              --jq ".[] | select(.title == \"${title}\") | .number" \
+              | head -n1
+          )"
+
+          if [[ -n "${existing}" ]]; then
+            gh issue edit "$existing" --body-file "$body_file"
+            echo "Updated issue #${existing}"
+          else
+            gh issue create \
+              --title "$title" \
+              --body-file "$body_file" \
+              --label "scope:quality" || \
+            gh issue create \
+              --title "$title" \
+              --body-file "$body_file"
+            echo "Created tracking issue"
+          fi

--- a/docs/superpowers/specs/2026-06-16-api-field-verify-tool-design.md
+++ b/docs/superpowers/specs/2026-06-16-api-field-verify-tool-design.md
@@ -1,8 +1,9 @@
 # API 字段核对工具设计
 
 **日期**: 2026-06-16
-**状态**: 已批准，待实现
+**状态**: 已实现并投入使用（`tools/verify_api_fields.py` + Official Document Evidence）
 **关联技能**: `openlark-api-field-verify`（手动单接口流程）、`openlark-api-validation`（覆盖率）
+**关联 Issue**: #618–#624（2026-08 字段核对流程加固）
 
 ## 背景与动机
 
@@ -16,7 +17,7 @@ OpenLark 仓库现有 **1593 个已实现 API**，分布在 15 个 crate。这�
 
 ## 目标
 
-产出自动化工具 `tools/verify_api_fields.py`，**本次只建工具不执行全量核对**，留作后续定期/分批执行。
+产出自动化工具 `tools/verify_api_fields.py`，用于定期/分批执行字段正确性核对。
 
 ### 非目标
 
@@ -34,7 +35,7 @@ OpenLark 仓库现有 **1593 个已实现 API**，分布在 15 个 crate。这�
 | **B. 正则结构匹配** | 够用（仓库字段定义高度规整） | 低（Python，复用现有扫描逻辑） | **✓** |
 | C. 运行时反射 | 100% 真实 | 极高（每个 API 要写序列化触发） | ✗ |
 
-方案 B 的可靠性依据：仓库 `Body`/`Response` struct 写法高度统一（`pub field: Type`，serde 属性独立成行），正则可稳定提取。能发现的主要问题——多余字段、缺字段、字段名错、上限不符——正是实际发生过的偏差类型。
+方案 B 的可靠性依据：仓库 `Body`/`Response` struct 写法高度统一（`pub field: Type`，serde 属性独立成行），正则可稳定提取。能发现的主要问题——多余字段、缺字段、字段名错、类型/必填不一致——正是实际发生过的偏差类型。
 
 ## 架构
 
@@ -47,8 +48,8 @@ api_list_export.csv ──┐
 crates/**/*.rs ───────┤
                       ├─→ 2. 代码字段提取（正则扫描 Body/Response struct）
                       │
-飞书文档页面 ─────────┤   （仅完整模式）
-                      ├─→ 3. 文档字段抓取（复用 fetch_doc.js + 解析）
+飞书文档页面 ─────────┤   （仅完整模式；经 Official Document Evidence）
+                      ├─→ 3. 文档字段抓取（structured detail → rendered fallback）
                       │
                       └─→ 4. 对比 → reports/api_field_verify/<crate>.md
 ```
@@ -57,7 +58,7 @@ crates/**/*.rs ───────┤
 
 **快速模式（默认）**：只做代码字段自检 + 可疑模式检测，**不抓文档**，秒级完成全仓。适合定期扫描发现明显问题。
 
-**完整模式（`--fetch-docs`）**：抓飞书文档对比字段，慢但彻底（1 个文档约 8 秒，全量约 3.5 小时）。适合分批跑单个 crate 或手动触发。
+**完整模式（`--fetch-docs`）**：经 Official Document Evidence 抓飞书文档对比字段，慢但彻底（1 个文档约 8 秒）。适合分批跑单个 crate 或手动触发。
 
 ## 组件设计
 
@@ -80,7 +81,7 @@ pub struct PassTaskBodyV4 {
     pub instance_code: String,                    // → instance_code, String, 必填
     #[serde(skip_serializing_if = "Option::is_none")]
     pub form: Option<String>,                     // → form, String, 选填
-    pub cc_user_ids: Vec<String>,                 // → cc_user_ids, Vec<String>, 必填(数组)
+    pub cc_user_ids: Vec<String>,                 // → cc_user_ids, String, 必填(数组)
 }
 ```
 
@@ -89,13 +90,14 @@ pub struct PassTaskBodyV4 {
 2. 提取字段行：块内匹配 `pub (\w+):\s*(.+?),?$`，跳过注释行和 `#[serde(...)]`/`#[cfg(...)]` 属性行
 3. 解析类型与可选性：
    - `Option<T>` → 选填
-   - `Vec<T>` → 数组必填
+   - `Vec<T>` → 数组必填（`is_array=true`）
    - 裸 `String`/`i32`/`bool` → 必填
    - 记录 `#[serde(rename = "xxx")]`（对比时用 rename 后的名字）
 
 **已知局限**（文档化，不阻塞）：
 - 复杂泛型（`HashMap<K,V>`、嵌套 `Vec<Vec<>>`）只取首层类型名
 - `#[serde(flatten)]` 字段无法展开（仓库极少）
+- 嵌套子对象的独立 struct（非 `*Body`）不参与对比——见技能「工具核对边界」
 
 ### 3. 可疑模式检测（快速模式核心）
 
@@ -103,13 +105,13 @@ pub struct PassTaskBodyV4 {
 
 | 红旗 | 检测逻辑 | 严重度 |
 |------|---------|--------|
-| 用户级接口含 `user_id`/`approval_code` | CSV 的 `fullPath` 含 `/reference/`（新版用户级文档路径），且其 Body 含这些字段。注：判定依据是 `fullPath` 而非 API url，因为 reference 是文档路径标识 | 🟡 警告 |
-| Vec 字段缺 `validate_required_list!` | Body 有 `Vec<String>` 字段，但同文件 `execute_with_options` 无对应校验 | 🟡 警告 |
+| 用户级接口含 `user_id`/`approval_code` | CSV 的 `fullPath` 含 `/reference/`（新版用户级文档路径），且其 Body 含这些字段。注：判定依据是 `fullPath` 而非 API url，因为 reference 是文档路径标识 | 🟢 提示（需人工判断） |
+| Vec 字段缺非空校验 | Body 有必填数组字段，但同文件无 `validate_required_list!` / `is_empty()` | 🟡 警告 |
 | GET 查询接口的 Response 为空 `{}` | CSV 的 `url` 以 `GET:` 开头，且 Response struct 无字段 | 🟢 提示 |
 
 ### 4. 文档字段抓取与对比（完整模式）
 
-**抓取**：复用 `.agents/skills/openlark-api-field-verify/scripts/fetch_doc.js`，URL 从 CSV 的 `fullPath` 拼接（不自己拼，避免路径格式错）。
+**抓取**：经 `tools/api_contracts/official_evidence`（structured detail 优先，rendered innerText fallback）。手动单页可用 `.agents/skills/openlark-api-field-verify/scripts/fetch_doc.js`（固定 `en-US` locale）。
 
 **文档字段解析**：
 
@@ -117,29 +119,38 @@ pub struct PassTaskBodyV4 {
 |---------|--------|------|
 | POST | Request body（第2次出现）→ Request example | 参数名 + 必填 + 类型 |
 | GET | Query parameters → Request example | 同上 |
-| 所有 | Response body example JSON | 响应字段名集合 |
+| 所有 | Response body example JSON | 响应字段名集合（正则 `"([a-z][a-z0-9_]*)"\s*:`，含数字字符） |
 
-**对比逻辑**：
+**对比逻辑**（`compare_fields`）：
 
 ```
 请求体：
-  代码有 ∩ 文档无  → 多余字段
-  代码无 ∩ 文档有  → 缺失字段
-  两边都有         → 一致
+  代码有 ∩ 文档无  → 多余字段（warning）
+  代码无 ∩ 文档有  → 缺失字段（error）
+  两边都有         → 继续比必填性与类型
+    文档 Yes + 代码 Option → required_mismatch（error）
+    文档 No  + 代码非 Option → required_mismatch（warning）
+    文档类型可映射且与 Rust 核心类型不符 → type_mismatch（warning）
+    文档 type 为空 / 未建模类型（object 等）→ 跳过类型对比
 
 响应体：
-  文档示例字段 - 代码 Response 字段 = 缺失的响应字段
+  文档示例字段 - 代码 Response 字段 = 缺失的响应字段（info，弱保证）
 ```
 
 **差异分级**：
-- 🔴 硬错误：必填字段缺失、字段名错（rename 不匹配）
-- 🟡 警告：多余字段、Vec 上限不符、响应字段漏建
-- 🟢 提示：可选字段差异
+- 🔴 硬错误：必填字段缺失、文档必填但代码为 Option
+- 🟡 警告：多余字段、类型不一致、文档选填但代码更严、证据不完整
+- 🟢 提示：响应字段可能缺失、用户级启发式红旗
 
-**性能控制**：
-- 默认串行抓（避免限流），`--max-workers N` 控制并发
-- 失败的 API 记入 `failed.json` 不阻塞整体
-- `--resume` 跳过已抓取的（按文件 mtime 判断）
+**缓存与刷新**（Official Evidence 快照，目录 `reports/api_field_verify/official_evidence/`）：
+- 批量 `--fetch-docs`：默认 `PreferSnapshotPolicy(max_age_days=30)`——有未超龄快照则复用，否则重抓
+- `--force-refresh`：`FreshOfficialPolicy`，忽略快照强制重抓
+- `--max-age N`：批量模式快照最大年龄（天），默认 30
+- 单 API 门禁（`--api-id` + `--fetch-docs`）：默认 `FreshOfficialPolicy`（单页约 8 秒，对齐官网）
+
+**并发**：当前**串行**抓取（避免限流）。`--max-workers N` **未实现**，列为后续可选优化。
+
+**失败处理**：失败的 API 记入 `failed.json` 不阻塞整体扫描；完整模式汇总 error/warning 时非 0 退出。
 
 ## 输出格式
 
@@ -152,60 +163,57 @@ pub struct PassTaskBodyV4 {
 | 指标 | 数量 |
 |------|------|
 | 核对 API 数 | 118 |
-| 完全一致 | 95 |
-| 有差异 | 23 |
-| 抓取失败 | 0 |
+| 文件存在 | 118 |
+| 有问题 | 23 |
 
-## 二、差异详情（按严重度分组）
+## 二、问题详情（按严重度）
 ### 🔴 硬错误（N）
-| API | 文件 | 问题 | 详情 |
 ### 🟡 警告（N）
 ### 🟢 提示（N）
-
-## 三、按 API 明细
-### POST /open-apis/approval/v4/tasks/pass
-- 文件: task/pass.rs
-- 请求体: ✅ 一致
-- 响应体: ✅ 一致
-- 模式检测: 🟢 通过
 ```
 
 ### JSON 汇总（`reports/api_field_verify/summary.json`）
 
-结构对齐现有 `api_validation/summary.json`，含每个 API 的字段级差异，便于趋势对比和 CI 集成。
+结构对齐现有 `api_validation/summary.json`，含每个 API 的字段级差异与 evidence provenance，便于趋势对比和 CI 集成。
 
 ## 命令行接口
 
 ```bash
-# 快速模式（默认）：全仓代码自检，秒级
-python3 tools/verify_api_fields.py --all-crates
+# 快速模式（默认）：全仓代码自检，秒级（无参数 = 全仓，无 --all-crates 旗标）
+python3 tools/verify_api_fields.py
 
 # 快速模式：单个 crate
 python3 tools/verify_api_fields.py --crate openlark-workflow
 
-# 完整模式：抓文档对比（慢）
+# 完整模式：抓文档对比（慢；批量默认复用未超龄快照）
 python3 tools/verify_api_fields.py --crate openlark-workflow --fetch-docs
 
-# 完整模式 + 并发 + 断点续跑
-python3 tools/verify_api_fields.py --crate openlark-docs --fetch-docs --max-workers 4 --resume
+# 完整模式：强制重抓 / 自定义超龄
+python3 tools/verify_api_fields.py --crate openlark-docs --fetch-docs --force-refresh
+python3 tools/verify_api_fields.py --crate openlark-docs --fetch-docs --max-age 7
 
-# 单个 API（调试用）
+# 单个 API（门禁；默认 Fresh 重抓）
 python3 tools/verify_api_fields.py --api-id 7642253323628383198 --fetch-docs
 ```
+
+> 历史设计中的 `--all-crates` / `--resume` / `--max-workers` **不是**当前 CLI 旗标。
+> 等价行为：裸跑 = 全仓；快照复用 + `--max-age`/`--force-refresh` 替代旧「文件存在即跳过」；并发为后续项。
 
 ## 测试与集成
 
 ### 回归测试（`tools/tests/test_verify_api_fields.py`）
 
-用几个**已知正确**的 API（如刚修正的 approval v4 用户级接口）做黄金样本：
-- 验证字段提取逻辑不回归
-- 验证可疑模式检测能正确识别用户级接口的 `user_id` 红旗
-- 复用现有 `tools/tests/` 的 unittest 框架
+- 字段提取（含 Vec `is_array`、serde rename）
+- 可疑模式检测
+- `compare_fields` 名字 / 必填 / 类型差异
+- 响应示例含数字字段名（`i18n_name` 等）
+- 单 API CLI evidence 契约与多 crate 路径告警
+- Official Evidence 快照 `max_age` 过期重抓
 
-### CI 集成（可选，后续）
+### CI 集成
 
-- 快速模式：每周定时跑，发现可疑模式开 issue（复用 `feishu-api-catalog-watch.yml` 模式）
-- 完整模式：`workflow_dispatch` 手动触发（耗时长，不适合定时）
+- **快速模式**：每周定时 workflow（`.github/workflows/api-field-verify-weekly.yml`），全仓自检；发现 error/warning 时开或更新 tracking issue，**不因 findings 失败**（工具崩溃除外）
+- **完整模式**：`workflow_dispatch`（`.github/workflows/api-field-verify-full.yml`），可选 crate，上传 `reports/api_field_verify/` artifact
 
 ## 与现有工具的关系
 
@@ -214,17 +222,10 @@ python3 tools/verify_api_fields.py --api-id 7642253323628383198 --fetch-docs
 | `validate_apis.py` | 文件在不在（覆盖率） | 互补，新工具检查正确性 |
 | `field-verify` 技能 | 手动单接口核对 | 新工具是其批量化版本 |
 | `compare_api_catalogs.py` | API 清单增删变 | 不同层面（清单 vs 字段） |
-
-## 实现顺序建议
-
-1. 路径解析 + 代码字段提取（复用 validate_apis.py 扫描）
-2. 可疑模式检测（快速模式即可用）
-3. 报告生成（Markdown + JSON）
-4. 文档抓取对接（完整模式，复用 fetch_doc.js）
-5. 回归测试
-6. 文档/技能更新（更新 field-verify 技能指向新工具）
+| `official_evidence` | 官方文档证据采集 | 完整模式的文档来源 |
 
 ## 开放问题
 
-- **飞书限流**：完整模式批量抓 100+ 文档可能触发限流，需观察后调整并发数和重试策略
-- **reference vs server-docs 路径**：部分老接口 fullPath 是 server-docs 格式，抓取逻辑需兼容两种（fetch_doc.js 已处理，但解析段位置可能不同）
+- **飞书限流**：完整模式批量抓 100+ 文档可能触发限流；当前串行，后续可评估受控并发（`--max-workers`）
+- **reference vs server-docs 路径**：部分老接口 fullPath 是 server-docs 格式，抓取逻辑需兼容两种（fetch_doc.js / rendered worker 已处理，但解析段位置可能不同）
+- **嵌套结构与响应体弱保证**：见技能「工具核对边界」；不在本工具自动门禁范围内

--- a/tools/api_contracts/official_evidence/__init__.py
+++ b/tools/api_contracts/official_evidence/__init__.py
@@ -300,7 +300,14 @@ class FreshOfficialPolicy:
 
 @dataclass(frozen=True)
 class PreferSnapshotPolicy:
-    """优先复用 provenance 匹配的持久快照，否则获取新快照。"""
+    """优先复用 provenance 匹配的持久快照，否则获取新快照。
+
+    max_age_days:
+      - None：不过期（仅按「有可用快照」复用）
+      - int：快照 acquired_at 超过 N 天则视为过期并重新抓取
+    """
+
+    max_age_days: int | None = None
 
 
 @dataclass(frozen=True)
@@ -816,7 +823,9 @@ class _OfficialEvidenceCollector(AbstractContextManager["_OfficialEvidenceCollec
     ) -> dict[EvidenceDimension, _Candidate]:
         if isinstance(policy, PreferSnapshotPolicy):
             cached = self._snapshot_store.load(catalog_entry, source)
-            if cached is not None:
+            if cached is not None and _snapshot_within_max_age(
+                cached, policy.max_age_days
+            ):
                 cached_candidates = {
                     dimension: _interpret_snapshot(cached, dimension)
                     for dimension in dimensions
@@ -1504,7 +1513,7 @@ def _interpret_rendered_inner_text_fields(
             return _incomplete(snapshot, "structure_incomplete")
         names = tuple(
             name
-            for name in re.findall(r'"([a-z_]+)"\s*:', section)
+            for name in re.findall(r'"([a-z][a-z0-9_]*)"\s*:', section)
             if name not in {"code", "msg", "data"}
         )
         observations = tuple(
@@ -1831,6 +1840,21 @@ def _snapshot_time(snapshot: RecordedSnapshot) -> datetime:
     return datetime.fromisoformat(
         snapshot.acquired_at.replace("Z", "+00:00")
     )
+
+
+def _snapshot_within_max_age(
+    snapshot: RecordedSnapshot, max_age_days: int | None
+) -> bool:
+    """PreferSnapshotPolicy 过期判断：None 表示不过期。"""
+    if max_age_days is None:
+        return True
+    if max_age_days < 0:
+        return False
+    acquired = _snapshot_time(snapshot)
+    if acquired.tzinfo is None:
+        acquired = acquired.replace(tzinfo=timezone.utc)
+    age = datetime.now(timezone.utc) - acquired.astimezone(timezone.utc)
+    return age.total_seconds() <= max_age_days * 86400
 
 
 def _snapshot_key(snapshot: RecordedSnapshot) -> str:

--- a/tools/api_contracts/official_evidence/rendered_document_worker.js
+++ b/tools/api_contracts/official_evidence/rendered_document_worker.js
@@ -5,6 +5,7 @@ const readline = require('readline');
 const { execFileSync } = require('child_process');
 
 let browser;
+let englishContext;
 
 function loadChromium() {
   try {
@@ -34,9 +35,26 @@ async function ensureBrowser() {
   return browser;
 }
 
-async function render(request) {
+async function ensureEnglishContext() {
   const activeBrowser = await ensureBrowser();
   if (!activeBrowser) {
+    return null;
+  }
+  if (!englishContext) {
+    // 固定英文 locale，避免飞书按地区渲染中文段标题导致解析归零
+    englishContext = await activeBrowser.newContext({
+      locale: 'en-US',
+      extraHTTPHeaders: {
+        'Accept-Language': 'en-US,en',
+      },
+    });
+  }
+  return englishContext;
+}
+
+async function render(request) {
+  const context = await ensureEnglishContext();
+  if (!context) {
     return {
       id: request.id,
       status: 'unavailable',
@@ -44,7 +62,7 @@ async function render(request) {
     };
   }
 
-  const page = await activeBrowser.newPage();
+  const page = await context.newPage();
   try {
     const timeout = Math.max(1, request.timeout_ms);
     await page.goto(request.url, {
@@ -79,6 +97,10 @@ async function render(request) {
 }
 
 async function shutdown() {
+  if (englishContext) {
+    await englishContext.close();
+    englishContext = undefined;
+  }
   if (browser) {
     await browser.close();
     browser = undefined;

--- a/tools/tests/test_official_evidence_live.py
+++ b/tools/tests/test_official_evidence_live.py
@@ -195,6 +195,19 @@ class LiveOfficialEvidenceCollectTests(unittest.TestCase):
                         previous.interpretation_provenance,
                     )
 
+                # max_age_days=0：任何已有快照都过期，必须重抓
+                expired = collector.collect(
+                    self.api,
+                    self.dimensions,
+                    PreferSnapshotPolicy(max_age_days=0),
+                )
+                self.assertEqual(server.requests, 2)
+                for dimension in self.dimensions:
+                    self.assertEqual(
+                        expired.for_dimension(dimension).status,
+                        EvidenceStatus.TRUSTED,
+                    )
+
     def test_fresh_policy_never_succeeds_from_an_existing_snapshot(self):
         with tempfile.TemporaryDirectory() as directory:
             with detail_server(structured_payload()) as (server, url):

--- a/tools/tests/test_verify_api_fields.py
+++ b/tools/tests/test_verify_api_fields.py
@@ -18,7 +18,12 @@ from tools.api_contracts.official_evidence import (
     EvidenceSource,
     EvidenceStatus,
     FieldObservation,
+    FreshOfficialPolicy,
     OfficialDocumentEvidence,
+    PreferSnapshotPolicy,
+    RecordedOnlyPolicy,
+    RecordedSnapshot,
+    collect,
 )
 
 class _FieldCollector:
@@ -148,7 +153,9 @@ pub struct DemoRequest {
         self.assertEqual(fields["task_type"].effective_name, "type")
         self.assertTrue(fields["user_ids"].required)
         self.assertEqual(fields["user_ids"].type_name, "String")
+        self.assertTrue(fields["user_ids"].is_array)
         self.assertFalse(fields["comment"].required)
+        self.assertFalse(fields["comment"].is_array)
 
 
 class SuspiciousPatternTests(unittest.TestCase):
@@ -208,6 +215,111 @@ class ComparisonTests(unittest.TestCase):
         self.assertEqual(diff.matched, ["instance_code"])
         self.assertEqual(diff.missing, ["task_id"])
         self.assertEqual(diff.extra, ["extra"])
+        self.assertEqual(diff.required_mismatches, [])
+        self.assertEqual(diff.type_mismatches, [])
+
+    def test_compare_fields_required_mismatch_doc_yes_code_option_is_error(self):
+        code = [verify_api_fields.FieldInfo("instance_code", "String", False)]
+        official = [verify_api_fields.FieldInfo("instance_code", "string", True)]
+        diff = verify_api_fields.compare_fields(code, official)
+        self.assertEqual(len(diff.required_mismatches), 1)
+        self.assertEqual(diff.required_mismatches[0].severity, "error")
+        self.assertEqual(diff.required_mismatches[0].category, "required_mismatch")
+
+    def test_compare_fields_required_mismatch_doc_no_code_required_is_warning(self):
+        code = [verify_api_fields.FieldInfo("comment", "String", True)]
+        official = [verify_api_fields.FieldInfo("comment", "string", False)]
+        diff = verify_api_fields.compare_fields(code, official)
+        self.assertEqual(len(diff.required_mismatches), 1)
+        self.assertEqual(diff.required_mismatches[0].severity, "warning")
+
+    def test_compare_fields_type_mismatch_warns(self):
+        code = [verify_api_fields.FieldInfo("add_sign_type", "String", True)]
+        official = [verify_api_fields.FieldInfo("add_sign_type", "int", True)]
+        diff = verify_api_fields.compare_fields(code, official)
+        self.assertEqual(len(diff.type_mismatches), 1)
+        self.assertEqual(diff.type_mismatches[0].category, "type_mismatch")
+        self.assertEqual(diff.type_mismatches[0].severity, "warning")
+
+    def test_compare_fields_array_type_mismatch_warns(self):
+        code = [
+            verify_api_fields.FieldInfo(
+                "user_ids", "String", True, is_array=False
+            )
+        ]
+        official = [
+            verify_api_fields.FieldInfo(
+                "user_ids", "string[]", True, is_array=True
+            )
+        ]
+        diff = verify_api_fields.compare_fields(code, official)
+        self.assertEqual(len(diff.type_mismatches), 1)
+
+    def test_compare_fields_skips_type_when_doc_type_empty(self):
+        code = [verify_api_fields.FieldInfo("x", "String", True)]
+        official = [verify_api_fields.FieldInfo("x", "", True)]
+        diff = verify_api_fields.compare_fields(code, official)
+        self.assertEqual(diff.type_mismatches, [])
+
+    def test_compare_fields_skips_required_when_doc_required_unknown(self):
+        code = [verify_api_fields.FieldInfo("x", "String", True)]
+        official = [verify_api_fields.FieldInfo("x", "string", None)]
+        diff = verify_api_fields.compare_fields(code, official)
+        self.assertEqual(diff.required_mismatches, [])
+
+    def test_evidence_comparison_surfaces_required_and_type_mismatches(self):
+        api = api_identity()
+        evidence = OfficialDocumentEvidence(
+            api,
+            (
+                DimensionEvidence(
+                    dimension=EvidenceDimension.REQUEST_FIELDS,
+                    status=EvidenceStatus.TRUSTED,
+                    selected_source=EvidenceSource.STRUCTURED_DETAIL,
+                    observations=(
+                        FieldObservation(
+                            ("add_sign_type",),
+                            "request_body",
+                            True,
+                            "int",
+                            EvidenceSource.STRUCTURED_DETAIL,
+                        ),
+                    ),
+                    snapshot_provenance=None,
+                    interpretation_provenance=None,
+                    diagnostics=(),
+                    acquisition_trail=(),
+                ),
+                DimensionEvidence(
+                    dimension=EvidenceDimension.RESPONSE_FIELDS,
+                    status=EvidenceStatus.TRUSTED,
+                    selected_source=EvidenceSource.STRUCTURED_DETAIL,
+                    observations=(),
+                    snapshot_provenance=None,
+                    interpretation_provenance=None,
+                    diagnostics=(),
+                    acquisition_trail=(),
+                ),
+            ),
+        )
+        issues = []
+        verify_api_fields._compare_evidence_against_code(
+            [
+                verify_api_fields.StructFields(
+                    "PassBody",
+                    [
+                        verify_api_fields.FieldInfo(
+                            "add_sign_type", "String", False
+                        )
+                    ],
+                )
+            ],
+            evidence,
+            issues,
+        )
+        categories = {item.category for item in issues}
+        self.assertIn("required_mismatch", categories)
+        self.assertIn("type_mismatch", categories)
 
     def test_evidence_comparison_consumes_only_top_level_observations(self):
         api = api_identity()
@@ -336,6 +448,8 @@ class FieldCliEvidenceTests(unittest.TestCase):
                     EvidenceDimension.RESPONSE_FIELDS,
                 ),
             )
+            # 单 API 门禁默认 FreshOfficialPolicy（重抓）
+            self.assertIsInstance(collector.requests[0][2], FreshOfficialPolicy)
             report = json.loads(
                 (output / "summary.json").read_text(encoding="utf-8")
             )
@@ -356,6 +470,106 @@ class FieldCliEvidenceTests(unittest.TestCase):
             self.assertEqual(
                 evidence["acquisition_trail"][0]["status"], "trusted"
             )
+
+    def test_single_api_warns_on_multiple_crate_matches(self):
+        api = api_identity()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for crate in ("openlark-workflow", "openlark-hr"):
+                path = root / "crates" / crate / "src" / api.expected_file
+                path.parent.mkdir(parents=True)
+                path.write_text(
+                    "pub struct PassBody {\n    pub instance_code: String,\n}\n",
+                    encoding="utf-8",
+                )
+            output = root / "reports"
+            argv = [
+                "verify_api_fields.py",
+                "--api-id",
+                api.api_id,
+                "--output-dir",
+                str(output),
+            ]
+            with (
+                mock.patch.object(sys, "argv", argv),
+                mock.patch.object(verify_api_fields, "REPO_ROOT", root),
+                mock.patch.object(
+                    verify_api_fields,
+                    "load_api_identities",
+                    return_value=[api],
+                ),
+                mock.patch("builtins.print") as printed,
+            ):
+                exit_code = verify_api_fields.main()
+
+            self.assertEqual(exit_code, 0)
+            warning_text = "\n".join(
+                str(call.args[0]) for call in printed.call_args_list if call.args
+            )
+            self.assertIn("多个 crate 中匹配", warning_text)
+            self.assertIn("openlark-hr", warning_text)
+            self.assertIn("openlark-workflow", warning_text)
+
+    def test_resolve_evidence_policy_defaults(self):
+        self.assertIsInstance(
+            verify_api_fields._resolve_evidence_policy(
+                force_refresh=False, max_age_days=30, single_api=True
+            ),
+            FreshOfficialPolicy,
+        )
+        self.assertIsInstance(
+            verify_api_fields._resolve_evidence_policy(
+                force_refresh=True, max_age_days=30, single_api=False
+            ),
+            FreshOfficialPolicy,
+        )
+        policy = verify_api_fields._resolve_evidence_policy(
+            force_refresh=False, max_age_days=7, single_api=False
+        )
+        self.assertIsInstance(policy, PreferSnapshotPolicy)
+        self.assertEqual(policy.max_age_days, 7)
+
+
+class ResponseFieldDigitNameTests(unittest.TestCase):
+    """#618: 响应示例字段名正则须保留含数字的名字（如 i18n_name）。"""
+
+    def test_rendered_response_keeps_digit_containing_field_names(self):
+        api = api_identity()
+        padding = "Rendered Feishu API document content.\n" * 20
+        content = (
+            padding
+            + "Response body example\n"
+            + "Response body example\n"
+            + '{"code": 0, "msg": "ok", "data": {'
+            + '"i18n_name": "n", "md5": "x", "s3_key": "k", "plain_name": "p"'
+            + "}}\n"
+            + "Error code\n"
+        )
+        snapshot = RecordedSnapshot.rendered(
+            version=1,
+            catalog_entry=api,
+            acquired_at="2026-08-11T00:00:00Z",
+            source_uri="https://open.feishu.cn/document/mock",
+            content=content,
+        )
+        result = collect(
+            api,
+            (EvidenceDimension.RESPONSE_FIELDS,),
+            RecordedOnlyPolicy((snapshot,)),
+        )
+        names = {
+            observation.path[0]
+            for observation in result.for_dimension(
+                EvidenceDimension.RESPONSE_FIELDS
+            ).observations
+        }
+        self.assertIn("i18n_name", names)
+        self.assertIn("md5", names)
+        self.assertIn("s3_key", names)
+        self.assertIn("plain_name", names)
+        self.assertNotIn("code", names)
+        self.assertNotIn("msg", names)
+        self.assertNotIn("data", names)
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_verify_api_fields.py
+++ b/tools/tests/test_verify_api_fields.py
@@ -261,6 +261,40 @@ class ComparisonTests(unittest.TestCase):
         diff = verify_api_fields.compare_fields(code, official)
         self.assertEqual(diff.type_mismatches, [])
 
+    def test_compare_fields_skips_custom_enum_vs_doc_string(self):
+        """serde 自定义枚举对文档 string 是合法建模，不得 type_mismatch。"""
+        code = [
+            verify_api_fields.FieldInfo(
+                "recognition_model", "RecognitionModel", False
+            )
+        ]
+        official = [
+            verify_api_fields.FieldInfo("recognition_model", "string", False)
+        ]
+        diff = verify_api_fields.compare_fields(code, official)
+        self.assertEqual(diff.type_mismatches, [])
+
+    def test_compare_fields_skips_custom_enum_vec_vs_doc_string_array(self):
+        code = [
+            verify_api_fields.FieldInfo(
+                "modes", "RecognitionModel", True, is_array=True
+            )
+        ]
+        official = [
+            verify_api_fields.FieldInfo(
+                "modes", "string[]", True, is_array=True
+            )
+        ]
+        diff = verify_api_fields.compare_fields(code, official)
+        self.assertEqual(diff.type_mismatches, [])
+
+    def test_compare_fields_still_warns_primitive_mismatch(self):
+        """已知原始类型不一致仍应 warning（回归：自定义跳过不能吞掉真冲突）。"""
+        code = [verify_api_fields.FieldInfo("count", "String", True)]
+        official = [verify_api_fields.FieldInfo("count", "int", True)]
+        diff = verify_api_fields.compare_fields(code, official)
+        self.assertEqual(len(diff.type_mismatches), 1)
+
     def test_compare_fields_skips_required_when_doc_required_unknown(self):
         code = [verify_api_fields.FieldInfo("x", "String", True)]
         official = [verify_api_fields.FieldInfo("x", "string", None)]

--- a/tools/verify_api_fields.py
+++ b/tools/verify_api_fields.py
@@ -5,6 +5,8 @@ API 字段核对工具：扫描代码字段、检测可疑模式、可选抓飞�
 用法：
     快速模式（默认，秒级）：python3 tools/verify_api_fields.py --crate openlark-workflow
     完整模式（抓文档）：    python3 tools/verify_api_fields.py --crate openlark-workflow --fetch-docs
+    强制重抓 / 超龄：       ... --fetch-docs --force-refresh | --max-age 7
+    单 API 门禁：           python3 tools/verify_api_fields.py --api-id <id> --fetch-docs
 
 设计文档：docs/superpowers/specs/2026-06-16-api-field-verify-tool-design.md
 """
@@ -27,6 +29,7 @@ from tools.api_contracts.official_evidence import (
     EvidenceDimension,
     EvidenceStatus,
     FieldObservation,
+    FreshOfficialPolicy,
     PreferSnapshotPolicy,
     compose_full,
 )
@@ -54,9 +57,10 @@ class FieldInfo:
     """单个字段信息。"""
 
     name: str  # Rust 字段名（rename 前的 snake_case）
-    type_name: str  # 类型名（Vec<String> -> String，Option<i32> -> i32）
-    required: bool  # 是否必填（Option -> False，其余 -> True）
+    type_name: str  # 核心类型名（Vec<String> -> String，Option<i32> -> i32）
+    required: Optional[bool]  # 是否必填；None=文档未标注（跳过必填对比）
     rename: Optional[str] = None  # serde rename 后的名字，无则 None
+    is_array: bool = False  # 是否数组（Vec / doc 的 T[]）
 
     @property
     def effective_name(self) -> str:
@@ -113,33 +117,37 @@ def _extract_fields_from_block(block: str) -> List[FieldInfo]:
             continue
         fname = field_match.group(1)
         raw_type = field_match.group(2).strip().rstrip(",")
-        required, type_name = _parse_type(raw_type)
+        required, type_name, is_array = _parse_type(raw_type)
         fields.append(
             FieldInfo(
                 name=fname,
                 type_name=type_name,
                 required=required,
                 rename=pending_rename,
+                is_array=is_array,
             )
         )
         pending_rename = None
     return fields
 
 
-def _parse_type(raw: str) -> Tuple[bool, str]:
-    """解析类型字符串，返回 (是否必填, 规范化类型名)。"""
+def _parse_type(raw: str) -> Tuple[bool, str, bool]:
+    """解析类型字符串，返回 (是否必填, 规范化类型名, 是否数组)。"""
     raw = raw.strip()
     # Option<T> -> 选填，内部类型
     opt_match = re.match(r"Option<(.+)>$", raw)
     if opt_match:
         inner = opt_match.group(1).strip()
-        return False, _unwrap_generic(inner)
+        vec_match = re.match(r"Vec<(.+)>$", inner)
+        if vec_match:
+            return False, _unwrap_generic(vec_match.group(1).strip()), True
+        return False, _unwrap_generic(inner), False
     # Vec<T> -> 必填，元素类型
     vec_match = re.match(r"Vec<(.+)>$", raw)
     if vec_match:
-        return True, _unwrap_generic(vec_match.group(1).strip())
+        return True, _unwrap_generic(vec_match.group(1).strip()), True
     # 裸类型
-    return True, _unwrap_generic(raw)
+    return True, _unwrap_generic(raw), False
 
 
 def _unwrap_generic(type_str: str) -> str:
@@ -406,20 +414,113 @@ class FieldDiff:
     matched: List[str] = field(default_factory=list)  # 两边都有
     missing: List[str] = field(default_factory=list)  # 文档有、代码无
     extra: List[str] = field(default_factory=list)  # 代码有、文档无
+    required_mismatches: List[FieldIssue] = field(default_factory=list)
+    type_mismatches: List[FieldIssue] = field(default_factory=list)
 
 
+# 文档类型 → 可接受的 Rust 核心类型名（不含 Option/Vec 外壳）
+_DOC_TYPE_TO_RUST: dict[str, set[str]] = {
+    "string": {"String"},
+    "int": {"i32", "i64", "u32", "u64", "isize", "usize"},
+    "integer": {"i32", "i64", "u32", "u64", "isize", "usize"},
+    "boolean": {"bool"},
+    "bool": {"bool"},
+    "number": {"f64", "f32", "i32", "i64"},
+    "float": {"f32", "f64"},
+    "double": {"f64"},
+}
+
+
+def _doc_type_core(type_name: str) -> Optional[Tuple[str, bool]]:
+    """解析文档类型为 (核心类型小写, 是否数组)。空类型返回 None（跳过对比）。"""
+    raw = (type_name or "").strip()
+    if not raw:
+        return None
+    is_array = raw.endswith("[]")
+    core = raw[:-2].strip() if is_array else raw
+    if not core:
+        return None
+    return core.lower(), is_array
+
+
+def _rust_type_basename(type_name: str) -> str:
+    """取 Rust 类型末段（忽略路径/模块前缀）。"""
+    return type_name.rsplit("::", 1)[-1].strip()
 
 
 def compare_fields(
     code_fields: List[FieldInfo], doc_fields: List[FieldInfo]
 ) -> FieldDiff:
-    """对比代码字段与文档字段。"""
-    code_names = {f.effective_name for f in code_fields}
-    doc_names = {f.effective_name for f in doc_fields}
+    """对比代码字段与文档字段（名字 + 必填性 + 类型）。
+
+    必填性：文档 Yes + 代码 Option → error；文档 No + 代码非 Option → warning。
+    类型：文档类型映射到 Rust 核心类型后不匹配 → warning；空类型跳过。
+    """
+    code_by_name = {f.effective_name: f for f in code_fields}
+    doc_by_name = {f.effective_name: f for f in doc_fields}
+    code_names = set(code_by_name)
+    doc_names = set(doc_by_name)
+    matched = sorted(code_names & doc_names)
+    required_mismatches: List[FieldIssue] = []
+    type_mismatches: List[FieldIssue] = []
+
+    for name in matched:
+        code_f = code_by_name[name]
+        doc_f = doc_by_name[name]
+
+        if doc_f.required is True and code_f.required is False:
+            required_mismatches.append(
+                FieldIssue(
+                    severity="error",
+                    category="required_mismatch",
+                    detail=(
+                        f"字段 {name} 文档必填(Yes) 但代码为 Option"
+                    ),
+                )
+            )
+        elif doc_f.required is False and code_f.required is True:
+            required_mismatches.append(
+                FieldIssue(
+                    severity="warning",
+                    category="required_mismatch",
+                    detail=(
+                        f"字段 {name} 文档选填(No) 但代码非 Option（代码更严，可能有意）"
+                    ),
+                )
+            )
+
+        parsed = _doc_type_core(doc_f.type_name)
+        if parsed is None:
+            continue
+        doc_core, doc_is_array = parsed
+        accepted = _DOC_TYPE_TO_RUST.get(doc_core)
+        if accepted is None:
+            # object/file/自定义等未建模类型：跳过，避免误报
+            continue
+        code_core = _rust_type_basename(code_f.type_name)
+        array_mismatch = doc_is_array != code_f.is_array
+        core_mismatch = code_core not in accepted
+        if array_mismatch or core_mismatch:
+            doc_display = f"{doc_core}[]" if doc_is_array else doc_core
+            code_display = (
+                f"Vec<{code_f.type_name}>" if code_f.is_array else code_f.type_name
+            )
+            type_mismatches.append(
+                FieldIssue(
+                    severity="warning",
+                    category="type_mismatch",
+                    detail=(
+                        f"字段 {name} 类型不一致：文档 {doc_display} vs 代码 {code_display}"
+                    ),
+                )
+            )
+
     return FieldDiff(
-        matched=sorted(code_names & doc_names),
+        matched=matched,
         missing=sorted(doc_names - code_names),
         extra=sorted(code_names - doc_names),
+        required_mismatches=required_mismatches,
+        type_mismatches=type_mismatches,
     )
 
 
@@ -473,7 +574,8 @@ def _compare_evidence_against_code(
             FieldInfo(
                 name=item.path[0],
                 type_name=item.field_type or "",
-                required=bool(item.required),
+                required=item.required,
+                is_array=(item.field_type or "").rstrip().endswith("[]"),
             )
             for item in request.observations
             if isinstance(item, FieldObservation)
@@ -509,6 +611,8 @@ def _compare_evidence_against_code(
                         f"请求体多余字段: {', '.join(diff.extra)}",
                     )
                 )
+            issues.extend(diff.required_mismatches)
+            issues.extend(diff.type_mismatches)
 
     if response.status is EvidenceStatus.TRUSTED:
         doc_response_names = {
@@ -532,28 +636,73 @@ def _compare_evidence_against_code(
                 )
 
 
-def _collect_field_evidence(collector, api: ApiIdentity):
+def _collect_field_evidence(collector, api: ApiIdentity, policy):
     return collector.collect(
         api,
         (
             EvidenceDimension.REQUEST_FIELDS,
             EvidenceDimension.RESPONSE_FIELDS,
         ),
-        PreferSnapshotPolicy(),
+        policy,
     )
+
+
+def _resolve_evidence_policy(
+    *,
+    force_refresh: bool,
+    max_age_days: int,
+    single_api: bool,
+):
+    """选择 Official Evidence 抓取策略。
+
+    - --force-refresh：始终 FreshOfficialPolicy
+    - 单 API + --fetch-docs：默认 FreshOfficialPolicy（门禁应对齐官网）
+    - 批量完整模式：PreferSnapshotPolicy(max_age_days=...)
+    """
+    if force_refresh or single_api:
+        return FreshOfficialPolicy()
+    return PreferSnapshotPolicy(max_age_days=max_age_days)
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="API 字段核对工具")
     parser.add_argument("--csv", default=str(DEFAULT_CSV), help="API 清单 CSV 路径")
     parser.add_argument("--crate", help="指定单个 crate（如 openlark-workflow）")
-    parser.add_argument("--fetch-docs", action="store_true", help="完整模式：抓飞书文档对比（慢，默认跳过已缓存）")
+    parser.add_argument(
+        "--fetch-docs",
+        action="store_true",
+        help=(
+            "完整模式：抓飞书文档对比（慢）。"
+            "批量模式默认复用未超龄快照；单 API 模式默认重抓"
+        ),
+    )
+    parser.add_argument(
+        "--force-refresh",
+        action="store_true",
+        help="忽略本地 Official Evidence 快照，强制重新抓取文档",
+    )
+    parser.add_argument(
+        "--max-age",
+        type=int,
+        default=30,
+        metavar="DAYS",
+        help="批量 --fetch-docs 时快照最大年龄（天），超时重抓；默认 30",
+    )
     parser.add_argument("--output-dir", default="reports/api_field_verify", help="报告输出目录")
     parser.add_argument("--api-id", help="只核对单个 API（调试用，按 CSV id 过滤）")
     args = parser.parse_args()
 
+    if args.max_age < 0:
+        print("❌ --max-age 必须是非负整数")
+        return 1
+
     csv_path = Path(args.csv)
     out_dir = Path(args.output_dir)
+    evidence_policy = _resolve_evidence_policy(
+        force_refresh=args.force_refresh,
+        max_age_days=args.max_age,
+        single_api=bool(args.api_id),
+    )
 
     # 单 API 模式：按 id 过滤，src 根用 crates 目录。
     if args.api_id:
@@ -574,6 +723,7 @@ def main() -> int:
                     crate_label,
                     True,
                     collector,
+                    evidence_policy,
                 )
         return _run_single_api(
             args.api_id,
@@ -583,6 +733,7 @@ def main() -> int:
             crate_label,
             False,
             None,
+            evidence_policy,
         )
 
     # 确定 src 根目录和 bizTag 过滤
@@ -591,7 +742,7 @@ def main() -> int:
         filter_tags = _load_crate_tags(args.crate)
         crate_label = args.crate
     else:
-        # --all-crates 或无参数：扫描整个 crates 目录
+        # 无参数：扫描整个 crates 目录（无 --all-crates 旗标）
         src_root = REPO_ROOT / "crates"
         filter_tags = None
         crate_label = "all"
@@ -602,6 +753,13 @@ def main() -> int:
 
     if args.fetch_docs:
         print("🐌 完整模式（通过 Official Document Evidence 收集）")
+        if isinstance(evidence_policy, FreshOfficialPolicy):
+            print("🔄 文档策略: FreshOfficialPolicy（强制重抓）")
+        else:
+            print(
+                f"💾 文档策略: PreferSnapshotPolicy"
+                f"（max_age={args.max_age} 天）"
+            )
         with compose_full(
             snapshot_directory=out_dir / "official_evidence",
             timeout_seconds=90,
@@ -614,6 +772,7 @@ def main() -> int:
                 crate_label,
                 filter_tags,
                 collector,
+                evidence_policy,
             )
 
     # 快速模式
@@ -637,6 +796,7 @@ def _run_single_api(
     crate_label,
     fetch_docs,
     collector,
+    evidence_policy=None,
 ) -> int:
     """核对单个 API。--fetch-docs 时抓取失败或 error/warning 返回非 0。"""
     api = next((a for a in all_apis if a.api_id == api_id), None)
@@ -645,18 +805,24 @@ def _run_single_api(
         return 1
     print(f"🔍 单 API 核对: {api.name} ({api.url})")
     rel_path = api.expected_file
-    # 单 API 模式：在所有 crate 的 src 目录下查找文件
-    full_path = None
-    for crate_dir in src_root.iterdir():
+    # 单 API 模式：在所有 crate 的 src 目录下查找文件；多匹配时告警仍取第一个
+    matches: List[Path] = []
+    for crate_dir in sorted(src_root.iterdir(), key=lambda p: p.name):
         if not crate_dir.is_dir():
             continue
         candidate = crate_dir / "src" / rel_path
         if candidate.exists():
-            full_path = candidate
-            break
-    if full_path is None:
+            matches.append(candidate)
+    if not matches:
         print(f"❌ 文件不存在（在所有 crate 中查找）: {rel_path}")
         return 1
+    if len(matches) > 1:
+        listed = "\n".join(f"  - {path}" for path in matches)
+        print(
+            f"⚠️ 相对路径 {rel_path} 在多个 crate 中匹配，"
+            f"使用第一个：{matches[0]}\n候选：\n{listed}"
+        )
+    full_path = matches[0]
     source = full_path.read_text(encoding="utf-8")
     structs = extract_structs(source)
     issues = detect_suspicious_patterns(api, structs, source)
@@ -665,7 +831,8 @@ def _run_single_api(
     evidence_metadata = []
     if fetch_docs:
         mode = "full"
-        evidence = _collect_field_evidence(collector, api)
+        policy = evidence_policy or FreshOfficialPolicy()
+        evidence = _collect_field_evidence(collector, api, policy)
         evidence_metadata = evidence_to_jsonable(evidence)["dimensions"]
         _compare_evidence_against_code(structs, evidence, issues)
 
@@ -713,6 +880,7 @@ def _run_full_mode(
     crate_label,
     filter_tags,
     collector,
+    evidence_policy=None,
 ) -> int:
     """完整模式：复用同一个 collect 行为核对所有字段。"""
     import json
@@ -720,6 +888,7 @@ def _run_full_mode(
     apis = load_api_identities(csv_path, filter_tags)
     reports: List[ApiFieldReport] = []
     failed: List[Tuple[str, str]] = []
+    policy = evidence_policy or PreferSnapshotPolicy(max_age_days=30)
 
     for idx, api in enumerate(apis, 1):
         rel_path = api.expected_file
@@ -730,7 +899,7 @@ def _run_full_mode(
         source = full_path.read_text(encoding="utf-8")
         structs = extract_structs(source)
         issues = detect_suspicious_patterns(api, structs, source)
-        evidence = _collect_field_evidence(collector, api)
+        evidence = _collect_field_evidence(collector, api, policy)
         dimensions = evidence_to_jsonable(evidence)["dimensions"]
         _compare_evidence_against_code(structs, evidence, issues)
         nonpassing = [

--- a/tools/verify_api_fields.py
+++ b/tools/verify_api_fields.py
@@ -430,6 +430,10 @@ _DOC_TYPE_TO_RUST: dict[str, set[str]] = {
     "double": {"f64"},
 }
 
+# 仅当代码侧是这些已知原始类型时才做类型对比；
+# 自定义 enum/newtype（如 RecognitionModel）对文档 string/string[] 跳过，避免假绿反向的假警告。
+_KNOWN_RUST_PRIMITIVES: frozenset[str] = frozenset().union(*_DOC_TYPE_TO_RUST.values())
+
 
 def _doc_type_core(type_name: str) -> Optional[Tuple[str, bool]]:
     """解析文档类型为 (核心类型小写, 是否数组)。空类型返回 None（跳过对比）。"""
@@ -454,7 +458,8 @@ def compare_fields(
     """对比代码字段与文档字段（名字 + 必填性 + 类型）。
 
     必填性：文档 Yes + 代码 Option → error；文档 No + 代码非 Option → warning。
-    类型：文档类型映射到 Rust 核心类型后不匹配 → warning；空类型跳过。
+    类型：仅当代码侧是已知原始类型时对比；不匹配 → warning。
+    空文档类型 / 未建模文档类型 / 代码自定义 enum·newtype → 跳过类型对比。
     """
     code_by_name = {f.effective_name: f for f in code_fields}
     doc_by_name = {f.effective_name: f for f in doc_fields}
@@ -498,6 +503,10 @@ def compare_fields(
             # object/file/自定义等未建模类型：跳过，避免误报
             continue
         code_core = _rust_type_basename(code_f.type_name)
+        if code_core not in _KNOWN_RUST_PRIMITIVES:
+            # 代码侧是自定义 enum/newtype 等：跳过类型对比
+            # （文档 string ↔ serde 枚举是合法建模，不能假警告阻断门禁）
+            continue
         array_mismatch = doc_is_array != code_f.is_array
         core_mismatch = code_core not in accepted
         if array_mismatch or core_mismatch:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
加固 `verify_api_fields` / Official Document Evidence 字段核对门禁，一次性覆盖 #618–#624。

## 变更概要

字段核对工具此前存在假绿（含数字字段名漏匹配、只比字段名）、缓存永不过期、locale 隐式假设、设计文档漂移，且未接入 CI。本 PR 按 issue 清单补齐对比能力、缓存策略、locale 固定、CI 留痕与文档边界说明。

## 按 Issue

### Fixes #618 — 响应字段正则漏掉含数字名字
- `official_evidence` 响应示例解析：`"[a-z_]+"` → `"[a-z][a-z0-9_]*"`（对齐请求侧）
- SKILL.md 第 3 步 / 常见陷阱 2 的 grep 辅助命令同步
- 回归：`i18n_name` / `md5` / `s3_key`

> 注：实现已迁到 Official Document Evidence；issue 原文指向的 `parse_doc_response_fields()` 已不在 `verify_api_fields.py`，修复落在实际解析路径。

### Fixes #619 — 对比类型与必填性
- `compare_fields()` 对 matched 字段追加：
  - 文档 Yes + 代码 `Option` → **error** (`required_mismatch`)
  - 文档 No + 代码非 Option → **warning**
  - 文档类型可映射且与 Rust 核心类型不符 → **warning** (`type_mismatch`)
  - 空/`object` 等未建模类型跳过，避免误报
- `FieldInfo` 增加 `is_array`；数组上限仍 OUT OF SCOPE

### Fixes #620 — 缓存过期 / 强制刷新
- `--force-refresh` → `FreshOfficialPolicy`
- `--max-age DAYS`（默认 30）→ `PreferSnapshotPolicy(max_age_days=...)`
- **单 API** `--api-id --fetch-docs` 默认 Fresh 重抓
- 批量模式默认走未超龄快照
- SKILL 文案从「默认跳过已缓存」改为上述策略

> 判断：旧 `doc_cache/<api_id>.txt` 已演进为 `official_evidence/` 快照；过期按快照 `acquired_at`（语义等价于“何时抓的文档”）。

### Fixes #621 — 固定英文 locale
- `fetch_doc.js`：`browser.newContext({ locale: 'en-US', Accept-Language })`，缺英文标准段标题时 warn
- 同步固定 `rendered_document_worker.js`（`--fetch-docs` 实际路径）

### Fixes #622 — CI 接线
- `.github/workflows/api-field-verify-weekly.yml`：每周快速模式全仓自检；有 error/warning 时 **open/update** 固定标题 tracking issue；**findings 不 fail job**（仅工具崩溃失败）
- `.github/workflows/api-field-verify-full.yml`：`workflow_dispatch`（可选 crate / force_refresh / max_age），上传 `reports/api_field_verify/` artifact；verify 非 0 会使 job 失败（先 upload artifact）

**告警策略判断（#622）**：weekly = issue-only / exit 0；full dispatch = 非 0 失败以便人工触发时可见结果。

### Fixes #623 — 工具核对边界文档
- `openlark-api-field-verify` SKILL 增加「工具核对边界」（嵌套盲区 / 响应弱保证 / 人工项）
- `openlark-api` §0 步骤 8 与 §4 checklist 指向该边界；类型/必填已从人工清单移除（随 #619）

### Fixes #624 — 设计文档漂移 + 多匹配告警
- 设计文档状态改为「已实现」；标明 `--max-workers` 未实现、`--all-crates`/`--resume` 非现 CLI，并文档化新缓存旗标
- `_run_single_api` 收集全部 crate 匹配；多于一个时 warning 列出候选，仍取第一个

## 验证

```bash
python3 -m unittest tools.tests.test_verify_api_fields \
  tools.tests.test_official_evidence_collect \
  tools.tests.test_official_evidence_live -v
# OK（47 tests, 2 live smoke skipped）
node --check .agents/skills/openlark-api-field-verify/scripts/fetch_doc.js
node --check tools/api_contracts/official_evidence/rendered_document_worker.js
```

Playwright 真抓飞书页面未在本环境实跑；locale 变更按代码审查 + JS syntax check 验证。

## 变更类型

- [x] 🐛 修复
- [x] ✨ 新功能
- [x] 📚 文档 / 格式
- [x] 🔧 构建 / CI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ed3e36a-a8dd-441a-9e0a-41c412197e52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ed3e36a-a8dd-441a-9e0a-41c412197e52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

