### PR TITLE
fix(api): 补齐必填列表非空校验并修正检测器

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 可选：approval instance/task subscription 模块 `docPath` 注释对齐新 `fullPath` slug；
     wire method/path 与 Request/Response 形状不变。
 
+### Fixed
+
+- **api：必填列表非空校验 + 快速模式假阳性（#646）**：
+  批量删除补充信息在空 `user_ids` 时于 Transport 前返回校验错误。
+  `detect_suspicious_patterns` 认字段级 `validate_required!`（与
+  `validate_required_list!` / `{field}.is_empty()` 同等效力）；
+  `skip_serializing_if = "Vec::is_empty"` 的可选列表不再报
+  `missing_list_validation`。人员组成员 write 的空 add/remove 仍为合法 no-op。
+
 ## [0.20.0] - 2026-07-27
 
 > Content freeze for the 0.20 release window (parent #566). Package identity + dated

--- a/crates/openlark-hr/src/performance/performance/v2/additional_informations/batch/delete.rs
+++ b/crates/openlark-hr/src/performance/performance/v2/additional_informations/batch/delete.rs
@@ -53,6 +53,7 @@ impl DeleteRequest {
 
         // 1. 验证必填字段
         validate_required!(self.cycle_id.trim(), "cycle_id");
+        validate_required!(self.user_ids, "user_ids 不能为空");
 
         // 2. 构建端点
         let api_endpoint = PerformanceApiV1::AdditionalInformationsBatchDelete;
@@ -139,6 +140,7 @@ mod tests {
             .build();
 
         let data = DeleteRequest::new(config, "cycle_001".to_string())
+            .add_user_id("user_001".to_string())
             .execute()
             .await
             .expect("performance_v2_additional_informations_batch_delete 应成功");
@@ -151,5 +153,22 @@ mod tests {
             received[0].url.path(),
             "/open-apis/performance/v2/additional_informations/batch"
         );
+    }
+
+    #[tokio::test]
+    async fn test_performance_v2_additional_informations_batch_delete_rejects_empty_user_ids() {
+        let config = Config::builder()
+            .app_id("ci_app_id")
+            .app_secret("ci_app_secret")
+            .base_url("https://127.0.0.1:9")
+            .enable_token_cache(false)
+            .build();
+
+        let err = DeleteRequest::new(config, "cycle_001".to_string())
+            .execute()
+            .await
+            .expect_err("空 user_ids 应在发请求前校验失败");
+
+        assert!(err.to_string().contains("user_ids"));
     }
 }

--- a/tools/tests/test_verify_api_fields.py
+++ b/tools/tests/test_verify_api_fields.py
@@ -184,6 +184,55 @@ class SuspiciousPatternTests(unittest.TestCase):
         )
         self.assertNotIn("missing_list_validation", [item.category for item in issues])
 
+    def test_validate_required_macro_suppresses_warning(self):
+        api = api_identity()
+        structs = [
+            verify_api_fields.StructFields(
+                "PassBody",
+                [verify_api_fields.FieldInfo("user_ids", "String", True)],
+            )
+        ]
+        issues = verify_api_fields.detect_suspicious_patterns(
+            api,
+            structs,
+            'validate_required!(self.body.user_ids, "user_ids 不能为空");',
+        )
+        self.assertNotIn("missing_list_validation", [item.category for item in issues])
+
+    def test_unrelated_list_macro_does_not_suppress_other_field(self):
+        api = api_identity()
+        structs = [
+            verify_api_fields.StructFields(
+                "PassBody",
+                [verify_api_fields.FieldInfo("user_ids", "String", True)],
+            )
+        ]
+        issues = verify_api_fields.detect_suspicious_patterns(
+            api, structs, 'validate_required_list!(self.other_ids, 50, "other_ids");'
+        )
+        self.assertIn("missing_list_validation", [item.category for item in issues])
+
+    def test_skip_serializing_empty_vec_does_not_warn(self):
+        api = api_identity()
+        structs = [
+            verify_api_fields.StructFields(
+                "WriteRequestBody",
+                [
+                    verify_api_fields.FieldInfo("add_user_ids", "String", True),
+                    verify_api_fields.FieldInfo("remove_user_ids", "String", True),
+                ],
+            )
+        ]
+        source = """
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        pub add_user_ids: Vec<String>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        pub remove_user_ids: Vec<String>,
+        """
+        issues = verify_api_fields.detect_suspicious_patterns(api, structs, source)
+        self.assertNotIn("missing_list_validation", [item.category for item in issues])
+
+
     def test_empty_get_response_is_informational(self):
         api = api_identity(method="GET")
         structs = [verify_api_fields.StructFields("GetResponse", [])]

--- a/tools/verify_api_fields.py
+++ b/tools/verify_api_fields.py
@@ -13,6 +13,7 @@ API 字段核对工具：扫描代码字段、检测可疑模式、可选抓飞�
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -79,6 +80,30 @@ class FieldIssue:
     detail: str  # 人可读的描述
 
 
