### PR TITLE
fix(application): align app_badge/set body with Feishu OpenAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- **application：对齐飞书 app_badge/set OpenAPI 请求体**：按官方文档重写
+  `openlark-application` `application/v6/app_badge/set`（及历史 v1 同名模块）Body。
+  - 移除错误推断字段 `app_id` / `badge`。
+  - 官方字段：必填 `user_id` + `version`；可选 `extra`、`pc`/`mobile`
+    （`client_badge_num`：`web_app` / `gadget`）；查询参数 `user_id_type`。
+  - 响应 `data` 为空对象，去掉错误的双重嵌套 `Response { data: Option<Value> }`。
+
 - **user：对齐飞书 personal_settings system_status OpenAPI 请求/响应体**：按官方文档重写
   `openlark-user` 全部 6 个 system_status 接口的 Body/Response。
   - `batch_close`：请求体字段 `user_ids` → `user_list`（`string[]`，长度 1～50）；响应为

--- a/crates/openlark-application/src/application/application/v1/app_badge/set.rs
+++ b/crates/openlark-application/src/application/application/v1/app_badge/set.rs
@@ -1,46 +1,74 @@
-//! 更新应用红点
+//! 更新应用红点（历史 v1 模块路径；HTTP 端点为 application/v6）
+//!
+//! docPath: <https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/application-v6/app_badge/set>
+//!
+//! 与 `application::v6::app_badge::set` 字段对齐；请优先使用 v6 路径。
 
 use openlark_core::{
     SDKResult,
-    api::{ApiRequest, ApiResponseTrait, ResponseFormat},
+    api::{ApiRequest, ApiResponseTrait},
     config::Config,
+    constants::AccessTokenType,
     http::Transport,
     req_option::RequestOption,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+
+/// 客户端红点数量（`client_badge_num`）。
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClientBadgeNum {
+    /// h5 / web_app 能力的 badge 数量。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub web_app: Option<i32>,
+    /// 小程序能力的 badge 数量。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gadget: Option<i32>,
+}
 
 /// 设置应用徽标的请求。
 #[derive(Debug, Clone)]
 pub struct SetAppBadgeRequest {
     config: Arc<Config>,
+    /// 查询参数 `user_id_type`。
+    user_id_type: Option<String>,
     body: SetAppBadgeBody,
 }
 
 /// 设置应用徽标的请求体。
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SetAppBadgeBody {
-    /// 应用 ID。
-    pub app_id: String,
-    /// 徽标。
-    pub badge: i32,
+    /// 用户 ID（类型由 `user_id_type` 决定）。
+    pub user_id: String,
+    /// 红点数据版本号。
+    pub version: String,
+    /// 红点额外信息（JSON 字符串）。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra: Option<String>,
+    /// PC 端红点数量。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pc: Option<ClientBadgeNum>,
+    /// 移动端红点数量。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mobile: Option<ClientBadgeNum>,
 }
 
-/// 设置应用徽标的响应。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SetAppBadgeResponse {
-    /// 响应数据。
-    pub data: Option<serde_json::Value>,
+impl SetAppBadgeBody {
+    fn validate(&self) -> SDKResult<()> {
+        validate_required!(self.user_id.trim(), "user_id 不能为空");
+        validate_required!(self.version.trim(), "version 不能为空");
+        Ok(())
+    }
 }
+
+/// 设置应用徽标的响应 `data`（文档为空对象）。
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SetAppBadgeResponse {}
 
 impl ApiResponseTrait for SetAppBadgeResponse {
-    fn data_format() -> ResponseFormat {
-        ResponseFormat::Data
-    }
-
-    /// 成功但无 `data` 字段时的空成功（set 类 API，与旧 `unwrap_or` 默认值一致）。
     fn empty_success() -> Option<Self> {
-        Some(Self { data: None })
+        Some(Self::default())
     }
 }
 
@@ -49,19 +77,44 @@ impl SetAppBadgeRequest {
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,
+            user_id_type: None,
             body: SetAppBadgeBody::default(),
         }
     }
 
