### PR TITLE
refactor(tools): consolidate Rust contract extraction into rust_source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **tools：Rust 合约提取收口为单一深 module（#636）**：`verify_api_fields`
+  删除内嵌提取栈（~105 行，正则停在首个 `}`、不认 `rename_all`），改为库消费
+  `api_contracts.rust_source`——`extract_structs` 成为唯一分组提取 interface，
+  `FieldInfo`/`StructFields` 模型移入 `models.py`。共享层修复与增强（两 CLI 同时
+  受益）：struct 体改为括号配平提取（平衡花括号的 doc 注释不再截断字段）；类型
+  整行捕获修复 `HashMap<String, String>` 逗号截断（161 处）；`#[serde(rename)]`
+  可跨 doc 注解生效；`std::option::Option` 前缀识别为选填；`__` 前缀内部字段
+  全局跳过；新增 `matches_struct_suffix` 支持版本尾缀命名（`*BodyV4`/`*ResponseV1`，
+  workflow 244 个字段恢复可见）；multipart 表单字段（Meta struct/`json!` 字面量）
+  以 `MultipartForm` 合成分组进入字段核对（二进制 `file` 通道除外——官方
+  request_body 字段表不列它，live 实证）。响应对比改为 `*Response` 优先、
+  `*Result`/`*Resp`/`*ResponseData` 兜底的确定性选择（auth 域 10 个
+  `*ResponseData` 唯一响应 struct 的文件恢复对比能力）。提取语义测试迁入
+  `test_validate_api_contracts_rust_source.py` 并补新语义正测；对拍验证：全仓
+  新旧提取 diff 零意外回归，1,628 个 API quick 模式问题集零漂移；两个 multipart
+  API live full 模式实跑通过。另发现既有 bug 另案跟踪（#638：weekly 门无
+  `--crate` 调用时扫描量为零）。
+
 - **tools：删除休眠回归锁与平行 URL 解析器，fetch 栈就近 schema_cache（#635）**：
   删除 `tools/check_api_urls.py`（659 行激进 URL 解析器，与 `rust_source` 的对齐仅靠
   注释维持，零 CI/justfile 引用）；删除 7 个休眠验收测试（~1,046 行，断言冻结在历史

--- a/tools/api_contracts/models.py
+++ b/tools/api_contracts/models.py
@@ -106,6 +106,33 @@ class RustField:
 
 
 @dataclass(frozen=True)
+class FieldInfo:
+    """单个字段信息（类型语义视图，供字段核对消费）。
+
+    由 rust_source 从 RustField 派生，或由调用方从官方 FieldObservation 构造。
+    """
+
+    name: str  # Rust 字段名（rename 前的 snake_case）
+    type_name: str  # 核心类型名（Vec<String> -> String，Option<i32> -> i32）
+    required: bool | None  # 是否必填；None=文档未标注（跳过必填对比）
+    rename: str | None = None  # serde rename 后的名字，无则 None
+    is_array: bool = False  # 是否数组（Vec / doc 的 T[]）
+
+    @property
+    def effective_name(self) -> str:
+        """对比时用的名字：rename 优先。"""
+        return self.rename or self.name
+
+
+@dataclass(frozen=True)
+class StructFields:
+    """一个 struct 提取出的字段集合。"""
+
+    name: str  # struct 名
+    fields: list[FieldInfo] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
 class ContractFinding:
     severity: str
     code: str

