### PR TITLE
fix(user): align system_status request/response with Feishu OpenAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- **user：对齐飞书 personal_settings system_status OpenAPI 请求/响应体**：按官方文档重写
+  `openlark-user` 全部 6 个 system_status 接口的 Body/Response。
+  - `batch_close`：请求体字段 `user_ids` → `user_list`（`string[]`，长度 1～50）；响应为
+    `result_list[{user_id,result}]`；支持查询参数 `user_id_type`。
+  - `batch_open`：补齐必填 body.`user_list[{user_id,end_time}]`；响应为
+    `result_list[{user_id,end_time,result}]`。
+  - `create`：补齐 body（`title`/`icon_key` 必填，及 `i18n_title`/`color`/`priority`/`sync_setting`）；
+    响应为 `system_status`。
+  - `patch`：补齐 body.`system_status` + `update_fields`；路径参数 setter 为 `system_status_id`；
+    响应为 `system_status`。
+  - `list`：补齐查询参数 `page_size`/`page_token`；响应为 `items`/`has_more`/`page_token`。
+  - `delete`：路径参数 setter 为 `system_status_id`；响应 `data` 为空对象。
+  - 移除错误的双重嵌套 `Response { data: Option<Value> }`（`Transport` 已解包外层 `data`）。
+
 - **cardkit：对齐飞书 CardKit OpenAPI 请求体（#603）**：按官方文档重写
   `openlark-cardkit` 全量/局部更新、配置、组件增删改、流式文本与 `id_convert` 的 Body 字段。
   - 所有流式相关写接口补齐必填 `sequence`（及可选 `uuid`）；路径参数 `card_id`/`element_id` 不再序列化进 JSON body。

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/batch_close.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/batch_close.rs
@@ -1,10 +1,12 @@
 //! 批量关闭系统状态
-//! docPath: <https://open.feishu.cn/document/server-docs/personal_settings-v1/system_status/batch_close>
+//!
+//! docPath: <https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/personal_settings-v1/system_status/batch_close>
 
 use openlark_core::{
     SDKResult,
-    api::{ApiRequest, ApiResponseTrait, ResponseFormat},
+    api::{ApiRequest, ApiResponseTrait},
     config::Config,
+    constants::AccessTokenType,
     http::Transport,
     req_option::RequestOption,
     validate_required, validate_required_list,
@@ -12,52 +14,60 @@ use openlark_core::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+use super::models::SystemStatusUserCloseResult;
+
 /// 批量关闭系统状态的请求。
 #[derive(Debug, Clone)]
 pub struct BatchCloseSystemStatusRequest {
     config: Arc<Config>,
-    status_id: String,
+    /// 路径参数 `system_status_id`。
+    system_status_id: String,
+    /// 查询参数 `user_id_type`。
+    user_id_type: Option<String>,
     body: BatchCloseSystemStatusBody,
 }
 
 /// 批量关闭系统状态请求体。
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct BatchCloseSystemStatusBody {
-    /// 用户 ID 列表。
-    pub user_ids: Vec<String>,
+    /// 用户 ID 列表（官方字段名 `user_list`，长度 1～50）。
+    pub user_list: Vec<String>,
 }
 
-/// 批量关闭系统状态的响应。
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// 批量关闭系统状态响应 `data`。
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct BatchCloseSystemStatusResponse {
-    /// 响应数据。
-    pub data: Option<serde_json::Value>,
+    /// 关闭结果列表。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_list: Option<Vec<SystemStatusUserCloseResult>>,
 }
 
 impl ApiResponseTrait for BatchCloseSystemStatusResponse {
-    fn data_format() -> ResponseFormat {
-        ResponseFormat::Data
-    }
-
-    /// 成功但无 `data` 字段时的空成功（batch_close 类 API，与旧 `unwrap_or` 默认值一致）。
     fn empty_success() -> Option<Self> {
-        Some(Self { data: None })
+        Some(Self::default())
     }
 }
 
 impl BatchCloseSystemStatusRequest {
     /// 创建请求实例。
-    pub fn new(config: Arc<Config>, status_id: impl Into<String>) -> Self {
+    pub fn new(config: Arc<Config>, system_status_id: impl Into<String>) -> Self {
         Self {
             config,
-            status_id: status_id.into(),
+            system_status_id: system_status_id.into(),
+            user_id_type: None,
             body: BatchCloseSystemStatusBody::default(),
         }
     }
 
-    /// 设置用户 ID 列表。
-    pub fn user_ids(mut self, ids: Vec<String>) -> Self {
-        self.body.user_ids = ids;
+    /// 设置用户 ID 类型（查询参数）。
+    pub fn user_id_type(mut self, user_id_type: impl Into<String>) -> Self {
+        self.user_id_type = Some(user_id_type.into());
+        self
+    }
+
+    /// 设置用户 ID 列表（body.`user_list`）。
+    pub fn user_list(mut self, ids: Vec<String>) -> Self {
+        self.body.user_list = ids;
         self
     }
 
@@ -71,25 +81,27 @@ impl BatchCloseSystemStatusRequest {
         self,
         option: RequestOption,
     ) -> SDKResult<BatchCloseSystemStatusResponse> {
-        validate_required!(self.status_id.trim(), "status_id 不能为空");
+        validate_required!(self.system_status_id.trim(), "system_status_id 不能为空");
         validate_required_list!(
-            self.body.user_ids,
-            1000,
-            "user_ids 不能为空且不能超过 1000 个"
+            self.body.user_list,
+            50,
+            "user_list 不能为空且不能超过 50 个"
         );
 
         let path = format!(
             "/open-apis/personal_settings/v1/system_statuses/{}/batch_close",
-            self.status_id
+            self.system_status_id
         );
         let body = serde_json::to_value(&self.body)?;
-        let req: ApiRequest<BatchCloseSystemStatusResponse> = ApiRequest::post(&path).body(body);
+        let req: ApiRequest<BatchCloseSystemStatusResponse> = ApiRequest::post(&path)
+            .query_opt("user_id_type", self.user_id_type.as_ref())
+            .body(body)
+            .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
         Transport::request_typed(req, &self.config, Some(option), "批量关闭系统状态").await
     }
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
     use super::*;
     use serde_json::json;
@@ -97,7 +109,7 @@ mod tests {
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, ResponseTemplate};
 
-    /// 端到端：POST .../system_statuses/{status_id}/batch_close + body{user_ids} → 响应解析。
+    /// 端到端：POST .../batch_close + body{user_list} → 响应解析。
     #[tokio::test]
     async fn test_batch_close_system_status_returns_data_on_success() {
         let server = MockServer::start().await;
@@ -107,8 +119,13 @@ mod tests {
             ))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
-                "msg": "success",
-                "data": { "data": { "system_status_id": "ss_001" } }
+                "msg": "Success",
+                "data": {
+                    "result_list": [{
+                        "user_id": "ou_1",
+                        "result": "Success"
+                    }]
+                }
             })))
             .mount(&server)
             .await;