-    /// 设置应用 ID。
-    pub fn app_id(mut self, id: impl Into<String>) -> Self {
-        self.body.app_id = id.into();
+    /// 设置用户 ID 类型（查询参数）。
+    pub fn user_id_type(mut self, user_id_type: impl Into<String>) -> Self {
+        self.user_id_type = Some(user_id_type.into());
         self
     }
 
-    /// 设置徽标。
-    pub fn badge(mut self, badge: i32) -> Self {
-        self.body.badge = badge;
+    /// 设置用户 ID。
+    pub fn user_id(mut self, user_id: impl Into<String>) -> Self {
+        self.body.user_id = user_id.into();
+        self
+    }
+
+    /// 设置红点数据版本号。
+    pub fn version(mut self, version: impl Into<String>) -> Self {
+        self.body.version = version.into();
+        self
+    }
+
+    /// 设置红点额外信息。
+    pub fn extra(mut self, extra: impl Into<String>) -> Self {
+        self.body.extra = Some(extra.into());
+        self
+    }
+
+    /// 设置 PC 端红点数量。
+    pub fn pc(mut self, pc: ClientBadgeNum) -> Self {
+        self.body.pc = Some(pc);
+        self
+    }
+
+    /// 设置移动端红点数量。
+    pub fn mobile(mut self, mobile: ClientBadgeNum) -> Self {
+        self.body.mobile = Some(mobile);
         self
     }
 
@@ -75,30 +128,37 @@ impl SetAppBadgeRequest {
         self,
         option: RequestOption,
     ) -> SDKResult<SetAppBadgeResponse> {
-        let path = "/open-apis/application/v6/app_badge/set";
+        self.body.validate()?;
         let body = serde_json::to_value(&self.body)?;
-        let req: ApiRequest<SetAppBadgeResponse> = ApiRequest::post(path).body(body);
+        let req: ApiRequest<SetAppBadgeResponse> =
+            ApiRequest::post("/open-apis/application/v6/app_badge/set")
+                .query_opt("user_id_type", self.user_id_type.as_ref())
+                .body(body)
+                .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
         Transport::request_typed(req, &self.config, Some(option), "更新应用红点").await
     }
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_serialization_roundtrip() {
-        // 基础序列化测试
-        let json = r#"{"test": "value"}"#;
-        assert!(serde_json::from_str::<serde_json::Value>(json).is_ok());
-    }
-
-    #[test]
-    fn test_deserialization_from_json() {
-        // 基础反序列化测试
-        let json = r#"{"field": "data"}"#;
-        let value: serde_json::Value = serde_json::from_str(json).expect("JSON 反序列化失败");
-        assert_eq!(value["field"], "data");
+    fn test_body_serialization_matches_official_fields() {
+        let body = SetAppBadgeBody {
+            user_id: "ou_1".into(),
+            version: "1664360599355".into(),
+            extra: Some("{}".into()),
+            pc: Some(ClientBadgeNum {
+                web_app: Some(1),
+                gadget: Some(2),
+            }),
+            mobile: None,
+        };
+        let v = serde_json::to_value(&body).unwrap();
+        assert_eq!(v["user_id"], "ou_1");
+        assert_eq!(v["version"], "1664360599355");
+        assert!(v.get("app_id").is_none());
+        assert!(v.get("badge").is_none());
     }
 }

--- a/crates/openlark-application/src/application/application/v6/app_badge/set.rs
+++ b/crates/openlark-application/src/application/application/v6/app_badge/set.rs
@@ -1,47 +1,72 @@
 //! 更新应用红点
-//! docPath: <https://open.feishu.cn/document/server-docs/application-v6/app_badge/set>
+//!
+//! docPath: <https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/application-v6/app_badge/set>
 
 use openlark_core::{
     SDKResult,
-    api::{ApiRequest, ApiResponseTrait, ResponseFormat},
+    api::{ApiRequest, ApiResponseTrait},
     config::Config,
+    constants::AccessTokenType,
     http::Transport,
     req_option::RequestOption,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+
+/// 客户端红点数量（`client_badge_num`）。
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClientBadgeNum {
+    /// h5 / web_app 能力的 badge 数量。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub web_app: Option<i32>,
+    /// 小程序能力的 badge 数量。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gadget: Option<i32>,
+}
 
 /// 更新应用红点的请求。
 #[derive(Debug, Clone)]
 pub struct SetAppBadgeRequest {
     config: Arc<Config>,
+    /// 查询参数 `user_id_type`。
+    user_id_type: Option<String>,
     body: SetAppBadgeBody,
 }
 
 /// 更新应用红点的请求体。
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SetAppBadgeBody {
-    /// 应用 ID。
-    pub app_id: String,
-    /// 徽标。
-    pub badge: i32,
+    /// 用户 ID（类型由 `user_id_type` 决定）。
+    pub user_id: String,
+    /// 红点数据版本号。
+    pub version: String,
+    /// 红点额外信息（JSON 字符串）。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra: Option<String>,
+    /// PC 端红点数量。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pc: Option<ClientBadgeNum>,
+    /// 移动端红点数量。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mobile: Option<ClientBadgeNum>,
 }
 
-/// 更新应用红点的响应。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SetAppBadgeResponse {
-    /// 响应数据。
-    pub data: Option<serde_json::Value>,
+impl SetAppBadgeBody {
+    fn validate(&self) -> SDKResult<()> {
+        validate_required!(self.user_id.trim(), "user_id 不能为空");
+        validate_required!(self.version.trim(), "version 不能为空");
+        Ok(())
+    }
 }
+
+/// 更新应用红点响应 `data`（文档为空对象）。
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SetAppBadgeResponse {}
 
 impl ApiResponseTrait for SetAppBadgeResponse {
-    fn data_format() -> ResponseFormat {
-        ResponseFormat::Data
-    }
-
-    /// 成功但无 `data` 字段时的空成功（set 类 API，与旧 `unwrap_or` 默认值一致）。
     fn empty_success() -> Option<Self> {
-        Some(Self { data: None })
+        Some(Self::default())
     }
 }
 
@@ -50,19 +75,44 @@ impl SetAppBadgeRequest {
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,
+            user_id_type: None,
             body: SetAppBadgeBody::default(),
         }
     }
 
-    /// 设置应用 ID。
-    pub fn app_id(mut self, id: impl Into<String>) -> Self {
-        self.body.app_id = id.into();
+    /// 设置用户 ID 类型（查询参数）。
+    pub fn user_id_type(mut self, user_id_type: impl Into<String>) -> Self {
+        self.user_id_type = Some(user_id_type.into());
         self
     }
 
-    /// 设置徽标。
-    pub fn badge(mut self, badge: i32) -> Self {
-        self.body.badge = badge;
+    /// 设置用户 ID。
+    pub fn user_id(mut self, user_id: impl Into<String>) -> Self {
+        self.body.user_id = user_id.into();
+        self
+    }
+
+    /// 设置红点数据版本号。
+    pub fn version(mut self, version: impl Into<String>) -> Self {
+        self.body.version = version.into();
+        self
+    }
+
+    /// 设置红点额外信息。
+    pub fn extra(mut self, extra: impl Into<String>) -> Self {
+        self.body.extra = Some(extra.into());
+        self
+    }
+
+    /// 设置 PC 端红点数量。
+    pub fn pc(mut self, pc: ClientBadgeNum) -> Self {
+        self.body.pc = Some(pc);
+        self
+    }
+
+    /// 设置移动端红点数量。
+    pub fn mobile(mut self, mobile: ClientBadgeNum) -> Self {
+        self.body.mobile = Some(mobile);
         self
     }
 
@@ -76,33 +126,35 @@ impl SetAppBadgeRequest {
         self,
         option: RequestOption,
     ) -> SDKResult<SetAppBadgeResponse> {
-        let path = "/open-apis/application/v6/app_badge/set";
+        self.body.validate()?;
         let body = serde_json::to_value(&self.body)?;
-        let req: ApiRequest<SetAppBadgeResponse> = ApiRequest::post(path).body(body);
+        let req: ApiRequest<SetAppBadgeResponse> =
+            ApiRequest::post("/open-apis/application/v6/app_badge/set")
+                .query_opt("user_id_type", self.user_id_type.as_ref())
+                .body(body)
+                .with_supported_access_token_types(vec![AccessTokenType::Tenant]);
         Transport::request_typed(req, &self.config, Some(option), "更新应用红点").await
     }
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
+    use wiremock::MockServer;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, ResponseTemplate};
 
-    /// 端到端：POST .../app_badge/set → 强类型 SetAppBadgeResponse 解析（双层 data 信封）。
+    /// 端到端：POST .../app_badge/set + 官方 body → 空 data。
     #[tokio::test]
     async fn test_set_app_badge_returns_data_on_success() {
-        use serde_json::json;
-        use wiremock::MockServer;
-        use wiremock::matchers::{method, path};
-        use wiremock::{Mock, ResponseTemplate};
-
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/open-apis/application/v6/app_badge/set"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": { "data": { "app_id": "cli_test_app", "badge": 5 } }
+                "data": {}
             })))
             .mount(&server)
             .await;
