### PR TITLE
feat(ws): callback event handler response channel for ACK data (#632)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ConvertCardIdBody` 仅保留官方 `message_id`（旧 `source_id_type`/`card_ids` 为错误推断）。
   - 多数写接口响应 `data` 为空对象，对应 Response 结构同步收敛。
 
+### Added
+
+- **websocket：callback 型事件处理器业务响应通道（#632）**：新增
+  `CallbackEventHandler` trait（`handle` 返回 `Option<serde_json::Value>`）与
+  `EventDispatcherHandler::register_callback(key, handler)`。卡片回传交互
+  （`card.action.trigger`）等 callback 型事件的业务响应（如 `{"toast": {...}}` /
+  `{"card": {...}}`）现经 ACK 帧 `data` 字段以 base64(JSON) 写回服务端（3 秒内），
+  对齐官方 Go `OnP2CardActionTrigger` / Python `register_p2_card_action_trigger`
+  的双 handler map 形态：callback 命中即短路，不再落 raw 处理器；`payload_sender`
+  转发不受影响。既有 `EventHandler` / `register_raw` / `do_without_validation`
+  签名不变，纯增量公开 API。
+
 ### Changed
 
 - **websocket：ACK data 对齐官方 base64 wire 格式 + card 帧文档化（#631）**：

--- a/crates/openlark-client/src/lib.rs
+++ b/crates/openlark-client/src/lib.rs
@@ -231,7 +231,7 @@ mod test_utils;
 ///
 /// 提供与飞书 WebSocket 服务的实时连接与事件接收。
 /// 公开入口：[`ws_client::LarkWsClient`]、[`ws_client::EventDispatcherHandler`]、
-/// [`ws_client::EventHandler`]。
+/// [`ws_client::EventHandler`]、[`ws_client::CallbackEventHandler`]。
 #[cfg(feature = "websocket")]
 pub mod ws_client;
 

--- a/crates/openlark-client/src/ws_client/dispatcher.rs
+++ b/crates/openlark-client/src/ws_client/dispatcher.rs
@@ -1,6 +1,7 @@
 //! WebSocket 事件分发处理器。
 //!
-//! 把原始事件负载分发到 channel 转发器或注册的 [`EventHandler`]；不做 schema 校验。
+//! 把原始事件负载分发到 channel 转发器、注册的 [`EventHandler`] 或可返回业务响应的
+//! [`CallbackEventHandler`]；不做 schema 校验。
 //! 会话协议见 [`super::session::Session`]。
 
 use std::collections::HashMap;
@@ -34,16 +35,35 @@ pub trait EventHandler: Send + Sync + 'static {
     fn handle(&self, payload: &[u8]) -> EventHandlerResult;
 }
 
+/// 回调型事件处理器。
+///
+/// 与 [`EventHandler`] 的区别：`handle` 可返回业务响应，经 ACK 帧的 `data`
+/// 字段以 base64(JSON) 写回服务端（对齐官方 Go `OnP2CardActionTrigger` /
+/// Python `register_p2_card_action_trigger` 的 callback 通道）。典型场景是
+/// 卡片回传交互（`card.action.trigger`）：返回 `{"toast": {...}}` 或
+/// `{"card": {...}}` 即可弹提示 / 更新卡片，服务端要求 3 秒内回包。
+pub trait CallbackEventHandler: Send + Sync + 'static {
+    /// 处理回调负载。
+    ///
+    /// 返回 `Some(value)` 作为业务响应写入 ACK `data`；`None` 表示无响应。
+    fn handle(
+        &self,
+        payload: &[u8],
+    ) -> Result<Option<serde_json::Value>, Box<dyn std::error::Error + Send + Sync>>;
+}
+
 /// WebSocket 事件分发处理器。
 ///
-/// 目前支持两类分发目标：
+/// 目前支持三类分发目标：
 ///
 /// - `payload_sender(...)`：把原始负载转发到 channel
 /// - `register_raw(...)`：注册原始事件处理器
