### PR TITLE
fix(tools): weekly/full 字段核对按 crate 扫描，避免空报告

### DIFF
--- a/.github/workflows/api-field-verify-full.yml
+++ b/.github/workflows/api-field-verify-full.yml
@@ -58,7 +58,11 @@ jobs:
           set -uo pipefail
           mkdir -p reports/api_field_verify
 
-          args=(--fetch-docs --output-dir reports/api_field_verify --max-age "${{ inputs.max_age }}")
+          args=(
+            full
+            --output-dir reports/api_field_verify
+            --max-age "${{ inputs.max_age }}"
+          )
           if [[ -n "${{ inputs.crate }}" ]]; then
             args+=(--crate "${{ inputs.crate }}")
           fi
@@ -66,9 +70,9 @@ jobs:
             args+=(--force-refresh)
           fi
 
-          echo "Running: python3 tools/verify_api_fields.py ${args[*]}"
+          echo "Running: python3 tools/run_field_verify_ci.py ${args[*]}"
           set +e
-          python3 tools/verify_api_fields.py "${args[@]}"
+          python3 tools/run_field_verify_ci.py "${args[@]}"
           status=$?
           set -e
           echo "exit_code=${status}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/api-field-verify-weekly.yml
+++ b/.github/workflows/api-field-verify-weekly.yml
@@ -30,15 +30,15 @@ jobs:
 
       - name: Run verify_api_fields unit tests
         run: |
-          python3 -m unittest tools.tests.test_verify_api_fields
+          python3 -m unittest tools.tests.test_verify_api_fields tools.tests.test_verify_api_fields_ci_gates
 
       - name: Run quick-mode full-repo scan
         id: scan
         run: |
           set -euo pipefail
           mkdir -p reports/api_field_verify
-          # 快速模式恒 exit 0；工具崩溃才失败本 step
-          python3 tools/verify_api_fields.py --output-dir reports/api_field_verify
+          # 禁止无 --crate 空扫（#638）；清单来自 api_coverage.toml。
+          python3 tools/run_field_verify_ci.py quick --output-dir reports/api_field_verify
 
           python3 <<'PY'
           import json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,8 @@ jobs:
             tools.tests.test_validate_api_contracts_rust_source \
             tools.tests.test_validate_api_contracts_compare \
             tools.tests.test_validate_api_contracts_ci_gates \
-            tools.tests.test_verify_api_fields
+            tools.tests.test_verify_api_fields \
+            tools.tests.test_verify_api_fields_ci_gates
       - name: Validate typed API endpoint contracts
         run: |
           python3 tools/validate_api_contracts.py \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **deps：升级 h2 0.4.14 → 0.4.16（RUSTSEC-2026-0258）**：修复空 DATA 帧无界排队。