@@ -116,19 +168,33 @@ mod tests {
                 .build(),
         );
 
-        let resp = SetAppBadgeRequest::new(config)
-            .app_id("cli_test_app")
-            .badge(5)
+        let _resp = SetAppBadgeRequest::new(config)
+            .user_id_type("open_id")
+            .user_id("ou_d317f090b7258ad0372aa53963cda70d")
+            .version("1664360599355")
+            .extra("{}")
+            .pc(ClientBadgeNum {
+                web_app: Some(1),
+                gadget: Some(2),
+            })
+            .mobile(ClientBadgeNum {
+                web_app: Some(1),
+                gadget: Some(2),
+            })
             .execute()
             .await
             .expect("更新应用红点应成功");
-        assert_eq!(resp.data.unwrap()["app_id"], "cli_test_app");
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
-        assert_eq!(
-            received[0].url.path(),
-            "/open-apis/application/v6/app_badge/set"
-        );
+        let query = received[0].url.query().unwrap_or("");
+        assert!(query.contains("user_id_type=open_id"));
+        let sent: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert_eq!(sent["user_id"], "ou_d317f090b7258ad0372aa53963cda70d");
+        assert_eq!(sent["version"], "1664360599355");
+        assert_eq!(sent["pc"]["web_app"], 1);
+        assert_eq!(sent["mobile"]["gadget"], 2);
+        assert!(sent.get("app_id").is_none());
+        assert!(sent.get("badge").is_none());
     }
 }