+/// - `register_callback(...)`：注册可返回业务响应的回调型处理器
 #[derive(Clone)]
 pub struct EventDispatcherHandler {
     payload_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
     raw_handlers: HashMap<String, Arc<dyn EventHandler>>,
+    callback_handlers: HashMap<String, Arc<dyn CallbackEventHandler>>,
 }
 
 impl std::fmt::Debug for EventDispatcherHandler {
@@ -56,6 +76,10 @@ impl std::fmt::Debug for EventDispatcherHandler {
             .field(
                 "raw_handler_keys",
                 &self.raw_handlers.keys().collect::<Vec<_>>(),
+            )
+            .field(
+                "callback_handler_keys",
+                &self.callback_handlers.keys().collect::<Vec<_>>(),
             )
             .finish()
     }
@@ -70,6 +94,7 @@ impl EventDispatcherHandler {
         Self {
             payload_tx: None,
             raw_handlers: HashMap::new(),
+            callback_handlers: HashMap::new(),
         }
     }
 
@@ -104,6 +129,28 @@ impl EventDispatcherHandler {
         Ok(self)
     }
 
+    /// 注册回调型事件处理器（可返回业务响应写入 ACK `data`）。
+    ///
+    /// 按事件 `header.event_type` 匹配（例如 `"card.action.trigger"`）。同一
+    /// 事件命中 callback 后不再走 [`Self::register_raw`] 注册的处理器（对齐
+    /// 官方 callback 通道优先的行为）；需要旁路观察全部负载时用
+    /// [`Self::payload_sender`]。
+    pub fn register_callback<S, H>(mut self, key: S, handler: H) -> Result<Self, String>
+    where
+        S: Into<String>,
+        H: CallbackEventHandler,
+    {
+        let key = key.into();
+        if key.trim().is_empty() {
+            return Err("processor key cannot be empty".to_string());
+        }
+        if self.callback_handlers.contains_key(&key) {
+            return Err(format!("processor already registered, type: {key}"));
+        }
+        self.callback_handlers.insert(key, Arc::new(handler));
+        Ok(self)
+    }
+
     fn extract_event_type(payload: &[u8]) -> Option<String> {
         serde_json::from_slice::<RawEventEnvelope>(payload)
             .ok()
@@ -122,6 +169,21 @@ impl EventDispatcherHandler {
 
     /// 在不做 schema 校验的前提下分发原始负载。
     pub fn do_without_validation(&self, payload: &[u8]) -> Result<(), String> {
+        self.dispatch_with_response(payload).map(|_| ())
+    }
+
+    /// 分发原始负载并返回 callback 型业务响应（若有）。
+    ///
+    /// 分发顺序（对齐官方 Go `dispatcher.Do` 的双 map 行为）：
+    ///
+    /// 1. `payload_sender` 转发（若有，callback 路径同样转发）
+    /// 2. callback map 按 `header.event_type` 命中：调用并返回业务响应，
+    ///    不再进入 raw 路径
+    /// 3. 未命中 callback：按 `event_type` 分发 raw handler，再分发 `"raw"`
+    ///    catch-all
+    ///
+    /// 返回 `Some(json_bytes)` 表示应写入 ACK `data` 的业务响应。
+    pub fn dispatch_with_response(&self, payload: &[u8]) -> Result<Option<Vec<u8>>, String> {
         if let Some(payload_tx) = &self.payload_tx {
             payload_tx
                 .send(payload.to_vec())
@@ -129,11 +191,22 @@ impl EventDispatcherHandler {
         }
 
         if let Some(event_type) = Self::extract_event_type(payload) {
+            if let Some(handler) = self.callback_handlers.get(&event_type) {
+                let value = handler
+                    .handle(payload)
+                    .map_err(|err| format!("处理回调事件 {event_type} 失败: {err}"))?;
+                return match value {
+                    Some(v) => serde_json::to_vec(&v)
+                        .map(Some)
+                        .map_err(|e| format!("序列化回调响应失败: {e}")),
+                    None => Ok(None),
+                };
+            }
             self.dispatch_raw_handler(&event_type, payload)?;
         }
 
         self.dispatch_raw_handler(Self::RAW_EVENT_KEY, payload)?;
 
-        Ok(())
+        Ok(None)
     }
 }

--- a/crates/openlark-client/src/ws_client/frame_handler.rs
+++ b/crates/openlark-client/src/ws_client/frame_handler.rs
@@ -132,6 +132,15 @@ impl EventAck {
         }
     }
 
+    /// 携带业务响应的成功应答（data 以 base64 写回，官方 callback 通道）。
+    fn ok_with_data(data: Vec<u8>) -> Self {
+        Self {
+            code: 200,
+            headers: Default::default(),
+            data: Some(data),
+        }
+    }
+
     fn error() -> Self {
         Self {
             code: 500,
@@ -245,11 +254,14 @@ impl FrameHandler {
 
     fn process_event(payload: &[u8], event_handler: &EventDispatcherHandler) -> EventAck {
         let start = Instant::now();
-        let result = event_handler.do_without_validation(payload);
+        let result = event_handler.dispatch_with_response(payload);
         let elapsed = start.elapsed().as_millis();
 
         let mut response = match result {
-            Ok(_) => EventAck::ok(),
+            // callback 型业务响应写入 ACK data（base64），对齐官方
+            // `if rsp != nil { resp.Data = json.Marshal(rsp) }`
+            Ok(Some(data)) => EventAck::ok_with_data(data),
+            Ok(None) => EventAck::ok(),
             Err(err) => {
                 error!("Failed to handle event: {err:?}");
                 EventAck::error()
@@ -284,6 +296,7 @@ impl FrameHandler {
 mod tests {
     use super::*;
     use crate::ws_client::EventHandler;
+    use base64::Engine;
     use lark_websocket_protobuf::pbbp2::Header;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -664,5 +677,225 @@ mod tests {
         assert!(body.contains(r#""code":200"#), "got: {body}");
         // 当前 EventHandler 无返回值通道，业务响应恒为空 → 不携带 data 字段
         assert!(!body.contains(r#""data":"#), "got: {body}");
+    }
+
+    /// 返回 toast 业务响应的 callback handler fixture（官方 CardActionTriggerResponse 形态）。
+    struct ToastCallback {
+        calls: Arc<AtomicUsize>,
+        response: Option<serde_json::Value>,
+    }
+
+    impl crate::ws_client::CallbackEventHandler for ToastCallback {
+        fn handle(
+            &self,
+            _payload: &[u8],
+        ) -> Result<Option<serde_json::Value>, Box<dyn std::error::Error + Send + Sync>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.response.clone())
+        }
+    }
+
+    /// 官方 schema 2.0 的 card.action.trigger event 帧 payload。
+    fn card_action_trigger_payload() -> Vec<u8> {
+        br#"{"schema":"2.0","header":{"event_id":"f7984f25108f8137722bb63c1d00bd823c2","event_type":"card.action.trigger","create_time":"1603977298000000","token":"066zT6pS4QCbgj5Do145GfDbbagrRzvV3","app_id":"cli_a511af62e2b5d07f","tenant_key":"736588c9260f175d"},"event":{"operator":{"tenant_key":"736588c9260f175d","user_id":"on_8f6f0d15799e5c45","open_id":"ou_4063d88c980c9f2d"},"token":"c-295eed59e6dbb014b72cba6f2ff6d48da9971e99","action":{"value":{"key":"value"},"tag":"button","timezone":"8","name":"btn"},"host":"im_message","context":{"open_message_id":"om_dc0d7ab6d7b734d5bff5c0556e8e7616","open_chat_id":"oc_4d83f1dc8596c773a09e86f50a931b77"}}}"#.to_vec()
+    }
+
+    #[test]
+    fn test_callback_response_writes_base64_ack_data() {
+        // callback handler 返回业务响应（toast）→ ACK data = base64(JSON)，
+        // 对齐官方 Go ws/client.go `if rsp != nil { resp.Data = json.Marshal(rsp) }`。
+        let calls = Arc::new(AtomicUsize::new(0));
+        let toast = serde_json::json!({"toast": {"type": "success", "content": "卡片交互成功"}});
+        let event_handler = EventDispatcherHandler::builder()
+            .register_callback(
+                "card.action.trigger",
+                ToastCallback {
+                    calls: Arc::clone(&calls),
+                    response: Some(toast.clone()),
+                },
+            )
+            .expect("callback handler should register")
+            .build();
+
+        let frame = create_data_frame("event", Some(card_action_trigger_payload()));
+        let returned =
+            FrameHandler::handle_data_frame(frame, &event_handler).expect("event 帧必须回写 ACK");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        let body: serde_json::Value =
+            serde_json::from_slice(&returned.payload.expect("ACK payload")).unwrap();
+        assert_eq!(body["code"], 200, "got: {body}");
+        // data 是 base64(JSON(toast))，解码后与 handler 返回值逐字节一致
+        let data_b64 = body["data"].as_str().expect("data 应为 base64 字符串");
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(data_b64)
+            .expect("data 应为合法 base64");
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&decoded).unwrap(),
+            toast
+        );
+    }
+
+    #[test]
+    fn test_callback_none_response_omits_ack_data() {
+        let event_handler = EventDispatcherHandler::builder()
+            .register_callback(
+                "card.action.trigger",
+                ToastCallback {
+                    calls: Arc::new(AtomicUsize::new(0)),
+                    response: None,
+                },
+            )
+            .expect("callback handler should register")
+            .build();
+
+        let frame = create_data_frame("event", Some(card_action_trigger_payload()));
+        let returned =
+            FrameHandler::handle_data_frame(frame, &event_handler).expect("event 帧必须回写 ACK");
+        let body = String::from_utf8(returned.payload.expect("ACK payload")).unwrap();
+        assert!(body.contains(r#""code":200"#), "got: {body}");
+        assert!(
+            !body.contains(r#""data":"#),
+            "无业务响应应省略 data: {body}"
+        );
+    }
+
+    #[test]
+    fn test_callback_error_yields_ack_500() {
+        struct FailingCallback;
+        impl crate::ws_client::CallbackEventHandler for FailingCallback {
+            fn handle(
+                &self,
+                _payload: &[u8],
+            ) -> Result<Option<serde_json::Value>, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Err("callback failed".into())
+            }
+        }
+
+        let event_handler = EventDispatcherHandler::builder()
+            .register_callback("card.action.trigger", FailingCallback)
+            .expect("callback handler should register")
+            .build();
+
+        let frame = create_data_frame("event", Some(card_action_trigger_payload()));
+        let returned =
+            FrameHandler::handle_data_frame(frame, &event_handler).expect("event 帧必须回写 ACK");
+        let body = String::from_utf8(returned.payload.expect("ACK payload")).unwrap();
+        assert!(body.contains(r#""code":500"#), "got: {body}");
+    }
+
+    #[test]
+    fn test_callback_takes_precedence_over_raw_for_same_event_type() {
+        // 对齐官方 dispatcher.Do：callback map 命中即返回，不再走普通事件 handler
+        let callback_calls = Arc::new(AtomicUsize::new(0));
+        let raw_calls = Arc::new(AtomicUsize::new(0));
+        let event_handler = EventDispatcherHandler::builder()
+            .register_callback(
+                "card.action.trigger",
+                ToastCallback {
+                    calls: Arc::clone(&callback_calls),
+                    response: None,
+                },
+            )
+            .expect("callback handler should register")
+            .register_raw(
+                "card.action.trigger",
+                CountingHandler {
+                    calls: Arc::clone(&raw_calls),
+                },
+            )
+            .expect("raw handler should register")
+            .build();
+
+        let payload = card_action_trigger_payload();
+        event_handler
+            .do_without_validation(&payload)
+            .expect("dispatch should succeed");
+        assert_eq!(callback_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            raw_calls.load(Ordering::SeqCst),
+            0,
+            "callback 命中不应落 raw"
+        );
+    }
+
+    #[test]
+    fn test_callback_unregistered_event_falls_back_to_raw() {
+        let raw_calls = Arc::new(AtomicUsize::new(0));
+        let event_handler = EventDispatcherHandler::builder()
+            .register_callback(
+                "card.action.trigger",
+                ToastCallback {
+                    calls: Arc::new(AtomicUsize::new(0)),
+                    response: None,
+                },
+            )
+            .expect("callback handler should register")
+            .register_raw(
+                EventDispatcherHandler::RAW_EVENT_KEY,
+                CountingHandler {
+                    calls: Arc::clone(&raw_calls),
+                },
+            )
+            .expect("raw handler should register")
+            .build();
+
+        // 非 callback 事件照常走 raw 路径
+        let payload = br#"{"header":{"event_type":"im.message.receive_v1"}}"#;
+        event_handler
+            .do_without_validation(payload)
+            .expect("dispatch should succeed");
+        assert_eq!(raw_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn test_register_callback_rejects_duplicate_key() {
+        let handler = EventDispatcherHandler::builder()
+            .register_callback(
+                "card.action.trigger",
+                ToastCallback {
+                    calls: Arc::new(AtomicUsize::new(0)),
+                    response: None,
+                },
+            )
+            .expect("first registration should work");
+        assert!(
+            handler
+                .register_callback(
+                    "card.action.trigger",
+                    ToastCallback {
+                        calls: Arc::new(AtomicUsize::new(0)),
+                        response: None,
+                    },
+                )
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_callback_path_still_forwards_payload_sender() {
+        // payload_tx 转发在 callback 路径仍然发生（channel 消费方不应漏掉 callback 事件）
+        let (payload_tx, mut payload_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+        let event_handler = EventDispatcherHandler::builder()
+            .payload_sender(payload_tx)
+            .register_callback(
+                "card.action.trigger",
+                ToastCallback {
+                    calls: Arc::new(AtomicUsize::new(0)),
+                    response: None,
+                },
+            )
+            .expect("callback handler should register")
+            .build();
+
+        let payload = card_action_trigger_payload();
+        event_handler
+            .do_without_validation(&payload)
+            .expect("dispatch should succeed");
+        assert_eq!(
+            payload_rx.try_recv().expect("payload should be forwarded"),
+            payload
+        );
     }
 }

--- a/crates/openlark-client/src/ws_client/mod.rs
+++ b/crates/openlark-client/src/ws_client/mod.rs
@@ -14,7 +14,7 @@ mod session;
 /// 会话级公开 API。
 pub use client::LarkWsClient;
 #[cfg(feature = "websocket")]
-pub use dispatcher::{EventDispatcherHandler, EventHandler};
+pub use dispatcher::{CallbackEventHandler, EventDispatcherHandler, EventHandler};
 #[cfg(feature = "websocket")]
 pub use session::{InvalidStateKind, WsClientError, WsClientResult, WsCloseReason};
 


### PR DESCRIPTION
## 概要

实现 #632：为长连接 callback 型事件（`card.action.trigger`、`url.preview.get` 等）补齐业务响应返回通道。#631 修好 ACK data base64 wire 格式后，`data` 因 `EventHandler::handle` 无返回值而恒为空——卡片回调能收到但无法回写 toast/卡片更新（平台要求 3 秒内回包，否则用户端 200340）。

## 设计（对齐官方双 handler map 形态）

官方 Go `OnP2CardActionTrigger` / Python `register_p2_card_action_trigger` 均将 callback 与普通事件分为两个 handler map，callback handler 可返回业务响应。本 PR 同构：

```rust
// 新 trait（纯增量公开 API，零 breaking）
pub trait CallbackEventHandler: Send + Sync + 'static {
    fn handle(&self, payload: &[u8])
        -> Result<Option<serde_json::Value>, Box<dyn Error + Send + Sync>>;
}

impl EventDispatcherHandler {
    pub fn register_callback<S, H>(self, key: S, handler: H) -> Result<Self, String>;
    pub fn dispatch_with_response(&self, payload: &[u8]) -> Result<Option<Vec<u8>>, String>;
}
```

**分发顺序**（对齐官方 `dispatcher.Do`）：`payload_sender` 转发（callback 路径同样转发）→ callback map 按 `header.event_type` 命中即短路（不再落 raw）→ raw event_type handler → `"raw"` catch-all。

**ACK 写回**：`Ok(Some(value))` → `data = base64(JSON(value))`；`None` → 省略字段；`Err` → code 500。

**否决的备选**：改 `EventHandler` trait 签名（breaking；官方普通事件 handler 本就无返回值，两类分离才是官方形态）；返回强类型 cardkit Response（ws 层不耦合业务 crate）。

## 用法

```rust
EventDispatcherHandler::builder()
    .register_callback("card.action.trigger", MyToastCallback)
    // MyToastCallback: Ok(Some(json!({"toast": {"type": "success", "content": "ok"}})))
    .build()
```

## 变更类型

- [x] ✨ 新功能

## 关联 Issue

Fixes #632

## 验证

- [x] TDD：7 个新测试先红后绿（toast 响应经 base64 ACK round-trip 逐字节比对 / None 省略 data / 错误 500 / callback 优先于同 key raw / 未注册落 raw / 重复 key 拒绝 / payload_sender 兼容）
- [x] `cargo test -p openlark-client --features websocket --lib ws_client`（66 passed）
- [x] `cargo test --workspace --all-features`（6019 passed / 0 failed）
- [x] `cargo fmt --all -- --check`；clippy `--all-features` 与 `--no-default-features` 双模式
- [x] feature 组合 `websocket` / `communication,websocket` check
- [x] `cargo machete` / `cargo doc` 0 警告 / `cargo deny check advisories`
- [x] code-review 双轴（Standards 0 硬违规 / Spec 0 缺失；agent 报告的 3 条「发现」经逐条核实均为误报）
- [x] CHANGELOG（Unreleased → Added）+ `lib.rs` 公开入口 doc 同步

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live WebSocket dispatch and ACK payload behavior for callback events; mistakes could break card interactions, though existing raw-only paths are preserved and tests cover precedence and encoding.
> 
> **Overview**
> Adds a **callback-style WebSocket event path** so apps can answer platform callback events (e.g. `card.action.trigger`) within the ~3s window.
> 
> **New public API:** `CallbackEventHandler` (`handle` → `Option<serde_json::Value>`) and `EventDispatcherHandler::register_callback`. `dispatch_with_response` runs after optional `payload_sender` forwarding; on a callback match it **short-circuits** and does not invoke `register_raw` handlers for that `event_type`. `EventHandler`, `register_raw`, and `do_without_validation` stay unchanged.
> 
> **ACK wiring:** `FrameHandler` now uses `dispatch_with_response`; when a callback returns JSON, the ACK uses **base64(JSON)** in `data` (aligned with #631 wire format). `None` omits `data`; handler errors yield ACK `code` 500.
> 
> CHANGELOG and `ws_client` re-exports document `CallbackEventHandler`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 269f992357e428896d228a6ee1f24188c83c3544. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->