### PR TITLE
refactor(ws): 将 CloseIntent 收敛进 SessionState::Closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **websocket：SessionState 收敛 CloseIntent + harness 瘦身（#641）**：
+  `SessionState{Active,Closing,Closed}` × `CloseIntent{None,WithoutReason,WithReason}`
+  两个必须手工对齐的字段收为 `SessionState::Closing(Option<WsCloseReason>)`。
+  stream 错误与 outcome 错误的 reason 保留镜像块收敛为单一
+  `fail_preserving_close_reason`。两枚举均私有，`InvalidStateKind` /
+  `WsClientError` 公开面不变。`full_session_tests` 删除被 #640 新层替代的
+  15 个用例（1478 → ~622 行），保留 B 组 6 个墙钟测试与 C 组 3 个端点发现测试。
+
 - **deps：升级 h2 0.4.14 → 0.4.16（RUSTSEC-2026-0258）**：修复空 DATA 帧无界排队。
 
 - **tools：weekly/full 字段核对无 `--crate` 时扫描量为零（#638）**：

--- a/crates/openlark-client/src/ws_client/full_session_tests.rs
+++ b/crates/openlark-client/src/ws_client/full_session_tests.rs
@@ -76,16 +76,6 @@ impl LocalSessionHarness {
         }
     }
 