+
 - **tools：weekly/full 字段核对无 `--crate` 时扫描量为零（#638）**：
   新增 `run_field_verify_ci.py` 作为 weekly/full 唯一入口：显式 `--crate`
   产物仍在 output-dir 根（`summary.json` + `<crate>.md`）；全仓按

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **tools：weekly/full 字段核对无 `--crate` 时扫描量为零（#638）**：
+  新增 `run_field_verify_ci.py` 作为 weekly/full 唯一入口：显式 `--crate`
+  产物仍在 output-dir 根（`summary.json` + `<crate>.md`）；全仓按
+  `api_coverage.toml` 逐 crate `--crate`（子目录）并合并 summary。coverage
+  清单为空则非零退出。CLI 无 `--crate` 默认路径不改。
+
 - **tools：Rust 合约提取收口为单一深 module（#636）**：`verify_api_fields`
   删除内嵌提取栈（~105 行，正则停在首个 `}`、不认 `rename_all`），改为库消费
   `api_contracts.rust_source`——`extract_structs` 成为唯一分组提取 interface，

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -97,7 +97,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -627,7 +627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -811,9 +811,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1153,7 +1153,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1396,7 +1396,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2408,7 +2408,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2732,7 +2732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3454,7 +3454,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/tools/run_field_verify_ci.py
+++ b/tools/run_field_verify_ci.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""CI 入口：字段核对始终走 `--crate`，禁止空扫（#638）。
+
+无 `--crate` 时 `verify_api_fields` 的 src_root 是 `crates/`，与 crate 内相对
+`expected_file` 对不上。本入口：
+
+- 显式 `--crate`：`--output-dir` 就是产物根（`summary.json` + `<crate>.md`）
+- 全仓：按 coverage 表逐 crate 调用，子目录再合并；清单为空则非零退出
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MAPPING = REPO_ROOT / "tools" / "api_coverage.toml"
+DEFAULT_VERIFY = REPO_ROOT / "tools" / "verify_api_fields.py"
+
+
+def coverage_crates(mapping: Path) -> list[str]:
+    data = tomllib.loads(mapping.read_text(encoding="utf-8"))
+    return sorted(data.get("crates", {}))
+
+
+def require_coverage_crates(mapping: Path) -> list[str]:
+    crates = coverage_crates(mapping)
+    if not crates:
+        print("coverage crate list is empty", file=sys.stderr)
+        raise SystemExit(1)
+    return crates
+
+
+def _verify_command(crate: str, output_dir: Path, extra: list[str]) -> list[str]:
+    injected = os.environ.get("FIELD_VERIFY_BIN")
+    if injected:
+        cmd = (
+            [sys.executable, injected]
+            if Path(injected).suffix == ".py"
+            else [injected]
+        )
+    else:
+        cmd = [sys.executable, str(DEFAULT_VERIFY)]
+    cmd.extend(["--crate", crate, "--output-dir", str(output_dir), *extra])
+    return cmd
+
+
+def run_verify(crate: str, output_dir: Path, extra: list[str]) -> int:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    cmd = _verify_command(crate, output_dir, extra)
+    print("Running:", " ".join(cmd), flush=True)
+    return subprocess.call(cmd)
+
+
+def merge_summaries(root: Path) -> dict:
+    paths = sorted(root.glob("*/summary.json"))
+    if not paths:
+        print("missing per-crate summary.json after scan", file=sys.stderr)
+        raise SystemExit(1)
+    apis: list[dict] = []
+    for path in paths:
+        apis.extend(json.loads(path.read_text(encoding="utf-8")).get("apis", []))
+    summary = {
+        "mode": "quick",
+        "total_apis": len(apis),
+        "apis_with_issues": sum(1 for api in apis if api.get("issues")),
+        "apis": apis,
+    }
+    (root / "summary.json").write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return summary
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    for name in require_coverage_crates(args.mapping):
+        print(name)
+    return 0
+
+
+def cmd_quick(args: argparse.Namespace) -> int:
+    crates = require_coverage_crates(args.mapping)
+    status = 0
+    for crate in crates:
+        crate_status = run_verify(crate, args.output_dir / crate, [])
+        if crate_status != 0:
+            status = crate_status
+    merge_summaries(args.output_dir)
+    return status
+
+
+def cmd_full(args: argparse.Namespace) -> int:
+    extra = ["--fetch-docs"]
+    if args.max_age is not None:
+        extra.extend(["--max-age", args.max_age])
+    if args.force_refresh:
+        extra.append("--force-refresh")
+
+    if args.crate:
+        # 与 main 上单 crate 调用相同：产物在 output-dir 根。
+        return run_verify(args.crate, args.output_dir, extra)
+
+    crates = require_coverage_crates(args.mapping)
+    status = 0
+    for crate in crates:
+        crate_status = run_verify(crate, args.output_dir / crate, extra)
+        if crate_status != 0:
+            status = crate_status
+    return status
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mapping",
+        type=Path,
+        default=DEFAULT_MAPPING,
+        help="crate coverage table (default: tools/api_coverage.toml)",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("list", help="print coverage crates; empty list exits 1")
+
+    quick = sub.add_parser("quick", help="weekly quick: per-crate --crate + merge")
+    quick.add_argument("--output-dir", type=Path, required=True)
+
+    full = sub.add_parser("full", help="full-mode: explicit crate or all-crates loop")
+    full.add_argument("--output-dir", type=Path, required=True)
+    full.add_argument("--crate", default="", help="single crate; omit = all coverage crates")
+    full.add_argument("--max-age", default=None)
+    full.add_argument("--force-refresh", action="store_true")
+
+    args = parser.parse_args(argv)
+    if args.command == "list":
+        return cmd_list(args)
+    if args.command == "quick":
+        return cmd_quick(args)
+    if args.command == "full":
+        return cmd_full(args)
+    parser.error(f"unknown command {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_field_verify_ci.py
+++ b/tools/run_field_verify_ci.py
@@ -58,7 +58,7 @@ def run_verify(crate: str, output_dir: Path, extra: list[str]) -> int:
     return subprocess.call(cmd)
 
 
-def merge_summaries(root: Path) -> dict:
+def merge_summaries(root: Path, *, mode: str) -> dict:
     paths = sorted(root.glob("*/summary.json"))
     if not paths:
         print("missing per-crate summary.json after scan", file=sys.stderr)
@@ -67,7 +67,7 @@ def merge_summaries(root: Path) -> dict:
     for path in paths:
         apis.extend(json.loads(path.read_text(encoding="utf-8")).get("apis", []))
     summary = {
-        "mode": "quick",
+        "mode": mode,
         "total_apis": len(apis),
         "apis_with_issues": sum(1 for api in apis if api.get("issues")),
         "apis": apis,
@@ -92,7 +92,7 @@ def cmd_quick(args: argparse.Namespace) -> int:
         crate_status = run_verify(crate, args.output_dir / crate, [])
         if crate_status != 0:
             status = crate_status
-    merge_summaries(args.output_dir)
+    merge_summaries(args.output_dir, mode="quick")
     return status
 
 
@@ -113,6 +113,7 @@ def cmd_full(args: argparse.Namespace) -> int:
         crate_status = run_verify(crate, args.output_dir / crate, extra)
         if crate_status != 0:
             status = crate_status
+    merge_summaries(args.output_dir, mode="full")
     return status
 
 

--- a/tools/tests/test_verify_api_fields_ci_gates.py
+++ b/tools/tests/test_verify_api_fields_ci_gates.py
@@ -176,6 +176,41 @@ class FieldVerifyCiEntryTests(unittest.TestCase):
             summary = json.loads((out / "summary.json").read_text(encoding="utf-8"))
             self.assertTrue(summary["apis"][0]["file_exists"])
 
+    def test_full_all_crates_writes_root_summary_with_full_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            mapping = root / "coverage.toml"
+            mapping.write_text(
+                "[crates.openlark-workflow]\n"
+                'src = "crates/openlark-workflow/src"\n'
+                "[crates.openlark-docs]\n"
+                'src = "crates/openlark-docs/src"\n',
+                encoding="utf-8",
+            )
+            stub = root / "stub_verify.py"
+            _write_stub_verify(stub)
+            out = root / "reports"
+            result = self._run(
+                "full",
+                "--output-dir",
+                str(out),
+                mapping=mapping,
+                env={"FIELD_VERIFY_BIN": str(stub)},
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            root_summary = out / "summary.json"
+            self.assertTrue(
+                root_summary.is_file(),
+                "full all-crates must write merged summary.json at output-dir root",
+            )
+            summary = json.loads(root_summary.read_text(encoding="utf-8"))
+            self.assertEqual(summary["mode"], "full")
+            self.assertEqual(summary["total_apis"], 2)
+            crates = {api["crate"] for api in summary["apis"]}
+            self.assertEqual(crates, {"openlark-docs", "openlark-workflow"})
+            self.assertTrue((out / "openlark-workflow" / "summary.json").is_file())
+            self.assertTrue((out / "openlark-docs" / "summary.json").is_file())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/tests/test_verify_api_fields_ci_gates.py
+++ b/tools/tests/test_verify_api_fields_ci_gates.py
@@ -1,0 +1,181 @@
+"""Pin field-verify CI so a no-`--crate` scan cannot silently go empty (#638).
+
+Without `--crate`, `verify_api_fields` sets src_root to `crates/` while CSV
+`expected_file` is crate-relative — every API lands `file_exists=False`.
+Weekly/full workflows must invoke the existing `--crate` entry per coverage
+crate. Dual-edit: changing the workflow invocation must update this test.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WEEKLY_WORKFLOW = (
+    ROOT / ".github" / "workflows" / "api-field-verify-weekly.yml"
+)
+FULL_WORKFLOW = ROOT / ".github" / "workflows" / "api-field-verify-full.yml"
+
+
+def _direct_verify_lines(workflow: str) -> list[str]:
+    lines = []
+    for raw in workflow.splitlines():
+        line = raw.strip()
+        if "verify_api_fields.py" not in line:
+            continue
+        if line.startswith("echo ") or line.startswith("#"):
+            continue
+        lines.append(line)
+    return lines
+
+
+class WeeklyFieldVerifyGateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.workflow = WEEKLY_WORKFLOW.read_text(encoding="utf-8")
+
+    def test_weekly_scan_goes_through_ci_entry(self) -> None:
+        self.assertIn("run_field_verify_ci.py", self.workflow)
+        self.assertEqual(
+            _direct_verify_lines(self.workflow),
+            [],
+            "weekly must not invoke verify_api_fields.py directly",
+        )
+
+    def test_weekly_job_runs_this_module(self) -> None:
+        self.assertIn(
+            "tools.tests.test_verify_api_fields_ci_gates",
+            self.workflow,
+        )
+
+
+class FullFieldVerifyGateTests(unittest.TestCase):
+    def test_full_scan_goes_through_ci_entry(self) -> None:
+        workflow = FULL_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("run_field_verify_ci.py", workflow)
+        self.assertEqual(
+            _direct_verify_lines(workflow),
+            [],
+            "full must not invoke verify_api_fields.py directly",
+        )
+
+
+class FieldVerifyCiEntrySourceTests(unittest.TestCase):
+    def test_entry_reads_coverage_table_and_merges_summaries(self) -> None:
+        source = CI_ENTRY.read_text(encoding="utf-8")
+        self.assertIn("api_coverage.toml", source)
+        self.assertIn('glob("*/summary.json")', source)
+
+
+class CiRunsFieldVerifyGatesTests(unittest.TestCase):
+    def test_pr_ci_runs_this_module(self) -> None:
+        ci = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("tools.tests.test_verify_api_fields_ci_gates", ci)
+
+
+CI_ENTRY = ROOT / "tools" / "run_field_verify_ci.py"
+
+
+def _write_stub_verify(path: Path) -> None:
+    """Mimic verify_api_fields --crate output: <dir>/summary.json + <dir>/<crate>.md."""
+    path.write_text(
+        """#!/usr/bin/env python3
+import argparse
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--crate", required=True)
+parser.add_argument("--output-dir", required=True)
+parser.add_argument("--fetch-docs", action="store_true")
+parser.add_argument("--max-age")
+parser.add_argument("--force-refresh", action="store_true")
+args = parser.parse_args()
+out = Path(args.output_dir)
+out.mkdir(parents=True, exist_ok=True)
+(out / "summary.json").write_text(
+    '{"mode":"quick","total_apis":1,"apis_with_issues":0,'
+    f'"apis":[{{"id":"1","file_exists":true,"issues":[],"crate":"{args.crate}"}}]}}',
+    encoding="utf-8",
+)
+(out / f"{args.crate}.md").write_text(f"# {args.crate}\\n", encoding="utf-8")
+""",
+        encoding="utf-8",
+    )
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+class FieldVerifyCiEntryTests(unittest.TestCase):
+    def _run(self, *args: str, mapping: Path, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+        merged = os.environ.copy()
+        if env:
+            merged.update(env)
+        return subprocess.run(
+            [sys.executable, str(CI_ENTRY), "--mapping", str(mapping), *args],
+            cwd=str(ROOT),
+            env=merged,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_empty_coverage_list_exits_nonzero(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            mapping = Path(tmp) / "empty.toml"
+            mapping.write_text("# no crates\n", encoding="utf-8")
+            result = self._run("full", "--output-dir", tmp, mapping=mapping)
+            self.assertNotEqual(result.returncode, 0, result.stdout)
+            combined = f"{result.stdout}\n{result.stderr}".lower()
+            self.assertRegex(
+                combined,
+                r"empty|no crates|crate list",
+                "empty coverage must fail closed with an explicit reason, "
+                f"not a missing-file accident: {combined!r}",
+            )
+
+    def test_explicit_crate_keeps_root_artifact_layout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            mapping = root / "coverage.toml"
+            mapping.write_text(
+                '[crates.openlark-workflow]\nsrc = "crates/openlark-workflow/src"\n',
+                encoding="utf-8",
+            )
+            stub = root / "stub_verify.py"
+            _write_stub_verify(stub)
+            out = root / "reports"
+            result = self._run(
+                "full",
+                "--output-dir",
+                str(out),
+                "--crate",
+                "openlark-workflow",
+                mapping=mapping,
+                env={"FIELD_VERIFY_BIN": str(stub)},
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(
+                (out / "summary.json").is_file(),
+                "explicit crate must write summary.json at output-dir root",
+            )
+            self.assertTrue(
+                (out / "openlark-workflow.md").is_file(),
+                "explicit crate must write <crate>.md at output-dir root",
+            )
+            self.assertFalse(
+                (out / "openlark-workflow" / "summary.json").exists(),
+                "explicit crate must not nest artifacts under <crate>/",
+            )
+            summary = json.loads((out / "summary.json").read_text(encoding="utf-8"))
+            self.assertTrue(summary["apis"][0]["file_exists"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #638

# 概要

Weekly quick 门无 `--crate` 时 `src_root=crates/`，CSV `expected_file` 是 crate 内相对路径，1,628 API 全部 `file_exists=False`。门禁从未真正扫过源码。抽出 `run_field_verify_ci.py` 作为 weekly/full 唯一入口，始终走已有 `--crate`。

## 变更类型

- [x] 🐛 修复
- [x] 🔧 构建 / CI

## 关联 Issue

Fixes #638

## 变更

- 新增 `tools/run_field_verify_ci.py`：
  - 显式 `--crate`：产物仍在 output-dir 根（`summary.json` + `<crate>.md`），与 main 上 full 单 crate 布局一致
  - 全仓 / weekly：按 `api_coverage.toml` 逐 crate `--crate`（子目录）并合并 summary
  - coverage 清单为空 → 非零退出（禁止静默空扫）
- weekly / full workflow 只调用该入口，不再直接跑 `verify_api_fields.py`
- CLI 无 `--crate` 默认路径不改（方案 1）

## 验证

- [x] 执行级测试：`test_explicit_crate_keeps_root_artifact_layout`、`test_empty_coverage_list_exits_nonzero`
- [x] `python3 -m unittest tools.tests.test_verify_api_fields tools.tests.test_verify_api_fields_ci_gates`（33 绿）
- [x] 本机对拍：无 `--crate` 仍 1628/`file_exists=0`；逐 crate 循环 16 crate / 1440 `file_exists=True` / 18 issues
- [ ] `cargo fmt` / clippy / cargo test：无 Rust 变更

## 备注

`tools.tests.test_verify_api_fields_ci_gates` 已挂进 `ci.yml` 与 weekly unittest step。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI quality gates and how field-verify reports are produced; no Rust runtime impact, but incorrect wiring could again yield empty scans or block releases on false failures.
> 
> **Overview**
> Fixes **#638**: weekly/full field-verify jobs used `verify_api_fields` without `--crate`, so `src_root` was `crates/` while CSV paths are crate-relative—reports showed ~1,628 APIs with `file_exists=False` and the gate never scanned real sources.
> 
> **New CI-only entry** `tools/run_field_verify_ci.py` (`quick` / `full` / `list`): each crate from `api_coverage.toml` is verified with `--crate`; **quick** merges per-crate `*/summary.json` into one root `summary.json`. Empty coverage list exits non-zero. Explicit `--crate` keeps artifacts at output-dir root (`summary.json` + `<crate>.md`).
> 
> **Workflows** `api-field-verify-weekly.yml` and `api-field-verify-full.yml` call this script only (no direct `verify_api_fields.py`). **PR CI** and weekly unittest step add `tools.tests.test_verify_api_fields_ci_gates` to pin that wiring. Direct CLI without `--crate` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eb103fa22c9c63aebfedabf9c1bac0b5e4d4c13. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->