### PR TITLE
fix(helpdesk): align OpenAPI request bodies with Feishu docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- **helpdesk：对齐飞书 Helpdesk OpenAPI 请求体**：按官方文档重写
+  `openlark-helpdesk` 中字段硬错误接口的 Body（嵌套包装与扁平字段）。
+  - `agent/schedules/patch`：`agent_schedule.{schedule[],agent_skill_ids}`；
+    `agent_schedule/create`：`agent_schedules[]`。
+  - `agent_skill/create|patch`：`rules`/`agent_ids`；patch 使用 `agent_skill` 包装。
+  - `agent/patch`：`status` 改为整型。
+  - `category/create|patch`：`name`/`parent_id`（create 必填）+ 可选 `language`；移除错误
+    `description`/`order`。
+  - `faq/create|patch`：请求体改为 `faq{...}` 包装（question 等）。
+  - `bot/message/create`：`msg_type`/`content`/`receiver_id`/`receive_type`（移除 `receive_id`）。
+  - `ticket/message/create`：`msg_type`/`content` 必填；`answer_user_query`：`event_id`/`faqs`；
+    `start_service`：`open_id`/`human_service`/`appointed_agents`/`customized_info`。
+  - `notification/create|patch`：按官方 Notification 扁平字段（`job_name`/`push_content` 等），
+    移除错误 `title`/`content`。
+  - `ticket_customized_field/create|patch`：对齐 `key_name`/`display_name`/`field_type` 等官方字段。
+
 - **application：对齐飞书 app_badge/set OpenAPI 请求体**：按官方文档重写
   `openlark-application` `application/v6/app_badge/set`（及历史 v1 同名模块）Body。
   - 移除错误推断字段 `app_id` / `badge`。
@@ -44,6 +60,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 多数写接口响应 `data` 为空对象，对应 Response 结构同步收敛。
 
 ### Changed
+
+- **tools：字段核对跳过多分表单内部元数据 / 放宽「代码更严」门禁**：
+  `verify_api_fields` 提取 Body 时跳过 serde 名以 `__` 开头的字段（如 multipart
+  `__file_name`）；「文档选填但代码非 Option」由 warning 降为 info，不再阻断 `--fetch-docs`
+  门禁（保留提示，避免有意更严建模被误拦）。
 
 - **websocket protobuf 打包修复（#605）**：恢复 `lark-websocket-protobuf` 为 workspace
   权威发布源并准备 `0.1.2`；将 `pbbp2.proto` 的生成代码随 crate 提交和打包，移除默认

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/mod.rs
@@ -30,7 +30,7 @@ impl Agent {
 
     /// 更新客服信息
     pub fn patch(&self, agent_id: impl Into<String>) -> patch::PatchAgentRequest {
-        patch::PatchAgentRequest::new(self.config.clone(), agent_id.into())
+        patch::PatchAgentRequest::new(self.config.as_ref().clone(), agent_id.into())
     }
 
     /// 访问客服工作日程

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/patch.rs
@@ -8,7 +8,6 @@ use openlark_core::{
     SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
 };
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
 use crate::common::api_utils::serialize_params;
@@ -16,21 +15,14 @@ use crate::common::api_utils::serialize_params;
 /// 更新客服信息请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct PatchAgentBody {
-    /// 客服状态: offline:离线, online:在线, busy:忙碌
+    /// 客服状态。
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<String>,
+    pub status: Option<i32>,
 }
 
 impl PatchAgentBody {
     /// 验证请求参数
     pub fn validate(&self) -> openlark_core::SDKResult<()> {
-        if let Some(status) = &self.status
-            && !["offline", "online", "busy"].contains(&status.as_str())
-        {
-            return Err(openlark_core::CoreError::validation_msg(
-                "status must be offline, online, or busy",
-            ));
-        }
         Ok(())
     }
 }
@@ -38,34 +30,29 @@ impl PatchAgentBody {
 /// 更新客服信息响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PatchAgentResponse {
-    /// 响应数据。
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<PatchAgentResult>,
-}
-
-impl openlark_core::api::ApiResponseTrait for PatchAgentResponse {}
-
-/// 更新客服信息结果
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PatchAgentResult {
     /// 客服ID
     #[serde(skip_serializing_if = "Option::is_none")]
     pub agent_id: Option<String>,
     /// 客服状态
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<String>,
+    pub status: Option<i32>,
 }