@@ -123,19 +140,23 @@ mod tests {
         );
 
         let resp = BatchCloseSystemStatusRequest::new(config, "ss_001")
-            .user_ids(vec!["u_001".into(), "u_002".into()])
+            .user_id_type("open_id")
+            .user_list(vec!["ou_1".into(), "ou_2".into()])
             .execute()
             .await
             .expect("批量关闭系统状态应成功");
-        assert_eq!(resp.data.unwrap()["system_status_id"], "ss_001");
+        assert_eq!(resp.result_list.as_ref().unwrap().len(), 1);
+        assert_eq!(
+            resp.result_list.as_ref().unwrap()[0].user_id.as_deref(),
+            Some("ou_1")
+        );
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
-        assert_eq!(
-            received[0].url.path(),
-            "/open-apis/personal_settings/v1/system_statuses/ss_001/batch_close"
-        );
+        let query = received[0].url.query().unwrap_or("");
+        assert!(query.contains("user_id_type=open_id"));
         let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
-        assert_eq!(sent["user_ids"].as_array().unwrap().len(), 2);
+        assert_eq!(sent["user_list"].as_array().unwrap().len(), 2);
+        assert!(sent.get("user_ids").is_none());
     }
 }

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/batch_open.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/batch_open.rs
@@ -1,43 +1,74 @@
-//! system_status batch_open
-//! docPath: <https://open.feishu.cn/document/server-docs/personal_settings-v1/system_status/batch_open>
+//! 批量开启系统状态
+//!
+//! docPath: <https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/personal_settings-v1/system_status/batch_open>
 
 use openlark_core::{
     SDKResult,
-    api::{ApiRequest, ApiResponseTrait, ResponseFormat},
+    api::{ApiRequest, ApiResponseTrait},
     config::Config,
+    constants::AccessTokenType,
     http::Transport,
     req_option::RequestOption,
+    validate_required, validate_required_list,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+
+use super::models::{SystemStatusUserOpenParam, SystemStatusUserOpenResult};
 
 /// 批量开启系统状态的请求。
 #[derive(Debug, Clone)]
 pub struct SystemStatusBatchOpenRequest {
     config: Arc<Config>,
-    status_id: String,
+    /// 路径参数 `system_status_id`。
+    system_status_id: String,
+    /// 查询参数 `user_id_type`。
+    user_id_type: Option<String>,
+    body: SystemStatusBatchOpenBody,
 }
 
-/// 批量开启系统状态的响应。
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// 批量开启系统状态请求体。
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SystemStatusBatchOpenBody {
+    /// 用户列表（官方字段 `user_list`，元素含 `user_id` + `end_time`）。
+    pub user_list: Vec<SystemStatusUserOpenParam>,
+}
+
+/// 批量开启系统状态响应 `data`。
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SystemStatusBatchOpenResponse {
-    /// 响应数据。
-    pub data: Option<serde_json::Value>,
+    /// 开启结果列表。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_list: Option<Vec<SystemStatusUserOpenResult>>,
 }
 
 impl ApiResponseTrait for SystemStatusBatchOpenResponse {
-    fn data_format() -> ResponseFormat {
-        ResponseFormat::Data
+    fn empty_success() -> Option<Self> {
+        Some(Self::default())
     }
 }
 
 impl SystemStatusBatchOpenRequest {
     /// 创建请求实例。
-    pub fn new(config: Arc<Config>, status_id: impl Into<String>) -> Self {
+    pub fn new(config: Arc<Config>, system_status_id: impl Into<String>) -> Self {
         Self {
             config,
-            status_id: status_id.into(),
+            system_status_id: system_status_id.into(),
+            user_id_type: None,
+            body: SystemStatusBatchOpenBody::default(),
         }
+    }
+
+    /// 设置用户 ID 类型（查询参数）。
+    pub fn user_id_type(mut self, user_id_type: impl Into<String>) -> Self {
+        self.user_id_type = Some(user_id_type.into());
+        self
+    }
+
+    /// 设置用户列表（body.`user_list`）。
+    pub fn user_list(mut self, user_list: Vec<SystemStatusUserOpenParam>) -> Self {
+        self.body.user_list = user_list;
+        self
     }
 
     /// 执行批量开启系统状态请求。
@@ -50,18 +81,32 @@ impl SystemStatusBatchOpenRequest {
         self,
         option: RequestOption,
     ) -> SDKResult<SystemStatusBatchOpenResponse> {
+        validate_required!(self.system_status_id.trim(), "system_status_id 不能为空");
+        validate_required_list!(
+            self.body.user_list,
+            50,
+            "user_list 不能为空且不能超过 50 个"
+        );
+        for item in &self.body.user_list {
+            validate_required!(item.user_id.trim(), "user_list[].user_id 不能为空");
+            validate_required!(item.end_time.trim(), "user_list[].end_time 不能为空");
+        }
+
         let path = format!(
             "/open-apis/personal_settings/v1/system_statuses/{}/batch_open",
-            self.status_id
+            self.system_status_id
         );
-        let req: ApiRequest<SystemStatusBatchOpenResponse> = ApiRequest::post(&path);
+        let body = serde_json::to_value(&self.body)?;
+        let req: ApiRequest<SystemStatusBatchOpenResponse> = ApiRequest::post(&path)
+            .query_opt("user_id_type", self.user_id_type.as_ref())
+            .body(body)
+            .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
-        Transport::request_typed(req, &self.config, Some(option), "system_status batch_open").await
+        Transport::request_typed(req, &self.config, Some(option), "批量开启系统状态").await
     }
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
     use super::*;
     use serde_json::json;
@@ -69,7 +114,7 @@ mod tests {
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, ResponseTemplate};
 
-    /// 端到端：POST .../system_statuses/{status_id}/batch_open → 响应解析。
+    /// 端到端：POST .../batch_open + body{user_list:[{user_id,end_time}]}。
     #[tokio::test]
     async fn test_batch_open_system_status_returns_data_on_success() {
         let server = MockServer::start().await;
@@ -80,7 +125,13 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": { "data": { "system_status_id": "ss_001" } }
+                "data": {
+                    "result_list": [{
+                        "user_id": "ou_1",
+                        "end_time": "1665990378",
+                        "result": "success_show"
+                    }]
+                }
             })))
             .mount(&server)
             .await;
@@ -95,16 +146,21 @@ mod tests {
         );
 
         let resp = SystemStatusBatchOpenRequest::new(config, "ss_001")
+            .user_list(vec![SystemStatusUserOpenParam {
+                user_id: "ou_1".into(),
+                end_time: "1665990378".into(),
+            }])
             .execute()
             .await
             .expect("批量开启系统状态应成功");
-        assert_eq!(resp.data.unwrap()["system_status_id"], "ss_001");
+        assert_eq!(
+            resp.result_list.as_ref().unwrap()[0].result.as_deref(),
+            Some("success_show")
+        );
 
         let received = server.received_requests().await.unwrap_or_default();
-        assert_eq!(received.len(), 1);
-        assert_eq!(
-            received[0].url.path(),
-            "/open-apis/personal_settings/v1/system_statuses/ss_001/batch_open"
-        );
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["user_list"][0]["user_id"], "ou_1");
+        assert_eq!(sent["user_list"][0]["end_time"], "1665990378");
     }
 }

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/create.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/create.rs
@@ -1,39 +1,114 @@
-//! system_status create
-//! docPath: <https://open.feishu.cn/document/server-docs/personal_settings-v1/system_status/create>
+//! 创建系统状态
+//!
+//! docPath: <https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/personal_settings-v1/system_status/create>
 
 use openlark_core::{
     SDKResult,
-    api::{ApiRequest, ApiResponseTrait, ResponseFormat},
+    api::{ApiRequest, ApiResponseTrait},
     config::Config,
+    constants::AccessTokenType,
     http::Transport,
     req_option::RequestOption,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+
+use super::models::{SystemStatus, SystemStatusI18nName, SystemStatusSyncSetting};
 
 /// 创建系统状态的请求。
 #[derive(Debug, Clone)]
 pub struct SystemStatusCreateRequest {
     config: Arc<Config>,
+    body: SystemStatusCreateBody,
 }
 
-/// 创建系统状态的响应。
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// 创建系统状态请求体。
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SystemStatusCreateBody {
+    /// 系统状态标题（必填，1～20 字符）。
+    pub title: String,
+    /// 系统状态国际化标题。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub i18n_title: Option<SystemStatusI18nName>,
+    /// 图标 key（必填）。
+    pub icon_key: String,
+    /// 颜色。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    /// 优先级。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<i32>,
+    /// 同步设置。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sync_setting: Option<SystemStatusSyncSetting>,
+}
+
+impl SystemStatusCreateBody {
+    fn validate(&self) -> SDKResult<()> {
+        validate_required!(self.title.trim(), "title 不能为空");
+        validate_required!(self.icon_key.trim(), "icon_key 不能为空");
+        Ok(())
+    }
+}
+
+/// 创建系统状态响应 `data`。
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SystemStatusCreateResponse {
-    /// 响应数据。
-    pub data: Option<serde_json::Value>,
+    /// 创建后的系统状态。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_status: Option<SystemStatus>,
 }
 
 impl ApiResponseTrait for SystemStatusCreateResponse {
-    fn data_format() -> ResponseFormat {
-        ResponseFormat::Data
+    fn empty_success() -> Option<Self> {
+        Some(Self::default())
     }
 }
 
 impl SystemStatusCreateRequest {
     /// 创建请求实例。
     pub fn new(config: Arc<Config>) -> Self {
-        Self { config }
+        Self {
+            config,
+            body: SystemStatusCreateBody::default(),
+        }
+    }
+
+    /// 设置标题。
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.body.title = title.into();
+        self
+    }
+
+    /// 设置国际化标题。
+    pub fn i18n_title(mut self, i18n_title: SystemStatusI18nName) -> Self {
+        self.body.i18n_title = Some(i18n_title);
+        self
+    }
+
+    /// 设置图标 key。
+    pub fn icon_key(mut self, icon_key: impl Into<String>) -> Self {
+        self.body.icon_key = icon_key.into();
+        self
+    }
+
+    /// 设置颜色。
+    pub fn color(mut self, color: impl Into<String>) -> Self {
+        self.body.color = Some(color.into());
+        self
+    }
+
+    /// 设置优先级。
+    pub fn priority(mut self, priority: i32) -> Self {
+        self.body.priority = Some(priority);
+        self
+    }
+
+    /// 设置同步设置。
+    pub fn sync_setting(mut self, sync_setting: SystemStatusSyncSetting) -> Self {
+        self.body.sync_setting = Some(sync_setting);
+        self
     }
 
     /// 执行创建系统状态请求。
@@ -46,15 +121,18 @@ impl SystemStatusCreateRequest {
         self,
         option: RequestOption,
     ) -> SDKResult<SystemStatusCreateResponse> {
+        self.body.validate()?;
+        let body = serde_json::to_value(&self.body)?;
         let req: ApiRequest<SystemStatusCreateResponse> =
-            ApiRequest::post("/open-apis/personal_settings/v1/system_statuses");
+            ApiRequest::post("/open-apis/personal_settings/v1/system_statuses")
+                .body(body)
+                .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
-        Transport::request_typed(req, &self.config, Some(option), "system_status create").await
+        Transport::request_typed(req, &self.config, Some(option), "创建系统状态").await
     }
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
     use super::*;
     use serde_json::json;
@@ -62,7 +140,7 @@ mod tests {
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, ResponseTemplate};
 
-    /// 端到端：POST .../system_statuses（无 body）→ 响应解析。
+    /// 端到端：POST .../system_statuses + body → 响应 `system_status`。
     #[tokio::test]
     async fn test_create_system_status_returns_data_on_success() {
         let server = MockServer::start().await;
@@ -71,7 +149,15 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": { "data": { "system_status_id": "ss_new" } }
+                "data": {
+                    "system_status": {
+                        "system_status_id": "ss_new",
+                        "title": "出差",
+                        "icon_key": "GeneralBusinessTrip",
+                        "color": "BLUE",
+                        "priority": 1
+                    }
+                }
             })))
             .mount(&server)
             .await;