--- a/tools/api_contracts/rust_source.py
+++ b/tools/api_contracts/rust_source.py
@@ -38,7 +38,8 @@ from .catalog_endpoints import (
 
 
 REQUEST_STRUCT_SUFFIXES = ("Body", "Query", "Params", "RequestBody")
-RESPONSE_STRUCT_SUFFIXES = ("Response", "Result", "Resp")
+# *ResponseData：auth 域若干 API 的唯一响应 payload（无 *Response 信封）
+RESPONSE_STRUCT_SUFFIXES = ("Response", "Result", "Resp", "ResponseData")
 
 # AccessTokenType 枚举变体 → 飞书凭证名（与 constants.rs 的 as_str/Display 一致）。
 # 用于把 Rust 声明的 token 类型翻译成可与官方 supportedAccessToken 直接比对的形态。

--- a/tools/api_contracts/rust_source.py
+++ b/tools/api_contracts/rust_source.py
@@ -7,7 +7,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
 
-from .models import DEFAULT_ACCESS_TOKEN_TYPES, RustApiContract, RustEndpointCall, RustField
+from .models import (
+    DEFAULT_ACCESS_TOKEN_TYPES,
+    FieldInfo,
+    RustApiContract,
+    RustEndpointCall,
+    RustField,
+    StructFields,
+)
 
 
 # CatalogEndpoint / .to_request 解析（#568）— 实现见 catalog_endpoints；此处 re-export 供校验器/测试
@@ -668,11 +675,14 @@ def _extract_meta_struct_fields(struct_name: str, body: str, base_line: int) -> 
         stripped = line.strip()
         if not stripped:
             continue
+        if stripped.startswith("//"):
+            # doc 注释不打断 attr 与字段的关联（rename 可夹在注释之间）
+            continue
         if stripped.startswith("#["):
             pending_attrs.append(stripped)
             continue
         # 兼容 "pub field: T," 与 "field: T," 两种写法
-        match = re.match(r"(?:pub\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*:\s*([^,]+),", stripped)
+        match = re.match(r"(?:pub\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+?)\s*,?\s*$", stripped)
         if not match:
             pending_attrs.clear()
             continue
@@ -681,7 +691,7 @@ def _extract_meta_struct_fields(struct_name: str, body: str, base_line: int) -> 
         if "skip_serializing" in attrs and "skip_serializing_if" not in attrs:
             continue
         field_name = match.group(1)
-        type_name = match.group(2).strip()
+        type_name = _type_from_line(match.group(2))
         rename_match = re.search(r'rename\s*=\s*"([^"]+)"', attrs)
         serialized_name = rename_match.group(1) if rename_match else field_name
         fields.append(
@@ -732,22 +742,128 @@ def _extract_json_literal_fields(text: str) -> list[RustField]:
     return fields
 
 
+def matches_struct_suffix(struct_name: str, suffixes: tuple[str, ...]) -> bool:
+    """struct 名是否命中后缀组：直接尾缀，或尾缀+版本号（如 BodyV4/ResponseV1）。"""
+    for suffix in suffixes:
+        if struct_name.endswith(suffix) or re.fullmatch(rf".+{suffix}V\d+", struct_name):
+            return True
+    return False
+
+
 def extract_rust_struct_fields(text: str, suffixes: tuple[str, ...]) -> tuple[RustField, ...]:
     fields: list[RustField] = []
+    for struct_name, body, base_line, rename_all in _iter_matching_struct_bodies(text, suffixes):
+        fields.extend(extract_struct_fields(struct_name, body, base_line, rename_all))
+    return tuple(fields)
+
+
+def _iter_matching_struct_bodies(
+    text: str, suffixes: tuple[str, ...]
+) -> Iterable[tuple[str, str, int, str]]:
+    """产出 (struct_name, 括号配平的 struct 体, 起始行号, rename_all)。
+
+    suffix 匹配 + find_matching_brace 取体 + struct 前 attrs 的 rename_all，
+    flat（RustField）与分组（StructFields）两种视图共用本脚手架。
+    """
     for match in re.finditer(r"pub\s+struct\s+([A-Za-z_][A-Za-z0-9_]*)\s*\{", text):
         struct_name = match.group(1)
-        if not struct_name.endswith(suffixes):
+        if not matches_struct_suffix(struct_name, suffixes):
             continue
         open_brace = text.find("{", match.end() - 1)
         close_brace = find_matching_brace(text, open_brace)
         if close_brace < 0:
             continue
-        struct_attrs = preceding_attrs(text, match.start())
-        rename_all = serde_rename_all(struct_attrs)
-        body = text[open_brace + 1 : close_brace]
-        base_line = line_of(text, open_brace + 1)
-        fields.extend(extract_struct_fields(struct_name, body, base_line, rename_all))
-    return tuple(fields)
+        rename_all = serde_rename_all(preceding_attrs(text, match.start()))
+        yield struct_name, text[open_brace + 1 : close_brace], line_of(text, open_brace + 1), rename_all
+
+
+# multipart 文件的请求体字段（file/Meta struct/json! 字面量三通道）在分组视图里
+# 合成的 struct 名。不用 body 后缀，避免混入「必填数组缺校验」等 builder 类启发式。
+MULTIPART_FORM_STRUCT_NAME = "MultipartForm"
+
+
+def extract_structs(
+    text: str,
+    suffixes: tuple[str, ...] = REQUEST_STRUCT_SUFFIXES + RESPONSE_STRUCT_SUFFIXES,
+) -> list[StructFields]:
+    """按 struct 分组提取字段（类型语义视图，供 verify_api_fields 消费）。
+
+    struct 匹配与 extract_rust_struct_fields 同一 endswith 后缀规则；字段解析复用
+    extract_struct_fields（括号配平体、rename/rename_all、skip 规则、`__` 前缀跳过），
+    在其上派生 (required, 核心类型, is_array) 类型语义。multipart 文件追加一个
+    MULTIPART_FORM_STRUCT_NAME 合成分组（file_content/Meta/json! 三通道）。
+    """
+    structs: list[StructFields] = []
+    for struct_name, body, base_line, rename_all in _iter_matching_struct_bodies(text, suffixes):
+        structs.append(
+            StructFields(
+                name=struct_name,
+                fields=[
+                    rust_field_to_field_info(item)
+                    for item in extract_struct_fields(struct_name, body, base_line, rename_all)
+                ],
+            )
+        )
+    multipart_fields = [
+        item
+        for item in extract_file_content_fields(text)
+        # 二进制 file 通道是 wire 层产物：官方 request_body 字段表不列它，
+        # 注入会制造系统性 extra_field 假警告（live 实证：document_ai contract）
+        if item.struct_name != "MultipartFile"
+    ]
+    if multipart_fields:
+        structs.append(
+            StructFields(
+                name=MULTIPART_FORM_STRUCT_NAME,
+                fields=[rust_field_to_field_info(item) for item in multipart_fields],
+            )
+        )
+    return structs
+
+
+def rust_field_to_field_info(rust_field: RustField) -> FieldInfo:
+    """把 flat 视图的 RustField 派生成类型语义视图的 FieldInfo。"""
+    required, core_type, is_array = parse_field_type(rust_field.type_name)
+    rename = (
+        rust_field.serialized_name
+        if rust_field.serialized_name != rust_field.field_name
+        else None
+    )
+    return FieldInfo(
+        name=rust_field.field_name,
+        type_name=core_type,
+        required=required,
+        rename=rename,
+        is_array=is_array,
+    )
+
+
+def parse_field_type(raw: str) -> tuple[bool, str, bool]:
+    """解析类型字符串 → (是否必填, 核心类型名, 是否数组)。
+
+    Option<T> → 选填；Vec<T> → 必填数组；Option<Vec<T>> → 选填数组。
+    兼容 std::option::Option 全路径写法（与 is_optional_type 对齐）。
+    """
+    type_str = raw.strip()
+    opt_match = re.match(r"(?:std::option::)?Option<(.+)>$", type_str)
+    if opt_match:
+        inner = opt_match.group(1).strip()
+        vec_match = re.match(r"Vec<(.+)>$", inner)
+        if vec_match:
+            return False, _unwrap_generic(vec_match.group(1).strip()), True
+        return False, _unwrap_generic(inner), False
+    vec_match = re.match(r"Vec<(.+)>$", type_str)
+    if vec_match:
+        return True, _unwrap_generic(vec_match.group(1).strip()), True
+    return True, _unwrap_generic(type_str), False
+
+
+def _unwrap_generic(type_str: str) -> str:
+    """去掉外层泛型，取核心类型名（Vec<String> -> String，HashMap<K,V> -> K）。"""
+    inner_match = re.match(r"\w+<(.+)>$", type_str)
+    if inner_match:
+        return inner_match.group(1).split(",")[0].strip()
+    return type_str
 
 
 def preceding_attrs(text: str, start_index: int) -> str:
@@ -770,6 +886,11 @@ def serde_rename_all(attrs: str) -> str:
     return match.group(1) if match else ""
 
 
+def _type_from_line(raw: str) -> str:
+    """截掉行尾注释与尾逗号，保留完整类型（含泛型内逗号，如 HashMap<K, V>）。"""
+    return raw.split("//", 1)[0].rstrip().rstrip(",").rstrip()
+
+
 def extract_struct_fields(
     struct_name: str,
     body: str,
@@ -782,10 +903,13 @@ def extract_struct_fields(
         stripped = line.strip()
         if not stripped:
             continue
+        if stripped.startswith("//"):
+            # doc 注释不打断 attr 与字段的关联（rename 可夹在注释之间）
+            continue
         if stripped.startswith("#["):
             pending_attrs.append(stripped)
             continue
-        match = re.match(r"pub\s+([A-Za-z_][A-Za-z0-9_]*)\s*:\s*([^,]+),", stripped)
+        match = re.match(r"pub\s+([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+?)\s*,?\s*$", stripped)
         if not match:
             pending_attrs.clear()
             continue
@@ -794,9 +918,12 @@ def extract_struct_fields(
         if "skip_serializing" in attrs and "skip_serializing_if" not in attrs:
             continue
         field_name = match.group(1)
-        type_name = match.group(2).strip()
+        type_name = _type_from_line(match.group(2))
         rename_match = re.search(r'rename\s*=\s*"([^"]+)"', attrs)
         serialized_name = rename_match.group(1) if rename_match else apply_rename_rule(field_name, rename_all)
+        # multipart 内部元数据（如 __file_name）不参与官方字段对比
+        if field_name.startswith("__") or serialized_name.startswith("__"):
+            continue
         fields.append(
             RustField(
                 struct_name=struct_name,

--- a/tools/tests/test_validate_api_contracts_rust_source.py
+++ b/tools/tests/test_validate_api_contracts_rust_source.py
@@ -4,11 +4,13 @@ from pathlib import Path
 
 from tools.api_contracts.rust_source import (
     EndpointResolver,
+    MULTIPART_FORM_STRUCT_NAME,
     extract_access_token_types,
     extract_endpoint_calls,
     extract_manual_auth_token,
     extract_rust_response_fields,
     extract_rust_fields,
+    extract_structs,
     load_endpoint_constants,
     load_enum_endpoints,
     load_enum_methods,
@@ -505,6 +507,215 @@ class ExtractManualAuthTokenTests(unittest.TestCase):
             REPO_ROOT / "crates/openlark-auth/src/auth/authen/v1/user_info/get.rs"
         ).read_text(encoding="utf-8")
         self.assertEqual(extract_manual_auth_token(source), "user_access_token")
+
+
+class ExtractStructsTypedTests(unittest.TestCase):
+    """分组类型语义视图（verify_api_fields 消费；#636 收口后唯一提取实现）。
+
+    由 tools/tests/test_verify_api_fields.py 的 ExtractStructFieldsTests 迁入并按
+    新语义改写（multipart 元字段用例改为 dunder 序列名版本，skip_serializing 的
+    file 字段用例并入 path params 用例与 MultipartForm 分组用例），另补齐收口
+    引入的新语义正测：rename_all / 括号配平 / 逗号泛型 / std::option / 版本尾缀。
+    """
+
+    def test_groups_body_and_response_with_type_semantics(self):
+        source = """
+pub struct DemoBody {
+    #[serde(rename = "type")]
+    pub task_type: String,
+    pub user_ids: Vec<String>,
+    pub comment: Option<String>,
+}
+pub struct DemoResponse {
+    pub result: String,
+}
+pub struct DemoRequest {
+    pub config: Config,
+}
+"""
+        structs = extract_structs(source)
+        self.assertEqual([item.name for item in structs], ["DemoBody", "DemoResponse"])
+        fields = {item.name: item for item in structs[0].fields}
+        self.assertEqual(fields["task_type"].effective_name, "type")
+        self.assertTrue(fields["user_ids"].required)
+        self.assertEqual(fields["user_ids"].type_name, "String")
+        self.assertTrue(fields["user_ids"].is_array)
+        self.assertFalse(fields["comment"].required)
+        self.assertFalse(fields["comment"].is_array)
+
+    def test_skips_absolute_skip_serializing_path_params(self):
+        source = """
+pub struct UpdateBody {
+    /// path param
+    #[serde(skip_serializing)]
+    pub card_id: String,
+    #[serde(rename = "type")]
+    pub type_: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uuid: Option<String>,
+    pub sequence: i32,
+}
+"""
+        structs = extract_structs(source)
+        fields = {item.effective_name: item for item in structs[0].fields}
+        self.assertNotIn("card_id", fields)
+        self.assertIn("type", fields)
+        self.assertIn("uuid", fields)
+        self.assertFalse(fields["uuid"].required)
+        self.assertIn("sequence", fields)
+
+    def test_skips_dunder_serialized_fields(self):
+        source = """
+pub struct UploadBody {
+    #[serde(rename = "__file_name", skip_serializing_if = "Option::is_none")]
+    pub file_name: Option<String>,
+    pub pdf_page_limit: i32,
+}
+"""
+        structs = extract_structs(source)
+        fields = {item.effective_name: item for item in structs[0].fields}
+        self.assertNotIn("__file_name", fields)
+        self.assertNotIn("file_name", fields)
+        self.assertIn("pdf_page_limit", fields)
+
+    def test_rename_all_camel_case_feeds_effective_name(self):
+        source = """
+#[serde(rename_all = "camelCase")]
+pub struct DemoBody {
+    pub page_size: Option<i32>,
+}
+"""
+        structs = extract_structs(source)
+        fields = structs[0].fields
+        self.assertEqual(fields[0].effective_name, "pageSize")
+        self.assertFalse(fields[0].required)
+
+    def test_rename_survives_doc_comment_between_attr_and_field(self):
+        # 现实写法（whiteboard node create）：#[serde(rename)] 与字段之间夹 doc 注释
+        source = """
+pub struct DemoBody {
+    #[serde(rename = "type")]
+    /// 节点类型。
+    pub node_type: String,
+}
+"""
+        structs = extract_structs(source)
+        self.assertEqual(structs[0].fields[0].effective_name, "type")
+
+    def test_balanced_braces_in_doc_comment_do_not_truncate_fields(self):
+        # 旧 verify 正则 ([^}]*) 停在 doc 注释里的第一个 }（含平衡花括号），截断后续字段；
+        # 括号配平后平衡的 JSON 示例不再截断。不平衡的孤立 } 仍会截断（注释感知不在范围）。
+        source = '''
+pub struct DemoBody {
+    /// 示例 payload：{"a": 1} 与 {"b": 2} 的花括号会截断旧实现
+    pub keep_me: String,
+    pub also_kept: i32,
+}
+'''
+        structs = extract_structs(source)
+        self.assertEqual(
+            [item.effective_name for item in structs[0].fields],
+            ["keep_me", "also_kept"],
+        )
+
+    def test_comma_generic_type_stays_whole(self):
+        source = """
+pub struct DemoBody {
+    pub extra: HashMap<String, String>,
+}
+"""
+        flat = extract_rust_fields(source)
+        self.assertEqual(flat[0].type_name, "HashMap<String, String>")
+        typed = extract_structs(source)[0].fields
+        # 核心类型取首个泛型参数（HashMap<K, V> -> K），与旧 _parse_type 语义一致
+        self.assertEqual(typed[0].type_name, "String")
+        self.assertTrue(typed[0].required)
+
+    def test_std_option_prefix_is_optional(self):
+        source = """
+pub struct DemoBody {
+    pub flag: std::option::Option<bool>,
+}
+"""
+        structs = extract_structs(source)
+        self.assertFalse(structs[0].fields[0].required)
+
+    def test_suffix_match_excludes_substring_only_names(self):
+        # endswith 后缀匹配：BodyWrapper 含 "Body" 子串但不尾缀，不进入提取
+        source = """
+pub struct DemoBodyWrapper {
+    pub x: String,
+}
+pub struct DemoQuery {
+    pub page: Option<i32>,
+}
+"""
+        structs = extract_structs(source)
+        self.assertEqual([item.name for item in structs], ["DemoQuery"])
+
+    def test_versioned_suffix_structs_match(self):
+        # approval v4 用户级 / workflow v1 的版本尾缀命名（BodyV4/ResponseV1）
+        source = """
+pub struct AddCcInstanceBodyV4 {
+    pub instance_code: String,
+}
+pub struct UpdateTaskResponseV1 {
+    pub task_id: String,
+}
+"""
+        structs = extract_structs(source)
+        self.assertEqual(
+            [item.name for item in structs],
+            ["AddCcInstanceBodyV4", "UpdateTaskResponseV1"],
+        )
+        flat = extract_rust_fields(source)
+        self.assertEqual([item.serialized_name for item in flat], ["instance_code"])
+
+    def test_last_field_without_trailing_comma_is_captured(self):
+        source = """
+pub struct DemoBody {
+    pub a: String,
+    pub b: i32
+}
+"""
+        structs = extract_structs(source)
+        self.assertEqual(
+            [item.name for item in structs[0].fields], ["a", "b"]
+        )
+
+    def test_multipart_channels_join_as_synthetic_group(self):
+        source = """
+pub struct UploadAllResponse {
+    pub file_token: String,
+}
+
+pub async fn execute(self) -> SDKResult<UploadAllResponse> {
+    #[derive(Serialize)]
+    struct UploadMeta {
+        file_name: String,
+        parent_node: String,
+    }
+
+    let request = ApiRequest::<UploadAllResponse>::post(&api_endpoint.to_url())
+        .json_body(&meta)
+        .file_content(self.file);
+}
+"""
+        structs = extract_structs(source)
+        by_name = {item.name: item for item in structs}
+        self.assertIn(MULTIPART_FORM_STRUCT_NAME, by_name)
+        form_fields = {
+            item.effective_name for item in by_name[MULTIPART_FORM_STRUCT_NAME].fields
+        }
+        # 二进制 file 通道不进合成分组（官方 request_body 字段表不列它）
+        self.assertNotIn("file", form_fields)
+        self.assertIn("file_name", form_fields)
+        self.assertIn("parent_node", form_fields)
+        # 响应 struct 与合成分组并存，互不混入
+        self.assertEqual(
+            [item.effective_name for item in by_name["UploadAllResponse"].fields],
+            ["file_token"],
+        )
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_validate_api_contracts_rust_source.py
+++ b/tools/tests/test_validate_api_contracts_rust_source.py
@@ -671,6 +671,23 @@ pub struct UpdateTaskResponseV1 {
         flat = extract_rust_fields(source)
         self.assertEqual([item.serialized_name for item in flat], ["instance_code"])
 
+    def test_extracts_response_data_suffix_structs(self):
+        # auth 域 *ResponseData 是文件内唯一响应 payload，须进入默认提取
+        source = """
+pub struct UserAccessTokenV1ResponseData {
+    pub access_token: String,
+    pub expires_in: i32,
+}
+"""
+        structs = extract_structs(source)
+        self.assertEqual(
+            [item.name for item in structs], ["UserAccessTokenV1ResponseData"]
+        )
+        self.assertEqual(
+            [item.effective_name for item in structs[0].fields],
+            ["access_token", "expires_in"],
+        )
+
     def test_last_field_without_trailing_comma_is_captured(self):
         source = """
 pub struct DemoBody {

--- a/tools/tests/test_verify_api_fields.py
+++ b/tools/tests/test_verify_api_fields.py
@@ -588,6 +588,60 @@ class FieldCliEvidenceTests(unittest.TestCase):
         self.assertIsInstance(policy, PreferSnapshotPolicy)
         self.assertEqual(policy.max_age_days, 7)
 
+    def test_response_data_struct_reaches_response_comparison(self):
+        """提取层回归（#639 Bugbot）：*ResponseData 必须经真实提取路径进对比。
+
+        auth 域以 UserAccessTokenV1ResponseData 命名文件内唯一响应 payload
+        struct；若提取层不收它，选择层 fallback 只能在空列表里挑选，full 模式
+        响应对比静默关闭、doc 字段缺失诊断消失。走 _run_single_api 真路径
+        （临时 crate 源文件 → extract_structs → _compare_evidence_against_code）。
+        """
+        api = api_identity()
+        collector = _FieldCollector(api)
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "crates/openlark-workflow/src" / api.expected_file
+            source.parent.mkdir(parents=True)
+            # 文件内只有 *ResponseData 命名的响应 struct，且缺文档字段 result
+            source.write_text(
+                "pub struct UserAccessTokenV1ResponseData {\n"
+                "    pub expires_in: i32,\n"
+                "}\n",
+                encoding="utf-8",
+            )
+            output = root / "reports"
+            argv = [
+                "verify_api_fields.py",
+                "--api-id",
+                api.api_id,
+                "--fetch-docs",
+                "--output-dir",
+                str(output),
+            ]
+            with (
+                mock.patch.object(sys, "argv", argv),
+                mock.patch.object(verify_api_fields, "REPO_ROOT", root),
+                mock.patch.object(
+                    verify_api_fields,
+                    "load_api_identities",
+                    return_value=[api],
+                ),
+                mock.patch.object(
+                    verify_api_fields,
+                    "compose_full",
+                    return_value=collector,
+                ),
+            ):
+                verify_api_fields.main()
+
+            report = json.loads(
+                (output / "summary.json").read_text(encoding="utf-8")
+            )
+        categories = [
+            issue["category"] for issue in report["apis"][0]["issues"]
+        ]
+        self.assertIn("missing_response_field", categories)
+
 
 class ResponseFieldDigitNameTests(unittest.TestCase):
     """#618: 响应示例字段名正则须保留含数字的名字（如 i18n_name）。"""

--- a/tools/tests/test_verify_api_fields.py
+++ b/tools/tests/test_verify_api_fields.py
@@ -131,73 +131,6 @@ def field_evidence(
     )
 
 
-class ExtractStructFieldsTests(unittest.TestCase):
-    def test_extracts_required_optional_vec_and_serde_names(self):
-        source = '''
-pub struct DemoBody {
-    #[serde(rename = "type")]
-    pub task_type: String,
-    pub user_ids: Vec<String>,
-    pub comment: Option<String>,
-}
-pub struct DemoResponse {
-    pub result: String,
-}
-pub struct DemoRequest {
-    pub config: Config,
-}
-'''
-        structs = verify_api_fields.extract_structs(source)
-        self.assertEqual([item.name for item in structs], ["DemoBody", "DemoResponse"])
-        fields = {item.name: item for item in structs[0].fields}
-        self.assertEqual(fields["task_type"].effective_name, "type")
-        self.assertTrue(fields["user_ids"].required)
-        self.assertEqual(fields["user_ids"].type_name, "String")
-        self.assertTrue(fields["user_ids"].is_array)
-        self.assertFalse(fields["comment"].required)
-        self.assertFalse(fields["comment"].is_array)
-
-    def test_skips_absolute_skip_serializing_path_params(self):
-        source = '''
-pub struct UpdateBody {
-    /// path param
-    #[serde(skip_serializing)]
-    pub card_id: String,
-    #[serde(rename = "type")]
-    pub type_: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub uuid: Option<String>,
-    pub sequence: i32,
-}
-'''
-        structs = verify_api_fields.extract_structs(source)
-        fields = {item.effective_name: item for item in structs[0].fields}
-        self.assertNotIn("card_id", fields)
-        self.assertIn("type", fields)
-        self.assertIn("uuid", fields)
-        self.assertFalse(fields["uuid"].required)
-        self.assertIn("sequence", fields)
-
-    def test_skips_multipart_internal_meta_fields(self):
-        source = '''
-pub struct UploadBody {
-    #[serde(skip_serializing)]
-    pub file: Vec<u8>,
-    #[serde(rename = "__file_name", skip_serializing_if = "Option::is_none")]
-    pub file_name: Option<String>,
-    pub pdf_page_limit: i32,
-    pub ocr_mode: String,
-}
-'''
-        structs = verify_api_fields.extract_structs(source)
-        fields = {item.effective_name: item for item in structs[0].fields}
-        self.assertNotIn("__file_name", fields)
-        self.assertNotIn("file_name", fields)
-        self.assertNotIn("file", fields)
-        self.assertIn("pdf_page_limit", fields)
-        self.assertIn("ocr_mode", fields)
-
-
 class SuspiciousPatternTests(unittest.TestCase):
     def test_user_level_extra_field_is_informational(self):
         api = api_identity(full_path="/document/x/reference/approval-v4/task/pass")
@@ -412,6 +345,58 @@ class ComparisonTests(unittest.TestCase):
             structs, field_evidence(api), issues
         )
         self.assertEqual(issues, [])
+
+    def test_response_data_fallback_enables_comparison(self):
+        """auth 域 *ResponseData 是文件内唯一响应 payload struct，须兜底命中。
+
+        无兜底时 code_response=[]，doc 有字段而 code 无的 missing_response_field
+        诊断会被静默跳过。
+        """
+        api = api_identity()
+        structs = [
+            verify_api_fields.StructFields(
+                "UserAccessTokenV1ResponseData",
+                [verify_api_fields.FieldInfo("expires_in", "i32", True)],
+            )
+        ]
+        evidence = OfficialDocumentEvidence(
+            api,
+            (
+                DimensionEvidence(
+                    dimension=EvidenceDimension.REQUEST_FIELDS,
+                    status=EvidenceStatus.TRUSTED,
+                    selected_source=EvidenceSource.STRUCTURED_DETAIL,
+                    observations=(),
+                    snapshot_provenance=None,
+                    interpretation_provenance=None,
+                    diagnostics=(),
+                    acquisition_trail=(),
+                ),
+                DimensionEvidence(
+                    dimension=EvidenceDimension.RESPONSE_FIELDS,
+                    status=EvidenceStatus.TRUSTED,
+                    selected_source=EvidenceSource.STRUCTURED_DETAIL,
+                    observations=(
+                        FieldObservation(
+                            ("access_token",),
+                            "response_body",
+                            None,
+                            "string",
+                            EvidenceSource.STRUCTURED_DETAIL,
+                        ),
+                    ),
+                    snapshot_provenance=None,
+                    interpretation_provenance=None,
+                    diagnostics=(),
+                    acquisition_trail=(),
+                ),
+            ),
+        )
+        issues = []
+        verify_api_fields._compare_evidence_against_code(structs, evidence, issues)
+        self.assertEqual(
+            [item.category for item in issues], ["missing_response_field"]
+        )
 
     def test_trusted_empty_request_evidence_preserves_nonpassing_semantics(self):
         api = api_identity()

--- a/tools/verify_api_fields.py
+++ b/tools/verify_api_fields.py
@@ -54,7 +54,7 @@ _BODY_STRUCT_SUFFIXES = ("Body", "RequestBody")
 # 会让 full 模式响应对比静默关闭）。嵌套 Result 先于 Response 定义时不能抢位，
 # 否则文档顶层字段会对到嵌套 payload 上。
 _RESPONSE_PRIMARY_SUFFIXES = ("Response",)
-_RESPONSE_FALLBACK_SUFFIXES = RESPONSE_STRUCT_SUFFIXES + ("ResponseData",)
+_RESPONSE_FALLBACK_SUFFIXES = RESPONSE_STRUCT_SUFFIXES
 
 
 # ---------------------------------------------------------------------------

--- a/tools/verify_api_fields.py
+++ b/tools/verify_api_fields.py
@@ -13,7 +13,6 @@ API 字段核对工具：扫描代码字段、检测可疑模式、可选抓飞�
 from __future__ import annotations
 
 import argparse
-import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -23,7 +22,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from tools.api_contracts.models import ApiIdentity
+from tools.api_contracts.models import ApiIdentity, FieldInfo, StructFields
 from tools.api_contracts.official import load_api_identities
 from tools.api_contracts.official_evidence import (
     EvidenceDimension,
@@ -37,150 +36,25 @@ from tools.api_contracts.report import (
     evidence_markdown_lines,
     evidence_to_jsonable,
 )
+from tools.api_contracts.rust_source import (
+    MULTIPART_FORM_STRUCT_NAME,
+    RESPONSE_STRUCT_SUFFIXES,
+    extract_structs,
+    matches_struct_suffix,
+)
+
 DEFAULT_CSV = REPO_ROOT / "api_list_export.csv"
 
-
-# ---------------------------------------------------------------------------
-# 数据模型
-# ---------------------------------------------------------------------------
-
-
-
-
-# ---------------------------------------------------------------------------
-# Rust 源码字段提取
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class FieldInfo:
-    """单个字段信息。"""
-
-    name: str  # Rust 字段名（rename 前的 snake_case）
-    type_name: str  # 核心类型名（Vec<String> -> String，Option<i32> -> i32）
-    required: Optional[bool]  # 是否必填；None=文档未标注（跳过必填对比）
-    rename: Optional[str] = None  # serde rename 后的名字，无则 None
-    is_array: bool = False  # 是否数组（Vec / doc 的 T[]）
-
-    @property
-    def effective_name(self) -> str:
-        """对比时用的名字：rename 优先。"""
-        return self.rename or self.name
-
-
-@dataclass
-class StructFields:
-    """一个 struct 提取出的字段集合。"""
-
-    name: str  # struct 名
-    fields: List[FieldInfo] = field(default_factory=list)
-
-
-def extract_structs(source: str) -> List[StructFields]:
-    """从 Rust 源码提取 Body/Response struct 的字段。
-
-    只提取名字含 Body 或 Response 的 struct（请求体/响应体），
-    跳过 Request struct（那是 builder，不是字段定义）。
-    """
-    results: List[StructFields] = []
-    # 匹配 pub struct Name { ... }，非贪婪到第一个 }
-    pattern = re.compile(r"pub\s+struct\s+(\w+)\s*\{([^}]*)\}", re.S)
-    for m in pattern.finditer(source):
-        name = m.group(1)
-        if "Body" not in name and "Response" not in name:
-            continue
-        body = m.group(2)
-        results.append(StructFields(name=name, fields=_extract_fields_from_block(body)))
-    return results
-
-
-def _extract_fields_from_block(block: str) -> List[FieldInfo]:
-    """从 struct 体内提取字段列表。"""
-    fields: List[FieldInfo] = []
-    lines = block.split("\n")
-    pending_rename: Optional[str] = None
-    # 纯 skip_serializing（路径参数）不进入请求体对比；skip_serializing_if 仍参与。
-    pending_skip_serializing = False
-    pending_attrs: List[str] = []
-    for line in lines:
-        stripped = line.strip()
-        if not stripped:
-            continue
-        if stripped.startswith("//"):
-            continue
-        if stripped.startswith("#["):
-            pending_attrs.append(stripped)
-            rename_match = re.search(
-                r'#\[serde\s*\([^)]*rename\s*=\s*"([^"]+)"', stripped
-            )
-            if rename_match:
-                pending_rename = rename_match.group(1)
-            # 与 tools/api_contracts/rust_source.py 对齐：仅绝对 skip_serializing 跳过
-            if "skip_serializing" in stripped and "skip_serializing_if" not in stripped:
-                pending_skip_serializing = True
-            continue
-        # 匹配 pub field_name: Type,
-        field_match = re.match(r"pub\s+(\w+)\s*:\s*(.+?),?\s*$", stripped)
-        if not field_match:
-            pending_rename = None
-            pending_skip_serializing = False
-            pending_attrs.clear()
-            continue
-        if pending_skip_serializing:
-            pending_rename = None
-            pending_skip_serializing = False
-            pending_attrs.clear()
-            continue
-        fname = field_match.group(1)
-        raw_type = field_match.group(2).strip().rstrip(",")
-        # multipart 内部元数据（如 __file_name）不参与官方字段对比
-        effective = pending_rename or fname
-        if effective.startswith("__"):
-            pending_rename = None
-            pending_skip_serializing = False
-            pending_attrs.clear()
-            continue
-        required, type_name, is_array = _parse_type(raw_type)
-        fields.append(
-            FieldInfo(
-                name=fname,
-                type_name=type_name,
-                required=required,
-                rename=pending_rename,
-                is_array=is_array,
-            )
-        )
-        pending_rename = None
-        pending_skip_serializing = False
-        pending_attrs.clear()
-    return fields
-
-
-def _parse_type(raw: str) -> Tuple[bool, str, bool]:
-    """解析类型字符串，返回 (是否必填, 规范化类型名, 是否数组)。"""
-    raw = raw.strip()
-    # Option<T> -> 选填，内部类型
-    opt_match = re.match(r"Option<(.+)>$", raw)
-    if opt_match:
-        inner = opt_match.group(1).strip()
-        vec_match = re.match(r"Vec<(.+)>$", inner)
-        if vec_match:
-            return False, _unwrap_generic(vec_match.group(1).strip()), True
-        return False, _unwrap_generic(inner), False
-    # Vec<T> -> 必填，元素类型
-    vec_match = re.match(r"Vec<(.+)>$", raw)
-    if vec_match:
-        return True, _unwrap_generic(vec_match.group(1).strip()), True
-    # 裸类型
-    return True, _unwrap_generic(raw), False
-
-
-def _unwrap_generic(type_str: str) -> str:
-    """去掉外层泛型，取核心类型名（Vec<String> -> String，HashMap<K,V> -> K）。"""
-    inner_match = re.match(r"\w+<(.+)>$", type_str)
-    if inner_match:
-        return inner_match.group(1).split(",")[0].strip()
-    return type_str
+# 请求体 struct 后缀：REQUEST_STRUCT_SUFFIXES 的 body 子集——Query/Params 是查询
+# 参数而非请求体，混入会把「GET+query 无 body」的 API 误报 doc_parse_empty。
+_BODY_STRUCT_SUFFIXES = ("Body", "RequestBody")
+# 响应对比优先取 *Response（信封 struct）；仅当文件没有 *Response 时才回落
+# *Result/*Resp/*ResponseData（如 baike 的 MatchEntityResp、auth 的
+# UserAccessTokenV1ResponseData——后者是文件内唯一响应 payload struct，不兜底
+# 会让 full 模式响应对比静默关闭）。嵌套 Result 先于 Response 定义时不能抢位，
+# 否则文档顶层字段会对到嵌套 payload 上。
+_RESPONSE_PRIMARY_SUFFIXES = ("Response",)
+_RESPONSE_FALLBACK_SUFFIXES = RESPONSE_STRUCT_SUFFIXES + ("ResponseData",)
 
 
 # ---------------------------------------------------------------------------
@@ -210,8 +84,10 @@ def detect_suspicious_patterns(
     """
     issues: List[FieldIssue] = []
 
-    # 收集所有 Body struct 的字段
-    body_structs = [s for s in structs if "Body" in s.name]
+    # 收集所有请求体 struct 的字段
+    body_structs = [
+        s for s in structs if matches_struct_suffix(s.name, _BODY_STRUCT_SUFFIXES)
+    ]
 
     # 红旗 1：用户级接口含 user_id / approval_code
     # 注意：is_user_level 基于 /reference/ 路径，但 reference 也含管理员级接口，
@@ -263,7 +139,9 @@ def detect_suspicious_patterns(
 
     # 红旗 3：GET 查询接口 Response 为空
     if api.official_method == "GET":
-        resp_structs = [s for s in structs if "Response" in s.name]
+        resp_structs = [
+            s for s in structs if matches_struct_suffix(s.name, _RESPONSE_PRIMARY_SUFFIXES)
+        ]
         for s in resp_structs:
             if not s.fields:
                 issues.append(
@@ -617,9 +495,22 @@ def _compare_evidence_against_code(
             and len(item.path) == 1
             and item.location == "request_body"
         ]
-        code_body = next(
-            (item.fields for item in structs if "Body" in item.name), []
+        # 请求体 = 首个 body 后缀 struct 的字段 + multipart 合成分组的表单字段
+        body_fields = next(
+            (
+                item.fields
+                for item in structs
+                if matches_struct_suffix(item.name, _BODY_STRUCT_SUFFIXES)
+            ),
+            [],
         )
+        multipart_fields = next(
+            (item.fields for item in structs if item.name == MULTIPART_FORM_STRUCT_NAME),
+            [],
+        )
+        # Body struct（强类型）在前：compare_fields 按名字建 dict 后写覆盖先写，
+        # 同名字段以 Body struct 的 required/类型语义为准，multipart 通道不静默盖掉
+        code_body = list(multipart_fields) + list(body_fields)
         if not doc_req and code_body:
             issues.append(
                 FieldIssue(
@@ -656,7 +547,19 @@ def _compare_evidence_against_code(
             if isinstance(item, FieldObservation) and len(item.path) == 1
         }
         code_response = next(
-            (item.fields for item in structs if "Response" in item.name), []
+            (
+                item.fields
+                for item in structs
+                if matches_struct_suffix(item.name, _RESPONSE_PRIMARY_SUFFIXES)
+            ),
+            next(
+                (
+                    item.fields
+                    for item in structs
+                    if matches_struct_suffix(item.name, _RESPONSE_FALLBACK_SUFFIXES)
+                ),
+                [],
+            ),
         )
         if doc_response_names and code_response:
             code_names = {item.effective_name for item in code_response}


### PR DESCRIPTION
Fixes #636（语义半边；机械半边 #635 已由 #637 落地）

## 问题

「从 Rust 源码提取合约」两份平行实现，对齐靠注释维持：verify_api_fields 内嵌栈（正则停在首个 `}`、不认 `rename_all`、遇 doc 注释夹住的 rename 会丢）vs rust_source（括号配平、认 rename_all、但 type_name 遇逗号截断 `HashMap<String, String>` → `HashMap<String`）。

## 变更（6 文件，+500/−229）

**库消费（决策 ①②）**
- verify_api_fields 删内嵌栈，`import api_contracts.rust_source`；`extract_structs` 成为唯一分组提取 interface
- `FieldInfo`/`StructFields` → models.py（frozen，与既有值类型惯例一致）；`parse_field_type`/`_unwrap_generic`/分组脚手架进 rust_source（`_iter_matching_struct_bodies` 供 flat 与分组两视图共用）
- verify 保留 `detect_suspicious_patterns` + 比较层

**匹配规则（决策 ③）**
- `matches_struct_suffix`：endswith 后缀集统一 + 版本尾缀兜底（`*BodyV4`/`*ResponseV1`——对拍发现 134 个真实版本尾缀 struct 被漏，workflow 244 个字段恢复可见）

**共享层修复（决策 ④，两 CLI 同时受益）**
- 括号配平 struct 体：平衡花括号的 doc 注释不再截断字段
- 整行类型捕获：`HashMap<String, String>` 逗号截断修复（全仓 161 处）
- `#[serde(rename)]` 跨 doc 注解生效（对拍抓到 whiteboard `node_type` 1 处真回归后修复）
- `std::option::Option` 识别为选填；`__` 前缀内部字段全局跳过

**审查驱动的两处补充**（三轴审查 should_fix + live 实证）
- 响应对比确定性选择：`*Response` 优先，`*Result`/`*Resp`/`*ResponseData` 兜底——auth 域 10 个 `*ResponseData` 唯一响应 struct 的文件恢复 full 模式对比能力
- multipart 表单字段（Meta struct/`json!` 字面量）以 `MultipartForm` 合成分组进入请求体对比；二进制 `file` 通道排除（官方 request_body 字段表不列它——document_ai 合同字段提取 live 实跑出过 `extra_field: file` 假警告后剔除，drive upload_all live 实跑通过）

**测试（决策 ⑤）**：提取语义用例迁入 `test_validate_api_contracts_rust_source.py`（interface 即测试面）+ 10 条新语义正测

## 验证（三层 + live）

| 层 | 结果 |
|---|---|
| 全仓对拍（旧 vs 新提取，diff 分类） | **零意外回归**；全部桶归类：comma_fix 161 / 版本尾缀恢复 244 字段 / multipart 11 / 恒等 rename 坍缩 193（effective 不变）/ ResponseData 兜底 |
| quick 模式 CLI 端到端（1,628 API） | 问题集**零漂移**（新旧逐 API 比对） |
| CI 7 模块 | 136 tests OK（2 skipped 为 env 门控 live smoke） |
| live full 模式 | document_ai 合同字段提取（multipart）、drive upload_all（Meta 通道）实跑通过 |

诚实边界：full 模式文档对比的批量行为由上线后 weekly 门覆盖（本地无快照语料）；`*Result` 嵌套 payload 的响应对比语义沿旧首匹配行为近似。

## 附带发现

对抗审查发现**既有 bug**（非本 PR 引入）：weekly quick 门无 `--crate` 调用时 `src_root=crates` 与 crate 内相对路径不匹配，1,628 API 全部 `file_exists=False`——每周门实际扫描量为零。已另案 #638（建议修 CI yml 逐 crate 调用）。

## 非目标（与 issue 一致）

validate_apis 平行映射（ADR-0005 非目标）· codegen 重接快照 · 新建第三共享模块

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> 改动集中在内部 tools 与提取语义，影响全仓 1,628 API 字段核对结果；已做对拍与测试，但 full 模式文档对比仍依赖线上 weekly 门与快照语料。
> 
> **Overview**
> **`verify_api_fields` 不再自带 Rust 提取栈**（约 105 行正则实现），改为调用 **`api_contracts.rust_source`**；`FieldInfo` / `StructFields` 迁入 **`models.py`**，`extract_structs` 成为唯一的分组提取入口。
> 
> **共享 `rust_source` 提取能力增强**（合约校验与字段核对 CLI 共用）：struct 体用**括号配平**（doc 里平衡 `{}` 不再截断字段）；整行类型解析修复 **`HashMap<String, String>`** 逗号截断；`#[serde(rename)]` 可跨 doc 注释生效；`std::option::Option` 视为选填；`__` 前缀字段跳过；**`matches_struct_suffix`** 支持 `*BodyV4` / `*ResponseV1` 等版本尾缀。
> 
> **字段核对行为**：multipart 的 Meta / `json!` 字段合成 **`MultipartForm`** 分组参与请求体对比（二进制 `file` 通道排除）；响应侧 **`*Response` 优先**，无则回落 `*Result` / `*Resp` / `*ResponseData`；请求体只认 **Body / RequestBody** 后缀，避免 Query 误报。
> 
> 提取语义测试从 **`test_verify_api_fields.py`** 迁到 **`test_validate_api_contracts_rust_source.py`**，并补充新语义用例；响应 `*ResponseData` 兜底对比有单测。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9368af7abe8b99174d40a4389ddc00d9d89f423d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->