-    fn config(&self) -> Config {
-        Config::builder()
-            .app_id("test_app_id")
-            .app_secret("test_app_secret")
-            .base_url(self.mock_server.uri())
-            .allow_custom_base_url(true)
-            .req_timeout(Duration::from_secs(5))
-            .build()
-    }
-
     async fn accept_peer(&mut self) -> WebSocketStream<tokio::net::TcpStream> {
         let listener = self.listener.take().expect("listener already consumed");
         let (stream, _) = timeout(SESSION_TIMEOUT, listener.accept())
@@ -108,7 +98,7 @@ where
     Fut: Future<Output = T> + Send + 'static,
     T: Send + 'static,
 {
-    let config = Arc::new(harness.config());
+    let config = Arc::new(test_config(&harness.mock_server));
     let (peer_done_tx, peer_done_rx) = oneshot::channel::<T>();
 
     let peer_task = tokio::spawn(async move {
@@ -549,8 +539,8 @@ fn local_endpoint_client_config_shape_matches_production() {
     assert_eq!(cfg.ping_interval, 3600);
 }
 
-/// 端点发现错误用 config：复用 LocalSessionHarness 的构建规则，但不绑 WS listener。
-fn endpoint_only_config(mock_server: &MockServer) -> Config {
+/// 测试用 Config：允许自定义 base_url，短超时。harness 与端点-only 用例共用。
+fn test_config(mock_server: &MockServer) -> Config {
     Config::builder()
         .app_id("test_app_id")
         .app_secret("test_app_secret")
@@ -579,7 +569,7 @@ async fn open_endpoint_business_error_wraps_core_error_with_request_id() {
         .mount(&mock_server)
         .await;
 
-    let config = Arc::new(endpoint_only_config(&mock_server));
+    let config = Arc::new(test_config(&mock_server));
     let result = LarkWsClient::open(config, EventDispatcherHandler::builder().build()).await;
 
     match result {
@@ -612,7 +602,7 @@ async fn open_endpoint_success_without_url_is_unexpected_response() {
         .mount(&mock_server)
         .await;
 
-    let config = Arc::new(endpoint_only_config(&mock_server));
+    let config = Arc::new(test_config(&mock_server));
     let result = LarkWsClient::open(config, EventDispatcherHandler::builder().build()).await;
 
     match result {

--- a/crates/openlark-client/src/ws_client/full_session_tests.rs
+++ b/crates/openlark-client/src/ws_client/full_session_tests.rs
@@ -1,11 +1,15 @@
-//! 完整会话本地 adapter 测试（#426–#429 + 单 session 重构）。
+//! 完整会话本地 adapter 测试：墙钟时序 + 端点发现（#641）。
+//!
+//! 状态机行为已下沉至 [`super::session_behavior_tests`]（ADR-0006 / #640）。
+//! 本文件只保留：
+//! - B 组墙钟测试（与真实定时器的集成语义，端到端层最诚实）
+//! - C 组端点发现测试（无 WS）
 //!
 //! 测试 seam：[`LarkWsClient::open`] / `open_with` + 本地 endpoint + WS peer。
 
 #![cfg(feature = "websocket")]
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use futures_util::{SinkExt, StreamExt};
@@ -32,23 +36,6 @@ use super::{
 const SERVICE_ID: i32 = 42;
 const SESSION_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// 记录原始事件处理器调用次数。
-struct CountingHandler {
-    calls: Arc<AtomicUsize>,
-    last_payload: Arc<std::sync::Mutex<Vec<u8>>>,
-}
-
-impl EventHandler for CountingHandler {
-    fn handle(&self, payload: &[u8]) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        self.calls.fetch_add(1, Ordering::SeqCst);
-        *self
-            .last_payload
-            .lock()
-            .expect("payload mutex should not be poisoned") = payload.to_vec();
-        Ok(())
-    }
-}
-
 /// 本地完整会话 harness：wiremock endpoint + 本机 WebSocket peer。
 struct LocalSessionHarness {
     mock_server: MockServer,
@@ -56,10 +43,6 @@ struct LocalSessionHarness {
 }
 
 impl LocalSessionHarness {
-    async fn start() -> Self {
-        Self::start_with_ping_interval(3600).await
-    }
-
     async fn start_with_ping_interval(ping_interval_secs: i32) -> Self {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
@@ -93,17 +76,14 @@ impl LocalSessionHarness {
         }
     }
 
-    fn config_with_max_response_size(&self, max_response_size: Option<usize>) -> Config {
-        let mut b = Config::builder()
+    fn config(&self) -> Config {
+        Config::builder()
             .app_id("test_app_id")
             .app_secret("test_app_secret")
             .base_url(self.mock_server.uri())
             .allow_custom_base_url(true)
-            .req_timeout(Duration::from_secs(5));
-        if let Some(max) = max_response_size {
-            b = b.max_response_size(max as u64);
-        }
-        b.build()
+            .req_timeout(Duration::from_secs(5))
+            .build()
     }
 
     async fn accept_peer(&mut self) -> WebSocketStream<tokio::net::TcpStream> {
@@ -118,32 +98,17 @@ impl LocalSessionHarness {
 
 /// 运行一次完整会话：peer 脚本与 `open_with` 并发，返回 open 结果与 peer 产出。
 async fn run_session<F, Fut, T>(
-    harness: LocalSessionHarness,
-    event_handler: EventDispatcherHandler,
-    options: SessionOptions,
-    peer_script: F,
-) -> (WsClientResult<()>, T)
-where
-    F: FnOnce(WebSocketStream<tokio::net::TcpStream>) -> Fut + Send + 'static,
-    Fut: std::future::Future<Output = T> + Send + 'static,
-    T: Send + 'static,
-{
-    run_session_with_config(harness, event_handler, options, None, peer_script).await
-}
-
-async fn run_session_with_config<F, Fut, T>(
     mut harness: LocalSessionHarness,
     event_handler: EventDispatcherHandler,
     options: SessionOptions,
-    max_response_size: Option<usize>,
     peer_script: F,
 ) -> (WsClientResult<()>, T)
 where
     F: FnOnce(WebSocketStream<tokio::net::TcpStream>) -> Fut + Send + 'static,
-    Fut: std::future::Future<Output = T> + Send + 'static,
+    Fut: Future<Output = T> + Send + 'static,
     T: Send + 'static,
 {
-    let config = Arc::new(harness.config_with_max_response_size(max_response_size));
+    let config = Arc::new(harness.config());
     let (peer_done_tx, peer_done_rx) = oneshot::channel::<T>();
 
     let peer_task = tokio::spawn(async move {
@@ -175,48 +140,25 @@ where
 }
 
 fn event_data_frame(payload: &[u8]) -> Frame {
-    multipart_event_frame("full-session-msg-1", None, None, payload)
-}
-
-fn multipart_event_frame(
-    message_id: &str,
-    sum: Option<usize>,
-    seq: Option<usize>,
-    payload: &[u8],
-) -> Frame {
-    let mut headers = vec![
-        Header {
-            key: "type".to_string(),
-            value: "event".to_string(),
-        },
-        Header {
-            key: "message_id".to_string(),
-            value: message_id.to_string(),
-        },
-        Header {
-            key: "trace_id".to_string(),
-            value: format!("trace-{message_id}"),
-        },
-    ];
-    if let Some(sum) = sum {
-        headers.push(Header {
-            key: "sum".to_string(),
-            value: sum.to_string(),
-        });
-    }
-    if let Some(seq) = seq {
-        headers.push(Header {
-            key: "seq".to_string(),
-            value: seq.to_string(),
-        });
-    }
-
     Frame {
-        seq_id: seq.unwrap_or(0) as u64,
+        seq_id: 0,
         log_id: 100,
         service: SERVICE_ID,
         method: FRAME_METHOD_DATA,
-        headers,
+        headers: vec![
+            Header {
+                key: "type".to_string(),
+                value: "event".to_string(),
+            },
+            Header {
+                key: "message_id".to_string(),
+                value: "full-session-msg-1".to_string(),
+            },
+            Header {
+                key: "trace_id".to_string(),
+                value: "trace-full-session-msg-1".to_string(),
+            },
+        ],
         payload_encoding: None,
         payload_type: None,
         payload: Some(payload.to_vec()),
@@ -236,15 +178,6 @@ async fn recv_next_frame(peer: &mut WebSocketStream<tokio::net::TcpStream>) -> F
             Message::Ping(_) | Message::Pong(_) => continue,
             Message::Close(_) => panic!("unexpected close while waiting for frame"),
             other => panic!("unexpected websocket message: {other:?}"),
-        }
-    }
-}
-
-async fn recv_data_response_frame(peer: &mut WebSocketStream<tokio::net::TcpStream>) -> Frame {
-    loop {
-        let frame = recv_next_frame(peer).await;
-        if frame.method == FRAME_METHOD_DATA {
-            return frame;
         }
     }
 }
@@ -290,52 +223,6 @@ fn pong_control_frame(ping_interval: i32) -> Frame {
     }
 }
 
-fn malformed_pong_frame() -> Frame {
-    Frame {
-        seq_id: 0,
-        log_id: 0,
-        service: SERVICE_ID,
-        method: FRAME_METHOD_CONTROL,
-        headers: vec![Header {
-            key: "type".to_string(),
-            value: "pong".to_string(),
-        }],
-        payload_encoding: None,
-        payload_type: None,
-        payload: Some(b"{ not-json".to_vec()),
-        log_id_new: None,
-    }
-}
-
-fn invalid_method_frame() -> Frame {
-    Frame {
-        seq_id: 0,
-        log_id: 0,
-        service: SERVICE_ID,
-        method: 99,
-        headers: vec![],
-        payload_encoding: None,
-        payload_type: None,
-        payload: Some(b"x".to_vec()),
-        log_id_new: None,
-    }
-}
-
-/// 构造一个 server→client 的 WebSocket Binary 帧（无 mask；payload_len ≤ 65535）。
-/// 用于 peer 端 tungstenite 已进入 CLOSING、无法再 `send` 时绕过其状态机违约发送数据帧。
-fn raw_binary_ws_frame(payload: &[u8]) -> Vec<u8> {
-    let mut frame = Vec::with_capacity(2 + payload.len());
-    frame.push(0x82); // FIN + opcode 2 (binary)；server→client 不 mask
-    if payload.len() <= 125 {
-        frame.push(payload.len() as u8);
-    } else {
-        frame.push(126);
-        frame.extend_from_slice(&(payload.len() as u16).to_be_bytes());
-    }
-    frame.extend_from_slice(payload);
-    frame
-}
-
 fn assert_normal_close(result: WsClientResult<()>) {
     match result {
         Err(WsClientError::ConnectionClosed {
@@ -349,249 +236,7 @@ fn assert_normal_close(result: WsClientResult<()>) {
     }
 }
 
-/// 在 `window` 内统计入站数据响应帧数（忽略 Ping/Pong）；超时或流结束则返回已计数。
-/// 用于「不应派发 / 无 ACK」负向断言，避免三处 deadline 轮询复制粘贴。
-async fn count_data_responses_within(
-    peer: &mut WebSocketStream<tokio::net::TcpStream>,
-    window: Duration,
-) -> usize {
-    let mut data_responses = 0usize;
-    let deadline = tokio::time::Instant::now() + window;
-    loop {
-        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-        if remaining.is_zero() {
-            break;
-        }
-        match timeout(remaining, peer.next()).await {
-            Ok(Some(Ok(Message::Binary(data)))) => {
-                let frame = Frame::decode(&*data).expect("decode");
-                if frame.method == FRAME_METHOD_DATA {
-                    data_responses += 1;
-                }
-            }
-            Ok(Some(Ok(Message::Ping(_) | Message::Pong(_)))) => continue,
-            Ok(Some(Ok(_))) | Ok(Some(Err(_))) | Ok(None) | Err(_) => break,
-        }
-    }
-    data_responses
-}
-
-#[tokio::test]
-async fn full_session_dispatches_handler_and_emits_response_frame() {
-    let calls = Arc::new(AtomicUsize::new(0));
-    let last_payload = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let event_payload =
-        br#"{"header":{"event_type":"im.message.receive_v1"},"event":{"text":"hi"}}"#;
-
-    let event_handler = EventDispatcherHandler::builder()
-        .register_raw(
-            EventDispatcherHandler::RAW_EVENT_KEY,
-            CountingHandler {
-                calls: Arc::clone(&calls),
-                last_payload: Arc::clone(&last_payload),
-            },
-        )
-        .expect("register raw handler")
-        .build();
-
-    let (open_result, response_frame) = run_session(
-        LocalSessionHarness::start().await,
-        event_handler,
-        SessionOptions::default(),
-        move |mut peer| async move {
-            let _ = timeout(SESSION_TIMEOUT, peer.next()).await;
-            peer.send(Message::Binary(
-                event_data_frame(event_payload).encode_to_vec().into(),
-            ))
-            .await
-            .expect("send event");
-            let response = recv_data_response_frame(&mut peer).await;
-            peer.close(Some(CloseFrame {
-                code: CloseCode::Normal,
-                reason: "session complete".into(),
-            }))
-            .await
-            .ok();
-            response
-        },
-    )
-    .await;
-
-    assert_eq!(calls.load(Ordering::SeqCst), 1);
-    assert_eq!(
-        last_payload.lock().expect("mutex").as_slice(),
-        event_payload
-    );
-    assert_eq!(response_frame.method, 1);
-    let body = String::from_utf8(response_frame.payload.expect("payload")).expect("utf8");
-    assert!(body.contains("\"code\":200"), "got: {body}");
-    assert!(response_frame.headers.iter().any(|h| h.key == "biz_rt"));
-    assert_normal_close(open_result);
-}
-
-#[tokio::test]
-async fn full_session_remote_close_reason_is_observable() {
-    let (open_result, ()) = run_session(
-        LocalSessionHarness::start().await,
-        EventDispatcherHandler::builder().build(),
-        SessionOptions::default(),
-        |mut peer| async move {
-            let _ = timeout(SESSION_TIMEOUT, peer.next()).await;
-            peer.close(Some(CloseFrame {
-                code: CloseCode::Away,
-                reason: "server restarting".into(),
-            }))
-            .await
-            .ok();
-            while let Some(Ok(msg)) = peer.next().await {
-                if matches!(msg, Message::Close(_)) {
-                    break;
-                }
-            }
-        },
-    )
-    .await;
-
-    match open_result {
-        Err(WsClientError::ConnectionClosed {
-            reason: Some(WsCloseReason { code, message }),
-        }) => {
-            assert_eq!(code, CloseCode::Away);
-            assert_eq!(message, "server restarting");
-        }
-        other => panic!("expected remote close reason, got: {other:?}"),
-    }
-}
-
-#[tokio::test]
-async fn full_session_abrupt_peer_drop_is_observable_as_session_error() {
-    let (open_result, ()) = run_session(
-        LocalSessionHarness::start().await,
-        EventDispatcherHandler::builder().build(),
-        SessionOptions::default(),
-        |peer| async move {
-            drop(peer);
-        },
-    )
-    .await;
-
-    match open_result {
-        Err(WsClientError::WsError(_)) | Err(WsClientError::ConnectionClosed { reason: None }) => {}
-        other => panic!("expected session transport/close error, got: {other:?}"),
-    }
-}
-
-#[tokio::test]
-async fn full_session_multipart_out_of_order_dispatches_once() {
-    let calls = Arc::new(AtomicUsize::new(0));
-    let last_payload = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let part0 = b"Hello ";
-    let part1 = b"World!";
-    let combined = b"Hello World!";
-    let message_id = "multipart-ood-1";
-
-    let event_handler = EventDispatcherHandler::builder()
-        .register_raw(
-            EventDispatcherHandler::RAW_EVENT_KEY,
-            CountingHandler {
-                calls: Arc::clone(&calls),
-                last_payload: Arc::clone(&last_payload),
-            },
-        )
-        .expect("register")
-        .build();
-
-    let (open_result, response_frame) = run_session(
-        LocalSessionHarness::start().await,
-        event_handler,
-        SessionOptions::default(),
-        move |mut peer| async move {
-            let _ = timeout(SESSION_TIMEOUT, peer.next()).await;
-            peer.send(Message::Binary(
-                multipart_event_frame(message_id, Some(2), Some(1), part1)
-                    .encode_to_vec()
-                    .into(),
-            ))
-            .await
-            .expect("send part1");
-            peer.send(Message::Binary(
-                multipart_event_frame(message_id, Some(2), Some(0), part0)
-                    .encode_to_vec()
-                    .into(),
-            ))
-            .await
-            .expect("send part0");
-            let response = recv_data_response_frame(&mut peer).await;
-            peer.close(Some(CloseFrame {
-                code: CloseCode::Normal,
-                reason: "multipart complete".into(),
-            }))
-            .await
-            .ok();
-            response
-        },
-    )
-    .await;
-
-    assert_eq!(calls.load(Ordering::SeqCst), 1);
-    assert_eq!(
-        last_payload.lock().expect("mutex").as_slice(),
-        combined.as_slice()
-    );
-    let body = String::from_utf8(response_frame.payload.expect("payload")).expect("utf8");
-    assert!(body.contains("\"code\":200"), "got: {body}");
-    assert_normal_close(open_result);
-}
-
-#[tokio::test]
-async fn full_session_multipart_incomplete_does_not_dispatch() {
-    let calls = Arc::new(AtomicUsize::new(0));
-    let last_payload = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let message_id = "multipart-incomplete-1";
-
-    let event_handler = EventDispatcherHandler::builder()
-        .register_raw(
-            EventDispatcherHandler::RAW_EVENT_KEY,
-            CountingHandler {
-                calls: Arc::clone(&calls),
-                last_payload: Arc::clone(&last_payload),
-            },
-        )
-        .expect("register")
-        .build();
-
-    let (open_result, data_responses) = run_session(
-        LocalSessionHarness::start().await,
-        event_handler,
-        SessionOptions::default(),
-        move |mut peer| async move {
-            let _ = timeout(SESSION_TIMEOUT, peer.next()).await;
-            peer.send(Message::Binary(
-                multipart_event_frame(message_id, Some(2), Some(0), b"only-part-0")
-                    .encode_to_vec()
-                    .into(),
-            ))
-            .await
-            .expect("send incomplete");
-
-            let data_responses =
-                count_data_responses_within(&mut peer, Duration::from_millis(200)).await;
-
-            peer.close(Some(CloseFrame {
-                code: CloseCode::Normal,
-                reason: "incomplete package test".into(),
-            }))
-            .await
-            .ok();
-            data_responses
-        },
-    )
-    .await;
-
-    assert_eq!(calls.load(Ordering::SeqCst), 0);
-    assert_eq!(data_responses, 0);
-    assert_normal_close(open_result);
-}
+// === B 组：墙钟时序（与真实定时器的集成语义） ===
 
 #[tokio::test]
 async fn full_session_pong_updates_ping_interval() {
@@ -639,95 +284,6 @@ async fn full_session_pong_updates_ping_interval() {
     assert_normal_close(open_result);
 }
 
-/// 无效 frame method 经会话 Result 可观察（规范测试决策）。
-#[tokio::test]
-async fn full_session_invalid_frame_method_is_session_error() {
-    let (open_result, ()) = run_session(
-        LocalSessionHarness::start().await,
-        EventDispatcherHandler::builder().build(),
-        SessionOptions::default(),
-        |mut peer| async move {
-            let _ = timeout(SESSION_TIMEOUT, peer.next()).await;
-            peer.send(Message::Binary(
-                invalid_method_frame().encode_to_vec().into(),
-            ))
-            .await
-            .expect("send invalid method frame");
-            while let Some(Ok(_)) = peer.next().await {}
-        },
-    )
-    .await;
-
-    match open_result {
-        Err(WsClientError::InvalidFrameMethod { method }) => {
-            assert_eq!(method, 99);
-        }
-        other => panic!("expected InvalidFrameMethod, got: {other:?}"),
-    }
-}
-
-/// 超大帧受 `max_response_size` 限制，会话以传输错误结束（US 10）。
-#[tokio::test]
-async fn full_session_oversized_frame_is_rejected() {
-    // 上限须大于端点发现 bootstrap 响应（~200 字节：ADR-0003 起端点 POST 经 Transport，
-    // 其响应与所有 Transport 响应一样受 max_response_size 守护），又远小于下方 4096 测试帧。
-    const TINY_MAX: usize = 512;
-    let (open_result, ()) = run_session_with_config(
-        LocalSessionHarness::start().await,
-        EventDispatcherHandler::builder().build(),
-        SessionOptions::default(),
-        Some(TINY_MAX),
-        |mut peer| async move {
-            let _ = timeout(SESSION_TIMEOUT, peer.next()).await;
-            // 远超 64 字节的 binary（含 protobuf frame 开销）
-            let huge = vec![0u8; 4096];
-            let _ = peer.send(Message::Binary(huge.into())).await;
-            while let Some(Ok(_)) = peer.next().await {}
-        },
-    )
-    .await;
-
-    // 对端超限通常表现为传输/协议错误或连接关闭，而非成功派发
-    assert!(
-        matches!(
-            open_result,
-            Err(WsClientError::WsError(_))
-                | Err(WsClientError::ConnectionClosed { .. })
-                | Err(WsClientError::ProstError(_))
-        ),
-        "expected oversized frame to end session with transport/close error, got: {open_result:?}"
-    );
-}
-
-#[tokio::test]
-async fn full_session_malformed_pong_is_session_error() {
-    let (open_result, ()) = run_session(
-        LocalSessionHarness::start().await,
-        EventDispatcherHandler::builder().build(),
-        SessionOptions::default(),
-        |mut peer| async move {
-            let _ = timeout(SESSION_TIMEOUT, peer.next()).await;
-            peer.send(Message::Binary(
-                malformed_pong_frame().encode_to_vec().into(),
-            ))
-            .await
-            .expect("send malformed pong");
-            while let Some(Ok(_)) = peer.next().await {}
-        },
-    )
-    .await;
-
-    match open_result {
-        Err(WsClientError::MalformedControlFrame { message }) => {
-            assert!(
-                message.contains("invalid ClientConfig") || message.contains("malformed"),
-                "unexpected message: {message}"
-            );
-        }
-        other => panic!("expected MalformedControlFrame, got: {other:?}"),
-    }
-}
-
 #[tokio::test]
 async fn full_session_heartbeat_timeout_is_observable() {
     // 仅 WS Ping 刷新存活；peer 不发 Ping → 超时。会话级注入超时。
@@ -754,261 +310,6 @@ async fn full_session_heartbeat_timeout_is_observable() {
         ),
         "expected heartbeat ConnectionClosed, got: {open_result:?}"
     );
-}
-
-/// 事件 handler 串行：先完成的慢任务不得被后到的快任务抢先 ACK（Codex：保留串行 contract）。
-#[tokio::test]
-async fn full_session_handlers_run_serially_in_arrival_order() {
-    use std::sync::Mutex;
-    use std::thread;
-
-    struct OrderedHandler {
-        log: Arc<Mutex<Vec<u8>>>,
-    }
-    impl EventHandler for OrderedHandler {
-        fn handle(&self, payload: &[u8]) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-            let id = payload.last().copied().unwrap_or(0);
-            if id == 1 {
-                thread::sleep(Duration::from_millis(400));
-            }
-            self.log.lock().expect("mutex").push(id);
-            Ok(())
-        }
-    }
-
-    let log = Arc::new(Mutex::new(Vec::new()));
-    let event_handler = EventDispatcherHandler::builder()
-        .register_raw(
-            EventDispatcherHandler::RAW_EVENT_KEY,
-            OrderedHandler {
-                log: Arc::clone(&log),
-            },
-        )
-        .expect("register")
-        .build();
-
-    let (open_result, ()) = run_session(
-        LocalSessionHarness::start().await,
-        event_handler,
-        SessionOptions::default(),
-        |mut peer| async move {
-            let _ = timeout(SESSION_TIMEOUT, peer.next()).await;
-            // 两个完整事件：慢(1) 先到，快(2) 后到
-            let mut p1 = br#"{"header":{"event_type":"t"},"event":{"n":1}}"#.to_vec();
-            p1.push(1);
-            let mut p2 = br#"{"header":{"event_type":"t"},"event":{"n":2}}"#.to_vec();
-            p2.push(2);
-            peer.send(Message::Binary(
-                event_data_frame(&p1).encode_to_vec().into(),
-            ))
-            .await
-            .expect("send 1");
-            peer.send(Message::Binary(
-                event_data_frame(&p2).encode_to_vec().into(),
-            ))
-            .await
-            .expect("send 2");
-            // 等两个 ACK
-            let _ = recv_data_response_frame(&mut peer).await;
-            let _ = recv_data_response_frame(&mut peer).await;
-            peer.close(Some(CloseFrame {
-                code: CloseCode::Normal,
-                reason: "serial order test".into(),
-            }))
-            .await
-            .ok();
-        },
-    )
-    .await;
-
-    assert_eq!(
-        log.lock().expect("mutex").as_slice(),
-        &[1, 2],
-        "handlers must run in arrival order (serial worker)"
-    );
-    assert_normal_close(open_result);
-}
-
-/// Closing 后再收到 Binary → 必须得到 InvalidStateTransition（证明可达状态错误路径）。
-///
-/// 用短心跳 + 慢 handler 进入 Closing（仍有 inflight），再由 peer 发送 late Binary。
-/// 不用 peer.close()（会触发 SendAfterClosing，无法再送 Binary）。
-#[tokio::test]
-async fn full_session_data_after_close_is_invalid_state() {
-    use std::thread;
-
-    struct SlowHandler;
-    impl EventHandler for SlowHandler {
-        fn handle(&self, _payload: &[u8]) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-            thread::sleep(Duration::from_millis(800));
-            Ok(())
-        }
-    }
-
-    let event_handler = EventDispatcherHandler::builder()
-        .register_raw(EventDispatcherHandler::RAW_EVENT_KEY, SlowHandler)
-        .expect("register")
-        .build();
-
-    let options = SessionOptions {
-        heartbeat_timeout: Duration::from_millis(200),
-    };
-
-    let (open_result, ()) = run_session(
-        LocalSessionHarness::start_with_ping_interval(3600).await,
-        event_handler,
-        options,
-        |mut peer| async move {
-            let _ = timeout(SESSION_TIMEOUT, peer.next()).await;
-            peer.send(Message::Binary(
-                event_data_frame(br#"{"header":{"event_type":"slow"},"event":{}}"#)
-                    .encode_to_vec()
-                    .into(),
-            ))
-            .await
-            .expect("send slow event");
-            // 等会话因无 WS Ping 进入 Closing（heartbeat 200ms，checkout ≤200ms），
-            // 且 handler 仍 inflight（800ms）
-            tokio::time::sleep(Duration::from_millis(400)).await;
-            peer.send(Message::Binary(
-                event_data_frame(br#"{"header":{"event_type":"late"}}"#)
-                    .encode_to_vec()
-                    .into(),
-            ))
-            .await
-            .expect("send late binary while session Closing");
-            while let Some(Ok(_)) = peer.next().await {}
-        },
-    )
-    .await;
-
-    match open_result {
-        Err(WsClientError::InvalidStateTransition {
-            kind: InvalidStateKind::DataWhileClosing,
-        }) => {}
-        other => panic!("expected InvalidStateTransition(DataWhileClosing), got: {other:?}"),
-    }
-}
-
-/// Close + inflight handler：排空后必须保留远端关闭原因（不得被 EOF 覆盖为别的错误）。
-#[tokio::test]
-async fn full_session_close_reason_preserved_with_inflight_handler() {
-    use std::thread;
-
-    struct SlowHandler;
-    impl EventHandler for SlowHandler {
-        fn handle(&self, _payload: &[u8]) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-            thread::sleep(Duration::from_millis(300));
-            Ok(())
-        }
-    }
-
-    let event_handler = EventDispatcherHandler::builder()
-        .register_raw(EventDispatcherHandler::RAW_EVENT_KEY, SlowHandler)
-        .expect("register")
-        .build();
-
-    let (open_result, ()) = run_session(
-        LocalSessionHarness::start().await,
-        event_handler,
-        SessionOptions::default(),
-        |mut peer| async move {
-            let _ = timeout(SESSION_TIMEOUT, peer.next()).await;
-            peer.send(Message::Binary(
-                event_data_frame(br#"{"header":{"event_type":"slow"},"event":{}}"#)
-                    .encode_to_vec()
-                    .into(),
-            ))
-            .await
-            .expect("send event");
-            tokio::time::sleep(Duration::from_millis(30)).await;
-            peer.close(Some(CloseFrame {
-                code: CloseCode::Away,
-                reason: "server restarting".into(),
-            }))
-            .await
-            .ok();
-            // 不再发 Binary；连接自然 EOF 时 begin_close 必须幂等保留 Away 原因
-            while let Some(Ok(_)) = peer.next().await {}
-        },
-    )
-    .await;
-
-    match open_result {
-        Err(WsClientError::ConnectionClosed {
-            reason: Some(WsCloseReason { code, message }),
-        }) => {
-            assert_eq!(code, CloseCode::Away);
-            assert_eq!(message, "server restarting");
-        }
-        other => panic!("expected ConnectionClosed with Away reason, got: {other:?}"),
-    }
-}
-
-/// 远端先发 Close(Away)（服务端记录 WithReason(Away)），再违约发数据帧：client 端
-/// tungstenite 此时已 CLOSING，违约帧在协议层报错。该后续错误不得覆盖已记录的
-/// Away 关闭原因，必须经 `ConnectionClosed { Some(Away) }` 返回（#421 US9）。
-#[tokio::test]
-async fn full_session_data_after_remote_close_preserves_close_reason() {
-    use std::thread;
-    use tokio::io::AsyncWriteExt;
-
-    struct SlowHandler;
-    impl EventHandler for SlowHandler {
-        fn handle(&self, _: &[u8]) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-            thread::sleep(Duration::from_millis(300));
-            Ok(())
-        }
-    }
-
-    let event_handler = EventDispatcherHandler::builder()
-        .register_raw(EventDispatcherHandler::RAW_EVENT_KEY, SlowHandler)
-        .expect("register")
-        .build();
-
-    let (open_result, ()) = run_session(
-        LocalSessionHarness::start().await,
-        event_handler,
-        SessionOptions::default(),
-        |mut peer| async move {
-            let _ = timeout(SESSION_TIMEOUT, peer.next()).await;
-            // 先投递一个 event 让 handler 进入 inflight（否则收到 Close 后会话立即
-            // idle 终止，来不及观察后续违约 Binary 的处理）
-            peer.send(Message::Binary(
-                event_data_frame(br#"{"header":{"event_type":"slow"},"event":{}}"#)
-                    .encode_to_vec()
-                    .into(),
-            ))
-            .await
-            .expect("send event");
-            tokio::time::sleep(Duration::from_millis(30)).await;
-            // 发 Close(Away)：服务端 begin_close(Some(Away)) → Closing + WithReason(Away)
-            peer.send(Message::Close(Some(CloseFrame {
-                code: CloseCode::Away,
-                reason: "server restarting".into(),
-            })))
-            .await
-            .expect("send close");
-            // peer 端 tungstenite 已 CLOSING，无法再 send Binary；用 raw write 违约发送
-            let late = event_data_frame(br#"{"header":{"event_type":"late"}}"#).encode_to_vec();
-            peer.get_mut()
-                .write_all(&raw_binary_ws_frame(&late))
-                .await
-                .expect("raw write late binary");
-            while let Some(Ok(_)) = peer.next().await {}
-        },
-    )
-    .await;
-
-    match open_result {
-        Err(WsClientError::ConnectionClosed {
-            reason: Some(WsCloseReason { code, message }),
-        }) => {
-            assert_eq!(code, CloseCode::Away);
-            assert_eq!(message, "server restarting");
-        }
-        other => panic!("expected ConnectionClosed with Away reason, got: {other:?}"),
-    }
 }
 
 /// 慢 EventHandler 不应阻塞 app-level ping 发出（串行 worker + spawn_blocking）。
@@ -1077,7 +378,6 @@ async fn full_session_slow_handler_does_not_block_app_ping() {
 #[tokio::test]
 async fn full_session_backlog_does_not_block_app_ping() {
     use std::thread;
-    use std::time::Instant;
 
     struct SlowHandler;
     impl EventHandler for SlowHandler {
@@ -1114,11 +414,9 @@ async fn full_session_backlog_does_not_block_app_ping() {
                 .expect("send burst event");
             }
 
-            let t0 = Instant::now();
             let got_ping = timeout(Duration::from_millis(2000), recv_app_ping_frame(&mut peer))
                 .await
                 .is_ok();
-            let _ = t0;
 
             peer.close(Some(CloseFrame {
                 code: CloseCode::Normal,
@@ -1144,216 +442,64 @@ async fn full_session_backlog_does_not_block_app_ping() {
     assert_normal_close(open_result);
 }
 
-/// 非法多包（空 message_id）：扣留、不派发、无 ACK（#421 US2）。
+/// Closing 后再收到 Binary → 必须得到 InvalidStateTransition（证明可达状态错误路径）。
+///
+/// 用短心跳 + 慢 handler 进入 Closing（仍有 inflight），再由 peer 发送 late Binary。
+/// 不用 peer.close()（会触发 SendAfterClosing，无法再送 Binary）。
 #[tokio::test]
-async fn full_session_multipart_empty_message_id_does_not_dispatch() {
-    let calls = Arc::new(AtomicUsize::new(0));
-    let last_payload = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let partial = b"withheld-empty-mid";
+async fn full_session_data_after_close_is_invalid_state() {
+    use std::thread;
 
-    let event_handler = EventDispatcherHandler::builder()
-        .register_raw(
-            EventDispatcherHandler::RAW_EVENT_KEY,
-            CountingHandler {
-                calls: Arc::clone(&calls),
-                last_payload: Arc::clone(&last_payload),
-            },
-        )
-        .expect("register")
-        .build();
-
-    let (open_result, data_responses) = run_session(
-        LocalSessionHarness::start().await,
-        event_handler,
-        SessionOptions::default(),
-        move |mut peer| async move {
-            let _ = timeout(SESSION_TIMEOUT, peer.next()).await;
-            let mut frame = multipart_event_frame("", Some(2), Some(0), partial);
-            frame.headers.retain(|h| h.key != "message_id");
-            frame.headers.push(Header {
-                key: "message_id".to_string(),
-                value: String::new(),
-            });
-            peer.send(Message::Binary(frame.encode_to_vec().into()))
-                .await
-                .expect("send invalid multipart");
-
-            let data_responses =
-                count_data_responses_within(&mut peer, Duration::from_millis(200)).await;
-
-            peer.close(Some(CloseFrame {
-                code: CloseCode::Normal,
-                reason: "empty message_id withhold".into(),
-            }))
-            .await
-            .ok();
-            data_responses
-        },
-    )
-    .await;
-
-    assert_eq!(calls.load(Ordering::SeqCst), 0);
-    assert_eq!(data_responses, 0);
-    assert!(last_payload.lock().expect("mutex").is_empty());
-    assert_normal_close(open_result);
-}
-
-/// 非法多包（seq>=sum）：扣留、不派发、无 ACK（#421 US2）。
-#[tokio::test]
-async fn full_session_multipart_seq_out_of_range_does_not_dispatch() {
-    let calls = Arc::new(AtomicUsize::new(0));
-    let last_payload = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let oob = b"withheld-oob-seq";
-
-    let event_handler = EventDispatcherHandler::builder()
-        .register_raw(
-            EventDispatcherHandler::RAW_EVENT_KEY,
-            CountingHandler {
-                calls: Arc::clone(&calls),
-                last_payload: Arc::clone(&last_payload),
-            },
-        )
-        .expect("register")
-        .build();
-
-    let (open_result, data_responses) = run_session(
-        LocalSessionHarness::start().await,
-        event_handler,
-        SessionOptions::default(),
-        move |mut peer| async move {
-            let _ = timeout(SESSION_TIMEOUT, peer.next()).await;
-            peer.send(Message::Binary(
-                multipart_event_frame("oob-msg", Some(2), Some(5), oob)
-                    .encode_to_vec()
-                    .into(),
-            ))
-            .await
-            .expect("send oob multipart");
-
-            let data_responses =
-                count_data_responses_within(&mut peer, Duration::from_millis(200)).await;
-
-            peer.close(Some(CloseFrame {
-                code: CloseCode::Normal,
-                reason: "seq oob withhold".into(),
-            }))
-            .await
-            .ok();
-            data_responses
-        },
-    )
-    .await;
-
-    assert_eq!(calls.load(Ordering::SeqCst), 0);
-    assert_eq!(data_responses, 0);
-    assert!(last_payload.lock().expect("mutex").is_empty());
-    assert_normal_close(open_result);
-}
-
-/// EventHandler panic → 会话以 `HandlerPanicked` 结束。
-#[tokio::test]
-async fn full_session_handler_panic_is_session_error() {
-    struct PanicHandler;
-    impl EventHandler for PanicHandler {
+    struct SlowHandler;
+    impl EventHandler for SlowHandler {
         fn handle(&self, _payload: &[u8]) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-            panic!("intentional handler panic for full_session test");
+            thread::sleep(Duration::from_millis(800));
+            Ok(())
         }
     }
 
     let event_handler = EventDispatcherHandler::builder()
-        .register_raw(EventDispatcherHandler::RAW_EVENT_KEY, PanicHandler)
+        .register_raw(EventDispatcherHandler::RAW_EVENT_KEY, SlowHandler)
         .expect("register")
         .build();
 
+    let options = SessionOptions {
+        heartbeat_timeout: Duration::from_millis(200),
+    };
+
     let (open_result, ()) = run_session(
-        LocalSessionHarness::start().await,
+        LocalSessionHarness::start_with_ping_interval(3600).await,
         event_handler,
-        SessionOptions::default(),
+        options,
         |mut peer| async move {
             let _ = timeout(SESSION_TIMEOUT, peer.next()).await;
-            let payload =
-                br#"{"header":{"event_type":"im.message.receive_v1"},"event":{"panic":true}}"#;
             peer.send(Message::Binary(
-                event_data_frame(payload).encode_to_vec().into(),
+                event_data_frame(br#"{"header":{"event_type":"slow"},"event":{}}"#)
+                    .encode_to_vec()
+                    .into(),
             ))
             .await
-            .expect("send event");
+            .expect("send slow event");
+            // 等会话因无 WS Ping 进入 Closing（heartbeat 200ms，checkout ≤200ms），
+            // 且 handler 仍 inflight（800ms）
+            tokio::time::sleep(Duration::from_millis(400)).await;
+            peer.send(Message::Binary(
+                event_data_frame(br#"{"header":{"event_type":"late"}}"#)
+                    .encode_to_vec()
+                    .into(),
+            ))
+            .await
+            .expect("send late binary while session Closing");
             while let Some(Ok(_)) = peer.next().await {}
         },
     )
     .await;
 
     match open_result {
-        Err(WsClientError::HandlerPanicked) => {}
-        other => panic!("expected HandlerPanicked, got: {other:?}"),
-    }
-}
-
-/// 队列 + outbox 双满时返回 `BacklogFull`（handler 短暂占住 worker，突发灌满缓冲）。
-#[tokio::test]
-async fn full_session_backlog_full_is_session_error() {
-    use std::thread;
-
-    /// 首个 job 阻塞足够久，让 peer 灌满 channel(64)+outbox(64)。
-    struct HoldFirstHandler {
-        hold_ms: u64,
-    }
-    impl EventHandler for HoldFirstHandler {
-        fn handle(&self, _payload: &[u8]) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-            thread::sleep(Duration::from_millis(self.hold_ms));
-            Ok(())
-        }
-    }
-
-    let event_handler = EventDispatcherHandler::builder()
-        .register_raw(
-            EventDispatcherHandler::RAW_EVENT_KEY,
-            HoldFirstHandler { hold_ms: 800 },
-        )
-        .expect("register")
-        .build();
-
-    // channel 64 + outbox 64 + 1 在飞 ≈ 需 ≥129 帧；多送一些抗调度抖动
-    const BURST: usize = 140;
-
-    let (open_result, ()) = run_session(
-        LocalSessionHarness::start().await,
-        event_handler,
-        SessionOptions::default(),
-        |mut peer| async move {
-            let _ = timeout(SESSION_TIMEOUT, peer.next()).await;
-
-            for i in 0..BURST {
-                let payload = format!(
-                    r#"{{"header":{{"event_type":"im.message.receive_v1"}},"event":{{"n":{i}}}}}"#
-                );
-                peer.send(Message::Binary(
-                    multipart_event_frame(&format!("backlog-{i}"), None, None, payload.as_bytes())
-                        .encode_to_vec()
-                        .into(),
-                ))
-                .await
-                .expect("send burst frame");
-            }
-
-            // 会话应因 BacklogFull 结束；排空对端
-            while let Some(Ok(_)) = timeout(Duration::from_millis(200), peer.next())
-                .await
-                .ok()
-                .flatten()
-            {}
-        },
-    )
-    .await;
-
-    match open_result {
-        Err(WsClientError::BacklogFull { message }) => {
-            assert!(
-                message.contains("64"),
-                "BacklogFull message should mention capacity, got: {message}"
-            );
-        }
-        other => panic!("expected BacklogFull, got: {other:?}"),
+        Err(WsClientError::InvalidStateTransition {
+            kind: InvalidStateKind::DataWhileClosing,
+        }) => {}
+        other => panic!("expected InvalidStateTransition(DataWhileClosing), got: {other:?}"),
     }
 }
 
@@ -1392,6 +538,8 @@ async fn full_session_ws_ping_refreshes_heartbeat() {
     assert_normal_close(open_result);
 }
 
+// === C 组：端点发现（无 WS） ===
+
 #[test]
 fn local_endpoint_client_config_shape_matches_production() {
     // 生产 JSON 可含 Reconnect*；仅 PingInterval 被反序列化消费
@@ -1400,10 +548,6 @@ fn local_endpoint_client_config_shape_matches_production() {
     let cfg: ClientConfig = serde_json::from_slice(raw).expect("ClientConfig shape");
     assert_eq!(cfg.ping_interval, 3600);
 }
-
-// === 端点发现收口到 Transport（ADR-0003）：open-seam 行为测试 ===
-//
-// 端点错误在 WS 连接前发生，故这些用例不启动 WS peer，直接断言 `open()` 返回值。
 
 /// 端点发现错误用 config：复用 LocalSessionHarness 的构建规则，但不绑 WS listener。
 fn endpoint_only_config(mock_server: &MockServer) -> Config {

--- a/crates/openlark-client/src/ws_client/mod.rs
+++ b/crates/openlark-client/src/ws_client/mod.rs
@@ -10,12 +10,9 @@ mod headers;
 mod package;
 mod session;
 
-#[cfg(feature = "websocket")]
 /// 会话级公开 API。
 pub use client::LarkWsClient;
-#[cfg(feature = "websocket")]
 pub use dispatcher::{CallbackEventHandler, EventDispatcherHandler, EventHandler};
-#[cfg(feature = "websocket")]
 pub use session::{InvalidStateKind, WsClientError, WsClientResult, WsCloseReason};
 
 #[cfg(test)]

--- a/crates/openlark-client/src/ws_client/session.rs
+++ b/crates/openlark-client/src/ws_client/session.rs
@@ -44,21 +44,33 @@ const PENDING_OUTBOX_CAP: usize = HANDLER_QUEUE_CAP;
 /// 会话结束后等待 worker 排空的最长时间。
 const WORKER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// 会话连接状态（#421 / #428）。
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// 会话连接状态（#421 / #428 / #641）。
+///
+/// 真实状态空间是 Active / Closing（排空中，可选远端 reason）/ Closed。
+/// reason 挂在 `Closing` 上，避免与独立 `CloseIntent` 手工对齐。
+#[derive(Debug, Clone)]
 enum SessionState {
     Active,
-    Closing,
+    /// 排空中。`Some` = 对端 Close 帧带来的 code/message，后续错误不得覆盖。
+    Closing(Option<WsCloseReason>),
     Closed,
 }
 
 impl SessionState {
-    fn as_str(self) -> &'static str {
+    fn as_str(&self) -> &'static str {
         match self {
             Self::Active => "Active",
-            Self::Closing => "Closing",
+            Self::Closing(_) => "Closing",
             Self::Closed => "Closed",
         }
+    }
+
+    fn is_active(&self) -> bool {
+        matches!(self, Self::Active)
+    }
+
+    fn is_closed(&self) -> bool {
+        matches!(self, Self::Closed)
     }
 }
 
@@ -66,16 +78,6 @@ impl SessionState {
 enum TrySendToWorker {
     Full(Box<Frame>),
     Closed,
-}
-
-/// 关闭意图：未开始 / 已 begin_close 且无远端 reason / 已 begin_close 且带 reason。
-#[derive(Debug, Clone)]
-enum CloseIntent {
-    None,
-    /// 超时或 EOF 等：无 WebSocket Close 载荷。
-    WithoutReason,
-    /// 对端 Close 帧带来的 code/message。
-    WithReason(WsCloseReason),
 }
 
 /// 会话运行选项（生产默认；测试可缩短心跳超时）。
@@ -109,7 +111,6 @@ pub(crate) struct Session<S> {
     ping_frame_interval: Interval,
     heartbeat_timeout: Duration,
     state: SessionState,
-    close_intent: CloseIntent,
     inflight_handlers: usize,
     /// worker 队列满时暂存的已组装帧（不丢弃；经 reserve 再入队）。
     pending_outbox: VecDeque<Frame>,
@@ -137,14 +138,13 @@ where
             ping_frame_interval: tokio::time::interval(Duration::from_secs(ping_secs)),
             heartbeat_timeout: options.heartbeat_timeout.max(Duration::from_millis(1)),
             state: SessionState::Active,
-            close_intent: CloseIntent::None,
             inflight_handlers: 0,
             pending_outbox: VecDeque::new(),
         }
     }
 
     fn ensure_active(&self) -> WsClientResult<()> {
-        if self.state != SessionState::Active {
+        if !self.state.is_active() {
             return Err(WsClientError::InvalidStateTransition {
                 kind: InvalidStateKind::ExpectedActive {
                     actual: self.state.as_str(),
@@ -155,41 +155,56 @@ where
     }
 
     fn begin_close(&mut self, reason: Option<WsCloseReason>) -> WsClientResult<()> {
-        match self.state {
+        match &self.state {
             SessionState::Closed => {
                 return Err(WsClientError::InvalidStateTransition {
                     kind: InvalidStateKind::AlreadyClosed,
                 });
             }
             // 幂等：保留首次 close 意图（远端 close reason 不被 EOF 覆盖）
-            SessionState::Closing => return Ok(()),
+            SessionState::Closing(_) => return Ok(()),
             SessionState::Active => {}
         }
-        self.state = SessionState::Closing;
-        self.close_intent = match reason {
-            Some(r) => CloseIntent::WithReason(r),
-            None => CloseIntent::WithoutReason,
-        };
+        self.state = SessionState::Closing(reason);
         Ok(())
     }
 
-    /// 取出并清空 close_intent 中的远端关闭原因（若有）。
-    fn drain_close_reason(&mut self) -> Option<WsCloseReason> {
-        match std::mem::replace(&mut self.close_intent, CloseIntent::None) {
-            CloseIntent::WithReason(r) => Some(r),
-            CloseIntent::WithoutReason | CloseIntent::None => None,
+    /// 后续错误不得覆盖已记录的远端 close reason（#421 US9）。
+    /// 无已记录 reason 时返回 `fallback`；两种错误入口共用。
+    fn fail_preserving_close_reason(
+        &mut self,
+        subsequent: impl std::fmt::Display,
+        fallback: WsClientError,
+    ) -> WsClientError {
+        let recorded = match std::mem::replace(&mut self.state, SessionState::Closed) {
+            SessionState::Closing(reason) => reason,
+            _ => None,
+        };
+        match recorded {
+            Some(reason) => {
+                warn!("{subsequent}; returning close reason");
+                WsClientError::ConnectionClosed {
+                    reason: Some(reason),
+                }
+            }
+            None => fallback,
         }
     }
 
     /// 若已进入 Closing 且 in-flight/outbox 均空，返回终态 `ConnectionClosed`。
     /// `None` 表示会话尚未结束，应继续 `select!`。
     fn take_connection_closed_if_idle(&mut self) -> Option<WsClientResult<()>> {
-        if self.state == SessionState::Closing
+        if matches!(self.state, SessionState::Closing(_))
             && self.inflight_handlers == 0
             && self.pending_outbox.is_empty()
         {
-            self.state = SessionState::Closed;
-            let reason = self.drain_close_reason();
+            let reason = match std::mem::replace(&mut self.state, SessionState::Closed) {
+                SessionState::Closing(reason) => reason,
+                other => {
+                    self.state = other;
+                    return None;
+                }
+            };
             return Some(Err(WsClientError::ConnectionClosed { reason }));
         }
         None
@@ -275,8 +290,7 @@ where
                 self.flush_outbox_try(&job_tx)?;
 
                 // Closing 时也要冲刷 outbox，否则 idle 检查永远等非空 outbox
-                let need_reserve =
-                    !self.pending_outbox.is_empty() && self.state != SessionState::Closed;
+                let need_reserve = !self.pending_outbox.is_empty() && !self.state.is_closed();
 
                 tokio::select! {
                     permit = job_tx.reserve(), if need_reserve => {
@@ -290,13 +304,13 @@ where
                             self.note_job_enqueued();
                         }
                     }
-                    item = self.stream.next(), if stream_open && self.state != SessionState::Closed => {
+                    item = self.stream.next(), if stream_open && !self.state.is_closed() => {
                         match item.transpose() {
                             Ok(Some(msg)) => {
                                 if msg.is_ping() {
                                     last_activity = Instant::now();
                                 }
-                                if self.state == SessionState::Closing {
+                                if matches!(self.state, SessionState::Closing(_)) {
                                     if matches!(msg, Message::Binary(_) | Message::Text(_)) {
                                         return Err(WsClientError::InvalidStateTransition {
                                             kind: InvalidStateKind::DataWhileClosing,
@@ -311,18 +325,8 @@ where
                                 self.begin_close(None)?;
                             }
                             Err(e) => {
-                                // 远端已正常 Close（带 reason）后，后续传输/协议错误不得
-                                // 覆盖已记录的关闭原因（#421 US9）；与 outcome-error 对称
-                                if let Some(reason) = self.drain_close_reason() {
-                                    self.state = SessionState::Closed;
-                                    warn!(
-                                        "stream error after remote close: {e}; returning close reason"
-                                    );
-                                    return Err(WsClientError::ConnectionClosed {
-                                        reason: Some(reason),
-                                    });
-                                }
-                                return Err(e.into());
+                                let msg = format!("stream error after remote close: {e}");
+                                return Err(self.fail_preserving_close_reason(msg, e.into()));
                             }
                         }
                     }
@@ -330,24 +334,14 @@ where
                         self.inflight_handlers = self.inflight_handlers.saturating_sub(1);
                         match outcome {
                             Ok(Some(response_frame)) => {
-                                if self.state == SessionState::Active {
+                                if self.state.is_active() {
                                     self.send_frame(response_frame).await?;
                                 }
                             }
                             Ok(None) => {}
                             Err(err) => {
-                                // 关闭排空中 handler 失败：优先返回已记录的远端关闭原因
-                                if matches!(self.close_intent, CloseIntent::WithReason(_)) {
-                                    self.state = SessionState::Closed;
-                                    let reason = self.drain_close_reason();
-                                    warn!(
-                                        "handler failed during close: {err}; returning close reason"
-                                    );
-                                    return Err(WsClientError::ConnectionClosed { reason });
-                                }
-                                self.state = SessionState::Closed;
-                                self.close_intent = CloseIntent::None;
-                                return Err(err);
+                                let msg = format!("handler failed during close: {err}");
+                                return Err(self.fail_preserving_close_reason(msg, err));
                             }
                         }
                         self.flush_outbox_try(&job_tx)?;
@@ -355,10 +349,10 @@ where
                             return done;
                         }
                     }
-                    _ = self.ping_frame_interval.tick(), if self.state == SessionState::Active => {
+                    _ = self.ping_frame_interval.tick(), if self.state.is_active() => {
                         self.send_app_ping().await?;
                     }
-                    _ = heartbeat_check_interval.tick(), if self.state == SessionState::Active => {
+                    _ = heartbeat_check_interval.tick(), if self.state.is_active() => {
                         if last_activity.elapsed() > self.heartbeat_timeout {
                             self.begin_close(None)?;
                         }

--- a/docs/adr/0006-ws-session-io-seam.md
+++ b/docs/adr/0006-ws-session-io-seam.md
@@ -3,7 +3,7 @@
 - **状态**: Accepted（随 #640 落地）
 - **日期**: 2026-08-17
 - **决策者**: 架构评审 + 用户 grilling 共识（候选 B）
-- **相关 issue**: #640（seam + 测试下沉）、#641（CloseIntent 收敛 + harness 瘦身）
+- **相关 issue**: #640（seam + 测试下沉）、#641（CloseIntent 收敛 + harness 瘦身，已落地）
 - **来源**: `/improve-codebase-architecture` 候选 B（Session 状态机只有全链路一档测试 seam）
 
 ## 背景
@@ -67,12 +67,12 @@ adapter 用 `tokio::io::duplex` + 两侧 `WebSocketStream::from_raw_socket(Role:
 - Session 状态机测试脱离真实 TCP/wiremock/真实时间（close reason 保留、
   outbox、背压、串行、DataWhileClosing 均可在内存 seam 上确定性测试）。
 - callback ACK 的 session 级 round-trip（base64 data 经 sink→对端）可测（#634 缺口）。
-- harness 保留的时序/端点测试语义不变，作为 parity 与集成层。
+- harness 保留的时序/端点测试语义不变（#641 起不再承担状态机 parity，只测墙钟与端点）。
 
 ### 负面 / 残差
 
 - `Session<S>` 的泛型参数使 session.rs 内部签名略重（对外零暴露）。
-- B组墙钟测试（6 个）仍留 harness，测试总时长不因本 ADR 缩短。
+- B组墙钟测试（6 个）仍留 harness；#641 已收敛 CloseIntent 并删掉被新层替代的 15 个用例。
 
 ## 非目标
 


### PR DESCRIPTION
Fixes #641（候选 B 第二半；第一半 seam 见 #640 / #642）

# 概要

`SessionState` 与 `CloseIntent` 两个私有字段必须手工对齐。真实状态空间收成 `SessionState::Closing(Option<WsCloseReason>)`；被 #640 新层替代的 15 个 harness 用例删除。公开 API 零变化。

## 变更类型

- [x] ♻️ 重构

## 关联 Issue

Fixes #641

## 变更

**CloseIntent 收敛**
- `SessionState{Active,Closing,Closed}` × `CloseIntent{None,WithoutReason,WithReason}` → `SessionState::Closing(Option<WsCloseReason>)`
- stream 错误与 outcome 错误的 reason 保留镜像块收敛为 `fail_preserving_close_reason`（后续错误不得覆盖已记录 reason）
- 两枚举均私有；`InvalidStateKind` / `WsClientError` 公开面不变

**harness 瘦身**
- `full_session_tests.rs` 删除被 `session_behavior_tests` 替代的 15 个用例（1478 → 612 行）
- 保留 B 组 6 个墙钟测试（ping 间隔 / 心跳超时 / 慢 handler / 积压 / 时间差进 Closing / WS Ping 刷新）+ C 组 3 个端点发现测试
- `ws_client/mod.rs` 去掉父级已门控的内层 `#[cfg(feature = "websocket")]`
- 审查 follow-up：`harness.config` 与 `endpoint_only_config` 收成共用 `test_config`

## 验证

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -Dwarnings`
- [x] `cargo clippy --workspace --all-targets --no-default-features -- -Dwarnings`
- [x] `cargo test --workspace --all-features`（6020 绿）
- [x] `cargo test -p openlark-client --all-features --lib`（160 绿，含新层 16 + 保留 harness 9）

## 非目标

B 组时序测试不迁、不加 paused clock（grilling Q7a）· 不动 `WsClientError` 公开面

## 备注

CHANGELOG Unreleased / ADR-0006 残差已回写（#641 已落地；harness 不再承担状态机 parity）。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal session refactor and test moves only; public WebSocket error types and LarkWsClient entry points are unchanged. Remaining harness tests still cover real timers and endpoint bootstrap.
> 
> **Overview**
> WebSocket **session** internals stop tracking shutdown in two places: the separate **`CloseIntent`** field is folded into **`SessionState::Closing(Option<WsCloseReason>)`**, so “closing + optional remote reason” is one state instead of manually keeping **`state`** and **`close_intent`** aligned.
> 
> Stream errors and handler failures during close no longer duplicate “don’t overwrite the recorded close reason” logic; both paths call **`fail_preserving_close_reason`**. **`InvalidStateKind`** / **`WsClientError`** stay the same for callers.
> 
> **`full_session_tests`** drops ~15 cases that **`session_behavior_tests`** (#640) already covers, leaving wall-clock timing (ping interval, heartbeat, slow handler vs app ping, backlog, **`DataWhileClosing`**, WS ping refresh) and endpoint-discovery tests. Harness helpers are trimmed (**`test_config`** shared, simpler **`event_data_frame`**). **`ws_client/mod.rs`** removes redundant inner **`#[cfg(feature = "websocket")]`** on re-exports. CHANGELOG and ADR-0006 note #641 is done and harness is no longer state-machine parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66bf0b936bbde8a2614fe76f31654b34b34f1abc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->