@@ -86,16 +172,25 @@ mod tests {
         );
 
         let resp = SystemStatusCreateRequest::new(config)
+            .title("出差")
+            .icon_key("GeneralBusinessTrip")
+            .color("BLUE")
+            .priority(1)
             .execute()
             .await
             .expect("创建系统状态应成功");
-        assert_eq!(resp.data.unwrap()["system_status_id"], "ss_new");
+        assert_eq!(
+            resp.system_status
+                .as_ref()
+                .unwrap()
+                .system_status_id
+                .as_deref(),
+            Some("ss_new")
+        );
 
         let received = server.received_requests().await.unwrap_or_default();
-        assert_eq!(received.len(), 1);
-        assert_eq!(
-            received[0].url.path(),
-            "/open-apis/personal_settings/v1/system_statuses"
-        );
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["title"], "出差");
+        assert_eq!(sent["icon_key"], "GeneralBusinessTrip");
     }
 }

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/delete.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/delete.rs
@@ -1,10 +1,12 @@
-//! system_status delete
-//! docPath: <https://open.feishu.cn/document/server-docs/personal_settings-v1/system_status/delete>
+//! 删除系统状态
+//!
+//! docPath: <https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/personal_settings-v1/system_status/delete>
 
 use openlark_core::{
     SDKResult,
-    api::{ApiRequest, ApiResponseTrait, ResponseFormat},
+    api::{ApiRequest, ApiResponseTrait},
     config::Config,
+    constants::AccessTokenType,
     http::Transport,
     req_option::RequestOption,
     validate_required,
@@ -16,19 +18,17 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub struct SystemStatusDeleteRequest {
     config: Arc<Config>,
-    status_id: String,
+    /// 路径参数 `system_status_id`。
+    system_status_id: String,
 }
 
-/// 删除系统状态的响应。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SystemStatusDeleteResponse {
-    /// 响应数据。
-    pub data: Option<serde_json::Value>,
-}
+/// 删除系统状态响应 `data`（文档为空对象）。
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SystemStatusDeleteResponse {}
 
 impl ApiResponseTrait for SystemStatusDeleteResponse {
-    fn data_format() -> ResponseFormat {
-        ResponseFormat::Data
+    fn empty_success() -> Option<Self> {
+        Some(Self::default())
     }
 }
 
@@ -37,13 +37,13 @@ impl SystemStatusDeleteRequest {
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,
-            status_id: String::new(),
+            system_status_id: String::new(),
         }
     }
 