--- a/crates/openlark-application/tests/application_contract_models.rs
+++ b/crates/openlark-application/tests/application_contract_models.rs
@@ -35,11 +35,17 @@ mod v1_tests {
     #[test]
     fn set_app_badge_body_contract() {
         let body: SetAppBadgeBody = parse_contract(json!({
-            "app_id": "cli_a5xxxxxxxx",
-            "badge": 3
+            "user_id": "ou_d317f090b7258ad0372aa53963cda70d",
+            "version": "1664360599355",
+            "extra": "{}",
+            "pc": { "web_app": 1, "gadget": 2 },
+            "mobile": { "web_app": 1, "gadget": 2 }
         }));
-        assert_eq!(body.app_id, "cli_a5xxxxxxxx");
-        assert_eq!(body.badge, 3);
+        assert_eq!(body.user_id, "ou_d317f090b7258ad0372aa53963cda70d");
+        assert_eq!(body.version, "1664360599355");
+        assert_eq!(body.extra.as_deref(), Some("{}"));
+        assert_eq!(body.pc.as_ref().unwrap().web_app, Some(1));
+        assert_eq!(body.mobile.as_ref().unwrap().gadget, Some(2));
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

接续 user/cardkit 字段核对：`openlark-application` 的 `app_badge/set` 请求体与官方文档不符（错误推断 `app_id`/`badge`）。已按飞书 OpenAPI 重写 Body/Response。

## 变更类型

- [x] 🐛 修复
- [x] 💥 破坏性改动

## 主要改动

- 移除错误字段 `app_id` / `badge`
- 官方 Body：必填 `user_id` + `version`；可选 `extra`、`pc`/`mobile`（`web_app`/`gadget`）
- 支持查询参数 `user_id_type`
- 响应 `data` 为空对象（去掉双重嵌套 `Response.data`）
- 同步修正历史 `application/v1/app_badge` 同名模块与契约测试

## 验证

- [x] `cargo test -p openlark-application --all-features`
- [x] `cargo clippy -p openlark-application --all-targets --all-features -- -Dwarnings`
- [x] `python3 tools/verify_api_fields.py --api-id 7291103260878356482 --fetch-docs --force-refresh`（通过）

## 备注

Breaking：调用方需改用 `user_id`/`version`（及可选 `pc`/`mobile`），不再传 `app_id`/`badge`。

crate 级核对中 `scope/apply`、`scope/list` 仍可能因文档证据 `structure_incomplete` 告警（与本次 Body 无关的既有证据噪声）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f9e3ece-ca16-4836-b694-7271fcb97396?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f9e3ece-ca16-4836-b694-7271fcb97396&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