+def _has_field_list_nonempty_check(source: str, field_name: str) -> bool:
+    """字段级非空校验：validate_required! / validate_required_list! / {field}.is_empty()。"""
+    if f"{field_name}.is_empty()" in source:
+        return True
+    return (
+        re.search(
+            rf"validate_required(?:_list)?!\([^;]*\b{re.escape(field_name)}\b",
+            source,
+        )
+        is not None
+    )
+
+
+def _vec_skips_empty_on_wire(source: str, field_name: str) -> bool:
+    """空 Vec 跳过序列化 → 该字段在 wire 上可选，空列表合法。"""
+    return (
+        re.search(
+            rf'#\[serde\([^)]*skip_serializing_if\s*=\s*"Vec::is_empty"[^)]*\)\]\s*(?:pub\s+)?{re.escape(field_name)}\s*:',
+            source,
+        )
+        is not None
+    )
+
+
 def detect_suspicious_patterns(
     api: ApiIdentity, structs: List[StructFields], source: str
 ) -> List[FieldIssue]:
@@ -87,7 +112,9 @@ def detect_suspicious_patterns(
     红旗依据：
       1. 用户级接口 Body 含 user_id/approval_code（弱启发式，info 级——
          /reference/ 路径也含管理员级接口，需人工判断）
-      2. 必填 Vec 字段缺非空校验（认 validate_required_list! 或 is_empty()）
+      2. 必填 Vec 字段缺非空校验（认字段级 validate_required! /
+         validate_required_list! 或 is_empty()；skip_serializing_if =
+         Vec::is_empty 视为可选）
       3. GET 查询接口 Response 为空（可能漏建响应字段）
     """
     issues: List[FieldIssue] = []
@@ -117,8 +144,7 @@ def detect_suspicious_patterns(
                     )
 
     # 红旗 2：必填 Vec 字段缺非空校验
-    # 认两种校验写法：validate_required_list! 宏 或 if xxx.is_empty() 手写
-    has_list_macro = "validate_required_list!" in source
+    # 认字段级校验：validate_required! / validate_required_list! / {field}.is_empty()
     for s in body_structs:
         # 只检查必填的数组字段（Option<Vec> 是选填，不报）
         vec_fields = [
@@ -131,16 +157,16 @@ def detect_suspicious_patterns(
             )
         ]
         for f in vec_fields:
-            # 检查字段名是否在 is_empty() 校验里出现
-            has_manual_check = f"{f.name}.is_empty()" in source
-            if not has_list_macro and not has_manual_check:
+            if _vec_skips_empty_on_wire(source, f.name):
+                continue
+            if not _has_field_list_nonempty_check(source, f.name):
                 issues.append(
                     FieldIssue(
                         severity="warning",
                         category="missing_list_validation",
                         detail=(
                             f"Body {s.name} 的必填数组字段 {f.name} "
-                            "缺少非空校验（validate_required_list! 或 is_empty()）"
+                            "缺少非空校验（validate_required! / validate_required_list! 或 is_empty()）"
                         ),
                     )
                 )


### PR DESCRIPTION
Fixes #646

# 概要

周报快速模式把 4 个 Catalog Entry 标成 `missing_list_validation`。真缺口只有批量删除补充信息的必填 `user_ids`；加签 / 三方任务查询已有 `validate_required!`，人员组成员 write 的空 Vec 是合法 no-op。补上真实校验，并让检测器认字段级 `validate_required!` 与 `skip_serializing_if = "Vec::is_empty"`。

## 变更类型

- [x] 🐛 修复

## 关联 Issue

Fixes #646

## 变更

- 批量删除补充信息：空 `user_ids` 在 Transport 前返回校验错误（`validate_required!`，不发明 max_len）
- `detect_suspicious_patterns`：字段级认 `validate_required!` / `validate_required_list!` / `{field}.is_empty()`；文件级 `validate_required_list!` 不再误伤其他字段
- `skip_serializing_if = "Vec::is_empty"` 的可选列表不报 `missing_list_validation`
- 人员组成员 write 的空 add/remove 保持合法 no-op（未改成必填）

## 验证

- [x] `python3 -m unittest tools.tests.test_verify_api_fields`（29 绿）
- [x] `cargo test -p openlark-hr --lib -- additional_informations_batch_delete user_group_user_rel_write`（3 绿）
- [x] `cargo test -p openlark-workflow --lib -- external_task_list_v4 instance_add_sign_v4`（2 绿）
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets --all-features`
- [ ] `cargo test --workspace --all-features`

## 备注

不限长必填列表继续允许 `validate_required!`，未强行改成 `validate_required_list!`。加签 / 三方任务查询的请求实现未改（本 issue 只修检测器识别）。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: pre-transport validation on one HR endpoint plus heuristic fixes in an internal verification tool; no auth or wire contract changes beyond rejecting invalid empty requests.
> 
> **Overview**
> Fixes **#646**: weekly quick-mode `missing_list_validation` noise and one real SDK gap on performance **batch delete additional informations**.
> 
> **Runtime:** `DeleteRequest` now calls `validate_required!` on `user_ids` before `Transport`, so an empty list returns a validation error instead of hitting the API. The happy-path wiremock test supplies a user id; a new unit test asserts empty `user_ids` fails locally.
> 
> **Tooling:** `detect_suspicious_patterns` in `verify_api_fields.py` no longer treats a file-level `validate_required_list!` as covering every list field. It checks **per field** for `validate_required!`, `validate_required_list!`, or `{field}.is_empty()`, and skips `missing_list_validation` when the field uses `#[serde(skip_serializing_if = "Vec::is_empty")]` (wire-optional empty vecs, e.g. user-group member write). Unit tests lock in macro recognition and the skip-serialize case.
> 
> CHANGELOG **Fixed** section documents the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98fcf393d18c71234983255df863aeb637043ff4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->