-    /// 设置状态 ID。
-    pub fn status_id(mut self, status_id: impl Into<String>) -> Self {
-        self.status_id = status_id.into();
+    /// 设置系统状态 ID（路径参数）。
+    pub fn system_status_id(mut self, system_status_id: impl Into<String>) -> Self {
+        self.system_status_id = system_status_id.into();
         self
     }
 
@@ -57,19 +57,19 @@ impl SystemStatusDeleteRequest {
         self,
         option: RequestOption,
     ) -> SDKResult<SystemStatusDeleteResponse> {
-        validate_required!(self.status_id.trim(), "status_id 不能为空");
+        validate_required!(self.system_status_id.trim(), "system_status_id 不能为空");
         let path = format!(
             "/open-apis/personal_settings/v1/system_statuses/{}",
-            self.status_id
+            self.system_status_id
         );
-        let req: ApiRequest<SystemStatusDeleteResponse> = ApiRequest::delete(&path);
+        let req: ApiRequest<SystemStatusDeleteResponse> = ApiRequest::delete(&path)
+            .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
-        Transport::request_typed(req, &self.config, Some(option), "system_status delete").await
+        Transport::request_typed(req, &self.config, Some(option), "删除系统状态").await
     }
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
     use super::*;
     use serde_json::json;
@@ -77,7 +77,7 @@ mod tests {
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, ResponseTemplate};
 
-    /// 端到端：DELETE .../system_statuses/{status_id} → 响应解析。
+    /// 端到端：DELETE .../system_statuses/{id} → 空 data。
     #[tokio::test]
     async fn test_delete_system_status_returns_data_on_success() {
         let server = MockServer::start().await;
@@ -88,7 +88,7 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": { "data": { "system_status_id": "ss_001" } }
+                "data": {}
             })))
             .mount(&server)
             .await;