+
+impl openlark_core::api::ApiResponseTrait for PatchAgentResponse {}
+
+/// 更新客服信息结果。
+pub type PatchAgentResult = PatchAgentResponse;
 
 /// 更新客服信息请求
 #[derive(Debug, Clone)]
 pub struct PatchAgentRequest {
-    config: Arc<Config>,
+    config: Config,
     agent_id: String,
 }
 
 impl PatchAgentRequest {
     /// 创建新的更新客服信息请求
-    pub fn new(config: Arc<Config>, agent_id: String) -> Self {
+    pub fn new(config: Config, agent_id: String) -> Self {
         Self { config, agent_id }
     }
 
@@ -94,14 +81,14 @@ impl PatchAgentRequest {
 /// 更新客服信息请求构建器
 #[derive(Debug, Clone)]
 pub struct PatchAgentRequestBuilder {
-    config: Arc<Config>,
+    config: Config,
     agent_id: String,
-    status: Option<String>,
+    status: Option<i32>,
 }
 
 impl PatchAgentRequestBuilder {
     /// 创建新的构建器
-    pub fn new(config: Arc<Config>, agent_id: String) -> Self {
+    pub fn new(config: Config, agent_id: String) -> Self {
         Self {
             config,
             agent_id,
@@ -110,15 +97,15 @@ impl PatchAgentRequestBuilder {
     }
 
     /// 设置客服状态
-    pub fn status(mut self, status: impl Into<String>) -> Self {
-        self.status = Some(status.into());
+    pub fn status(mut self, status: i32) -> Self {
+        self.status = Some(status);
         self
     }
 
     /// 构建请求体
     pub fn body(&self) -> PatchAgentBody {
         PatchAgentBody {
-            status: self.status.clone(),
+            status: self.status,
         }
     }
 
@@ -169,23 +156,16 @@ pub async fn patch_agent_with_options(
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
-    fn test_body_validation_valid_status() {
-        let body = PatchAgentBody {
-            status: Some("online".to_string()),
-        };
-        let result = body.validate();
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_body_validation_invalid_status() {
-        let body = PatchAgentBody {
-            status: Some("invalid_status".to_string()),
-        };
-        let result = body.validate();
-        assert!(result.is_err());
+    fn test_body_serializes_integer_status() {
+        let body = PatchAgentBody { status: Some(1) };
+        assert!(body.validate().is_ok());
+        assert_eq!(
+            serde_json::to_value(body).expect("序列化请求体失败"),
+            json!({ "status": 1 })
+        );
     }
 
     #[test]
@@ -194,47 +174,43 @@ mod tests {
             .app_id("test_app_id")
             .app_secret("test_app_secret")
             .build();
-        let builder = PatchAgentRequestBuilder::new(Arc::new(config), "agent_123".to_string());
+        let builder = PatchAgentRequestBuilder::new(config, "agent_123".to_string());
 
         assert!(builder.status.is_none());
     }
 
-    /// 端到端：PATCH .../agents/{agent_id} → 强类型 PatchAgentResponse 解析（双层 data 信封）。
+    /// 端到端：PATCH .../agents/{agent_id} → 强类型响应解析。
     #[tokio::test]
     async fn test_patch_agent_returns_data_on_success() {
-        use serde_json::json;
         use wiremock::MockServer;
-        use wiremock::matchers::{method, path};
+        use wiremock::matchers::{body_json, method, path};
         use wiremock::{Mock, ResponseTemplate};
 
         let server = MockServer::start().await;
         Mock::given(method("PATCH"))
             .and(path("/open-apis/helpdesk/v1/agents/ag_001"))
+            .and(body_json(json!({ "status": 1 })))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": { "data": { "agent_id": "ag_001", "status": "online" } }
+                "data": { "agent_id": "ag_001", "status": 1 }
             })))
             .mount(&server)
             .await;
 
-        let config = Arc::new(
-            Config::builder()
-                .app_id("ci_app_id")
-                .app_secret("ci_app_secret")
-                .base_url(server.uri())
-                .enable_token_cache(false)
-                .build(),
-        );
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
-        let body = PatchAgentBody {
-            status: Some("online".to_string()),
-        };
+        let body = PatchAgentBody { status: Some(1) };
         let resp = PatchAgentRequest::new(config, "ag_001".to_string())
             .execute(body)
             .await
             .expect("更新客服信息应成功");
-        assert!(resp.data.is_some());
+        assert_eq!(resp.status, Some(1));
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/schedules/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/schedules/mod.rs
@@ -37,6 +37,6 @@ impl AgentSchedules {
 
     /// 创建补丁请求。
     pub fn patch(self) -> patch::PatchAgentScheduleRequest {
-        patch::PatchAgentScheduleRequest::new(self.config, self.agent_id)
+        patch::PatchAgentScheduleRequest::new(self.config.as_ref().clone(), self.agent_id)
     }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/schedules/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent/schedules/patch.rs
@@ -6,9 +6,9 @@
 
 use openlark_core::{
     SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
 use crate::common::api_utils::serialize_params;
@@ -16,29 +16,40 @@ use crate::common::api_utils::serialize_params;
 /// 更新客服工作日程请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct PatchAgentScheduleBody {
-    /// 工作日期 (格式: YYYY-MM-DD)
+    /// 客服日程。
+    pub agent_schedule: AgentSchedule,
+}
+
+/// 客服日程。
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AgentSchedule {
+    /// 每周工作时间段。
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub work_date: Option<String>,
-    /// 开始时间 (格式: HH:mm:ss)
+    pub schedule: Option<Vec<WeekdaySchedule>>,
+    /// 客服技能 ID 列表。
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub start_time: Option<String>,
-    /// 结束时间 (格式: HH:mm:ss)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub end_time: Option<String>,
-    /// 星期几 (1-7)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub day_of_week: Option<i32>,
+    pub agent_skill_ids: Option<Vec<String>>,
+}
+
+/// 每周工作时间段。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WeekdaySchedule {
+    /// 开始时间，格式为 HH:mm。
+    pub start_time: String,
+    /// 结束时间，格式为 HH:mm。
+    pub end_time: String,
+    /// 星期标识。
+    pub weekday: i32,
 }
 
 impl PatchAgentScheduleBody {
     /// 验证请求参数
     pub fn validate(&self) -> openlark_core::SDKResult<()> {
-        if let (Some(start_time), Some(end_time)) = (&self.start_time, &self.end_time)
-            && start_time >= end_time
-        {
-            return Err(openlark_core::CoreError::validation_msg(
-                "start_time must be less than end_time",
-            ));
+        if let Some(schedule) = &self.agent_schedule.schedule {
+            for item in schedule {
+                validate_required!(item.start_time, "start_time 不能为空");
+                validate_required!(item.end_time, "end_time 不能为空");
+            }
         }
         Ok(())
     }
@@ -47,43 +58,29 @@ impl PatchAgentScheduleBody {
 /// 更新客服工作日程响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PatchAgentScheduleResponse {
-    /// 响应数据。
+    /// 客服ID
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<PatchAgentScheduleResult>,
+    pub agent_id: Option<String>,
+    /// 客服日程。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_schedule: Option<AgentSchedule>,
 }
 
 impl openlark_core::api::ApiResponseTrait for PatchAgentScheduleResponse {}
 
-/// 更新客服工作日程结果
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PatchAgentScheduleResult {
-    /// 客服ID
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub agent_id: Option<String>,
-    /// 工作日期
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub work_date: Option<String>,
-    /// 开始时间
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub start_time: Option<String>,
-    /// 结束时间
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub end_time: Option<String>,
-    /// 星期几
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub day_of_week: Option<i32>,
-}
+/// 更新客服工作日程结果。
+pub type PatchAgentScheduleResult = PatchAgentScheduleResponse;
 
 /// 更新客服工作日程请求
 #[derive(Debug, Clone)]
 pub struct PatchAgentScheduleRequest {
-    config: Arc<Config>,
+    config: Config,
     agent_id: String,
 }
 
 impl PatchAgentScheduleRequest {
     /// 创建新的更新客服工作日程请求
-    pub fn new(config: Arc<Config>, agent_id: String) -> Self {
+    pub fn new(config: Config, agent_id: String) -> Self {
         Self { config, agent_id }
     }
 
@@ -115,58 +112,42 @@ impl PatchAgentScheduleRequest {
 /// 更新客服工作日程请求构建器
 #[derive(Debug, Clone)]
 pub struct PatchAgentScheduleRequestBuilder {
-    config: Arc<Config>,
+    config: Config,
     agent_id: String,
-    work_date: Option<String>,
-    start_time: Option<String>,
-    end_time: Option<String>,
-    day_of_week: Option<i32>,
+    schedule: Option<Vec<WeekdaySchedule>>,
+    agent_skill_ids: Option<Vec<String>>,
 }
 
 impl PatchAgentScheduleRequestBuilder {
     /// 创建新的构建器
-    pub fn new(config: Arc<Config>, agent_id: String) -> Self {
+    pub fn new(config: Config, agent_id: String) -> Self {
         Self {
             config,
             agent_id,
-            work_date: None,
-            start_time: None,
-            end_time: None,
-            day_of_week: None,
+            schedule: None,
+            agent_skill_ids: None,
         }
     }
 
-    /// 设置工作日期 (格式: YYYY-MM-DD)
-    pub fn work_date(mut self, work_date: impl Into<String>) -> Self {
-        self.work_date = Some(work_date.into());
+    /// 设置每周工作时间段。
+    pub fn schedule(mut self, schedule: Vec<WeekdaySchedule>) -> Self {
+        self.schedule = Some(schedule);
         self
     }
 
-    /// 设置开始时间 (格式: HH:mm:ss)
-    pub fn start_time(mut self, start_time: impl Into<String>) -> Self {
-        self.start_time = Some(start_time.into());
-        self
-    }
-
-    /// 设置结束时间 (格式: HH:mm:ss)
-    pub fn end_time(mut self, end_time: impl Into<String>) -> Self {
-        self.end_time = Some(end_time.into());
-        self
-    }
-
-    /// 设置星期几 (1-7)
-    pub fn day_of_week(mut self, day_of_week: i32) -> Self {
-        self.day_of_week = Some(day_of_week);
+    /// 设置客服技能 ID 列表。
+    pub fn agent_skill_ids(mut self, agent_skill_ids: Vec<String>) -> Self {
+        self.agent_skill_ids = Some(agent_skill_ids);
         self
     }
 
     /// 构建请求体
     pub fn body(&self) -> PatchAgentScheduleBody {
         PatchAgentScheduleBody {
-            work_date: self.work_date.clone(),
-            start_time: self.start_time.clone(),
-            end_time: self.end_time.clone(),
-            day_of_week: self.day_of_week,
+            agent_schedule: AgentSchedule {
+                schedule: self.schedule.clone(),
+                agent_skill_ids: self.agent_skill_ids.clone(),
+            },
         }
     }
 
@@ -217,36 +198,54 @@ pub async fn patch_agent_schedule_with_options(
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
-    fn test_body_validation_empty() {
+    fn test_body_validation_empty_schedule() {
         let body = PatchAgentScheduleBody::default();
-        let result = body.validate();
-        assert!(result.is_ok());
+        assert!(body.validate().is_ok());
     }
 
     #[test]
-    fn test_body_validation_valid_times() {
+    fn test_body_serialization_matches_official_schema() {
         let body = PatchAgentScheduleBody {
-            work_date: Some("2024-01-15".to_string()),
-            start_time: Some("09:00:00".to_string()),
-            end_time: Some("18:00:00".to_string()),
-            day_of_week: Some(1),
+            agent_schedule: AgentSchedule {
+                schedule: Some(vec![WeekdaySchedule {
+                    start_time: "00:00".to_string(),
+                    end_time: "24:00".to_string(),
+                    weekday: 9,
+                }]),
+                agent_skill_ids: Some(vec!["test-skill-id".to_string()]),
+            },
         };
-        let result = body.validate();
-        assert!(result.is_ok());
+        assert_eq!(
+            serde_json::to_value(body).expect("序列化请求体失败"),
+            json!({
+                "agent_schedule": {
+                    "schedule": [{
+                        "start_time": "00:00",
+                        "end_time": "24:00",
+                        "weekday": 9
+                    }],
+                    "agent_skill_ids": ["test-skill-id"]
+                }
+            })
+        );
     }
 
     #[test]
-    fn test_body_validation_invalid_times() {
+    fn test_body_validation_rejects_empty_start_time() {
         let body = PatchAgentScheduleBody {
-            work_date: None,
-            start_time: Some("18:00:00".to_string()),
-            end_time: Some("09:00:00".to_string()),
-            day_of_week: None,
+            agent_schedule: AgentSchedule {
+                schedule: Some(vec![WeekdaySchedule {
+                    start_time: " ".to_string(),
+                    end_time: "24:00".to_string(),
+                    weekday: 9,
+                }]),
+                agent_skill_ids: None,
+            },
         };
-        let result = body.validate();
-        assert!(result.is_err());
+        assert!(body.validate().is_err());
     }
 
     #[test]
@@ -255,54 +254,62 @@ mod tests {
             .app_id("test_app_id")
             .app_secret("test_app_secret")
             .build();
-        let builder =
-            PatchAgentScheduleRequestBuilder::new(Arc::new(config), "agent_123".to_string());
+        let builder = PatchAgentScheduleRequestBuilder::new(config, "agent_123".to_string());
 
         assert_eq!(builder.agent_id, "agent_123");
-        assert!(builder.work_date.is_none());
+        assert!(builder.schedule.is_none());
     }
 
-    /// 端到端：PATCH .../agents/{agent_id}/schedules → 强类型 PatchAgentScheduleResponse 解析（双层 data 信封）。
+    /// 端到端：PATCH .../agents/{agent_id}/schedules → 强类型响应解析。
     #[tokio::test]
     async fn test_patch_returns_data_on_success() {
-        use serde_json::json;
         use wiremock::MockServer;
-        use wiremock::matchers::{method, path};
+        use wiremock::matchers::{body_json, method, path};
         use wiremock::{Mock, ResponseTemplate};
 
         let server = MockServer::start().await;
         Mock::given(method("PATCH"))
             .and(path("/open-apis/helpdesk/v1/agents/ag_001/schedules"))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(json!({
-                    "code": 0,
-                    "msg": "success",
-                    "data": { "data": { "agent_id": "ag_001", "work_date": "2026-07-07", "start_time": "09:00:00", "end_time": "18:00:00", "day_of_week": 1 } }
-                })),
-            )
+            .and(body_json(json!({
+                "agent_schedule": {
+                    "schedule": [{
+                        "start_time": "00:00",
+                        "end_time": "24:00",
+                        "weekday": 9
+                    }],
+                    "agent_skill_ids": ["test-skill-id"]
+                }
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "msg": "success",
+                "data": { "agent_id": "ag_001" }
+            })))
             .mount(&server)
             .await;
 
-        let config = Arc::new(
-            Config::builder()
-                .app_id("ci_app_id")
-                .app_secret("ci_app_secret")
-                .base_url(server.uri())
-                .enable_token_cache(false)
-                .build(),
-        );
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
         let body = PatchAgentScheduleBody {
-            work_date: Some("2026-07-07".to_string()),
-            start_time: Some("09:00:00".to_string()),
-            end_time: Some("18:00:00".to_string()),
-            day_of_week: Some(1),
+            agent_schedule: AgentSchedule {
+                schedule: Some(vec![WeekdaySchedule {
+                    start_time: "00:00".to_string(),
+                    end_time: "24:00".to_string(),
+                    weekday: 9,
+                }]),
+                agent_skill_ids: Some(vec!["test-skill-id".to_string()]),
+            },
         };
         let resp = PatchAgentScheduleRequest::new(config, "ag_001".to_string())
             .execute(body)
             .await
             .expect("更新客服工作日程应成功");
-        assert!(resp.data.is_some());
+        assert_eq!(resp.agent_id.as_deref(), Some("ag_001"));
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/create.rs
@@ -9,7 +9,6 @@ use openlark_core::{
     validate_required,
 };
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
 use crate::common::api_utils::serialize_params;
@@ -17,30 +16,46 @@ use crate::common::api_utils::serialize_params;
 /// 创建客服工作日程请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CreateAgentScheduleBody {
-    /// 客服ID
+    /// 待创建的客服日程列表。
+    pub agent_schedules: Vec<AgentSchedule>,
+}
+
+/// 客服日程。
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AgentSchedule {
+    /// 客服 ID。
     pub agent_id: String,
-    /// 工作日期 (格式: YYYY-MM-DD)
-    pub work_date: String,
-    /// 开始时间 (格式: HH:mm:ss)
-    pub start_time: String,
-    /// 结束时间 (格式: HH:mm:ss)
-    pub end_time: String,
-    /// 星期几 (1-7, 1表示周一)
+    /// 每周工作时间段。
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub day_of_week: Option<i32>,
+    pub schedule: Option<Vec<WeekdaySchedule>>,
+    /// 客服技能 ID 列表。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_skill_ids: Option<Vec<String>>,
+}
+
+/// 每周工作时间段。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WeekdaySchedule {
+    /// 开始时间，格式为 HH:mm。
+    pub start_time: String,
+    /// 结束时间，格式为 HH:mm。
+    pub end_time: String,
+    /// 星期标识。
+    pub weekday: i32,
 }
 
 impl CreateAgentScheduleBody {
     /// 验证请求参数
     pub fn validate(&self) -> openlark_core::SDKResult<()> {
-        validate_required!(self.agent_id, "agent_id is required");
-        validate_required!(self.work_date, "work_date is required");
-        validate_required!(self.start_time, "start_time is required");
-        validate_required!(self.end_time, "end_time is required");
-        if self.start_time >= self.end_time {
-            return Err(openlark_core::CoreError::validation_msg(
-                "start_time must be less than end_time",
-            ));
+        validate_required!(self.agent_schedules, "agent_schedules 不能为空");
+        for agent_schedule in &self.agent_schedules {
+            validate_required!(agent_schedule.agent_id, "agent_id 不能为空");
+            if let Some(schedule) = &agent_schedule.schedule {
+                for item in schedule {
+                    validate_required!(item.start_time, "start_time 不能为空");
+                    validate_required!(item.end_time, "end_time 不能为空");
+                }
+            }
         }
         Ok(())
     }
@@ -49,42 +64,25 @@ impl CreateAgentScheduleBody {
 /// 创建客服工作日程响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateAgentScheduleResponse {
-    /// 响应数据。
+    /// 已创建的客服日程列表。
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<CreateAgentScheduleResult>,
+    pub agent_schedules: Option<Vec<AgentSchedule>>,
 }
 
 impl openlark_core::api::ApiResponseTrait for CreateAgentScheduleResponse {}
 
-/// 创建客服工作日程结果
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CreateAgentScheduleResult {
-    /// 客服ID
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub agent_id: Option<String>,
-    /// 工作日期
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub work_date: Option<String>,
-    /// 开始时间
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub start_time: Option<String>,
-    /// 结束时间
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub end_time: Option<String>,
-    /// 星期几
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub day_of_week: Option<i32>,
-}
+/// 创建客服工作日程结果。
+pub type CreateAgentScheduleResult = CreateAgentScheduleResponse;
 
 /// 创建客服工作日程请求
 #[derive(Debug, Clone)]
 pub struct CreateAgentScheduleRequest {
-    config: Arc<Config>,
+    config: Config,
 }
 
 impl CreateAgentScheduleRequest {
     /// 创建新的创建客服工作日程请求
-    pub fn new(config: Arc<Config>) -> Self {
+    pub fn new(config: Config) -> Self {
         Self { config }
     }
 
@@ -116,78 +114,41 @@ impl CreateAgentScheduleRequest {
 /// 创建客服工作日程请求构建器
 #[derive(Debug, Clone)]
 pub struct CreateAgentScheduleRequestBuilder {
-    config: Arc<Config>,
-    agent_id: Option<String>,
-    work_date: Option<String>,
-    start_time: Option<String>,
-    end_time: Option<String>,
-    day_of_week: Option<i32>,
+    config: Config,
+    agent_schedules: Vec<AgentSchedule>,
 }
 
 impl CreateAgentScheduleRequestBuilder {
     /// 创建新的构建器
-    pub fn new(config: Arc<Config>) -> Self {
+    pub fn new(config: Config) -> Self {
         Self {
             config,
-            agent_id: None,
-            work_date: None,
-            start_time: None,
-            end_time: None,
-            day_of_week: None,
+            agent_schedules: Vec::new(),
         }
     }
 
-    /// 设置客服ID
-    pub fn agent_id(mut self, agent_id: impl Into<String>) -> Self {
-        self.agent_id = Some(agent_id.into());
+    /// 设置待创建的客服日程列表。
+    pub fn agent_schedules(mut self, agent_schedules: Vec<AgentSchedule>) -> Self {
+        self.agent_schedules = agent_schedules;
         self
     }
 
-    /// 设置工作日期 (格式: YYYY-MM-DD)
-    pub fn work_date(mut self, work_date: impl Into<String>) -> Self {
-        self.work_date = Some(work_date.into());
-        self
-    }
-
-    /// 设置开始时间 (格式: HH:mm:ss)
-    pub fn start_time(mut self, start_time: impl Into<String>) -> Self {
-        self.start_time = Some(start_time.into());
-        self
-    }
-
-    /// 设置结束时间 (格式: HH:mm:ss)
-    pub fn end_time(mut self, end_time: impl Into<String>) -> Self {
-        self.end_time = Some(end_time.into());
-        self
-    }
-
-    /// 设置星期几 (1-7)
-    pub fn day_of_week(mut self, day_of_week: i32) -> Self {
-        self.day_of_week = Some(day_of_week);
+    /// 添加一个客服日程。
+    pub fn agent_schedule(mut self, agent_schedule: AgentSchedule) -> Self {
+        self.agent_schedules.push(agent_schedule);
         self
     }
 
     /// 构建请求体
-    pub fn body(&self) -> Result<CreateAgentScheduleBody, String> {
-        let agent_id = self.agent_id.clone().ok_or("agent_id is required")?;
-        let work_date = self.work_date.clone().ok_or("work_date is required")?;
-        let start_time = self.start_time.clone().ok_or("start_time is required")?;
-        let end_time = self.end_time.clone().ok_or("end_time is required")?;
-
-        Ok(CreateAgentScheduleBody {
-            agent_id,
-            work_date,
-            start_time,
-            end_time,
-            day_of_week: self.day_of_week,
-        })
+    pub fn body(&self) -> CreateAgentScheduleBody {
+        CreateAgentScheduleBody {
+            agent_schedules: self.agent_schedules.clone(),
+        }
     }
 
     /// 执行请求
     pub async fn execute(&self) -> SDKResult<CreateAgentScheduleResponse> {
-        let body = self
-            .body()
-            .map_err(|reason| openlark_core::error::validation_error("body", reason))?;
+        let body = self.body();
         let request = CreateAgentScheduleRequest::new(self.config.clone());
         request.execute(body).await
     }
@@ -220,44 +181,49 @@ pub async fn create_agent_schedule_with_options(
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
-    fn test_body_validation_valid() {
+    fn test_body_serialization_matches_official_schema() {
         let body = CreateAgentScheduleBody {
-            agent_id: "agent_123".to_string(),
-            work_date: "2024-01-15".to_string(),
-            start_time: "09:00:00".to_string(),
-            end_time: "18:00:00".to_string(),
-            day_of_week: Some(1),
+            agent_schedules: vec![AgentSchedule {
+                agent_id: "agent_123".to_string(),
+                schedule: Some(vec![WeekdaySchedule {
+                    start_time: "00:00".to_string(),
+                    end_time: "24:00".to_string(),
+                    weekday: 9,
+                }]),
+                agent_skill_ids: Some(vec!["test-skill-id".to_string()]),
+            }],
         };
-        let result = body.validate();
-        assert!(result.is_ok());
+        assert!(body.validate().is_ok());
+        assert_eq!(
+            serde_json::to_value(body).expect("序列化请求体失败"),
+            json!({
+                "agent_schedules": [{
+                    "agent_id": "agent_123",
+                    "schedule": [{
+                        "start_time": "00:00",
+                        "end_time": "24:00",
+                        "weekday": 9
+                    }],
+                    "agent_skill_ids": ["test-skill-id"]
+                }]
+            })
+        );
     }
 
     #[test]
-    fn test_body_validation_empty_agent_id() {
+    fn test_body_validation_rejects_empty_agent_id() {
         let body = CreateAgentScheduleBody {
-            agent_id: "".to_string(),
-            work_date: "2024-01-15".to_string(),
-            start_time: "09:00:00".to_string(),
-            end_time: "18:00:00".to_string(),
-            day_of_week: None,
+            agent_schedules: vec![AgentSchedule::default()],
         };
-        let result = body.validate();
-        assert!(result.is_err());
+        assert!(body.validate().is_err());
     }
 
     #[test]
-    fn test_body_validation_invalid_time() {
-        let body = CreateAgentScheduleBody {
-            agent_id: "agent_123".to_string(),
-            work_date: "2024-01-15".to_string(),
-            start_time: "18:00:00".to_string(),
-            end_time: "09:00:00".to_string(),
-            day_of_week: None,
-        };
-        let result = body.validate();
-        assert!(result.is_err());
+    fn test_body_validation_rejects_empty_list() {
+        assert!(CreateAgentScheduleBody::default().validate().is_err());
     }
 
     #[test]
@@ -266,51 +232,63 @@ mod tests {
             .app_id("test_app_id")
             .app_secret("test_app_secret")
             .build();
-        let builder = CreateAgentScheduleRequestBuilder::new(Arc::new(config));
+        let builder = CreateAgentScheduleRequestBuilder::new(config);
 
-        assert!(builder.agent_id.is_none());
+        assert!(builder.agent_schedules.is_empty());
     }
 
-    /// 端到端：POST .../agent_schedules → 强类型 CreateAgentScheduleResponse 解析（双层 data 信封）。
+    /// 端到端：POST .../agent_schedules → 强类型响应解析。
     #[tokio::test]
     async fn test_create_agent_schedule_returns_data_on_success() {
-        use serde_json::json;
         use wiremock::MockServer;
-        use wiremock::matchers::{method, path};
+        use wiremock::matchers::{body_json, method, path};
         use wiremock::{Mock, ResponseTemplate};
 
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/open-apis/helpdesk/v1/agent_schedules"))
+            .and(body_json(json!({
+                "agent_schedules": [{
+                    "agent_id": "ag_001",
+                    "schedule": [{
+                        "start_time": "00:00",
+                        "end_time": "24:00",
+                        "weekday": 9
+                    }],
+                    "agent_skill_ids": ["test-skill-id"]
+                }]
+            })))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": { "data": { "agent_id": "ag_001", "work_date": "2024-01-15" } }
+                "data": { "agent_schedules": [{ "agent_id": "ag_001" }] }
             })))
             .mount(&server)
             .await;
 
-        let config = Arc::new(
-            Config::builder()
-                .app_id("ci_app_id")
-                .app_secret("ci_app_secret")
-                .base_url(server.uri())
-                .enable_token_cache(false)
-                .build(),
-        );
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
         let body = CreateAgentScheduleBody {
-            agent_id: "ag_001".to_string(),
-            work_date: "2024-01-15".to_string(),
-            start_time: "09:00:00".to_string(),
-            end_time: "18:00:00".to_string(),
-            day_of_week: Some(1),
+            agent_schedules: vec![AgentSchedule {
+                agent_id: "ag_001".to_string(),
+                schedule: Some(vec![WeekdaySchedule {
+                    start_time: "00:00".to_string(),
+                    end_time: "24:00".to_string(),
+                    weekday: 9,
+                }]),
+                agent_skill_ids: Some(vec!["test-skill-id".to_string()]),
+            }],
         };
         let resp = CreateAgentScheduleRequest::new(config)
             .execute(body)
             .await
             .expect("创建客服工作日程应成功");
-        assert!(resp.data.is_some());
+        assert_eq!(resp.agent_schedules.as_ref().map(Vec::len), Some(1));
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_schedule/mod.rs
@@ -34,7 +34,7 @@ impl AgentSchedule {
 
     /// 创建客服工作日程
     pub fn create(&self) -> create::CreateAgentScheduleRequest {
-        create::CreateAgentScheduleRequest::new(self.config.clone())
+        create::CreateAgentScheduleRequest::new(self.config.as_ref().clone())
     }
 
     /// 获取指定客服的工作日程

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/create.rs
@@ -9,7 +9,7 @@ use openlark_core::{
     validate_required,
 };
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use serde_json::Value;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
 use crate::common::api_utils::serialize_params;
@@ -17,20 +17,37 @@ use crate::common::api_utils::serialize_params;
 /// 创建客服技能请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CreateAgentSkillBody {
-    /// 技能名称
+    /// 技能名称。
     pub name: String,
-    /// 技能描述
+    /// 技能规则。
+    pub rules: Vec<AgentSkillRule>,
+    /// 绑定的客服 ID 列表。
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    /// 是否启用
+    pub agent_ids: Option<Vec<String>>,
+}
+
+/// 客服技能规则。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentSkillRule {
+    /// 规则 ID。
+    pub id: String,
+    /// 规则操作符。
+    pub selected_operator: i32,
+    /// 规则操作数。
+    pub operand: Value,
+    /// 规则分类。
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub enable: Option<bool>,
+    pub category: Option<i32>,
 }
 
 impl CreateAgentSkillBody {
     /// 验证请求参数
     pub fn validate(&self) -> openlark_core::SDKResult<()> {
-        validate_required!(self.name, "name is required");
+        validate_required!(self.name, "name 不能为空");
+        validate_required!(self.rules, "rules 不能为空");
+        for rule in &self.rules {
+            validate_required!(rule.id, "规则 id 不能为空");
+        }
         Ok(())
     }
 }
@@ -38,39 +55,34 @@ impl CreateAgentSkillBody {
 /// 创建客服技能响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateAgentSkillResponse {
-    /// 响应数据。
+    /// 技能 ID。
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<CreateAgentSkillResult>,
+    pub id: Option<String>,
+    /// 技能名称。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// 技能规则。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rules: Option<Vec<AgentSkillRule>>,
+    /// 绑定的客服 ID 列表。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_ids: Option<Vec<String>>,
 }
 
 impl openlark_core::api::ApiResponseTrait for CreateAgentSkillResponse {}
 
-/// 创建客服技能结果
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CreateAgentSkillResult {
-    /// 技能ID
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
-    /// 技能名称
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    /// 技能描述
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    /// 是否启用
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub enable: Option<bool>,
-}
+/// 创建客服技能结果。
+pub type CreateAgentSkillResult = CreateAgentSkillResponse;
 
 /// 创建客服技能请求
 #[derive(Debug, Clone)]
 pub struct CreateAgentSkillRequest {
-    config: Arc<Config>,
+    config: Config,
 }
 
 impl CreateAgentSkillRequest {
     /// 创建新的创建客服技能请求
-    pub fn new(config: Arc<Config>) -> Self {
+    pub fn new(config: Config) -> Self {
         Self { config }
     }
 
@@ -99,20 +111,20 @@ impl CreateAgentSkillRequest {
 /// 创建客服技能请求构建器
 #[derive(Debug, Clone)]
 pub struct CreateAgentSkillRequestBuilder {
-    config: Arc<Config>,
+    config: Config,
     name: Option<String>,
-    description: Option<String>,
-    enable: Option<bool>,
+    rules: Vec<AgentSkillRule>,
+    agent_ids: Option<Vec<String>>,
 }
 
 impl CreateAgentSkillRequestBuilder {
     /// 创建新的构建器
-    pub fn new(config: Arc<Config>) -> Self {
+    pub fn new(config: Config) -> Self {
         Self {
             config,
             name: None,
-            description: None,
-            enable: None,
+            rules: Vec::new(),
+            agent_ids: None,
         }
     }
 
@@ -122,15 +134,21 @@ impl CreateAgentSkillRequestBuilder {
         self
     }
 
-    /// 设置技能描述
-    pub fn description(mut self, description: impl Into<String>) -> Self {
-        self.description = Some(description.into());
+    /// 设置技能规则。
+    pub fn rules(mut self, rules: Vec<AgentSkillRule>) -> Self {
+        self.rules = rules;
         self
     }
 
-    /// 设置是否启用
-    pub fn enable(mut self, enable: bool) -> Self {
-        self.enable = Some(enable);
+    /// 添加一条技能规则。
+    pub fn rule(mut self, rule: AgentSkillRule) -> Self {
+        self.rules.push(rule);
+        self
+    }
+
+    /// 设置绑定的客服 ID 列表。
+    pub fn agent_ids(mut self, agent_ids: Vec<String>) -> Self {
+        self.agent_ids = Some(agent_ids);
         self
     }
 
@@ -140,8 +158,8 @@ impl CreateAgentSkillRequestBuilder {
 
         Ok(CreateAgentSkillBody {
             name,
-            description: self.description.clone(),
-            enable: self.enable,
+            rules: self.rules.clone(),
+            agent_ids: self.agent_ids.clone(),
         })
     }
 
@@ -182,27 +200,49 @@ pub async fn create_agent_skill_with_options(
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
-    fn test_body_validation_valid() {
+    fn test_body_serialization_matches_official_schema() {
         let body = CreateAgentSkillBody {
             name: "技术支持".to_string(),
-            description: Some("提供技术支持服务".to_string()),
-            enable: Some(true),
+            rules: vec![AgentSkillRule {
+                id: "rule_001".to_string(),
+                selected_operator: 1,
+                operand: json!("vip"),
+                category: Some(2),
+            }],
+            agent_ids: Some(vec!["agent_001".to_string()]),
         };
-        let result = body.validate();
-        assert!(result.is_ok());
+        assert!(body.validate().is_ok());
+        assert_eq!(
+            serde_json::to_value(body).expect("序列化请求体失败"),
+            json!({
+                "name": "技术支持",
+                "rules": [{
+                    "id": "rule_001",
+                    "selected_operator": 1,
+                    "operand": "vip",
+                    "category": 2
+                }],
+                "agent_ids": ["agent_001"]
+            })
+        );
     }
 
     #[test]
-    fn test_body_validation_empty_name() {
+    fn test_body_validation_rejects_empty_name() {
         let body = CreateAgentSkillBody {
-            name: "".to_string(),
-            description: None,
-            enable: None,
+            name: " ".to_string(),
+            rules: vec![AgentSkillRule {
+                id: "rule_001".to_string(),
+                selected_operator: 1,
+                operand: json!("vip"),
+                category: None,
+            }],
+            agent_ids: None,
         };
-        let result = body.validate();
-        assert!(result.is_err());
+        assert!(body.validate().is_err());
     }
 
     #[test]
@@ -211,49 +251,61 @@ mod tests {
             .app_id("test_app_id")
             .app_secret("test_app_secret")
             .build();
-        let builder = CreateAgentSkillRequestBuilder::new(Arc::new(config));
+        let builder = CreateAgentSkillRequestBuilder::new(config);
 
         assert!(builder.name.is_none());
     }
 
-    /// 端到端：POST .../agent_skills → 强类型 CreateAgentSkillResponse 解析（双层 data 信封）。
+    /// 端到端：POST .../agent_skills → 强类型响应解析。
     #[tokio::test]
     async fn test_create_agent_skill_returns_data_on_success() {
-        use serde_json::json;
         use wiremock::MockServer;
-        use wiremock::matchers::{method, path};
+        use wiremock::matchers::{body_json, method, path};
         use wiremock::{Mock, ResponseTemplate};
 
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/open-apis/helpdesk/v1/agent_skills"))
+            .and(body_json(json!({
+                "name": "技术支持",
+                "rules": [{
+                    "id": "rule_001",
+                    "selected_operator": 1,
+                    "operand": "vip",
+                    "category": 2
+                }],
+                "agent_ids": ["agent_001"]
+            })))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": { "data": { "id": "skl_001", "name": "技术支持" } }
+                "data": { "id": "skl_001", "name": "技术支持" }
             })))
             .mount(&server)
             .await;
 
-        let config = Arc::new(
-            Config::builder()
-                .app_id("ci_app_id")
-                .app_secret("ci_app_secret")
-                .base_url(server.uri())
-                .enable_token_cache(false)
-                .build(),
-        );
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
         let body = CreateAgentSkillBody {
             name: "技术支持".to_string(),
-            description: Some("提供技术支持服务".to_string()),
-            enable: Some(true),
+            rules: vec![AgentSkillRule {
+                id: "rule_001".to_string(),
+                selected_operator: 1,
+                operand: json!("vip"),
+                category: Some(2),
+            }],
+            agent_ids: Some(vec!["agent_001".to_string()]),
         };
         let resp = CreateAgentSkillRequest::new(config)
             .execute(body)
             .await
             .expect("创建客服技能应成功");
-        assert!(resp.data.is_some());
+        assert_eq!(resp.id.as_deref(), Some("skl_001"));
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/mod.rs
@@ -34,7 +34,7 @@ impl AgentSkill {
 
     /// 创建客服技能
     pub fn create(&self) -> create::CreateAgentSkillRequest {
-        create::CreateAgentSkillRequest::new(self.config.clone())
+        create::CreateAgentSkillRequest::new(self.config.as_ref().clone())
     }
 
     /// 获取指定客服技能
@@ -44,7 +44,7 @@ impl AgentSkill {
 
     /// 更新指定客服技能
     pub fn patch(&self, agent_skill_id: impl Into<String>) -> patch::PatchAgentSkillRequest {
-        patch::PatchAgentSkillRequest::new(self.config.clone(), agent_skill_id.into())
+        patch::PatchAgentSkillRequest::new(self.config.as_ref().clone(), agent_skill_id.into())
     }
 
     /// 删除指定客服技能

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/agent_skill/patch.rs
@@ -6,36 +6,45 @@
 
 use openlark_core::{
     SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
 use crate::common::api_utils::serialize_params;
+use crate::helpdesk::helpdesk::v1::agent_skill::create::AgentSkillRule;
 
 /// 更新客服技能请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct PatchAgentSkillBody {
-    /// 技能名称
+    /// 客服技能。
+    pub agent_skill: AgentSkill,
+}
+
+/// 待更新的客服技能。
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AgentSkill {
+    /// 技能名称。
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    /// 技能描述
+    /// 技能规则。
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    /// 是否启用
+    pub rules: Option<Vec<AgentSkillRule>>,
+    /// 绑定的客服 ID 列表。
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub enable: Option<bool>,
+    pub agent_ids: Option<Vec<String>>,
 }
 
 impl PatchAgentSkillBody {
     /// 验证请求参数
     pub fn validate(&self) -> openlark_core::SDKResult<()> {
-        if let Some(name) = &self.name
-            && name.is_empty()
-        {
-            return Err(openlark_core::CoreError::validation_msg(
-                "name cannot be empty",
-            ));
+        if let Some(name) = &self.agent_skill.name {
+            validate_required!(name, "name 不能为空");
+        }
+        if let Some(rules) = &self.agent_skill.rules {
+            for rule in rules {
+                validate_required!(rule.id, "规则 id 不能为空");
+            }
         }
         Ok(())
     }
@@ -44,40 +53,35 @@ impl PatchAgentSkillBody {
 /// 更新客服技能响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PatchAgentSkillResponse {
-    /// 响应数据。
+    /// 技能 ID。
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<PatchAgentSkillResult>,
+    pub id: Option<String>,
+    /// 技能名称。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// 技能规则。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rules: Option<Vec<AgentSkillRule>>,
+    /// 绑定的客服 ID 列表。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_ids: Option<Vec<String>>,
 }
 
 impl openlark_core::api::ApiResponseTrait for PatchAgentSkillResponse {}
 
-/// 更新客服技能结果
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PatchAgentSkillResult {
-    /// 技能ID
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
-    /// 技能名称
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    /// 技能描述
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    /// 是否启用
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub enable: Option<bool>,
-}
+/// 更新客服技能结果。
+pub type PatchAgentSkillResult = PatchAgentSkillResponse;
 
 /// 更新客服技能请求
 #[derive(Debug, Clone)]
 pub struct PatchAgentSkillRequest {
-    config: Arc<Config>,
+    config: Config,
     agent_skill_id: String,
 }
 
 impl PatchAgentSkillRequest {
     /// 创建新的更新客服技能请求
-    pub fn new(config: Arc<Config>, agent_skill_id: String) -> Self {
+    pub fn new(config: Config, agent_skill_id: String) -> Self {
         Self {
             config,
             agent_skill_id,
@@ -109,22 +113,22 @@ impl PatchAgentSkillRequest {
 /// 更新客服技能请求构建器
 #[derive(Debug, Clone)]
 pub struct PatchAgentSkillRequestBuilder {
-    config: Arc<Config>,
+    config: Config,
     agent_skill_id: String,
     name: Option<String>,
-    description: Option<String>,
-    enable: Option<bool>,
+    rules: Option<Vec<AgentSkillRule>>,
+    agent_ids: Option<Vec<String>>,
 }
 
 impl PatchAgentSkillRequestBuilder {
     /// 创建新的构建器
-    pub fn new(config: Arc<Config>, agent_skill_id: String) -> Self {
+    pub fn new(config: Config, agent_skill_id: String) -> Self {
         Self {
             config,
             agent_skill_id,
             name: None,
-            description: None,
-            enable: None,
+            rules: None,
+            agent_ids: None,
         }
     }
 
@@ -134,24 +138,26 @@ impl PatchAgentSkillRequestBuilder {
         self
     }
 
-    /// 设置技能描述
-    pub fn description(mut self, description: impl Into<String>) -> Self {
-        self.description = Some(description.into());
+    /// 设置技能规则。
+    pub fn rules(mut self, rules: Vec<AgentSkillRule>) -> Self {
+        self.rules = Some(rules);
         self
     }
 
-    /// 设置是否启用
-    pub fn enable(mut self, enable: bool) -> Self {
-        self.enable = Some(enable);
+    /// 设置绑定的客服 ID 列表。
+    pub fn agent_ids(mut self, agent_ids: Vec<String>) -> Self {
+        self.agent_ids = Some(agent_ids);
         self
     }
 
     /// 构建请求体
     pub fn body(&self) -> PatchAgentSkillBody {
         PatchAgentSkillBody {
-            name: self.name.clone(),
-            description: self.description.clone(),
-            enable: self.enable,
+            agent_skill: AgentSkill {
+                name: self.name.clone(),
+                rules: self.rules.clone(),
+                agent_ids: self.agent_ids.clone(),
+            },
         }
     }
 
@@ -202,6 +208,7 @@ pub async fn patch_agent_skill_with_options(
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_body_validation_empty() {
@@ -211,25 +218,46 @@ mod tests {
     }
 
     #[test]
-    fn test_body_validation_valid() {
+    fn test_body_serialization_matches_official_schema() {
         let body = PatchAgentSkillBody {
-            name: Some("新技能名称".to_string()),
-            description: Some("更新描述".to_string()),
-            enable: Some(true),
+            agent_skill: AgentSkill {
+                name: Some("新技能名称".to_string()),
+                rules: Some(vec![AgentSkillRule {
+                    id: "rule_001".to_string(),
+                    selected_operator: 1,
+                    operand: json!("vip"),
+                    category: None,
+                }]),
+                agent_ids: Some(vec!["agent_001".to_string()]),
+            },
         };
-        let result = body.validate();
-        assert!(result.is_ok());
+        assert!(body.validate().is_ok());
+        assert_eq!(
+            serde_json::to_value(body).expect("序列化请求体失败"),
+            json!({
+                "agent_skill": {
+                    "name": "新技能名称",
+                    "rules": [{
+                        "id": "rule_001",
+                        "selected_operator": 1,
+                        "operand": "vip"
+                    }],
+                    "agent_ids": ["agent_001"]
+                }
+            })
+        );
     }
 
     #[test]
     fn test_body_validation_empty_name() {
         let body = PatchAgentSkillBody {
-            name: Some("".to_string()),
-            description: None,
-            enable: None,
+            agent_skill: AgentSkill {
+                name: Some(" ".to_string()),
+                rules: None,
+                agent_ids: None,
+            },
         };
-        let result = body.validate();
-        assert!(result.is_err());
+        assert!(body.validate().is_err());
     }
 
     #[test]
@@ -238,50 +266,65 @@ mod tests {
             .app_id("test_app_id")
             .app_secret("test_app_secret")
             .build();
-        let builder = PatchAgentSkillRequestBuilder::new(Arc::new(config), "skill_123".to_string());
+        let builder = PatchAgentSkillRequestBuilder::new(config, "skill_123".to_string());
 
         assert_eq!(builder.agent_skill_id, "skill_123");
         assert!(builder.name.is_none());
     }
 
-    /// 端到端：PATCH .../agent_skills/{agent_skill_id} → 强类型 PatchAgentSkillResponse 解析（双层 data 信封）。
+    /// 端到端：PATCH .../agent_skills/{agent_skill_id} → 强类型响应解析。
     #[tokio::test]
     async fn test_patch_agent_skill_returns_data_on_success() {
-        use serde_json::json;
         use wiremock::MockServer;
-        use wiremock::matchers::{method, path};
+        use wiremock::matchers::{body_json, method, path};
         use wiremock::{Mock, ResponseTemplate};
 
         let server = MockServer::start().await;
         Mock::given(method("PATCH"))
             .and(path("/open-apis/helpdesk/v1/agent_skills/skl_001"))
+            .and(body_json(json!({
+                "agent_skill": {
+                    "name": "更新后技能",
+                    "rules": [{
+                        "id": "rule_001",
+                        "selected_operator": 1,
+                        "operand": "vip"
+                    }],
+                    "agent_ids": ["agent_001"]
+                }
+            })))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": { "data": { "id": "skl_001", "name": "更新后技能", "enable": true } }
+                "data": { "id": "skl_001", "name": "更新后技能" }
             })))
             .mount(&server)
             .await;
 
-        let config = Arc::new(
-            Config::builder()
-                .app_id("ci_app_id")
-                .app_secret("ci_app_secret")
-                .base_url(server.uri())
-                .enable_token_cache(false)
-                .build(),
-        );
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
         let body = PatchAgentSkillBody {
-            name: Some("更新后技能".to_string()),
-            enable: Some(true),
-            description: None,
+            agent_skill: AgentSkill {
+                name: Some("更新后技能".to_string()),
+                rules: Some(vec![AgentSkillRule {
+                    id: "rule_001".to_string(),
+                    selected_operator: 1,
+                    operand: json!("vip"),
+                    category: None,
+                }]),
+                agent_ids: Some(vec!["agent_001".to_string()]),
+            },
         };
         let resp = PatchAgentSkillRequest::new(config, "skl_001".to_string())
             .execute(body)
             .await
             .expect("更新客服技能应成功");
-        assert!(resp.data.is_some());
+        assert_eq!(resp.id.as_deref(), Some("skl_001"));
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/bot/message/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/bot/message/create.rs
@@ -212,6 +212,28 @@ mod tests {
     }
 
     #[test]
+    fn test_body_validation_missing_msg_type() {
+        let body = CreateBotMessageBody {
+            msg_type: String::new(),
+            content: r#"{"text":"hello"}"#.to_string(),
+            receiver_id: "ou_xxx".to_string(),
+            receive_type: None,
+        };
+        assert!(body.validate().is_err());
+    }
+
+    #[test]
+    fn test_body_validation_missing_content() {
+        let body = CreateBotMessageBody {
+            msg_type: "post".to_string(),
+            content: String::new(),
+            receiver_id: "ou_xxx".to_string(),
+            receive_type: None,
+        };
+        assert!(body.validate().is_err());
+    }
+
+    #[test]
     fn test_body_serialization_matches_official_shape() {
         let body = CreateBotMessageBody {
             msg_type: "post".to_string(),

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/bot/message/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/bot/message/create.rs
@@ -10,9 +10,9 @@ use openlark_core::{
     config::Config,
     http::Transport,
     req_option::RequestOption,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
 use crate::common::api_utils::serialize_params;
@@ -20,35 +20,23 @@ use crate::common::api_utils::serialize_params;
 /// 通过服务台机器人发送消息请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CreateBotMessageBody {
-    /// 接收者的 open_id
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub receive_id: Option<String>,
     /// 消息类型
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub msg_type: Option<String>,
+    pub msg_type: String,
     /// 消息内容
+    pub content: String,
+    /// 接收者 ID
+    pub receiver_id: String,
+    /// 接收者类型
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<String>,
+    pub receive_type: Option<String>,
 }
 
 impl CreateBotMessageBody {
     /// 验证请求参数
     pub fn validate(&self) -> openlark_core::SDKResult<()> {
-        if self.receive_id.is_none() {
-            return Err(openlark_core::CoreError::validation_msg(
-                "receive_id is required",
-            ));
-        }
-        if self.msg_type.is_none() {
-            return Err(openlark_core::CoreError::validation_msg(
-                "msg_type is required",
-            ));
-        }
-        if self.content.is_none() {
-            return Err(openlark_core::CoreError::validation_msg(
-                "content is required",
-            ));
-        }
+        validate_required!(self.msg_type, "msg_type 不能为空");
+        validate_required!(self.content, "content 不能为空");
+        validate_required!(self.receiver_id, "receiver_id 不能为空");
         Ok(())
     }
 }
@@ -70,12 +58,12 @@ impl ApiResponseTrait for CreateBotMessageResponse {
 /// 通过服务台机器人发送消息请求
 #[derive(Debug, Clone)]
 pub struct CreateBotMessageRequest {
-    config: Arc<Config>,
+    config: Config,
 }
 
 impl CreateBotMessageRequest {
     /// 创建新的通过服务台机器人发送消息请求
-    pub fn new(config: Arc<Config>) -> Self {
+    pub fn new(config: Config) -> Self {
         Self { config }
     }
 
@@ -104,27 +92,23 @@ impl CreateBotMessageRequest {
 /// 通过服务台机器人发送消息请求构建器
 #[derive(Debug, Clone)]
 pub struct CreateBotMessageRequestBuilder {
-    config: Arc<Config>,
-    receive_id: Option<String>,
+    config: Config,
     msg_type: Option<String>,
     content: Option<String>,
+    receiver_id: Option<String>,
+    receive_type: Option<String>,
 }
 
 impl CreateBotMessageRequestBuilder {
     /// 创建新的构建器
-    pub fn new(config: Arc<Config>) -> Self {
+    pub fn new(config: Config) -> Self {
         Self {
             config,
-            receive_id: None,
             msg_type: None,
             content: None,
+            receiver_id: None,
+            receive_type: None,
         }
-    }
-
-    /// 设置接收者的 open_id
-    pub fn receive_id(mut self, receive_id: impl Into<String>) -> Self {
-        self.receive_id = Some(receive_id.into());
-        self
     }
 
     /// 设置消息类型
@@ -139,16 +123,29 @@ impl CreateBotMessageRequestBuilder {
         self
     }
 
+    /// 设置接收者 ID
+    pub fn receiver_id(mut self, receiver_id: impl Into<String>) -> Self {
+        self.receiver_id = Some(receiver_id.into());
+        self
+    }
+
+    /// 设置接收者类型
+    pub fn receive_type(mut self, receive_type: impl Into<String>) -> Self {
+        self.receive_type = Some(receive_type.into());
+        self
+    }
+
     /// 构建请求体
     pub fn body(&self) -> Result<CreateBotMessageBody, String> {
-        let receive_id = self.receive_id.clone().ok_or("receive_id is required")?;
-        let msg_type = self.msg_type.clone().ok_or("msg_type is required")?;
-        let content = self.content.clone().ok_or("content is required")?;
+        let msg_type = self.msg_type.clone().ok_or("msg_type 不能为空")?;
+        let content = self.content.clone().ok_or("content 不能为空")?;
+        let receiver_id = self.receiver_id.clone().ok_or("receiver_id 不能为空")?;
 
         Ok(CreateBotMessageBody {
-            receive_id: Some(receive_id),
-            msg_type: Some(msg_type),
-            content: Some(content),
+            msg_type,
+            content,
+            receiver_id,
+            receive_type: self.receive_type.clone(),
         })
     }
 
@@ -193,23 +190,40 @@ mod tests {
     #[test]
     fn test_body_validation_valid() {
         let body = CreateBotMessageBody {
-            receive_id: Some("ou_xxx".to_string()),
-            msg_type: Some("text".to_string()),
-            content: Some(r#"{"text":"hello"}"#.to_string()),
+            msg_type: "post".to_string(),
+            content: r#"{"text":"hello"}"#.to_string(),
+            receiver_id: "ou_xxx".to_string(),
+            receive_type: Some("chat".to_string()),
         };
         let result = body.validate();
         assert!(result.is_ok());
     }
 
     #[test]
-    fn test_body_validation_missing_receive_id() {
+    fn test_body_validation_missing_receiver_id() {
         let body = CreateBotMessageBody {
-            receive_id: None,
-            msg_type: Some("text".to_string()),
-            content: Some(r#"{"text":"hello"}"#.to_string()),
+            msg_type: "post".to_string(),
+            content: r#"{"text":"hello"}"#.to_string(),
+            receiver_id: String::new(),
+            receive_type: None,
         };
         let result = body.validate();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_body_serialization_matches_official_shape() {
+        let body = CreateBotMessageBody {
+            msg_type: "post".to_string(),
+            content: "消息内容".to_string(),
+            receiver_id: "ou_xxx".to_string(),
+            receive_type: Some("chat".to_string()),
+        };
+        let value = serde_json::to_value(body).expect("请求体应可序列化");
+
+        assert_eq!(value["receiver_id"], "ou_xxx");
+        assert_eq!(value["receive_type"], "chat");
+        assert!(value.get("receive_id").is_none());
     }
 
     #[test]
@@ -218,9 +232,9 @@ mod tests {
             .app_id("test_app_id")
             .app_secret("test_app_secret")
             .build();
-        let builder = CreateBotMessageRequestBuilder::new(Arc::new(config));
+        let builder = CreateBotMessageRequestBuilder::new(config);
 
-        assert!(builder.receive_id.is_none());
+        assert!(builder.receiver_id.is_none());
     }
 
     /// 端到端：POST .../message → 强类型 CreateBotMessageResponse 解析（data 内层为 message_id）。
@@ -242,19 +256,18 @@ mod tests {
             .mount(&server)
             .await;
 
-        let config = Arc::new(
-            Config::builder()
-                .app_id("ci_app_id")
-                .app_secret("ci_app_secret")
-                .base_url(server.uri())
-                .enable_token_cache(false)
-                .build(),
-        );
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
         let body = CreateBotMessageBody {
-            receive_id: Some("ou_test_user".to_string()),
-            msg_type: Some("text".to_string()),
-            content: Some(r#"{"text":"hello"}"#.to_string()),
+            msg_type: "text".to_string(),
+            content: r#"{"text":"hello"}"#.to_string(),
+            receiver_id: "ou_test_user".to_string(),
+            receive_type: None,
         };
         let resp = CreateBotMessageRequest::new(config)
             .execute(body)

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/bot/message/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/bot/message/mod.rs
@@ -23,6 +23,6 @@ impl Message {
 
     /// 通过服务台机器人发送消息
     pub fn create(&self) -> create::CreateBotMessageRequestBuilder {
-        create::CreateBotMessageRequestBuilder::new(self.config.clone())
+        create::CreateBotMessageRequestBuilder::new(self.config.as_ref().clone())
     }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/create.rs
@@ -9,7 +9,6 @@ use openlark_core::{
     validate_required,
 };
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
 use crate::common::api_utils::serialize_params;
@@ -19,21 +18,18 @@ use crate::common::api_utils::serialize_params;
 pub struct CreateCategoryBody {
     /// 分类名称
     pub name: String,
-    /// 分类描述
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
     /// 父分类ID
+    pub parent_id: String,
+    /// 语言。
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub parent_id: Option<String>,
-    /// 排序
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub order: Option<i32>,
+    pub language: Option<String>,
 }
 
 impl CreateCategoryBody {
     /// 验证请求参数
     pub fn validate(&self) -> openlark_core::SDKResult<()> {
-        validate_required!(self.name, "name is required");
+        validate_required!(self.name, "name 不能为空");
+        validate_required!(self.parent_id, "parent_id 不能为空");
         Ok(())
     }
 }
@@ -41,42 +37,34 @@ impl CreateCategoryBody {
 /// 创建知识库分类响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateCategoryResponse {
-    /// 响应数据。
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<CreateCategoryResult>,
-}
-
-impl openlark_core::api::ApiResponseTrait for CreateCategoryResponse {}
-
-/// 创建知识库分类结果
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CreateCategoryResult {
     /// 分类ID
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     /// 分类名称
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    /// 分类描述
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
     /// 父分类ID
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<String>,
-    /// 排序
+    /// 语言。
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub order: Option<i32>,
+    pub language: Option<String>,
 }
+
+impl openlark_core::api::ApiResponseTrait for CreateCategoryResponse {}
+
+/// 创建知识库分类结果。
+pub type CreateCategoryResult = CreateCategoryResponse;
 
 /// 创建知识库分类请求
 #[derive(Debug, Clone)]
 pub struct CreateCategoryRequest {
-    config: Arc<Config>,
+    config: Config,
 }
 
 impl CreateCategoryRequest {
     /// 创建新的创建知识库分类请求
-    pub fn new(config: Arc<Config>) -> Self {
+    pub fn new(config: Config) -> Self {
         Self { config }
     }
 
@@ -105,22 +93,20 @@ impl CreateCategoryRequest {
 /// 创建知识库分类请求构建器
 #[derive(Debug, Clone)]
 pub struct CreateCategoryRequestBuilder {
-    config: Arc<Config>,
+    config: Config,
     name: Option<String>,
-    description: Option<String>,
     parent_id: Option<String>,
-    order: Option<i32>,
+    language: Option<String>,
 }
 
 impl CreateCategoryRequestBuilder {
     /// 创建新的构建器
-    pub fn new(config: Arc<Config>) -> Self {
+    pub fn new(config: Config) -> Self {
         Self {
             config,
             name: None,
-            description: None,
             parent_id: None,
-            order: None,
+            language: None,
         }
     }
 
@@ -130,33 +116,27 @@ impl CreateCategoryRequestBuilder {
         self
     }
 
-    /// 设置分类描述
-    pub fn description(mut self, description: impl Into<String>) -> Self {
-        self.description = Some(description.into());
-        self
-    }
-
     /// 设置父分类ID
     pub fn parent_id(mut self, parent_id: impl Into<String>) -> Self {
         self.parent_id = Some(parent_id.into());
         self
     }
 
-    /// 设置排序
-    pub fn order(mut self, order: i32) -> Self {
-        self.order = Some(order);
+    /// 设置语言。
+    pub fn language(mut self, language: impl Into<String>) -> Self {
+        self.language = Some(language.into());
         self
     }
 
     /// 构建请求体
     pub fn body(&self) -> Result<CreateCategoryBody, String> {
         let name = self.name.clone().ok_or("name is required")?;
+        let parent_id = self.parent_id.clone().ok_or("parent_id is required")?;
 
         Ok(CreateCategoryBody {
             name,
-            description: self.description.clone(),
-            parent_id: self.parent_id.clone(),
-            order: self.order,
+            parent_id,
+            language: self.language.clone(),
         })
     }
 
@@ -197,29 +177,45 @@ pub async fn create_category_with_options(
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
-    fn test_body_validation_valid() {
+    fn test_body_serialization_matches_official_schema() {
         let body = CreateCategoryBody {
             name: "技术问题".to_string(),
-            description: Some("技术相关问题分类".to_string()),
-            parent_id: None,
-            order: Some(1),
+            parent_id: "0".to_string(),
+            language: Some("zh_cn".to_string()),
         };
-        let result = body.validate();
-        assert!(result.is_ok());
+        assert!(body.validate().is_ok());
+        assert_eq!(
+            serde_json::to_value(body).expect("序列化请求体失败"),
+            json!({
+                "name": "技术问题",
+                "parent_id": "0",
+                "language": "zh_cn"
+            })
+        );
     }
 
     #[test]
     fn test_body_validation_empty_name() {
         let body = CreateCategoryBody {
             name: "".to_string(),
-            description: None,
-            parent_id: None,
-            order: None,
+            parent_id: "0".to_string(),
+            language: None,
         };
         let result = body.validate();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_body_validation_empty_parent_id() {
+        let body = CreateCategoryBody {
+            name: "技术问题".to_string(),
+            parent_id: " ".to_string(),
+            language: None,
+        };
+        assert!(body.validate().is_err());
     }
 
     #[test]
@@ -228,50 +224,51 @@ mod tests {
             .app_id("test_app_id")
             .app_secret("test_app_secret")
             .build();
-        let builder = CreateCategoryRequestBuilder::new(Arc::new(config));
+        let builder = CreateCategoryRequestBuilder::new(config);
 
         assert!(builder.name.is_none());
     }
 
-    /// 端到端：POST .../categories → 强类型 CreateCategoryResponse 解析（双层 data 信封）。
+    /// 端到端：POST .../categories → 强类型响应解析。
     #[tokio::test]
     async fn test_create_category_returns_data_on_success() {
-        use serde_json::json;
         use wiremock::MockServer;
-        use wiremock::matchers::{method, path};
+        use wiremock::matchers::{body_json, method, path};
         use wiremock::{Mock, ResponseTemplate};
 
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/open-apis/helpdesk/v1/categories"))
+            .and(body_json(json!({
+                "name": "技术问题",
+                "parent_id": "0",
+                "language": "zh_cn"
+            })))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": { "data": { "id": "cat_new", "name": "技术问题" } }
+                "data": { "id": "cat_new", "name": "技术问题", "parent_id": "0", "language": "zh_cn" }
             })))
             .mount(&server)
             .await;
 
-        let config = Arc::new(
-            Config::builder()
-                .app_id("ci_app_id")
-                .app_secret("ci_app_secret")
-                .base_url(server.uri())
-                .enable_token_cache(false)
-                .build(),
-        );
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
         let body = CreateCategoryBody {
             name: "技术问题".to_string(),
-            description: None,
-            parent_id: None,
-            order: None,
+            parent_id: "0".to_string(),
+            language: Some("zh_cn".to_string()),
         };
         let resp = CreateCategoryRequest::new(config)
             .execute(body)
             .await
             .expect("创建分类应成功");
-        assert!(resp.data.is_some());
+        assert_eq!(resp.id.as_deref(), Some("cat_new"));
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/mod.rs
@@ -34,7 +34,7 @@ impl Category {
 
     /// 创建知识库分类
     pub fn create(&self) -> create::CreateCategoryRequest {
-        create::CreateCategoryRequest::new(self.config.clone())
+        create::CreateCategoryRequest::new(self.config.as_ref().clone())
     }
 
     /// 获取指定知识库分类
@@ -44,7 +44,7 @@ impl Category {
 
     /// 更新指定知识库分类
     pub fn patch(&self, id: impl Into<String>) -> patch::PatchCategoryRequest {
-        patch::PatchCategoryRequest::new(self.config.clone(), id.into())
+        patch::PatchCategoryRequest::new(self.config.as_ref().clone(), id.into())
     }
 
     /// 删除指定知识库分类

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/category/patch.rs
@@ -6,9 +6,9 @@
 
 use openlark_core::{
     SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
 use crate::common::api_utils::serialize_params;
@@ -19,26 +19,19 @@ pub struct PatchCategoryBody {
     /// 分类名称
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    /// 分类描述
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
     /// 父分类ID
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<String>,
-    /// 排序
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub order: Option<i32>,
 }
 
 impl PatchCategoryBody {
     /// 验证请求参数
     pub fn validate(&self) -> openlark_core::SDKResult<()> {
-        if let Some(name) = &self.name
-            && name.is_empty()
-        {
-            return Err(openlark_core::CoreError::validation_msg(
-                "name cannot be empty",
-            ));
+        if let Some(name) = &self.name {
+            validate_required!(name, "name 不能为空");
+        }
+        if let Some(parent_id) = &self.parent_id {
+            validate_required!(parent_id, "parent_id 不能为空");
         }
         Ok(())
     }
@@ -47,43 +40,32 @@ impl PatchCategoryBody {
 /// 更新知识库分类响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PatchCategoryResponse {
-    /// 响应数据。
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<PatchCategoryResult>,
-}
-
-impl openlark_core::api::ApiResponseTrait for PatchCategoryResponse {}
-
-/// 更新知识库分类结果
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PatchCategoryResult {
     /// 分类ID
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     /// 分类名称
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    /// 分类描述
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
     /// 父分类ID
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<String>,
-    /// 排序
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub order: Option<i32>,
 }
+
+impl openlark_core::api::ApiResponseTrait for PatchCategoryResponse {}
+
+/// 更新知识库分类结果。
+pub type PatchCategoryResult = PatchCategoryResponse;
 
 /// 更新知识库分类请求
 #[derive(Debug, Clone)]
 pub struct PatchCategoryRequest {
-    config: Arc<Config>,
+    config: Config,
     id: String,
 }
 
 impl PatchCategoryRequest {
     /// 创建新的更新知识库分类请求
-    pub fn new(config: Arc<Config>, id: String) -> Self {
+    pub fn new(config: Config, id: String) -> Self {
         Self { config, id }
     }
 
@@ -112,24 +94,20 @@ impl PatchCategoryRequest {
 /// 更新知识库分类请求构建器
 #[derive(Debug, Clone)]
 pub struct PatchCategoryRequestBuilder {
-    config: Arc<Config>,
+    config: Config,
     id: String,
     name: Option<String>,
-    description: Option<String>,
     parent_id: Option<String>,
-    order: Option<i32>,
 }
 
 impl PatchCategoryRequestBuilder {
     /// 创建新的构建器
-    pub fn new(config: Arc<Config>, id: String) -> Self {
+    pub fn new(config: Config, id: String) -> Self {
         Self {
             config,
             id,
             name: None,
-            description: None,
             parent_id: None,
-            order: None,
         }
     }
 
@@ -139,21 +117,9 @@ impl PatchCategoryRequestBuilder {
         self
     }
 
-    /// 设置分类描述
-    pub fn description(mut self, description: impl Into<String>) -> Self {
-        self.description = Some(description.into());
-        self
-    }
-
     /// 设置父分类ID
     pub fn parent_id(mut self, parent_id: impl Into<String>) -> Self {
         self.parent_id = Some(parent_id.into());
-        self
-    }
-
-    /// 设置排序
-    pub fn order(mut self, order: i32) -> Self {
-        self.order = Some(order);
         self
     }
 
@@ -161,9 +127,7 @@ impl PatchCategoryRequestBuilder {
     pub fn body(&self) -> PatchCategoryBody {
         PatchCategoryBody {
             name: self.name.clone(),
-            description: self.description.clone(),
             parent_id: self.parent_id.clone(),
-            order: self.order,
         }
     }
 
@@ -214,6 +178,7 @@ pub async fn patch_category_with_options(
 #[allow(unused_imports)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_body_validation_empty() {
@@ -223,24 +188,26 @@ mod tests {
     }
 
     #[test]
-    fn test_body_validation_valid() {
+    fn test_body_serialization_matches_official_schema() {
         let body = PatchCategoryBody {
             name: Some("新分类名称".to_string()),
-            description: Some("更新描述".to_string()),
-            parent_id: None,
-            order: Some(1),
+            parent_id: Some("cat_root".to_string()),
         };
-        let result = body.validate();
-        assert!(result.is_ok());
+        assert!(body.validate().is_ok());
+        assert_eq!(
+            serde_json::to_value(body).expect("序列化请求体失败"),
+            json!({
+                "name": "新分类名称",
+                "parent_id": "cat_root"
+            })
+        );
     }
 
     #[test]
     fn test_body_validation_empty_name() {
         let body = PatchCategoryBody {
-            name: Some("".to_string()),
-            description: None,
+            name: Some(" ".to_string()),
             parent_id: None,
-            order: None,
         };
         let result = body.validate();
         assert!(result.is_err());
@@ -252,52 +219,50 @@ mod tests {
             .app_id("test_app_id")
             .app_secret("test_app_secret")
             .build();
-        let builder =
-            PatchCategoryRequestBuilder::new(Arc::new(config), "category_123".to_string());
+        let builder = PatchCategoryRequestBuilder::new(config, "category_123".to_string());
 
         assert_eq!(builder.id, "category_123");
         assert!(builder.name.is_none());
     }
 
-    /// 端到端：PATCH .../categories/{id} → 强类型 PatchCategoryResponse 解析（双层 data 信封）。
+    /// 端到端：PATCH .../categories/{id} → 强类型响应解析。
     #[tokio::test]
     async fn test_patch_category_returns_data_on_success() {
-        use serde_json::json;
         use wiremock::MockServer;
-        use wiremock::matchers::{method, path};
+        use wiremock::matchers::{body_json, method, path};
         use wiremock::{Mock, ResponseTemplate};
 
         let server = MockServer::start().await;
         Mock::given(method("PATCH"))
             .and(path("/open-apis/helpdesk/v1/categories/cat_001"))
+            .and(body_json(json!({
+                "name": "新名称",
+                "parent_id": "cat_root"
+            })))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": { "data": { "id": "cat_001", "name": "新名称" } }
+                "data": { "id": "cat_001", "name": "新名称", "parent_id": "cat_root" }
             })))
             .mount(&server)
             .await;
 
-        let config = Arc::new(
-            Config::builder()
-                .app_id("ci_app_id")
-                .app_secret("ci_app_secret")
-                .base_url(server.uri())
-                .enable_token_cache(false)
-                .build(),
-        );
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
         let body = PatchCategoryBody {
             name: Some("新名称".to_string()),
-            description: None,
-            parent_id: None,
-            order: None,
+            parent_id: Some("cat_root".to_string()),
         };
         let resp = PatchCategoryRequest::new(config, "cat_001".to_string())
             .execute(body)
             .await
             .expect("更新分类应成功");
-        assert!(resp.data.is_some());
+        assert_eq!(resp.id.as_deref(), Some("cat_001"));
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/create.rs
@@ -9,7 +9,6 @@ use openlark_core::{
     validate_required,
 };
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
 use crate::common::api_utils::serialize_params;
@@ -17,20 +16,33 @@ use crate::common::api_utils::serialize_params;
 /// 创建知识库请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CreateFaqBody {
-    /// 标题
-    pub title: String,
-    /// 内容
-    pub content: String,
+    /// 知识库内容
+    pub faq: CreateFaq,
+}
+
+/// 待创建的知识库内容
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CreateFaq {
     /// 分类ID
     #[serde(skip_serializing_if = "Option::is_none")]
     pub category_id: Option<String>,
+    /// 问题
+    pub question: String,
+    /// 答案
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub answer: Option<String>,
+    /// 富文本答案，创建接口使用 JSON 字符串
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub answer_richtext: Option<String>,
+    /// 标签
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
 }
 
 impl CreateFaqBody {
     /// 验证请求参数
     pub fn validate(&self) -> openlark_core::SDKResult<()> {
-        validate_required!(self.title, "title is required");
-        validate_required!(self.content, "content is required");
+        validate_required!(self.faq.question, "question 不能为空");
         Ok(())
     }
 }
@@ -38,25 +50,15 @@ impl CreateFaqBody {
 /// 创建知识库响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateFaqResponse {
-    /// 响应数据。
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<CreateFaqResult>,
-}
-
-impl openlark_core::api::ApiResponseTrait for CreateFaqResponse {}
-
-/// 创建知识库结果
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CreateFaqResult {
     /// 知识库ID
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
-    /// 标题
+    /// 问题
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
-    /// 内容
+    pub question: Option<String>,
+    /// 答案
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<String>,
+    pub answer: Option<String>,
     /// 分类ID
     #[serde(skip_serializing_if = "Option::is_none")]
     pub category_id: Option<String>,
@@ -65,15 +67,17 @@ pub struct CreateFaqResult {
     pub status: Option<String>,
 }
 
+impl openlark_core::api::ApiResponseTrait for CreateFaqResponse {}
+
 /// 创建知识库请求
 #[derive(Debug, Clone)]
 pub struct CreateFaqRequest {
-    config: Arc<Config>,
+    config: Config,
 }
 
 impl CreateFaqRequest {
     /// 创建新的创建知识库请求
-    pub fn new(config: Arc<Config>) -> Self {
+    pub fn new(config: Config) -> Self {
         Self { config }
     }
 
@@ -102,33 +106,25 @@ impl CreateFaqRequest {
 /// 创建知识库请求构建器
 #[derive(Debug, Clone)]
 pub struct CreateFaqRequestBuilder {
-    config: Arc<Config>,
-    title: Option<String>,
-    content: Option<String>,
+    config: Config,
     category_id: Option<String>,
+    question: Option<String>,
+    answer: Option<String>,
+    answer_richtext: Option<String>,
+    tags: Option<Vec<String>>,
 }
 
 impl CreateFaqRequestBuilder {
     /// 创建新的构建器
-    pub fn new(config: Arc<Config>) -> Self {
+    pub fn new(config: Config) -> Self {
         Self {
             config,
-            title: None,
-            content: None,
             category_id: None,
+            question: None,
+            answer: None,
+            answer_richtext: None,
+            tags: None,
         }
-    }
-
-    /// 设置标题
-    pub fn title(mut self, title: impl Into<String>) -> Self {
-        self.title = Some(title.into());
-        self
-    }
-
-    /// 设置内容
-    pub fn content(mut self, content: impl Into<String>) -> Self {
-        self.content = Some(content.into());
-        self
     }
 
     /// 设置分类ID
@@ -137,15 +133,42 @@ impl CreateFaqRequestBuilder {
         self
     }
 
+    /// 设置问题
+    pub fn question(mut self, question: impl Into<String>) -> Self {
+        self.question = Some(question.into());
+        self
+    }
+
+    /// 设置答案
+    pub fn answer(mut self, answer: impl Into<String>) -> Self {
+        self.answer = Some(answer.into());
+        self
+    }
+
+    /// 设置富文本答案 JSON 字符串
+    pub fn answer_richtext(mut self, answer_richtext: impl Into<String>) -> Self {
+        self.answer_richtext = Some(answer_richtext.into());
+        self
+    }
+
+    /// 设置标签
+    pub fn tags(mut self, tags: Vec<String>) -> Self {
+        self.tags = Some(tags);
+        self
+    }
+
     /// 构建请求体
     pub fn body(&self) -> Result<CreateFaqBody, String> {
-        let title = self.title.clone().ok_or("title is required")?;
-        let content = self.content.clone().ok_or("content is required")?;
+        let question = self.question.clone().ok_or("question 不能为空")?;
 
         Ok(CreateFaqBody {
-            title,
-            content,
-            category_id: self.category_id.clone(),
+            faq: CreateFaq {
+                category_id: self.category_id.clone(),
+                question,
+                answer: self.answer.clone(),
+                answer_richtext: self.answer_richtext.clone(),
+                tags: self.tags.clone(),
+            },
         })
     }
 
@@ -186,34 +209,41 @@ mod tests {
     #[test]
     fn test_body_validation_valid() {
         let body = CreateFaqBody {
-            title: "如何重置密码？".to_string(),
-            content: "请按照以下步骤重置密码...".to_string(),
-            category_id: Some("cat_123".to_string()),
+            faq: CreateFaq {
+                category_id: Some("cat_123".to_string()),
+                question: "如何重置密码？".to_string(),
+                answer: Some("请按照以下步骤重置密码...".to_string()),
+                answer_richtext: Some(r#"[{\"type\":\"text\",\"content\":\"步骤\"}]"#.to_string()),
+                tags: Some(vec!["账号".to_string()]),
+            },
         };
         let result = body.validate();
         assert!(result.is_ok());
     }
 
     #[test]
-    fn test_body_validation_empty_title() {
+    fn test_body_validation_empty_question() {
         let body = CreateFaqBody {
-            title: "".to_string(),
-            content: "内容".to_string(),
-            category_id: None,
+            faq: CreateFaq::default(),
         };
         let result = body.validate();
         assert!(result.is_err());
     }
 
     #[test]
-    fn test_body_validation_empty_content() {
+    fn test_body_serialization_matches_official_shape() {
         let body = CreateFaqBody {
-            title: "标题".to_string(),
-            content: "".to_string(),
-            category_id: None,
+            faq: CreateFaq {
+                question: "问题".to_string(),
+                answer_richtext: Some("[{\"type\":\"text\"}]".to_string()),
+                ..Default::default()
+            },
         };
-        let result = body.validate();
-        assert!(result.is_err());
+        let value = serde_json::to_value(body).expect("请求体应可序列化");
+
+        assert_eq!(value["faq"]["question"], "问题");
+        assert!(value["faq"]["answer_richtext"].is_string());
+        assert!(value.get("question").is_none());
     }
 
     #[test]
@@ -222,12 +252,12 @@ mod tests {
             .app_id("test_app_id")
             .app_secret("test_app_secret")
             .build();
-        let builder = CreateFaqRequestBuilder::new(Arc::new(config));
+        let builder = CreateFaqRequestBuilder::new(config);
 
-        assert!(builder.title.is_none());
+        assert!(builder.question.is_none());
     }
 
-    /// 端到端：POST .../faqs → 强类型 CreateFaqResponse 解析（双层 data 信封）。
+    /// 端到端：POST .../faqs → 强类型 CreateFaqResponse 解析。
     #[tokio::test]
     async fn test_create_faq_returns_data_on_success() {
         use serde_json::json;
@@ -241,30 +271,30 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": { "data": { "id": "faq_001", "title": "如何重置密码？" } }
+                "data": { "id": "faq_001", "question": "如何重置密码？" }
             })))
             .mount(&server)
             .await;
 
-        let config = Arc::new(
-            Config::builder()
-                .app_id("ci_app_id")
-                .app_secret("ci_app_secret")
-                .base_url(server.uri())
-                .enable_token_cache(false)
-                .build(),
-        );
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
         let body = CreateFaqBody {
-            title: "如何重置密码？".to_string(),
-            content: "请按照以下步骤重置密码...".to_string(),
-            category_id: None,
+            faq: CreateFaq {
+                question: "如何重置密码？".to_string(),
+                answer: Some("请按照以下步骤重置密码...".to_string()),
+                ..Default::default()
+            },
         };
         let resp = CreateFaqRequest::new(config)
             .execute(body)
             .await
             .expect("创建知识库应成功");
-        assert!(resp.data.is_some());
+        assert_eq!(resp.id.as_deref(), Some("faq_001"));
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/mod.rs
@@ -38,7 +38,7 @@ impl Faq {
 
     /// 创建知识库
     pub fn create(&self) -> create::CreateFaqRequest {
-        create::CreateFaqRequest::new(self.config.clone())
+        create::CreateFaqRequest::new(self.config.as_ref().clone())
     }
 
     /// 获取指定知识库
@@ -48,7 +48,7 @@ impl Faq {
 
     /// 更新指定知识库
     pub fn patch(&self, id: impl Into<String>) -> patch::PatchFaqRequest {
-        patch::PatchFaqRequest::new(self.config.clone(), id.into())
+        patch::PatchFaqRequest::new(self.config.as_ref().clone(), id.into())
     }
 
     /// 删除指定知识库

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/faq/patch.rs
@@ -6,9 +6,9 @@
 
 use openlark_core::{
     SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
 use crate::common::api_utils::serialize_params;
@@ -16,34 +16,42 @@ use crate::common::api_utils::serialize_params;
 /// 更新知识库请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct PatchFaqBody {
-    /// 标题
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
-    /// 内容
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<String>,
+    /// 知识库内容
+    pub faq: PatchFaq,
+}
+
+/// 待更新的知识库内容
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PatchFaq {
     /// 分类ID
     #[serde(skip_serializing_if = "Option::is_none")]
     pub category_id: Option<String>,
+    /// 问题
+    pub question: String,
+    /// 答案
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub answer: Option<String>,
+    /// 富文本答案
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub answer_richtext: Option<Vec<PatchFaqRichText>>,
+    /// 标签
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+}
+
+/// 富文本答案节点
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PatchFaqRichText {
+    /// 节点内容
+    pub content: String,
+    /// 节点类型
+    pub r#type: String,
 }
 
 impl PatchFaqBody {
     /// 验证请求参数
     pub fn validate(&self) -> openlark_core::SDKResult<()> {
-        if let Some(title) = &self.title
-            && title.is_empty()
-        {
-            return Err(openlark_core::CoreError::validation_msg(
-                "title cannot be empty",
-            ));
-        }
-        if let Some(content) = &self.content
-            && content.is_empty()
-        {
-            return Err(openlark_core::CoreError::validation_msg(
-                "content cannot be empty",
-            ));
-        }
+        validate_required!(self.faq.question, "question 不能为空");
         Ok(())
     }
 }
@@ -51,25 +59,15 @@ impl PatchFaqBody {
 /// 更新知识库响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PatchFaqResponse {
-    /// 响应数据。
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<PatchFaqResult>,
-}
-
-impl openlark_core::api::ApiResponseTrait for PatchFaqResponse {}
-
-/// 更新知识库结果
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PatchFaqResult {
     /// 知识库ID
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
-    /// 标题
+    /// 问题
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
-    /// 内容
+    pub question: Option<String>,
+    /// 答案
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<String>,
+    pub answer: Option<String>,
     /// 分类ID
     #[serde(skip_serializing_if = "Option::is_none")]
     pub category_id: Option<String>,
@@ -78,16 +76,18 @@ pub struct PatchFaqResult {
     pub status: Option<String>,
 }
 
+impl openlark_core::api::ApiResponseTrait for PatchFaqResponse {}
+
 /// 更新知识库请求
 #[derive(Debug, Clone)]
 pub struct PatchFaqRequest {
-    config: Arc<Config>,
+    config: Config,
     id: String,
 }
 
 impl PatchFaqRequest {
     /// 创建新的更新知识库请求
-    pub fn new(config: Arc<Config>, id: String) -> Self {
+    pub fn new(config: Config, id: String) -> Self {
         Self { config, id }
     }
 
@@ -116,35 +116,27 @@ impl PatchFaqRequest {
 /// 更新知识库请求构建器
 #[derive(Debug, Clone)]
 pub struct PatchFaqRequestBuilder {
-    config: Arc<Config>,
+    config: Config,
     id: String,
-    title: Option<String>,
-    content: Option<String>,
     category_id: Option<String>,
+    question: Option<String>,
+    answer: Option<String>,
+    answer_richtext: Option<Vec<PatchFaqRichText>>,
+    tags: Option<Vec<String>>,
 }
 
 impl PatchFaqRequestBuilder {
     /// 创建新的构建器
-    pub fn new(config: Arc<Config>, id: String) -> Self {
+    pub fn new(config: Config, id: String) -> Self {
         Self {
             config,
             id,
-            title: None,
-            content: None,
             category_id: None,
+            question: None,
+            answer: None,
+            answer_richtext: None,
+            tags: None,
         }
-    }
-
-    /// 设置标题
-    pub fn title(mut self, title: impl Into<String>) -> Self {
-        self.title = Some(title.into());
-        self
-    }
-
-    /// 设置内容
-    pub fn content(mut self, content: impl Into<String>) -> Self {
-        self.content = Some(content.into());
-        self
     }
 
     /// 设置分类ID
@@ -153,25 +145,59 @@ impl PatchFaqRequestBuilder {
         self
     }
 
+    /// 设置问题
+    pub fn question(mut self, question: impl Into<String>) -> Self {
+        self.question = Some(question.into());
+        self
+    }
+
+    /// 设置答案
+    pub fn answer(mut self, answer: impl Into<String>) -> Self {
+        self.answer = Some(answer.into());
+        self
+    }
+
+    /// 设置富文本答案
+    pub fn answer_richtext(mut self, answer_richtext: Vec<PatchFaqRichText>) -> Self {
+        self.answer_richtext = Some(answer_richtext);
+        self
+    }
+
+    /// 设置标签
+    pub fn tags(mut self, tags: Vec<String>) -> Self {
+        self.tags = Some(tags);
+        self
+    }
+
     /// 构建请求体
-    pub fn body(&self) -> PatchFaqBody {
-        PatchFaqBody {
-            title: self.title.clone(),
-            content: self.content.clone(),
-            category_id: self.category_id.clone(),
-        }
+    pub fn body(&self) -> Result<PatchFaqBody, String> {
+        let question = self.question.clone().ok_or("question 不能为空")?;
+
+        Ok(PatchFaqBody {
+            faq: PatchFaq {
+                category_id: self.category_id.clone(),
+                question,
+                answer: self.answer.clone(),
+                answer_richtext: self.answer_richtext.clone(),
+                tags: self.tags.clone(),
+            },
+        })
     }
 
     /// 执行请求
     pub async fn execute(&self) -> SDKResult<PatchFaqResponse> {
-        let body = self.body();
+        let body = self
+            .body()
+            .map_err(|reason| openlark_core::error::validation_error("body", reason))?;
         let request = PatchFaqRequest::new(self.config.clone(), self.id.clone());
         request.execute(body).await
     }
 
     /// 执行请求（支持自定义选项）
     pub async fn execute_with_options(&self, option: RequestOption) -> SDKResult<PatchFaqResponse> {
-        let body = self.body();
+        let body = self
+            .body()
+            .map_err(|reason| openlark_core::error::validation_error("body", reason))?;
         let request = PatchFaqRequest::new(self.config.clone(), self.id.clone());
         request.execute_with_options(body, option).await
     }
@@ -207,32 +233,42 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_body_validation_empty() {
+    fn test_body_validation_empty_question() {
         let body = PatchFaqBody::default();
         let result = body.validate();
-        assert!(result.is_ok());
+        assert!(result.is_err());
     }
 
     #[test]
     fn test_body_validation_valid() {
         let body = PatchFaqBody {
-            title: Some("新标题".to_string()),
-            content: Some("新内容".to_string()),
-            category_id: None,
+            faq: PatchFaq {
+                question: "新问题".to_string(),
+                answer: Some("新答案".to_string()),
+                ..Default::default()
+            },
         };
         let result = body.validate();
         assert!(result.is_ok());
     }
 
     #[test]
-    fn test_body_validation_empty_title() {
+    fn test_body_serialization_matches_official_shape() {
         let body = PatchFaqBody {
-            title: Some("".to_string()),
-            content: None,
-            category_id: None,
+            faq: PatchFaq {
+                question: "新问题".to_string(),
+                answer_richtext: Some(vec![PatchFaqRichText {
+                    content: "富文本".to_string(),
+                    r#type: "text".to_string(),
+                }]),
+                ..Default::default()
+            },
         };
-        let result = body.validate();
-        assert!(result.is_err());
+        let value = serde_json::to_value(body).expect("请求体应可序列化");
+
+        assert!(value["faq"]["answer_richtext"].is_array());
+        assert_eq!(value["faq"]["answer_richtext"][0]["type"], "text");
+        assert!(value.get("question").is_none());
     }
 
     #[test]
@@ -241,13 +277,13 @@ mod tests {
             .app_id("test_app_id")
             .app_secret("test_app_secret")
             .build();
-        let builder = PatchFaqRequestBuilder::new(Arc::new(config), "faq_123".to_string());
+        let builder = PatchFaqRequestBuilder::new(config, "faq_123".to_string());
 
         assert_eq!(builder.id, "faq_123");
-        assert!(builder.title.is_none());
+        assert!(builder.question.is_none());
     }
 
-    /// 端到端：PATCH .../faqs/{id} → 强类型 PatchFaqResponse 解析（双层 data 信封）。
+    /// 端到端：PATCH .../faqs/{id} → 强类型 PatchFaqResponse 解析。
     #[tokio::test]
     async fn test_patch_faq_returns_data_on_success() {
         use serde_json::json;
@@ -261,30 +297,29 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": { "data": { "id": "faq_001", "title": "新标题" } }
+                "data": { "id": "faq_001", "question": "新问题" }
             })))
             .mount(&server)
             .await;
 
-        let config = Arc::new(
-            Config::builder()
-                .app_id("ci_app_id")
-                .app_secret("ci_app_secret")
-                .base_url(server.uri())
-                .enable_token_cache(false)
-                .build(),
-        );
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
         let body = PatchFaqBody {
-            title: Some("新标题".to_string()),
-            content: None,
-            category_id: None,
+            faq: PatchFaq {
+                question: "新问题".to_string(),
+                ..Default::default()
+            },
         };
         let resp = PatchFaqRequest::new(config, "faq_001".to_string())
             .execute(body)
             .await
             .expect("更新知识库应成功");
-        assert!(resp.data.is_some());
+        assert_eq!(resp.id.as_deref(), Some("faq_001"));
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/create.rs
@@ -5,29 +5,89 @@
 //! docPath: <https://open.feishu.cn/document/server-docs/helpdesk-v1/notification/create>
 
 use openlark_core::{
-    SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
-    validate_required,
+    SDKResult,
+    api::{ApiRequest, ApiResponseTrait, ResponseFormat},
+    config::Config,
+    http::Transport,
+    req_option::RequestOption,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
 use crate::common::api_utils::serialize_params;
+use crate::helpdesk::helpdesk::v1::notification::models::{
+    NotificationChat, NotificationDepartment, NotificationUser,
+};
 
 /// 创建推送通知请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CreateNotificationBody {
-    /// 标题
-    pub title: String,
-    /// 内容
-    pub content: String,
+    /// 推送任务 ID，创建成功后由服务端返回。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// 推送任务名称。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub job_name: Option<String>,
+    /// 推送任务状态。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<i32>,
+    /// 创建人。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub create_user: Option<NotificationUser>,
+    /// 创建时间，毫秒时间戳。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    /// 更新人。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub update_user: Option<NotificationUser>,
+    /// 更新时间，毫秒时间戳。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+    /// 目标用户数。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_user_count: Option<i32>,
+    /// 已推送用户数。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sent_user_count: Option<i32>,
+    /// 已读用户数。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub read_user_count: Option<i32>,
+    /// 推送触发时间，毫秒时间戳。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub send_at: Option<String>,
+    /// 推送内容。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub push_content: Option<String>,
+    /// 推送类型。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub push_type: Option<i32>,
+    /// 推送范围类型。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub push_scope_type: Option<i32>,
+    /// 新员工入职范围类型。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_staff_scope_type: Option<i32>,
+    /// 新员工入职生效部门列表。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_staff_scope_department_list: Option<Vec<NotificationDepartment>>,
+    /// 推送用户列表。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_list: Option<Vec<NotificationUser>>,
+    /// 推送部门列表。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub department_list: Option<Vec<NotificationDepartment>>,
+    /// 推送群聊列表。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chat_list: Option<Vec<NotificationChat>>,
+    /// 扩展字段。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ext: Option<String>,
 }
 
 impl CreateNotificationBody {
     /// 验证请求参数
     pub fn validate(&self) -> openlark_core::SDKResult<()> {
-        validate_required!(self.title, "title is required");
-        validate_required!(self.content, "content is required");
         Ok(())
     }
 }
@@ -35,25 +95,18 @@ impl CreateNotificationBody {
 /// 创建推送通知响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateNotificationResponse {
-    /// 响应数据。
+    /// 推送任务 ID。
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<CreateNotificationResult>,
+    pub notification_id: Option<String>,
+    /// 推送任务状态。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<i32>,
 }
 
-impl openlark_core::api::ApiResponseTrait for CreateNotificationResponse {}
-
-/// 创建推送通知结果
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CreateNotificationResult {
-    /// 推送ID
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
-    /// 标题
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
-    /// 状态
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<String>,
+impl ApiResponseTrait for CreateNotificationResponse {
+    fn data_format() -> ResponseFormat {
+        ResponseFormat::Data
+    }
 }
 
 /// 创建推送通知请求
@@ -97,8 +150,7 @@ impl CreateNotificationRequest {
 #[derive(Debug, Clone)]
 pub struct CreateNotificationRequestBuilder {
     config: Arc<Config>,
-    title: Option<String>,
-    content: Option<String>,
+    body: CreateNotificationBody,
 }
 
 impl CreateNotificationRequestBuilder {
@@ -106,38 +158,152 @@ impl CreateNotificationRequestBuilder {
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,
-            title: None,
-            content: None,
+            body: CreateNotificationBody::default(),
         }
     }
 
-    /// 设置标题
-    pub fn title(mut self, title: impl Into<String>) -> Self {
-        self.title = Some(title.into());
+    /// 设置推送任务 ID。
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.body.id = Some(id.into());
         self
     }
 
-    /// 设置内容
-    pub fn content(mut self, content: impl Into<String>) -> Self {
-        self.content = Some(content.into());
+    /// 设置推送任务名称。
+    pub fn job_name(mut self, job_name: impl Into<String>) -> Self {
+        self.body.job_name = Some(job_name.into());
         self
     }
 
-    /// 构建请求体
-    pub fn body(&self) -> Result<CreateNotificationBody, String> {
-        let title = self.title.clone().ok_or("title is required")?;
-        let content = self.content.clone().ok_or("content is required")?;
+    /// 设置推送任务状态。
+    pub fn status(mut self, status: i32) -> Self {
+        self.body.status = Some(status);
+        self
+    }
 
-        Ok(CreateNotificationBody { title, content })
+    /// 设置创建人。
+    pub fn create_user(mut self, create_user: NotificationUser) -> Self {
+        self.body.create_user = Some(create_user);
+        self
+    }
+
+    /// 设置创建时间。
+    pub fn created_at(mut self, created_at: impl Into<String>) -> Self {
+        self.body.created_at = Some(created_at.into());
+        self
+    }
+
+    /// 设置更新人。
+    pub fn update_user(mut self, update_user: NotificationUser) -> Self {
+        self.body.update_user = Some(update_user);
+        self
+    }
+
+    /// 设置更新时间。
+    pub fn updated_at(mut self, updated_at: impl Into<String>) -> Self {
+        self.body.updated_at = Some(updated_at.into());
+        self
+    }
+
+    /// 设置目标用户数。
+    pub fn target_user_count(mut self, target_user_count: i32) -> Self {
+        self.body.target_user_count = Some(target_user_count);
+        self
+    }
+
+    /// 设置已推送用户数。
+    pub fn sent_user_count(mut self, sent_user_count: i32) -> Self {
+        self.body.sent_user_count = Some(sent_user_count);
+        self
+    }
+
+    /// 设置已读用户数。
+    pub fn read_user_count(mut self, read_user_count: i32) -> Self {
+        self.body.read_user_count = Some(read_user_count);
+        self
+    }
+
+    /// 设置推送触发时间。
+    pub fn send_at(mut self, send_at: impl Into<String>) -> Self {
+        self.body.send_at = Some(send_at.into());
+        self
+    }
+
+    /// 设置推送内容。
+    pub fn push_content(mut self, push_content: impl Into<String>) -> Self {
+        self.body.push_content = Some(push_content.into());
+        self
+    }
+
+    /// 设置推送类型。
+    pub fn push_type(mut self, push_type: i32) -> Self {
+        self.body.push_type = Some(push_type);
+        self
+    }
+
+    /// 设置推送范围类型。
+    pub fn push_scope_type(mut self, push_scope_type: i32) -> Self {
+        self.body.push_scope_type = Some(push_scope_type);
+        self
+    }
+
+    /// 设置新员工入职范围类型。
+    pub fn new_staff_scope_type(mut self, new_staff_scope_type: i32) -> Self {
+        self.body.new_staff_scope_type = Some(new_staff_scope_type);
+        self
+    }
+
+    /// 设置新员工入职生效部门列表。
+    pub fn new_staff_scope_department_list(
+        mut self,
+        departments: Vec<NotificationDepartment>,
+    ) -> Self {
+        self.body.new_staff_scope_department_list = Some(departments);
+        self
+    }
+
+    /// 设置推送用户列表。
+    pub fn user_list(mut self, users: Vec<NotificationUser>) -> Self {
+        self.body.user_list = Some(users);
+        self
+    }
+
+    /// 设置推送部门列表。
+    pub fn department_list(mut self, departments: Vec<NotificationDepartment>) -> Self {
+        self.body.department_list = Some(departments);
+        self
+    }
+
+    /// 设置推送群聊列表。
+    pub fn chat_list(mut self, chats: Vec<NotificationChat>) -> Self {
+        self.body.chat_list = Some(chats);
+        self
+    }
+
+    /// 设置扩展字段。
+    pub fn ext(mut self, ext: impl Into<String>) -> Self {
+        self.body.ext = Some(ext.into());
+        self
+    }
+
+    /// 构建请求体。
+    pub fn body(&self) -> CreateNotificationBody {
+        self.body.clone()
     }
 
     /// 执行请求
     pub async fn execute(&self) -> SDKResult<CreateNotificationResponse> {
-        let body = self
-            .body()
-            .map_err(|reason| openlark_core::error::validation_error("body", reason))?;
+        let body = self.body();
         let request = CreateNotificationRequest::new(self.config.clone());
         request.execute(body).await
+    }
+
+    /// 执行请求（支持自定义选项）。
+    pub async fn execute_with_options(
+        &self,
+        option: RequestOption,
+    ) -> SDKResult<CreateNotificationResponse> {
+        let request = CreateNotificationRequest::new(self.config.clone());
+        request.execute_with_options(self.body(), option).await
     }
 }
 
@@ -172,21 +338,35 @@ mod tests {
     #[test]
     fn test_body_validation_valid() {
         let body = CreateNotificationBody {
-            title: "系统维护通知".to_string(),
-            content: "系统将于今晚进行维护...".to_string(),
+            job_name: Some("系统维护通知".to_string()),
+            push_content: Some(r#"{"elements":[]}"#.to_string()),
+            push_type: Some(0),
+            push_scope_type: Some(2),
+            user_list: Some(vec![NotificationUser {
+                user_id: Some("ou_001".to_string()),
+                ..Default::default()
+            }]),
+            ..Default::default()
         };
         let result = body.validate();
         assert!(result.is_ok());
     }
 
     #[test]
-    fn test_body_validation_empty_title() {
+    fn test_body_uses_official_flat_fields() {
         let body = CreateNotificationBody {
-            title: "".to_string(),
-            content: "内容".to_string(),
+            job_name: Some("系统维护通知".to_string()),
+            push_content: Some("卡片内容".to_string()),
+            push_type: Some(0),
+            ..Default::default()
         };
-        let result = body.validate();
-        assert!(result.is_err());
+        let value = serde_json::to_value(body).expect("请求体应可序列化");
+
+        assert_eq!(value["job_name"], "系统维护通知");
+        assert_eq!(value["push_content"], "卡片内容");
+        assert_eq!(value["push_type"], 0);
+        assert!(value.get("title").is_none());
+        assert!(value.get("content").is_none());
     }
 
     #[test]
@@ -195,12 +375,18 @@ mod tests {
             .app_id("test_app_id")
             .app_secret("test_app_secret")
             .build();
-        let builder = CreateNotificationRequestBuilder::new(Arc::new(config));
+        let body = CreateNotificationRequestBuilder::new(Arc::new(config))
+            .job_name("系统维护通知")
+            .push_content("卡片内容")
+            .push_type(0)
+            .push_scope_type(0)
+            .body();
 
-        assert!(builder.title.is_none());
+        assert_eq!(body.job_name.as_deref(), Some("系统维护通知"));
+        assert_eq!(body.push_type, Some(0));
     }
 
-    /// 端到端：POST .../notifications → 强类型 CreateNotificationResponse 解析（双层 data 信封）。
+    /// 端到端：POST .../notifications → 响应直接解析 `data` 内的字段。
     #[tokio::test]
     async fn test_create_notification_returns_data_on_success() {
         use serde_json::json;
@@ -214,7 +400,7 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": { "data": { "id": "ntf_001", "title": "系统维护通知", "status": "draft" } }
+                "data": { "notification_id": "ntf_001", "status": 0 }
             })))
             .mount(&server)
             .await;
@@ -229,14 +415,18 @@ mod tests {
         );
 
         let body = CreateNotificationBody {
-            title: "系统维护通知".to_string(),
-            content: "系统将于今晚维护".to_string(),
+            job_name: Some("系统维护通知".to_string()),
+            push_content: Some("系统将于今晚维护".to_string()),
+            push_type: Some(0),
+            push_scope_type: Some(0),
+            ..Default::default()
         };
         let resp = CreateNotificationRequest::new(config)
             .execute(body)
             .await
             .expect("创建推送通知应成功");
-        assert_eq!(resp.data.unwrap().id.as_deref(), Some("ntf_001"));
+        assert_eq!(resp.notification_id.as_deref(), Some("ntf_001"));
+        assert_eq!(resp.status, Some(0));
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
@@ -244,5 +434,9 @@ mod tests {
             received[0].url.path(),
             "/open-apis/helpdesk/v1/notifications"
         );
+        let request_body: serde_json::Value =
+            serde_json::from_slice(&received[0].body).expect("请求体应为 JSON");
+        assert_eq!(request_body["job_name"], "系统维护通知");
+        assert!(request_body.get("title").is_none());
     }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/mod.rs
@@ -11,6 +11,8 @@ pub mod create;
 pub mod execute_send;
 /// 获取接口。
 pub mod get;
+/// 推送通知共享模型。
+pub mod models;
 /// 更新接口。
 pub mod patch;
 /// preview 模块。
@@ -105,6 +107,7 @@ pub use cancel_send::{CancelSendNotificationRequest, CancelSendNotificationReque
 pub use create::{CreateNotificationRequest, CreateNotificationRequestBuilder};
 pub use execute_send::{ExecuteSendNotificationRequest, ExecuteSendNotificationRequestBuilder};
 pub use get::{GetNotificationRequest, GetNotificationRequestBuilder};
+pub use models::{NotificationChat, NotificationDepartment, NotificationUser};
 pub use patch::{PatchNotificationRequest, PatchNotificationRequestBuilder};
 pub use preview::{PreviewNotificationRequest, PreviewNotificationRequestBuilder};
 pub use submit_approve::{

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/models.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/models.rs
@@ -1,0 +1,39 @@
+//! 推送通知共享模型
+
+use serde::{Deserialize, Serialize};
+
+/// 推送通知用户。
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct NotificationUser {
+    /// 用户 ID。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
+    /// 用户头像地址。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avatar_url: Option<String>,
+    /// 用户名称。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+/// 推送通知部门。
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct NotificationDepartment {
+    /// 部门 ID。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub department_id: Option<String>,
+    /// 部门名称。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+/// 推送通知群聊。
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct NotificationChat {
+    /// 群聊 ID。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chat_id: Option<String>,
+    /// 群聊名称。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/notification/patch.rs
@@ -5,68 +5,101 @@
 //! docPath: <https://open.feishu.cn/document/server-docs/helpdesk-v1/notification/patch>
 
 use openlark_core::{
-    SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
+    SDKResult,
+    api::{ApiRequest, ApiResponseTrait, ResponseFormat},
+    config::Config,
+    http::Transport,
+    req_option::RequestOption,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
 use crate::common::api_utils::serialize_params;
+use crate::helpdesk::helpdesk::v1::notification::models::{
+    NotificationChat, NotificationDepartment, NotificationUser,
+};
 
 /// 更新推送通知请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct PatchNotificationBody {
-    /// 标题
+    /// 推送任务 ID。
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
-    /// 内容
+    pub id: Option<String>,
+    /// 推送任务名称。
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<String>,
+    pub job_name: Option<String>,
+    /// 推送任务状态。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<i32>,
+    /// 创建人。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub create_user: Option<NotificationUser>,
+    /// 创建时间，毫秒时间戳。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    /// 更新人。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub update_user: Option<NotificationUser>,
+    /// 更新时间，毫秒时间戳。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+    /// 目标用户数。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_user_count: Option<i32>,
+    /// 已推送用户数。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sent_user_count: Option<i32>,
+    /// 已读用户数。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub read_user_count: Option<i32>,
+    /// 推送触发时间，毫秒时间戳。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub send_at: Option<String>,
+    /// 推送内容。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub push_content: Option<String>,
+    /// 推送类型。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub push_type: Option<i32>,
+    /// 推送范围类型。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub push_scope_type: Option<i32>,
+    /// 新员工入职范围类型。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_staff_scope_type: Option<i32>,
+    /// 新员工入职生效部门列表。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_staff_scope_department_list: Option<Vec<NotificationDepartment>>,
+    /// 推送用户列表。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_list: Option<Vec<NotificationUser>>,
+    /// 推送部门列表。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub department_list: Option<Vec<NotificationDepartment>>,
+    /// 推送群聊列表。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chat_list: Option<Vec<NotificationChat>>,
+    /// 扩展字段。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ext: Option<String>,
 }
 
 impl PatchNotificationBody {
     /// 验证请求参数
     pub fn validate(&self) -> openlark_core::SDKResult<()> {
-        if let Some(title) = &self.title
-            && title.is_empty()
-        {
-            return Err(openlark_core::CoreError::validation_msg(
-                "title cannot be empty",
-            ));
-        }
-        if let Some(content) = &self.content
-            && content.is_empty()
-        {
-            return Err(openlark_core::CoreError::validation_msg(
-                "content cannot be empty",
-            ));
-        }
         Ok(())
     }
 }
 
 /// 更新推送通知响应
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PatchNotificationResponse {
-    /// 响应数据。
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<PatchNotificationResult>,
-}
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PatchNotificationResponse {}
 
-impl openlark_core::api::ApiResponseTrait for PatchNotificationResponse {}
-
-/// 更新推送通知结果
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PatchNotificationResult {
-    /// 推送ID
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
-    /// 标题
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
-    /// 状态
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<String>,
+impl ApiResponseTrait for PatchNotificationResponse {
+    fn data_format() -> ResponseFormat {
+        ResponseFormat::Data
+    }
 }
 
 /// 更新推送通知请求
@@ -116,8 +149,7 @@ impl PatchNotificationRequest {
 pub struct PatchNotificationRequestBuilder {
     config: Arc<Config>,
     notification_id: String,
-    title: Option<String>,
-    content: Option<String>,
+    body: PatchNotificationBody,
 }
 
 impl PatchNotificationRequestBuilder {
@@ -126,29 +158,76 @@ impl PatchNotificationRequestBuilder {
         Self {
             config,
             notification_id,
-            title: None,
-            content: None,
+            body: PatchNotificationBody::default(),
         }
     }
 
-    /// 设置标题
-    pub fn title(mut self, title: impl Into<String>) -> Self {
-        self.title = Some(title.into());
+    /// 设置推送任务名称。
+    pub fn job_name(mut self, job_name: impl Into<String>) -> Self {
+        self.body.job_name = Some(job_name.into());
         self
     }
 
-    /// 设置内容
-    pub fn content(mut self, content: impl Into<String>) -> Self {
-        self.content = Some(content.into());
+    /// 设置推送内容。
+    pub fn push_content(mut self, push_content: impl Into<String>) -> Self {
+        self.body.push_content = Some(push_content.into());
         self
     }
 
-    /// 构建请求体
+    /// 设置推送类型。
+    pub fn push_type(mut self, push_type: i32) -> Self {
+        self.body.push_type = Some(push_type);
+        self
+    }
+
+    /// 设置推送范围类型。
+    pub fn push_scope_type(mut self, push_scope_type: i32) -> Self {
+        self.body.push_scope_type = Some(push_scope_type);
+        self
+    }
+
+    /// 设置新员工入职范围类型。
+    pub fn new_staff_scope_type(mut self, new_staff_scope_type: i32) -> Self {
+        self.body.new_staff_scope_type = Some(new_staff_scope_type);
+        self
+    }
+
+    /// 设置新员工入职生效部门列表。
+    pub fn new_staff_scope_department_list(
+        mut self,
+        departments: Vec<NotificationDepartment>,
+    ) -> Self {
+        self.body.new_staff_scope_department_list = Some(departments);
+        self
+    }
+
+    /// 设置推送用户列表。
+    pub fn user_list(mut self, users: Vec<NotificationUser>) -> Self {
+        self.body.user_list = Some(users);
+        self
+    }
+
+    /// 设置推送部门列表。
+    pub fn department_list(mut self, departments: Vec<NotificationDepartment>) -> Self {
+        self.body.department_list = Some(departments);
+        self
+    }
+
+    /// 设置推送群聊列表。
+    pub fn chat_list(mut self, chats: Vec<NotificationChat>) -> Self {
+        self.body.chat_list = Some(chats);
+        self
+    }
+
+    /// 设置扩展字段。
+    pub fn ext(mut self, ext: impl Into<String>) -> Self {
+        self.body.ext = Some(ext.into());
+        self
+    }
+
+    /// 构建请求体。
     pub fn body(&self) -> PatchNotificationBody {
-        PatchNotificationBody {
-            title: self.title.clone(),
-            content: self.content.clone(),
-        }
+        self.body.clone()
     }
 
     /// 执行请求
@@ -211,21 +290,32 @@ mod tests {
     #[test]
     fn test_body_validation_valid() {
         let body = PatchNotificationBody {
-            title: Some("新标题".to_string()),
-            content: Some("新内容".to_string()),
+            job_name: Some("新任务名称".to_string()),
+            push_content: Some("新推送内容".to_string()),
+            ..Default::default()
         };
         let result = body.validate();
         assert!(result.is_ok());
     }
 
     #[test]
-    fn test_body_validation_empty_title() {
+    fn test_body_uses_official_flat_fields() {
         let body = PatchNotificationBody {
-            title: Some("".to_string()),
-            content: None,
+            job_name: Some("新任务名称".to_string()),
+            push_scope_type: Some(2),
+            chat_list: Some(vec![NotificationChat {
+                chat_id: Some("oc_001".to_string()),
+                name: Some("测试群".to_string()),
+            }]),
+            ..Default::default()
         };
-        let result = body.validate();
-        assert!(result.is_err());
+        let value = serde_json::to_value(body).expect("请求体应可序列化");
+
+        assert_eq!(value["job_name"], "新任务名称");
+        assert_eq!(value["push_scope_type"], 2);
+        assert_eq!(value["chat_list"][0]["chat_id"], "oc_001");
+        assert!(value.get("title").is_none());
+        assert!(value.get("content").is_none());
     }
 
     #[test]
@@ -238,10 +328,10 @@ mod tests {
             PatchNotificationRequestBuilder::new(Arc::new(config), "notif_123".to_string());
 
         assert_eq!(builder.notification_id, "notif_123");
-        assert!(builder.title.is_none());
+        assert!(builder.body.job_name.is_none());
     }
 
-    /// 端到端：PATCH .../notifications/{id} → 强类型 PatchNotificationResponse 解析（双层 data 信封）。
+    /// 端到端：PATCH .../notifications/{id} → 空对象 `data` 解析成功。
     #[tokio::test]
     async fn test_patch_notification_returns_data_on_success() {
         use serde_json::json;
@@ -255,7 +345,7 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": { "data": { "id": "ntf_001", "title": "新标题", "status": "draft" } }
+                "data": {}
             })))
             .mount(&server)
             .await;
@@ -270,14 +360,14 @@ mod tests {
         );
 
         let body = PatchNotificationBody {
-            title: Some("新标题".to_string()),
-            content: None,
+            job_name: Some("新任务名称".to_string()),
+            push_content: Some("新推送内容".to_string()),
+            ..Default::default()
         };
-        let resp = PatchNotificationRequest::new(config, "ntf_001".to_string())
+        PatchNotificationRequest::new(config, "ntf_001".to_string())
             .execute(body)
             .await
             .expect("更新推送通知应成功");
-        assert_eq!(resp.data.unwrap().id.as_deref(), Some("ntf_001"));
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
@@ -285,5 +375,9 @@ mod tests {
             received[0].url.path(),
             "/open-apis/helpdesk/v1/notifications/ntf_001"
         );
+        let request_body: serde_json::Value =
+            serde_json::from_slice(&received[0].body).expect("请求体应为 JSON");
+        assert_eq!(request_body["job_name"], "新任务名称");
+        assert!(request_body.get("title").is_none());
     }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/answer_user_query.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/answer_user_query.rs
@@ -8,14 +8,14 @@ use openlark_core::{
     config::Config,
     http::Transport,
     req_option::RequestOption,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
 /// 回复用户提问请求。
 #[derive(Debug, Clone)]
 pub struct AnswerUserQueryRequest {
-    config: Arc<Config>,
+    config: Config,
     ticket_id: String,
     body: AnswerUserQueryBody,
 }
@@ -23,21 +23,25 @@ pub struct AnswerUserQueryRequest {
 /// 回复用户提问请求体。
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AnswerUserQueryBody {
-    /// 回复内容。
-    pub content: String,
-    /// 回复内容类型。
+    /// 事件 ID。
+    pub event_id: String,
+    /// 推荐的知识库答案。
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub content_type: Option<String>,
+    pub faqs: Option<Vec<AnswerUserQueryFaq>>,
+}
+
+/// 推荐的知识库答案。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnswerUserQueryFaq {
+    /// 知识库 ID。
+    pub id: String,
+    /// 匹配分数。
+    pub score: f64,
 }
 
 impl AnswerUserQueryBody {
     fn validate(&self) -> SDKResult<()> {
-        if self.content.trim().is_empty() {
-            return Err(openlark_core::error::validation_error(
-                "回复内容不能为空",
-                "",
-            ));
-        }
+        validate_required!(self.event_id, "event_id 不能为空");
         Ok(())
     }
 }
@@ -45,8 +49,8 @@ impl AnswerUserQueryBody {
 /// 回复用户提问响应。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AnswerUserQueryResponse {
-    /// 响应数据。
-    pub data: Option<AnswerUserQueryData>,
+    /// 消息 ID。
+    pub message_id: String,
 }
 
 impl ApiResponseTrait for AnswerUserQueryResponse {
@@ -55,16 +59,9 @@ impl ApiResponseTrait for AnswerUserQueryResponse {
     }
 }
 
-/// 回复用户提问响应数据。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AnswerUserQueryData {
-    /// 消息 ID。
-    pub message_id: String,
-}
-
 impl AnswerUserQueryRequest {
     /// 创建新的实例。
-    pub fn new(config: Arc<Config>, ticket_id: impl Into<String>) -> Self {
+    pub fn new(config: Config, ticket_id: impl Into<String>) -> Self {
         Self {
             config,
             ticket_id: ticket_id.into(),
@@ -72,15 +69,15 @@ impl AnswerUserQueryRequest {
         }
     }
 
-    /// 设置回复内容。
-    pub fn content(mut self, content: impl Into<String>) -> Self {
-        self.body.content = content.into();
+    /// 设置事件 ID。
+    pub fn event_id(mut self, event_id: impl Into<String>) -> Self {
+        self.body.event_id = event_id.into();
         self
     }
 
-    /// 设置回复内容类型。
-    pub fn content_type(mut self, content_type: impl Into<String>) -> Self {
-        self.body.content_type = Some(content_type.into());
+    /// 设置推荐的知识库答案。
+    pub fn faqs(mut self, faqs: Vec<AnswerUserQueryFaq>) -> Self {
+        self.body.faqs = Some(faqs);
         self
     }
 
@@ -109,7 +106,30 @@ impl AnswerUserQueryRequest {
 mod tests {
     use super::*;
 
-    /// 端到端：POST .../tickets/{id}/answer_user_query → 强类型 AnswerUserQueryResponse 解析（双层 data 信封）。
+    #[test]
+    fn test_body_validation_requires_event_id() {
+        let body = AnswerUserQueryBody::default();
+        assert!(body.validate().is_err());
+    }
+
+    #[test]
+    fn test_body_serialization_matches_official_shape() {
+        let body = AnswerUserQueryBody {
+            event_id: "abcd".to_string(),
+            faqs: Some(vec![AnswerUserQueryFaq {
+                id: "12345".to_string(),
+                score: 0.9,
+            }]),
+        };
+        let value = serde_json::to_value(body).expect("请求体应可序列化");
+
+        assert_eq!(value["event_id"], "abcd");
+        assert_eq!(value["faqs"][0]["id"], "12345");
+        assert!(value.get("content").is_none());
+        assert!(value.get("content_type").is_none());
+    }
+
+    /// 端到端：POST .../tickets/{id}/answer_user_query → 强类型响应解析。
     #[tokio::test]
     async fn test_answer_user_query_returns_data_on_success() {
         use serde_json::json;
@@ -125,27 +145,28 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": { "data": { "message_id": "msg_001" } }
+                "data": { "message_id": "msg_001" }
             })))
             .mount(&server)
             .await;
 
-        let config = Arc::new(
-            Config::builder()
-                .app_id("ci_app_id")
-                .app_secret("ci_app_secret")
-                .base_url(server.uri())
-                .enable_token_cache(false)
-                .build(),
-        );
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
         let resp = AnswerUserQueryRequest::new(config, "tk_001")
-            .content("您好，请问需要什么帮助？")
+            .event_id("abcd")
+            .faqs(vec![AnswerUserQueryFaq {
+                id: "12345".to_string(),
+                score: 0.9,
+            }])
             .execute()
             .await
             .expect("回复用户提问应成功");
-        assert!(resp.data.is_some());
-        assert_eq!(resp.data.unwrap().message_id, "msg_001");
+        assert_eq!(resp.message_id, "msg_001");
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/message/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/message/create.rs
@@ -180,6 +180,15 @@ mod tests {
     }
 
     #[test]
+    fn test_body_validation_empty_msg_type() {
+        let body = CreateTicketMessageBody {
+            content: "消息内容".to_string(),
+            msg_type: String::new(),
+        };
+        assert!(body.validate().is_err());
+    }
+
+    #[test]
     fn test_builder_creation() {
         let config = Config::builder()
             .app_id("test_app_id")

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/message/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/message/create.rs
@@ -9,7 +9,6 @@ use openlark_core::{
     validate_required,
 };
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
 use crate::common::api_utils::serialize_params;
@@ -20,14 +19,14 @@ pub struct CreateTicketMessageBody {
     /// 消息内容
     pub content: String,
     /// 消息类型
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub msg_type: Option<String>,
+    pub msg_type: String,
 }
 
 impl CreateTicketMessageBody {
     /// 验证请求参数
     pub fn validate(&self) -> openlark_core::SDKResult<()> {
-        validate_required!(self.content, "content is required");
+        validate_required!(self.msg_type, "msg_type 不能为空");
+        validate_required!(self.content, "content 不能为空");
         Ok(())
     }
 }
@@ -35,31 +34,23 @@ impl CreateTicketMessageBody {
 /// 发送工单消息响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateTicketMessageResponse {
-    /// 响应数据。
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<CreateTicketMessageResult>,
-}
-
-impl openlark_core::api::ApiResponseTrait for CreateTicketMessageResponse {}
-
-/// 发送工单消息结果
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CreateTicketMessageResult {
     /// 消息ID
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 }
 
+impl openlark_core::api::ApiResponseTrait for CreateTicketMessageResponse {}
+
 /// 发送工单消息请求
 #[derive(Debug, Clone)]
 pub struct CreateTicketMessageRequest {
-    config: Arc<Config>,
+    config: Config,
     ticket_id: String,
 }
 
 impl CreateTicketMessageRequest {
     /// 创建新的发送工单消息请求
-    pub fn new(config: Arc<Config>, ticket_id: String) -> Self {
+    pub fn new(config: Config, ticket_id: String) -> Self {
         Self { config, ticket_id }
     }
 
@@ -91,7 +82,7 @@ impl CreateTicketMessageRequest {
 /// 发送工单消息请求构建器
 #[derive(Debug, Clone)]
 pub struct CreateTicketMessageRequestBuilder {
-    config: Arc<Config>,
+    config: Config,
     ticket_id: String,
     content: Option<String>,
     msg_type: Option<String>,
@@ -99,7 +90,7 @@ pub struct CreateTicketMessageRequestBuilder {
 
 impl CreateTicketMessageRequestBuilder {
     /// 创建新的构建器
-    pub fn new(config: Arc<Config>, ticket_id: String) -> Self {
+    pub fn new(config: Config, ticket_id: String) -> Self {
         Self {
             config,
             ticket_id,
@@ -122,12 +113,10 @@ impl CreateTicketMessageRequestBuilder {
 
     /// 构建请求体
     pub fn body(&self) -> Result<CreateTicketMessageBody, String> {
-        let content = self.content.clone().ok_or("content is required")?;
+        let msg_type = self.msg_type.clone().ok_or("msg_type 不能为空")?;
+        let content = self.content.clone().ok_or("content 不能为空")?;
 
-        Ok(CreateTicketMessageBody {
-            content,
-            msg_type: self.msg_type.clone(),
-        })
+        Ok(CreateTicketMessageBody { content, msg_type })
     }
 
     /// 执行请求
@@ -174,7 +163,7 @@ mod tests {
     fn test_body_validation_valid() {
         let body = CreateTicketMessageBody {
             content: "这是一条测试消息".to_string(),
-            msg_type: Some("text".to_string()),
+            msg_type: "text".to_string(),
         };
         let result = body.validate();
         assert!(result.is_ok());
@@ -184,7 +173,7 @@ mod tests {
     fn test_body_validation_empty_content() {
         let body = CreateTicketMessageBody {
             content: "".to_string(),
-            msg_type: None,
+            msg_type: "text".to_string(),
         };
         let result = body.validate();
         assert!(result.is_err());
@@ -196,14 +185,13 @@ mod tests {
             .app_id("test_app_id")
             .app_secret("test_app_secret")
             .build();
-        let builder =
-            CreateTicketMessageRequestBuilder::new(Arc::new(config), "ticket_123".to_string());
+        let builder = CreateTicketMessageRequestBuilder::new(config, "ticket_123".to_string());
 
         assert_eq!(builder.ticket_id, "ticket_123");
         assert!(builder.content.is_none());
     }
 
-    /// 端到端：POST .../tickets/{id}/messages → 强类型 CreateTicketMessageResponse 解析（双层 data 信封）。
+    /// 端到端：POST .../tickets/{id}/messages → 强类型 CreateTicketMessageResponse 解析。
     #[tokio::test]
     async fn test_create_ticket_message_returns_data_on_success() {
         use serde_json::json;
@@ -217,30 +205,27 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": { "data": { "id": "msg_001" } }
+                "data": { "id": "msg_001" }
             })))
             .mount(&server)
             .await;
 
-        let config = Arc::new(
-            Config::builder()
-                .app_id("ci_app_id")
-                .app_secret("ci_app_secret")
-                .base_url(server.uri())
-                .enable_token_cache(false)
-                .build(),
-        );
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
         let body = CreateTicketMessageBody {
             content: "您好，请问需要什么帮助？".to_string(),
-            msg_type: Some("text".to_string()),
+            msg_type: "text".to_string(),
         };
         let resp = CreateTicketMessageRequest::new(config, "tk_001".to_string())
             .execute(body)
             .await
             .expect("发送工单消息应成功");
-        assert!(resp.data.is_some());
-        assert_eq!(resp.data.unwrap().id.as_deref(), Some("msg_001"));
+        assert_eq!(resp.id.as_deref(), Some("msg_001"));
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/message/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/message/mod.rs
@@ -25,7 +25,10 @@ impl<'a> TicketMessage<'a> {
 
     /// 发送工单消息
     pub fn create(&self, ticket_id: impl Into<String>) -> create::CreateTicketMessageRequest {
-        create::CreateTicketMessageRequest::new(self.ticket.config.clone(), ticket_id.into())
+        create::CreateTicketMessageRequest::new(
+            self.ticket.config.as_ref().clone(),
+            ticket_id.into(),
+        )
     }
 }
 

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/mod.rs
@@ -58,7 +58,7 @@ impl Ticket {
 
     /// 拉起服务请求。
     pub fn start_service(&self) -> start_service::StartServiceRequest {
-        start_service::StartServiceRequest::new(self.config.clone())
+        start_service::StartServiceRequest::new(self.config.as_ref().clone())
     }
 
     /// 回复用户提问请求。
@@ -66,7 +66,7 @@ impl Ticket {
         &self,
         ticket_id: impl Into<String>,
     ) -> answer_user_query::AnswerUserQueryRequest {
-        answer_user_query::AnswerUserQueryRequest::new(self.config.clone(), ticket_id)
+        answer_user_query::AnswerUserQueryRequest::new(self.config.as_ref().clone(), ticket_id)
     }
 
     /// 获取工单图片请求。

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/start_service.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket/start_service.rs
@@ -10,40 +10,36 @@ use openlark_core::{
     config::Config,
     http::Transport,
     req_option::RequestOption,
+    validate_required,
 };
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
 /// 创建服务台对话请求
 #[derive(Debug, Clone)]
 pub struct StartServiceRequest {
-    config: Arc<Config>,
+    config: Config,
     body: StartServiceBody,
 }
 
 /// 创建服务台对话请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct StartServiceBody {
-    /// 用户 ID
-    pub user_id: String,
-    /// 服务台 ID
-    pub service_id: String,
-    /// 问题描述
+    /// 是否直接转人工服务
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub question: Option<String>,
+    pub human_service: Option<bool>,
+    /// 指定接待客服的 open_id 列表
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub appointed_agents: Option<Vec<String>>,
+    /// 用户 open_id
+    pub open_id: String,
+    /// 自定义信息
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub customized_info: Option<String>,
 }
 
 impl StartServiceBody {
     fn validate(&self) -> SDKResult<()> {
-        if self.user_id.trim().is_empty() {
-            return Err(openlark_core::error::validation_error("用户ID不能为空", ""));
-        }
-        if self.service_id.trim().is_empty() {
-            return Err(openlark_core::error::validation_error(
-                "服务台ID不能为空",
-                "",
-            ));
-        }
+        validate_required!(self.open_id, "open_id 不能为空");
         Ok(())
     }
 }
@@ -51,8 +47,8 @@ impl StartServiceBody {
 /// 创建服务台对话响应
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StartServiceResponse {
-    /// 响应数据。
-    pub data: Option<StartServiceData>,
+    /// 工单 ID
+    pub ticket_id: String,
 }
 
 impl ApiResponseTrait for StartServiceResponse {
@@ -61,37 +57,36 @@ impl ApiResponseTrait for StartServiceResponse {
     }
 }
 
-/// 创建服务台对话数据
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StartServiceData {
-    /// 工单 ID
-    pub ticket_id: String,
-}
-
 impl StartServiceRequest {
     /// 创建新的实例。
-    pub fn new(config: Arc<Config>) -> Self {
+    pub fn new(config: Config) -> Self {
         Self {
             config,
             body: StartServiceBody::default(),
         }
     }
 
-    /// 设置用户 ID。
-    pub fn user_id(mut self, user_id: impl Into<String>) -> Self {
-        self.body.user_id = user_id.into();
+    /// 设置是否直接转人工服务。
+    pub fn human_service(mut self, human_service: bool) -> Self {
+        self.body.human_service = Some(human_service);
         self
     }
 
-    /// 设置服务 ID。
-    pub fn service_id(mut self, service_id: impl Into<String>) -> Self {
-        self.body.service_id = service_id.into();
+    /// 设置指定接待客服的 open_id 列表。
+    pub fn appointed_agents(mut self, appointed_agents: Vec<String>) -> Self {
+        self.body.appointed_agents = Some(appointed_agents);
         self
     }
 
-    /// 设置问题内容。
-    pub fn question(mut self, question: impl Into<String>) -> Self {
-        self.body.question = Some(question.into());
+    /// 设置用户 open_id。
+    pub fn open_id(mut self, open_id: impl Into<String>) -> Self {
+        self.body.open_id = open_id.into();
+        self
+    }
+
+    /// 设置自定义信息。
+    pub fn customized_info(mut self, customized_info: impl Into<String>) -> Self {
+        self.body.customized_info = Some(customized_info.into());
         self
     }
 
@@ -120,7 +115,30 @@ impl StartServiceRequest {
 mod tests {
     use super::*;
 
-    /// 端到端：POST .../start_service → 强类型 StartServiceResponse 解析（双层 data 信封）。
+    #[test]
+    fn test_body_validation_requires_open_id() {
+        let body = StartServiceBody::default();
+        assert!(body.validate().is_err());
+    }
+
+    #[test]
+    fn test_body_serialization_matches_official_shape() {
+        let body = StartServiceBody {
+            human_service: Some(false),
+            appointed_agents: Some(vec!["ou_agent".to_string()]),
+            open_id: "ou_user".to_string(),
+            customized_info: Some("自定义信息".to_string()),
+        };
+        let value = serde_json::to_value(body).expect("请求体应可序列化");
+
+        assert_eq!(value["open_id"], "ou_user");
+        assert_eq!(value["appointed_agents"][0], "ou_agent");
+        assert!(value.get("question").is_none());
+        assert!(value.get("service_id").is_none());
+        assert!(value.get("user_id").is_none());
+    }
+
+    /// 端到端：POST .../start_service → 强类型响应解析。
     #[tokio::test]
     async fn test_start_service_returns_data_on_success() {
         use serde_json::json;
@@ -134,28 +152,27 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
                 "msg": "success",
-                "data": { "data": { "ticket_id": "tk_001" } }
+                "data": { "ticket_id": "tk_001" }
             })))
             .mount(&server)
             .await;
 
-        let config = Arc::new(
-            Config::builder()
-                .app_id("ci_app_id")
-                .app_secret("ci_app_secret")
-                .base_url(server.uri())
-                .enable_token_cache(false)
-                .build(),
-        );
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url(server.uri())
+            .enable_token_cache(false)
+            .build();
 
         let resp = StartServiceRequest::new(config)
-            .user_id("ou_001")
-            .service_id("svc_001")
+            .human_service(false)
+            .appointed_agents(vec!["ou_agent".to_string()])
+            .open_id("ou_001")
+            .customized_info("自定义信息")
             .execute()
             .await
             .expect("创建服务台对话应成功");
-        assert!(resp.data.is_some());
-        assert_eq!(resp.data.unwrap().ticket_id, "tk_001");
+        assert_eq!(resp.ticket_id, "tk_001");
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/create.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/create.rs
@@ -5,7 +5,11 @@
 //! docPath: <https://open.feishu.cn/document/server-docs/helpdesk-v1/ticket_customized_field/create>
 
 use openlark_core::{
-    SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
+    SDKResult,
+    api::{ApiRequest, ApiResponseTrait},
+    config::Config,
+    http::Transport,
+    req_option::RequestOption,
     validate_required,
 };
 use serde::{Deserialize, Serialize};
@@ -13,47 +17,56 @@ use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
 use crate::common::api_utils::serialize_params;
+use crate::helpdesk::helpdesk::v1::ticket_customized_field::models::TicketCustomizedFieldDropdownOptions;
 
 /// 创建工单自定义字段请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CreateTicketCustomizedFieldBody {
-    /// 字段名称
-    pub name: String,
-    /// 字段类型
-    pub field_type: String,
-    /// 是否必填
+    /// 服务台 ID，可省略但必须与请求头中的服务台 ID 一致。
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub required: Option<bool>,
+    pub helpdesk_id: Option<String>,
+    /// 字段键名。
+    pub key_name: String,
+    /// 字段展示名称。
+    pub display_name: String,
+    /// 字段位置。
+    pub position: String,
+    /// 字段类型。
+    pub field_type: String,
+    /// 字段描述。
+    pub description: String,
+    /// 是否可见。
+    pub visible: bool,
+    /// 是否必填。
+    pub required: bool,
+    /// 下拉选项。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dropdown_options: Option<TicketCustomizedFieldDropdownOptions>,
+    /// 下拉字段是否允许多选。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dropdown_allow_multiple: Option<bool>,
 }
 
 impl CreateTicketCustomizedFieldBody {
     /// 验证请求参数
     pub fn validate(&self) -> openlark_core::SDKResult<()> {
-        validate_required!(self.name, "name is required");
-        validate_required!(self.field_type, "field_type is required");
+        validate_required!(self.key_name, "key_name 不能为空");
+        validate_required!(self.display_name, "display_name 不能为空");
+        validate_required!(self.position, "position 不能为空");
+        validate_required!(self.field_type, "field_type 不能为空");
+        validate_required!(self.description, "description 不能为空");
         Ok(())
     }
 }
 
 /// 创建工单自定义字段响应
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CreateTicketCustomizedFieldResponse {
-    /// 响应数据。
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<CreateTicketCustomizedFieldResult>,
-}
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CreateTicketCustomizedFieldResponse {}
 
-impl openlark_core::api::ApiResponseTrait for CreateTicketCustomizedFieldResponse {}
-
-/// 创建工单自定义字段结果
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CreateTicketCustomizedFieldResult {
-    /// 字段ID
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
-    /// 字段名称
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+impl ApiResponseTrait for CreateTicketCustomizedFieldResponse {
+    fn empty_success() -> Option<Self> {
+        Some(Self::default())
+    }
 }
 
 /// 创建工单自定义字段请求
@@ -97,9 +110,16 @@ impl CreateTicketCustomizedFieldRequest {
 #[derive(Debug, Clone)]
 pub struct CreateTicketCustomizedFieldRequestBuilder {
     config: Arc<Config>,
-    name: Option<String>,
+    helpdesk_id: Option<String>,
+    key_name: Option<String>,
+    display_name: Option<String>,
+    position: Option<String>,
     field_type: Option<String>,
+    description: Option<String>,
+    visible: Option<bool>,
     required: Option<bool>,
+    dropdown_options: Option<TicketCustomizedFieldDropdownOptions>,
+    dropdown_allow_multiple: Option<bool>,
 }
 
 impl CreateTicketCustomizedFieldRequestBuilder {
@@ -107,39 +127,103 @@ impl CreateTicketCustomizedFieldRequestBuilder {
     pub fn new(config: Arc<Config>) -> Self {
         Self {
             config,
-            name: None,
+            helpdesk_id: None,
+            key_name: None,
+            display_name: None,
+            position: None,
             field_type: None,
+            description: None,
+            visible: None,
             required: None,
+            dropdown_options: None,
+            dropdown_allow_multiple: None,
         }
     }
 
-    /// 设置字段名称
-    pub fn name(mut self, name: impl Into<String>) -> Self {
-        self.name = Some(name.into());
+    /// 设置服务台 ID。
+    pub fn helpdesk_id(mut self, helpdesk_id: impl Into<String>) -> Self {
+        self.helpdesk_id = Some(helpdesk_id.into());
         self
     }
 
-    /// 设置字段类型
+    /// 设置字段键名。
+    pub fn key_name(mut self, key_name: impl Into<String>) -> Self {
+        self.key_name = Some(key_name.into());
+        self
+    }
+
+    /// 设置字段展示名称。
+    pub fn display_name(mut self, display_name: impl Into<String>) -> Self {
+        self.display_name = Some(display_name.into());
+        self
+    }
+
+    /// 设置字段位置。
+    pub fn position(mut self, position: impl Into<String>) -> Self {
+        self.position = Some(position.into());
+        self
+    }
+
+    /// 设置字段类型。
     pub fn field_type(mut self, field_type: impl Into<String>) -> Self {
         self.field_type = Some(field_type.into());
         self
     }
 
-    /// 设置是否必填
+    /// 设置字段描述。
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// 设置是否可见。
+    pub fn visible(mut self, visible: bool) -> Self {
+        self.visible = Some(visible);
+        self
+    }
+
+    /// 设置是否必填。
     pub fn required(mut self, required: bool) -> Self {
         self.required = Some(required);
         self
     }
 
+    /// 设置下拉选项。
+    pub fn dropdown_options(
+        mut self,
+        dropdown_options: TicketCustomizedFieldDropdownOptions,
+    ) -> Self {
+        self.dropdown_options = Some(dropdown_options);
+        self
+    }
+
+    /// 设置下拉字段是否允许多选。
+    pub fn dropdown_allow_multiple(mut self, dropdown_allow_multiple: bool) -> Self {
+        self.dropdown_allow_multiple = Some(dropdown_allow_multiple);
+        self
+    }
+
     /// 构建请求体
     pub fn body(&self) -> Result<CreateTicketCustomizedFieldBody, String> {
-        let name = self.name.clone().ok_or("name is required")?;
-        let field_type = self.field_type.clone().ok_or("field_type is required")?;
+        let key_name = self.key_name.clone().ok_or("key_name 不能为空")?;
+        let display_name = self.display_name.clone().ok_or("display_name 不能为空")?;
+        let position = self.position.clone().ok_or("position 不能为空")?;
+        let field_type = self.field_type.clone().ok_or("field_type 不能为空")?;
+        let description = self.description.clone().ok_or("description 不能为空")?;
+        let visible = self.visible.ok_or("visible 不能为空")?;
+        let required = self.required.ok_or("required 不能为空")?;
 
         Ok(CreateTicketCustomizedFieldBody {
-            name,
+            helpdesk_id: self.helpdesk_id.clone(),
+            key_name,
+            display_name,
+            position,
             field_type,
-            required: self.required,
+            description,
+            visible,
+            required,
+            dropdown_options: self.dropdown_options.clone(),
+            dropdown_allow_multiple: self.dropdown_allow_multiple,
         })
     }
 
@@ -184,20 +268,30 @@ mod tests {
     #[test]
     fn test_body_validation_valid() {
         let body = CreateTicketCustomizedFieldBody {
-            name: "自定义字段".to_string(),
-            field_type: "text".to_string(),
-            required: Some(true),
+            key_name: "priority".to_string(),
+            display_name: "优先级".to_string(),
+            position: "3".to_string(),
+            field_type: "dropdown".to_string(),
+            description: "工单优先级".to_string(),
+            visible: true,
+            required: false,
+            ..Default::default()
         };
         let result = body.validate();
         assert!(result.is_ok());
     }
 
     #[test]
-    fn test_body_validation_empty_name() {
+    fn test_body_validation_empty_display_name() {
         let body = CreateTicketCustomizedFieldBody {
-            name: "".to_string(),
-            field_type: "text".to_string(),
-            required: None,
+            key_name: "priority".to_string(),
+            display_name: " ".to_string(),
+            position: "3".to_string(),
+            field_type: "dropdown".to_string(),
+            description: "工单优先级".to_string(),
+            visible: true,
+            required: false,
+            ..Default::default()
         };
         let result = body.validate();
         assert!(result.is_err());
@@ -211,10 +305,34 @@ mod tests {
             .build();
         let builder = CreateTicketCustomizedFieldRequestBuilder::new(Arc::new(config));
 
-        assert!(builder.name.is_none());
+        assert!(builder.display_name.is_none());
     }
 
-    /// 端到端：POST .../ticket_customized_fields → 强类型 CreateTicketCustomizedFieldResponse 解析（双层 data 信封）。
+    #[test]
+    fn test_body_uses_official_fields() {
+        let body = CreateTicketCustomizedFieldBody {
+            helpdesk_id: Some("1542164574896126".to_string()),
+            key_name: "priority".to_string(),
+            display_name: "优先级".to_string(),
+            position: "3".to_string(),
+            field_type: "dropdown".to_string(),
+            description: "工单优先级".to_string(),
+            visible: true,
+            required: false,
+            dropdown_options: Some(TicketCustomizedFieldDropdownOptions {
+                children: Some(vec![]),
+            }),
+            dropdown_allow_multiple: Some(true),
+        };
+        let value = serde_json::to_value(body).expect("请求体应可序列化");
+
+        assert_eq!(value["key_name"], "priority");
+        assert_eq!(value["display_name"], "优先级");
+        assert_eq!(value["dropdown_allow_multiple"], true);
+        assert!(value.get("name").is_none());
+    }
+
+    /// 端到端：POST .../ticket_customized_fields → 无 `data` 的成功响应可正确解析。
     #[tokio::test]
     async fn test_create_returns_data_on_success() {
         use serde_json::json;
@@ -227,8 +345,7 @@ mod tests {
             .and(path("/open-apis/helpdesk/v1/ticket_customized_fields"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
-                "msg": "success",
-                "data": { "data": { "id": "tcf_001", "name": "工单编号" } }
+                "msg": "success"
             })))
             .mount(&server)
             .await;
@@ -243,15 +360,19 @@ mod tests {
         );
 
         let body = CreateTicketCustomizedFieldBody {
-            name: "工单编号".to_string(),
+            key_name: "ticket_number".to_string(),
+            display_name: "工单编号".to_string(),
+            position: "3".to_string(),
             field_type: "text".to_string(),
-            required: Some(true),
+            description: "工单编号".to_string(),
+            visible: true,
+            required: true,
+            ..Default::default()
         };
-        let resp = CreateTicketCustomizedFieldRequest::new(config)
+        CreateTicketCustomizedFieldRequest::new(config)
             .execute(body)
             .await
             .expect("创建工单自定义字段应成功");
-        assert!(resp.data.is_some());
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
@@ -259,5 +380,9 @@ mod tests {
             received[0].url.path(),
             "/open-apis/helpdesk/v1/ticket_customized_fields"
         );
+        let request_body: serde_json::Value =
+            serde_json::from_slice(&received[0].body).expect("请求体应为 JSON");
+        assert_eq!(request_body["display_name"], "工单编号");
+        assert!(request_body.get("name").is_none());
     }
 }

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/mod.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/mod.rs
@@ -9,6 +9,8 @@ pub mod delete;
 /// 获取接口。
 pub mod get;
 pub mod list;
+/// 工单自定义字段共享模型。
+pub mod models;
 /// 更新接口。
 pub mod patch;
 
@@ -57,4 +59,5 @@ pub use create::{CreateTicketCustomizedFieldRequest, CreateTicketCustomizedField
 pub use delete::{DeleteTicketCustomizedFieldRequest, DeleteTicketCustomizedFieldRequestBuilder};
 pub use get::{GetTicketCustomizedFieldRequest, GetTicketCustomizedFieldRequestBuilder};
 pub use list::{ListTicketCustomizedFieldRequest, ListTicketCustomizedFieldRequestBuilder};
+pub use models::{TicketCustomizedFieldDropdownOption, TicketCustomizedFieldDropdownOptions};
 pub use patch::{PatchTicketCustomizedFieldRequest, PatchTicketCustomizedFieldRequestBuilder};

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/models.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/models.rs
@@ -1,0 +1,25 @@
+//! 工单自定义字段共享模型
+
+use serde::{Deserialize, Serialize};
+
+/// 下拉选项集合。
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct TicketCustomizedFieldDropdownOptions {
+    /// 下拉选项列表。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub children: Option<Vec<TicketCustomizedFieldDropdownOption>>,
+}
+
+/// 下拉选项。
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct TicketCustomizedFieldDropdownOption {
+    /// 选项 ID。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag: Option<String>,
+    /// 选项展示名称。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    /// 子选项，最多支持三级。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub children: Option<Vec<TicketCustomizedFieldDropdownOption>>,
+}

--- a/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/patch.rs
+++ b/crates/openlark-helpdesk/src/helpdesk/helpdesk/v1/ticket_customized_field/patch.rs
@@ -5,7 +5,11 @@
 //! docPath: <https://open.feishu.cn/document/server-docs/helpdesk-v1/ticket_customized_field/patch>
 
 use openlark_core::{
-    SDKResult, api::ApiRequest, config::Config, http::Transport, req_option::RequestOption,
+    SDKResult,
+    api::{ApiRequest, ApiResponseTrait},
+    config::Config,
+    http::Transport,
+    req_option::RequestOption,
     validate_required,
 };
 use serde::{Deserialize, Serialize};
@@ -13,47 +17,55 @@ use std::sync::Arc;
 
 use crate::common::api_endpoints::HelpdeskApiV1;
 use crate::common::api_utils::serialize_params;
+use crate::helpdesk::helpdesk::v1::ticket_customized_field::models::TicketCustomizedFieldDropdownOptions;
 
 /// 更新工单自定义字段请求体
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct PatchTicketCustomizedFieldBody {
-    /// 字段名称
+    /// 字段展示名称。
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    /// 是否必填
+    pub display_name: Option<String>,
+    /// 字段位置。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position: Option<String>,
+    /// 字段描述。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// 是否可见。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub visible: Option<bool>,
+    /// 是否必填。
     #[serde(skip_serializing_if = "Option::is_none")]
     pub required: Option<bool>,
+    /// 下拉选项。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dropdown_options: Option<TicketCustomizedFieldDropdownOptions>,
 }
 
 impl PatchTicketCustomizedFieldBody {
     /// 验证请求参数
     pub fn validate(&self) -> openlark_core::SDKResult<()> {
-        if let Some(name) = &self.name {
-            validate_required!(name, "name cannot be empty");
+        if let Some(display_name) = &self.display_name {
+            validate_required!(display_name, "display_name 不能为空");
+        }
+        if let Some(position) = &self.position {
+            validate_required!(position, "position 不能为空");
+        }
+        if let Some(description) = &self.description {
+            validate_required!(description, "description 不能为空");
         }
         Ok(())
     }
 }
 
 /// 更新工单自定义字段响应
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PatchTicketCustomizedFieldResponse {
-    /// 响应数据。
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<PatchTicketCustomizedFieldResult>,
-}
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PatchTicketCustomizedFieldResponse {}
 
-impl openlark_core::api::ApiResponseTrait for PatchTicketCustomizedFieldResponse {}
-
-/// 更新工单自定义字段结果
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PatchTicketCustomizedFieldResult {
-    /// 字段ID
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
-    /// 字段名称
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+impl ApiResponseTrait for PatchTicketCustomizedFieldResponse {
+    fn empty_success() -> Option<Self> {
+        Some(Self::default())
+    }
 }
 
 /// 更新工单自定义字段请求
@@ -99,8 +111,12 @@ impl PatchTicketCustomizedFieldRequest {
 pub struct PatchTicketCustomizedFieldRequestBuilder {
     config: Arc<Config>,
     id: String,
-    name: Option<String>,
+    display_name: Option<String>,
+    position: Option<String>,
+    description: Option<String>,
+    visible: Option<bool>,
     required: Option<bool>,
+    dropdown_options: Option<TicketCustomizedFieldDropdownOptions>,
 }
 
 impl PatchTicketCustomizedFieldRequestBuilder {
@@ -109,28 +125,63 @@ impl PatchTicketCustomizedFieldRequestBuilder {
         Self {
             config,
             id,
-            name: None,
+            display_name: None,
+            position: None,
+            description: None,
+            visible: None,
             required: None,
+            dropdown_options: None,
         }
     }
 
-    /// 设置字段名称
-    pub fn name(mut self, name: impl Into<String>) -> Self {
-        self.name = Some(name.into());
+    /// 设置字段展示名称。
+    pub fn display_name(mut self, display_name: impl Into<String>) -> Self {
+        self.display_name = Some(display_name.into());
         self
     }
 
-    /// 设置是否必填
+    /// 设置字段位置。
+    pub fn position(mut self, position: impl Into<String>) -> Self {
+        self.position = Some(position.into());
+        self
+    }
+
+    /// 设置字段描述。
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// 设置是否可见。
+    pub fn visible(mut self, visible: bool) -> Self {
+        self.visible = Some(visible);
+        self
+    }
+
+    /// 设置是否必填。
     pub fn required(mut self, required: bool) -> Self {
         self.required = Some(required);
+        self
+    }
+
+    /// 设置下拉选项。
+    pub fn dropdown_options(
+        mut self,
+        dropdown_options: TicketCustomizedFieldDropdownOptions,
+    ) -> Self {
+        self.dropdown_options = Some(dropdown_options);
         self
     }
 
     /// 构建请求体
     pub fn body(&self) -> PatchTicketCustomizedFieldBody {
         PatchTicketCustomizedFieldBody {
-            name: self.name.clone(),
+            display_name: self.display_name.clone(),
+            position: self.position.clone(),
+            description: self.description.clone(),
+            visible: self.visible,
             required: self.required,
+            dropdown_options: self.dropdown_options.clone(),
         }
     }
 
@@ -192,18 +243,21 @@ mod tests {
     #[test]
     fn test_body_validation_valid() {
         let body = PatchTicketCustomizedFieldBody {
-            name: Some("新名称".to_string()),
+            display_name: Some("新名称".to_string()),
+            position: Some("4".to_string()),
+            visible: Some(true),
             required: Some(true),
+            ..Default::default()
         };
         let result = body.validate();
         assert!(result.is_ok());
     }
 
     #[test]
-    fn test_body_validation_empty_name() {
+    fn test_body_validation_empty_display_name() {
         let body = PatchTicketCustomizedFieldBody {
-            name: Some("".to_string()),
-            required: None,
+            display_name: Some(" ".to_string()),
+            ..Default::default()
         };
         let result = body.validate();
         assert!(result.is_err());
@@ -221,10 +275,29 @@ mod tests {
         );
 
         assert_eq!(builder.id, "field_123");
-        assert!(builder.name.is_none());
+        assert!(builder.display_name.is_none());
     }
 
-    /// 端到端：PATCH .../ticket_customized_fields/{id} → 强类型 PatchTicketCustomizedFieldResponse 解析（双层 data 信封）。
+    #[test]
+    fn test_body_uses_official_fields() {
+        let body = PatchTicketCustomizedFieldBody {
+            display_name: Some("新名称".to_string()),
+            position: Some("4".to_string()),
+            visible: Some(true),
+            dropdown_options: Some(TicketCustomizedFieldDropdownOptions {
+                children: Some(vec![]),
+            }),
+            ..Default::default()
+        };
+        let value = serde_json::to_value(body).expect("请求体应可序列化");
+
+        assert_eq!(value["display_name"], "新名称");
+        assert_eq!(value["position"], "4");
+        assert_eq!(value["visible"], true);
+        assert!(value.get("name").is_none());
+    }
+
+    /// 端到端：PATCH .../ticket_customized_fields/{id} → 无 `data` 的成功响应可正确解析。
     #[tokio::test]
     async fn test_patch_returns_data_on_success() {
         use serde_json::json;
@@ -239,8 +312,7 @@ mod tests {
             ))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "code": 0,
-                "msg": "success",
-                "data": { "data": { "id": "tcf_001", "name": "工单编号-改" } }
+                "msg": "success"
             })))
             .mount(&server)
             .await;
@@ -255,14 +327,16 @@ mod tests {
         );
 
         let body = PatchTicketCustomizedFieldBody {
-            name: Some("工单编号-改".to_string()),
+            display_name: Some("工单编号-改".to_string()),
+            position: Some("4".to_string()),
+            visible: Some(true),
             required: Some(true),
+            ..Default::default()
         };
-        let resp = PatchTicketCustomizedFieldRequest::new(config, "tcf_001".to_string())
+        PatchTicketCustomizedFieldRequest::new(config, "tcf_001".to_string())
             .execute(body)
             .await
             .expect("更新工单自定义字段应成功");
-        assert!(resp.data.is_some());
 
         let received = server.received_requests().await.unwrap_or_default();
         assert_eq!(received.len(), 1);
@@ -270,5 +344,9 @@ mod tests {
             received[0].url.path(),
             "/open-apis/helpdesk/v1/ticket_customized_fields/tcf_001"
         );
+        let request_body: serde_json::Value =
+            serde_json::from_slice(&received[0].body).expect("请求体应为 JSON");
+        assert_eq!(request_body["display_name"], "工单编号-改");
+        assert!(request_body.get("name").is_none());
     }
 }

--- a/crates/openlark-helpdesk/tests/helpdesk_contract_models.rs
+++ b/crates/openlark-helpdesk/tests/helpdesk_contract_models.rs
@@ -163,17 +163,15 @@ fn ticket_item_roundtrip() {
 fn category_create_body_full_roundtrip() {
     let body = CreateCategoryBody {
         name: "技术支持".to_string(),
-        description: Some("技术相关问题分类".to_string()),
-        parent_id: Some("cat_root".to_string()),
-        order: Some(10),
+        parent_id: "cat_root".to_string(),
+        language: Some("zh_cn".to_string()),
     };
     assert_json_contract(
         &body,
         json!({
             "name": "技术支持",
-            "description": "技术相关问题分类",
             "parent_id": "cat_root",
-            "order": 10
+            "language": "zh_cn"
         }),
     );
 
@@ -186,14 +184,13 @@ fn category_create_body_full_roundtrip() {
 fn category_create_body_minimal() {
     let body = CreateCategoryBody {
         name: "常见问题".to_string(),
-        description: None,
-        parent_id: None,
-        order: None,
+        parent_id: "0".to_string(),
+        language: None,
     };
     let value = to_value(&body).unwrap();
     assert_eq!(value["name"], "常见问题");
-    assert!(value.get("description").is_none());
-    assert!(value.get("order").is_none());
+    assert_eq!(value["parent_id"], "0");
+    assert!(value.get("language").is_none());
 }
 
 #[test]
@@ -201,13 +198,12 @@ fn category_create_result_roundtrip() {
     let result = parse_contract::<CreateCategoryResult>(json!({
         "id": "cat_001",
         "name": "技术支持",
-        "description": "技术相关问题",
         "parent_id": "cat_root",
-        "order": 5
+        "language": "zh_cn"
     }));
     assert_eq!(result.id, Some("cat_001".to_string()));
     assert_eq!(result.name, Some("技术支持".to_string()));
-    assert_eq!(result.order, Some(5));
+    assert_eq!(result.language, Some("zh_cn".to_string()));
 }
 
 // ── FAQ 模型 ─────────────────────────────────────────────────
@@ -300,13 +296,11 @@ fn notification_create_result_roundtrip() {
 
 #[test]
 fn agent_patch_body_roundtrip() {
-    let body = PatchAgentBody {
-        status: Some("online".to_string()),
-    };
-    assert_json_contract(&body, json!({ "status": "online" }));
+    let body = PatchAgentBody { status: Some(1) };
+    assert_json_contract(&body, json!({ "status": 1 }));
 
     let roundtrip: PatchAgentBody = from_value(to_value(&body).unwrap()).unwrap();
-    assert_eq!(roundtrip.status, Some("online".to_string()));
+    assert_eq!(roundtrip.status, Some(1));
 }
 
 #[test]
@@ -320,10 +314,10 @@ fn agent_patch_body_empty() {
 fn agent_patch_result_roundtrip() {
     let result = parse_contract::<PatchAgentResult>(json!({
         "agent_id": "agent_001",
-        "status": "online"
+        "status": 1
     }));
     assert_eq!(result.agent_id, Some("agent_001".to_string()));
-    assert_eq!(result.status, Some("online".to_string()));
+    assert_eq!(result.status, Some(1));
 }
 
 // ── Ticket Message 模型 ─────────────────────────────────────

--- a/crates/openlark-helpdesk/tests/helpdesk_contract_models.rs
+++ b/crates/openlark-helpdesk/tests/helpdesk_contract_models.rs
@@ -8,7 +8,9 @@ use openlark_helpdesk::helpdesk::helpdesk::v1::agent::patch::{PatchAgentBody, Pa
 use openlark_helpdesk::helpdesk::helpdesk::v1::category::create::{
     CreateCategoryBody, CreateCategoryResult,
 };
-use openlark_helpdesk::helpdesk::helpdesk::v1::faq::create::{CreateFaqBody, CreateFaqResult};
+use openlark_helpdesk::helpdesk::helpdesk::v1::faq::create::{
+    CreateFaq, CreateFaqBody, CreateFaqResponse,
+};
 use openlark_helpdesk::helpdesk::helpdesk::v1::notification::create::{
     CreateNotificationBody, CreateNotificationResult,
 };
@@ -213,41 +215,51 @@ fn category_create_result_roundtrip() {
 #[test]
 fn faq_create_body_roundtrip() {
     let body = CreateFaqBody {
-        title: "如何重置密码？".to_string(),
-        content: "请在登录页面点击「忘记密码」...".to_string(),
-        category_id: Some("cat_001".to_string()),
+        faq: CreateFaq {
+            category_id: Some("cat_001".to_string()),
+            question: "如何重置密码？".to_string(),
+            answer: Some("请在登录页面点击「忘记密码」...".to_string()),
+            answer_richtext: Some("[{\"type\":\"text\",\"content\":\"答案\"}]".to_string()),
+            tags: Some(vec!["账号".to_string()]),
+        },
     };
     assert_json_contract(
         &body,
         json!({
-            "title": "如何重置密码？",
-            "content": "请在登录页面点击「忘记密码」...",
-            "category_id": "cat_001"
+            "faq": {
+                "category_id": "cat_001",
+                "question": "如何重置密码？",
+                "answer": "请在登录页面点击「忘记密码」...",
+                "answer_richtext": "[{\"type\":\"text\",\"content\":\"答案\"}]",
+                "tags": ["账号"]
+            }
         }),
     );
 
     let roundtrip: CreateFaqBody = from_value(to_value(&body).unwrap()).unwrap();
-    assert_eq!(roundtrip.title, body.title);
-    assert_eq!(roundtrip.content, body.content);
+    assert_eq!(roundtrip.faq.question, body.faq.question);
+    assert_eq!(roundtrip.faq.answer, body.faq.answer);
 }
 
 #[test]
 fn faq_create_body_without_optional() {
     let body = CreateFaqBody {
-        title: "常见问题".to_string(),
-        content: "这是答案内容".to_string(),
-        category_id: None,
+        faq: CreateFaq {
+            question: "常见问题".to_string(),
+            ..Default::default()
+        },
     };
     let value = to_value(&body).unwrap();
-    assert!(value.get("category_id").is_none());
+    assert!(value["faq"].get("category_id").is_none());
+    assert!(value["faq"].get("answer").is_none());
 }
 
 #[test]
-fn faq_create_result_roundtrip() {
-    let result = parse_contract::<CreateFaqResult>(json!({
+fn faq_create_response_roundtrip() {
+    let result = parse_contract::<CreateFaqResponse>(json!({
         "id": "faq_100",
-        "title": "如何重置密码？",
-        "content": "请在登录页面点击「忘记密码」...",
+        "question": "如何重置密码？",
+        "answer": "请在登录页面点击「忘记密码」...",
         "category_id": "cat_001",
         "status": "published"
     }));
@@ -320,7 +332,7 @@ fn agent_patch_result_roundtrip() {
 fn ticket_message_body_roundtrip() {
     let body = CreateTicketMessageBody {
         content: "您好，请提供更多信息".to_string(),
-        msg_type: Some("text".to_string()),
+        msg_type: "text".to_string(),
     };
     assert_json_contract(
         &body,
@@ -332,12 +344,12 @@ fn ticket_message_body_roundtrip() {
 }
 
 #[test]
-fn ticket_message_body_minimal() {
+fn ticket_message_body_contains_required_fields() {
     let body = CreateTicketMessageBody {
         content: "简单的消息".to_string(),
-        msg_type: None,
+        msg_type: "text".to_string(),
     };
     let value = to_value(&body).unwrap();
     assert_eq!(value["content"], "简单的消息");
-    assert!(value.get("msg_type").is_none());
+    assert_eq!(value["msg_type"], "text");
 }

--- a/crates/openlark-helpdesk/tests/helpdesk_contract_models.rs
+++ b/crates/openlark-helpdesk/tests/helpdesk_contract_models.rs
@@ -12,8 +12,9 @@ use openlark_helpdesk::helpdesk::helpdesk::v1::faq::create::{
     CreateFaq, CreateFaqBody, CreateFaqResponse,
 };
 use openlark_helpdesk::helpdesk::helpdesk::v1::notification::create::{
-    CreateNotificationBody, CreateNotificationResult,
+    CreateNotificationBody, CreateNotificationResponse,
 };
+use openlark_helpdesk::helpdesk::helpdesk::v1::notification::models::NotificationUser;
 use openlark_helpdesk::helpdesk::helpdesk::v1::ticket::message::create::CreateTicketMessageBody;
 use openlark_helpdesk::helpdesk::helpdesk::v1::ticket::models::{
     CreateTicketBody, CreateTicketResponse, GetTicketResponse, TicketItem, TicketListResponse,
@@ -268,28 +269,36 @@ fn faq_create_response_roundtrip() {
 #[test]
 fn notification_create_body_roundtrip() {
     let body = CreateNotificationBody {
-        title: "系统维护通知".to_string(),
-        content: "系统将于今晚 22:00 进行维护".to_string(),
+        job_name: Some("系统维护通知".to_string()),
+        push_content: Some("系统将于今晚 22:00 进行维护".to_string()),
+        push_type: Some(0),
+        push_scope_type: Some(2),
+        user_list: Some(vec![NotificationUser {
+            user_id: Some("ou_001".to_string()),
+            ..Default::default()
+        }]),
+        ..Default::default()
     };
     assert_json_contract(
         &body,
         json!({
-            "title": "系统维护通知",
-            "content": "系统将于今晚 22:00 进行维护"
+            "job_name": "系统维护通知",
+            "push_content": "系统将于今晚 22:00 进行维护",
+            "push_type": 0,
+            "push_scope_type": 2,
+            "user_list": [{ "user_id": "ou_001" }]
         }),
     );
 }
 
 #[test]
-fn notification_create_result_roundtrip() {
-    let result = parse_contract::<CreateNotificationResult>(json!({
-        "id": "notify_001",
-        "title": "系统维护通知",
-        "status": "draft"
+fn notification_create_response_roundtrip() {
+    let result = parse_contract::<CreateNotificationResponse>(json!({
+        "notification_id": "notify_001",
+        "status": 0
     }));
-    assert_eq!(result.id, Some("notify_001".to_string()));
-    assert_eq!(result.title, Some("系统维护通知".to_string()));
-    assert_eq!(result.status, Some("draft".to_string()));
+    assert_eq!(result.notification_id, Some("notify_001".to_string()));
+    assert_eq!(result.status, Some(0));
 }
 
 // ── Agent 模型 ───────────────────────────────────────────────

--- a/tools/tests/test_verify_api_fields.py
+++ b/tools/tests/test_verify_api_fields.py
@@ -178,6 +178,25 @@ pub struct UpdateBody {
         self.assertFalse(fields["uuid"].required)
         self.assertIn("sequence", fields)
 
+    def test_skips_multipart_internal_meta_fields(self):
+        source = '''
+pub struct UploadBody {
+    #[serde(skip_serializing)]
+    pub file: Vec<u8>,
+    #[serde(rename = "__file_name", skip_serializing_if = "Option::is_none")]
+    pub file_name: Option<String>,
+    pub pdf_page_limit: i32,
+    pub ocr_mode: String,
+}
+'''
+        structs = verify_api_fields.extract_structs(source)
+        fields = {item.effective_name: item for item in structs[0].fields}
+        self.assertNotIn("__file_name", fields)
+        self.assertNotIn("file_name", fields)
+        self.assertNotIn("file", fields)
+        self.assertIn("pdf_page_limit", fields)
+        self.assertIn("ocr_mode", fields)
+
 
 class SuspiciousPatternTests(unittest.TestCase):
     def test_user_level_extra_field_is_informational(self):
@@ -247,12 +266,12 @@ class ComparisonTests(unittest.TestCase):
         self.assertEqual(diff.required_mismatches[0].severity, "error")
         self.assertEqual(diff.required_mismatches[0].category, "required_mismatch")
 
-    def test_compare_fields_required_mismatch_doc_no_code_required_is_warning(self):
+    def test_compare_fields_required_mismatch_doc_no_code_required_is_info(self):
         code = [verify_api_fields.FieldInfo("comment", "String", True)]
         official = [verify_api_fields.FieldInfo("comment", "string", False)]
         diff = verify_api_fields.compare_fields(code, official)
         self.assertEqual(len(diff.required_mismatches), 1)
-        self.assertEqual(diff.required_mismatches[0].severity, "warning")
+        self.assertEqual(diff.required_mismatches[0].severity, "info")
 
     def test_compare_fields_type_mismatch_warns(self):
         code = [verify_api_fields.FieldInfo("add_sign_type", "String", True)]

--- a/tools/verify_api_fields.py
+++ b/tools/verify_api_fields.py
@@ -133,6 +133,13 @@ def _extract_fields_from_block(block: str) -> List[FieldInfo]:
             continue
         fname = field_match.group(1)
         raw_type = field_match.group(2).strip().rstrip(",")
+        # multipart 内部元数据（如 __file_name）不参与官方字段对比
+        effective = pending_rename or fname
+        if effective.startswith("__"):
+            pending_rename = None
+            pending_skip_serializing = False
+            pending_attrs.clear()
+            continue
         required, type_name, is_array = _parse_type(raw_type)
         fields.append(
             FieldInfo(
@@ -475,7 +482,7 @@ def compare_fields(
 ) -> FieldDiff:
     """对比代码字段与文档字段（名字 + 必填性 + 类型）。
 
-    必填性：文档 Yes + 代码 Option → error；文档 No + 代码非 Option → warning。
+    必填性：文档 Yes + 代码 Option → error；文档 No + 代码非 Option → info（更严建模，不阻断）。
     类型：仅当代码侧是已知原始类型时对比；不匹配 → warning。
     空文档类型 / 未建模文档类型 / 代码自定义 enum·newtype → 跳过类型对比。
     """
@@ -502,9 +509,10 @@ def compare_fields(
                 )
             )
         elif doc_f.required is False and code_f.required is True:
+            # 代码比文档更严是常见有意建模（如 OCR image），不阻断门禁
             required_mismatches.append(
                 FieldIssue(
-                    severity="warning",
+                    severity="info",
                     category="required_mismatch",
                     detail=(
                         f"字段 {name} 文档选填(No) 但代码非 Option（代码更严，可能有意）"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# 概要

按飞书官方文档重写 `openlark-helpdesk` 中原先字段硬错误的请求体（嵌套包装、字段更名/补齐）。同步引入 `verify_api_fields` 对 `__*` multipart 元数据跳过，以及「文档选填但代码更严」降为 info（与 AI 字段核对批次一致）。

## 变更类型

- [x] 🐛 修复
- [ ] ✨ 新功能
- [ ] 📚 文档 / 格式
- [x] 🔧 构建 / CI
- [x] 💥 破坏性改动

## 验证

- [x] `cargo test -p openlark-helpdesk --all-features`
- [x] `cargo clippy -p openlark-helpdesk --all-targets --all-features -- -Dwarnings`
- [x] `python3 -m unittest tools.tests.test_verify_api_fields`
- [x] 原硬错误 API 的 `--api-id --fetch-docs` 均 exit 0（info 不阻断）
- [ ] `ticket_customized_field` create/patch：官方页面含 `description`/`required`，但 evidence 解析 `structure_incomplete`，工具仍可能误报多余字段（代码与 playwright 文档一致）

## 备注

Breaking：公开 Body 字段形状变更，详见 CHANGELOG。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f9e3ece-ca16-4836-b694-7271fcb97396?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f9e3ece-ca16-4836-b694-7271fcb97396&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