@@ -102,15 +102,13 @@ mod tests {
                 .build(),
         );
 
-        let resp = SystemStatusDeleteRequest::new(config)
-            .status_id("ss_001")
+        let _resp = SystemStatusDeleteRequest::new(config)
+            .system_status_id("ss_001")
             .execute()
             .await
             .expect("删除系统状态应成功");
-        assert_eq!(resp.data.unwrap()["system_status_id"], "ss_001");
 
         let received = server.received_requests().await.unwrap_or_default();
-        assert_eq!(received.len(), 1);
         assert_eq!(
             received[0].url.path(),
             "/open-apis/personal_settings/v1/system_statuses/ss_001"

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/list.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/list.rs
@@ -1,39 +1,68 @@
-//! system_status list
-//! docPath: <https://open.feishu.cn/document/server-docs/personal_settings-v1/system_status/list>
+//! 获取系统状态列表
+//!
+//! docPath: <https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/personal_settings-v1/system_status/list>
 
 use openlark_core::{
     SDKResult,
-    api::{ApiRequest, ApiResponseTrait, ResponseFormat},
+    api::{ApiRequest, ApiResponseTrait},
     config::Config,
+    constants::AccessTokenType,
     http::Transport,
     req_option::RequestOption,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+use super::models::SystemStatus;
+
 /// 获取系统状态列表的请求。
 #[derive(Debug, Clone)]
 pub struct SystemStatusListRequest {
     config: Arc<Config>,
+    page_size: Option<i32>,
+    page_token: Option<String>,
 }
 
-/// 获取系统状态列表的响应。
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// 获取系统状态列表响应 `data`。
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SystemStatusListResponse {
-    /// 响应数据。
-    pub data: Option<serde_json::Value>,
+    /// 系统状态列表。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub items: Option<Vec<SystemStatus>>,
+    /// 是否还有更多项。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub has_more: Option<bool>,
+    /// 下一页标记。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_token: Option<String>,
 }
 
 impl ApiResponseTrait for SystemStatusListResponse {
-    fn data_format() -> ResponseFormat {
-        ResponseFormat::Data
+    fn empty_success() -> Option<Self> {
+        Some(Self::default())
     }
 }
 
 impl SystemStatusListRequest {
     /// 创建请求实例。
     pub fn new(config: Arc<Config>) -> Self {
-        Self { config }
+        Self {
+            config,
+            page_size: None,
+            page_token: None,
+        }
+    }
+
+    /// 设置分页大小（1～50，默认 50）。
+    pub fn page_size(mut self, page_size: i32) -> Self {
+        self.page_size = Some(page_size);
+        self
+    }
+
+    /// 设置分页标记。
+    pub fn page_token(mut self, page_token: impl Into<String>) -> Self {
+        self.page_token = Some(page_token.into());
+        self
     }
 
     /// 执行获取系统状态列表请求。
@@ -46,15 +75,19 @@ impl SystemStatusListRequest {
         self,
         option: RequestOption,
     ) -> SDKResult<SystemStatusListResponse> {
-        let req: ApiRequest<SystemStatusListResponse> =
-            ApiRequest::get("/open-apis/personal_settings/v1/system_statuses");
+        let mut req: ApiRequest<SystemStatusListResponse> =
+            ApiRequest::get("/open-apis/personal_settings/v1/system_statuses")
+                .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
+        if let Some(size) = self.page_size {
+            req = req.query("page_size", size.to_string());
+        }
+        req = req.query_opt("page_token", self.page_token.as_ref());
 
-        Transport::request_typed(req, &self.config, Some(option), "system_status list").await
+        Transport::request_typed(req, &self.config, Some(option), "获取系统状态").await
     }
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
     use super::*;
     use serde_json::json;
@@ -62,7 +95,7 @@ mod tests {
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, ResponseTemplate};
 
-    /// 端到端：GET .../system_statuses → 响应解析（data:{data:{...}} 双层信封）。
+    /// 端到端：GET .../system_statuses?page_size= → items/has_more。
     #[tokio::test]
     async fn test_list_system_status_returns_data_on_success() {
         let server = MockServer::start().await;
@@ -71,7 +104,14 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": { "data": { "items": [{ "system_status_id": "ss_001" }] } }
+                "data": {
+                    "items": [{
+                        "system_status_id": "ss_001",
+                        "title": "出差",
+                        "icon_key": "GeneralBusinessTrip"
+                    }],
+                    "has_more": false
+                }
             })))
             .mount(&server)
             .await;
@@ -86,17 +126,15 @@ mod tests {
         );
 
         let resp = SystemStatusListRequest::new(config)
+            .page_size(50)
             .execute()
             .await
             .expect("获取系统状态列表应成功");
-        let data = resp.data.expect("响应 data 不应为空");
-        assert_eq!(data["items"].as_array().unwrap().len(), 1);
+        assert_eq!(resp.items.as_ref().unwrap().len(), 1);
+        assert_eq!(resp.has_more, Some(false));
 
         let received = server.received_requests().await.unwrap_or_default();
-        assert_eq!(received.len(), 1);
-        assert_eq!(
-            received[0].url.path(),
-            "/open-apis/personal_settings/v1/system_statuses"
-        );
+        let query = received[0].url.query().unwrap_or("");
+        assert!(query.contains("page_size=50"));
     }
 }

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/mod.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/mod.rs
@@ -5,4 +5,10 @@ pub mod batch_open;
 pub mod create;
 pub mod delete;
 pub mod list;
+pub mod models;
 pub mod patch;
+
+pub use models::{
+    SystemStatus, SystemStatusI18nName, SystemStatusSyncSetting, SystemStatusUserCloseResult,
+    SystemStatusUserOpenParam, SystemStatusUserOpenResult,
+};

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/models.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/models.rs
@@ -1,0 +1,97 @@
+//! system_status 共享模型（对齐飞书 personal_settings-v1）
+
+use serde::{Deserialize, Serialize};
+
+/// 系统状态多语言名称（`system_status_i18n_name` / sync i18n）。
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SystemStatusI18nName {
+    /// 中文名。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub zh_cn: Option<String>,
+    /// 英文名。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub en_us: Option<String>,
+    /// 日文名。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ja_jp: Option<String>,
+}
+
+/// 系统状态同步设置（`system_status_sync_setting`）。
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct SystemStatusSyncSetting {
+    /// 是否默认开启。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_open_by_default: Option<bool>,
+    /// 同步设置名称。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// 同步设置国际化名称。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub i18n_title: Option<SystemStatusI18nName>,
+    /// 同步设置解释文案。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub explain: Option<String>,
+    /// 同步设置国际化解释文案。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub i18n_explain: Option<SystemStatusI18nName>,
+}
+
+/// 系统状态实体（请求/响应共用字段子集）。
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct SystemStatus {
+    /// 系统状态 ID。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_status_id: Option<String>,
+    /// 系统状态标题。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// 系统状态国际化标题。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub i18n_title: Option<SystemStatusI18nName>,
+    /// 图标 key。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_key: Option<String>,
+    /// 颜色。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    /// 优先级（越小越优先）。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<i32>,
+    /// 同步设置。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sync_setting: Option<SystemStatusSyncSetting>,
+}
+
+/// 批量开启时的用户参数（`system_status_user_open_param`）。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SystemStatusUserOpenParam {
+    /// 用户 ID（类型由查询参数 `user_id_type` 决定）。
+    pub user_id: String,
+    /// 结束时间（Unix 秒级时间戳字符串）。
+    pub end_time: String,
+}
+
+/// 批量开启结果项。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SystemStatusUserOpenResult {
+    /// 用户 ID。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
+    /// 结束时间。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_time: Option<String>,
+    /// 开启结果。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<String>,
+}
+
+/// 批量关闭结果项。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SystemStatusUserCloseResult {
+    /// 用户 ID。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
+    /// 关闭结果。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<String>,
+}

--- a/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/patch.rs
+++ b/crates/openlark-user/src/personal_settings/personal_settings/v1/system_status/patch.rs
@@ -1,34 +1,57 @@
-//! system_status patch
-//! docPath: <https://open.feishu.cn/document/server-docs/personal_settings-v1/system_status/patch>
+//! 修改系统状态
+//!
+//! docPath: <https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/personal_settings-v1/system_status/patch>
 
 use openlark_core::{
     SDKResult,
-    api::{ApiRequest, ApiResponseTrait, ResponseFormat},
+    api::{ApiRequest, ApiResponseTrait},
     config::Config,
+    constants::AccessTokenType,
     http::Transport,
     req_option::RequestOption,
-    validate_required,
+    validate_required, validate_required_list,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+
+use super::models::SystemStatus;
 
 /// 更新系统状态的请求。
 #[derive(Debug, Clone)]
 pub struct SystemStatusPatchRequest {
     config: Arc<Config>,
-    status_id: String,
+    /// 路径参数 `system_status_id`。
+    system_status_id: String,
+    body: SystemStatusPatchBody,
 }
 
-/// 更新系统状态的响应。
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// 更新系统状态请求体。
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SystemStatusPatchBody {
+    /// 待更新的系统状态字段。
+    pub system_status: SystemStatus,
+    /// 需要更新的字段枚举列表（如 `TITLE` / `ICON` / `COLOR` 等）。
+    pub update_fields: Vec<String>,
+}
+
+impl SystemStatusPatchBody {
+    fn validate(&self) -> SDKResult<()> {
+        validate_required_list!(self.update_fields, 100, "update_fields 不能为空");
+        Ok(())
+    }
+}
+
+/// 更新系统状态响应 `data`。
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SystemStatusPatchResponse {
-    /// 响应数据。
-    pub data: Option<serde_json::Value>,
+    /// 更新后的系统状态。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_status: Option<SystemStatus>,
 }
 
 impl ApiResponseTrait for SystemStatusPatchResponse {
-    fn data_format() -> ResponseFormat {
-        ResponseFormat::Data
+    fn empty_success() -> Option<Self> {
+        Some(Self::default())
     }
 }
 
@@ -37,13 +60,26 @@ impl SystemStatusPatchRequest {
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,
-            status_id: String::new(),
+            system_status_id: String::new(),
+            body: SystemStatusPatchBody::default(),
         }
     }
 
-    /// 设置状态 ID。
-    pub fn status_id(mut self, status_id: impl Into<String>) -> Self {
-        self.status_id = status_id.into();
+    /// 设置系统状态 ID（路径参数）。
+    pub fn system_status_id(mut self, system_status_id: impl Into<String>) -> Self {
+        self.system_status_id = system_status_id.into();
+        self
+    }
+
+    /// 设置待更新的系统状态内容。
+    pub fn system_status(mut self, system_status: SystemStatus) -> Self {
+        self.body.system_status = system_status;
+        self
+    }
+
+    /// 设置需要更新的字段列表。
+    pub fn update_fields(mut self, update_fields: Vec<String>) -> Self {
+        self.body.update_fields = update_fields;
         self
     }
 
@@ -57,19 +93,22 @@ impl SystemStatusPatchRequest {
         self,
         option: RequestOption,
     ) -> SDKResult<SystemStatusPatchResponse> {
-        validate_required!(self.status_id.trim(), "status_id 不能为空");
+        validate_required!(self.system_status_id.trim(), "system_status_id 不能为空");
+        self.body.validate()?;
         let path = format!(
             "/open-apis/personal_settings/v1/system_statuses/{}",
-            self.status_id
+            self.system_status_id
         );
-        let req: ApiRequest<SystemStatusPatchResponse> = ApiRequest::patch(&path);
+        let body = serde_json::to_value(&self.body)?;
+        let req: ApiRequest<SystemStatusPatchResponse> = ApiRequest::patch(&path)
+            .body(body)
+            .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
 
-        Transport::request_typed(req, &self.config, Some(option), "system_status patch").await
+        Transport::request_typed(req, &self.config, Some(option), "修改系统状态").await
     }
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
     use super::*;
     use serde_json::json;
@@ -77,7 +116,7 @@ mod tests {
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, ResponseTemplate};
 
-    /// 端到端：PATCH .../system_statuses/{status_id} → 响应解析。
+    /// 端到端：PATCH .../system_statuses/{id} + body{system_status,update_fields}。
     #[tokio::test]
     async fn test_patch_system_status_returns_data_on_success() {
         let server = MockServer::start().await;
@@ -88,7 +127,14 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": { "data": { "system_status_id": "ss_001" } }
+                "data": {
+                    "system_status": {
+                        "system_status_id": "ss_001",
+                        "title": "出差",
+                        "icon_key": "GeneralBusinessTrip",
+                        "color": "BLUE"
+                    }
+                }
             })))
             .mount(&server)
             .await;
@@ -103,17 +149,28 @@ mod tests {
         );
 
         let resp = SystemStatusPatchRequest::new(config)
-            .status_id("ss_001")
+            .system_status_id("ss_001")
+            .system_status(SystemStatus {
+                icon_key: Some("GeneralBusinessTrip".into()),
+                color: Some("BLUE".into()),
+                ..Default::default()
+            })
+            .update_fields(vec!["ICON".into(), "COLOR".into()])
             .execute()
             .await
             .expect("更新系统状态应成功");
-        assert_eq!(resp.data.unwrap()["system_status_id"], "ss_001");
+        assert_eq!(
+            resp.system_status
+                .as_ref()
+                .unwrap()
+                .system_status_id
+                .as_deref(),
+            Some("ss_001")
+        );
 
         let received = server.received_requests().await.unwrap_or_default();
-        assert_eq!(received.len(), 1);
-        assert_eq!(
-            received[0].url.path(),
-            "/open-apis/personal_settings/v1/system_statuses/ss_001"
-        );
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["system_status"]["icon_key"], "GeneralBusinessTrip");
+        assert_eq!(sent["update_fields"].as_array().unwrap().len(), 2);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

接续 cardkit 字段核对，对 `openlark-user`（personal_settings / system_status，6 个 API）做官方文档字段对齐。原实现多处 Body 缺失或字段名错误（如 `user_ids`），且 Response 错误双重嵌套 `data`。

## 变更类型

- [x] 🐛 修复
- [x] 💥 破坏性改动

## 主要改动

- `batch_close`：`user_ids` → `user_list`（1～50）；响应 `result_list`；支持 `user_id_type`
- `batch_open`：补齐必填 `user_list[{user_id,end_time}]` 与 `result_list` 响应
- `create` / `patch`：补齐官方 Body（含 `sync_setting` / `update_fields`）
- `list`：补齐 `page_size` / `page_token` 与 `items`/`has_more` 响应
- `delete`：路径参数 setter 改为 `system_status_id`；空 data 响应
- 移除错误的 `Response { data: Option<Value> }` 双重嵌套

## 验证

- [x] `cargo test -p openlark-user --all-features`
- [x] `cargo clippy -p openlark-user --all-targets --all-features -- -Dwarnings`
- [x] `python3 tools/verify_api_fields.py --crate openlark-user --fetch-docs`（门禁通过；剩余 5 条 info 为嵌套子字段扁平比对噪声，与 cardkit 同类）

## 备注

Breaking：调用方需改用 `user_list`，并为 create/patch/batch_open 提供官方必填 Body；patch/delete 路径参数 setter 为 `system_status_id`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f9e3ece-ca16-4836-b694-7271fcb97396?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f9e3ece-ca16-4836-b694-7271fcb97396&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

